### PR TITLE
[TrapFocus] Fix TrapFocus stealing focus from contained nodes

### DIFF
--- a/src/components/Focus/Focus.tsx
+++ b/src/components/Focus/Focus.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import isEqual from 'lodash/isEqual';
 import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
 import {write} from '@shopify/javascript-utilities/fastdom';
 
@@ -10,6 +11,20 @@ export interface Props {
 
 export default class Focus extends React.PureComponent<Props, never> {
   componentDidMount() {
+    this.handleSelfFocus();
+  }
+
+  componentDidUpdate({children: prevChildren, ...restPrevProps}: Props) {
+    const {children, ...restProps} = this.props;
+
+    if (isEqual(restProps, restPrevProps)) {
+      return;
+    }
+
+    this.handleSelfFocus();
+  }
+
+  handleSelfFocus() {
     if (this.props.disabled) {
       return;
     }

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -14,20 +14,53 @@ export interface Props {
   children?: React.ReactNode;
 }
 
-export default class TrapFocus extends React.PureComponent<Props, never> {
-  private focusTrapWrapper: HTMLElement | null = null;
+export interface State {
+  shouldFocusSelf: boolean | undefined;
+}
+
+export default class TrapFocus extends React.PureComponent<Props, State> {
+  state = {
+    shouldFocusSelf: undefined,
+  };
+
+  private focusTrapWrapper: HTMLElement;
+
+  componentDidMount() {
+    this.setState(this.handleTrappingChange());
+  }
+
+  handleTrappingChange() {
+    const {trapping = true} = this.props;
+
+    if (this.focusTrapWrapper.contains(document.activeElement)) {
+      return {shouldFocusSelf: false};
+    }
+
+    return {shouldFocusSelf: trapping};
+  }
 
   render() {
-    const {children, trapping = true} = this.props;
+    const {children} = this.props;
 
     return (
-      <Focus disabled={!trapping}>
+      <Focus disabled={this.shouldDisable}>
         <div ref={this.setFocusTrapWrapper}>
           <EventListener event="focusout" handler={this.handleBlur} />
           {children}
         </div>
       </Focus>
     );
+  }
+
+  private get shouldDisable() {
+    const {trapping = true} = this.props;
+    const {shouldFocusSelf} = this.state;
+
+    if (shouldFocusSelf === undefined) {
+      return true;
+    }
+
+    return shouldFocusSelf ? !trapping : !shouldFocusSelf;
   }
 
   @autobind


### PR DESCRIPTION
### WHY are these changes introduced?
The issue as been raised on slack that trap focus steals focus from contained nodes.

### WHAT is this pull request doing?
* Focus will focus on update
* Focus sets initial state based on the DOM then re-renders itself
* Focus will now remain on inner nodes or TrapFocus will be focused

### Tophatting instructions

#### In the playground

- `git checkout tf-inner-focus`
- `yarn dev` and navigate to localhost:8080
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
/* eslint-disable */

import * as React from 'react';
import {
  Page,
  AppProvider,
  Modal,
  Button,
  TextField,
  TrapFocus,
} from '@shopify/polaris';

interface State {
  active: boolean;
  text: string;
}

export default class Playground extends React.Component<never, State> {
  state = {
    active: false,
    text: '',
  };

  handleChange = () => {
    this.setState(({active}) => ({active: !active}));
  };

  render() {
    const {active, text} = this.state;

    return (
      <AppProvider>
        <Page title="Playground">
          <Button onClick={this.handleChange}>Open</Button>
          <Modal
            open={active}
            onClose={this.handleChange}
            title="Reach more shoppers with Instagram product tags"
            primaryAction={{
              content: 'Add Instagram',
              onAction: this.handleChange,
            }}
            secondaryActions={[
              {
                content: 'Learn more',
                onAction: this.handleChange,
              },
            ]}
          >
            <Modal.Section>
              <TextField
                label="text"
                value={text}
                onChange={(text) => this.setState({text})}
                autoFocus
              />
            </Modal.Section>
          </Modal>
        </Page>
      </AppProvider>
    );
  }
}

/* eslint-enable */
```

</details>

#### In the admin

- In _`web`_ => `dev down && dev tophat pull collections-product-picker && dev up` 
- In _`polaris-react`_ => `yarn run build-consumer web`
- In `web` => `dev server`, then navigate to `/admin/collections`
- In click on either collection in the list to open its detail view, then scroll down to the "Products" card
- Begin typing into the product search field to trigger the product picker modal to open
- As you continue to type, the text field value should fluidly continue to change

### Notes

_*TrapFocus and Focus are not "exposed" components so a changelog entry is not needed_

_**You may need to `git pull origin v3-rc.1` in web after step 1, ping @chloerice on Slack if you'd like to tophat on `web` and are having trouble_

_***Will resolve conflict before merging_