### PR TITLE
[Autocomplete] Fix option selection with arrow keys

### DIFF
--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -359,7 +359,9 @@ export default class ComboBox extends React.PureComponent<Props, State> {
 
   @autobind
   private handleBlur() {
-    this.setState({popoverActive: false, popoverWasActive: false});
+    this.setState({popoverActive: false, popoverWasActive: false}, () => {
+      this.resetVisuallySelectedOptions();
+    });
   }
 
   @autobind
@@ -493,19 +495,21 @@ export default class ComboBox extends React.PureComponent<Props, State> {
 
   @autobind
   private selectOptionAtIndex(newOptionIndex: number) {
-    const {navigableOptions} = this.state;
+    const {navigableOptions, selectedOption: oldSelectedOption} = this.state;
     if (!navigableOptions || navigableOptions.length === 0) {
       return;
     }
     const newSelectedOption = navigableOptions[newOptionIndex];
-    const oldSelectedOption = this.state.selectedOption;
 
-    this.setState({
-      selectedOption: newSelectedOption,
-      selectedIndex: newOptionIndex,
-    });
-
-    this.visuallyUpdateSelectedOption(newSelectedOption, oldSelectedOption);
+    this.setState(
+      {
+        selectedOption: newSelectedOption,
+        selectedIndex: newOptionIndex,
+      },
+      () => {
+        this.visuallyUpdateSelectedOption(newSelectedOption, oldSelectedOption);
+      },
+    );
   }
 
   @autobind


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris-react/issues/472

Up and down arrow keys were not visually selecting the correct option.

### WHAT is this pull request doing?

Delays the visual update of the selection until setState has completed so the selection is correct. I also cleared the selection on blur.

![autocomplete-arrows-fixed](https://user-images.githubusercontent.com/6239480/47545512-88b99c80-d8a1-11e8-8c4f-275ba97576c5.gif)


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
/* eslint-disable */

import * as React from 'react';
import {
  Page,
  AppProvider,
  Stack,
  Tag,
  TextContainer,
  // Icon,
  Autocomplete,
} from '@shopify/polaris';
import _ from 'lodash';

interface Props {}
interface State {}

export default class DemoTagsAutocomplete extends React.Component<
  Props,
  State
> {
  // Quick Config
  ALLOW_MULTIPLE = false;
  RESULT_PAGE_LENGTH = 10;

  options = [
    {value: 'polyester', label: 'Polyester'},
    {value: 'wool', label: 'Wool'},
    {value: 'vinyl', label: 'Vinyl'},
    {value: 'vintage', label: 'Vintage'},
    {value: 'alpaca', label: 'Alpaca'},
  ];

  state = {
    selected: [],
    inputText: '',
    options: this.options.slice(0, this.RESULT_PAGE_LENGTH),
    filteredOptions: this.options.slice(
      this.RESULT_PAGE_LENGTH,
      this.options.length - 1,
    ),
    loading: false,
  };

  updateText = (newValue: string) => {
    this.setState({inputText: newValue});
    this.filterAndUpdateOptions(newValue);
  };

  removeTag = (tag: string) => {
    let newSelected: string[] = this.state.selected;
    newSelected.splice(newSelected.indexOf(tag), 1);
    this.setState({selected: newSelected});
  };

  addTag = (tag: string) => {
    if (!tag || tag === '') {
      return;
    }
    let tagLabel = '';
    tagLabel = tag.replace('_', ' ');
    tagLabel = _.startCase(tagLabel);

    this.options.push({value: tag, label: tagLabel});
    this.filterAndUpdateOptions(tag);
  };

  renderTags = (): React.ReactNode => {
    return this.state.selected.map((option: string) => {
      let tagLabel = '';
      tagLabel = option.replace('_', ' ');
      tagLabel = _.startCase(tagLabel);
      return (
        <Tag key={'option' + option} onRemove={() => this.removeTag(option)}>
          {tagLabel}
        </Tag>
      );
    });
  };

  shouldLoadMoreResults = (): boolean => {
    const {filteredOptions, loading} = this.state;
    if (filteredOptions.length === 0 || loading) {
      return false;
    }
    this.setState({loading: true});
    return true;
  };

  loadMoreResults = () => {
    const {filteredOptions, options} = this.state;
    if (this.shouldLoadMoreResults()) {
      let currentlyLoadedOptions = options;
      let unloadedOptions = filteredOptions;

      const endIndex =
        currentlyLoadedOptions.length + this.RESULT_PAGE_LENGTH - 1;
      let optionsToLoad = unloadedOptions.slice(0, endIndex);

      currentlyLoadedOptions = currentlyLoadedOptions.concat(optionsToLoad);
      unloadedOptions = unloadedOptions.slice(
        endIndex,
        unloadedOptions.length - 1,
      );

      setTimeout(() => {
        this.setState({
          options: currentlyLoadedOptions,
          filteredOptions: unloadedOptions,
          loading: false,
        });
      }, 300);
    }
  };

  shouldShowRenderActionButton = (): boolean => {
    const {inputText} = this.state;
    return !(
      !inputText ||
      inputText === '' ||
      (this.ALLOW_MULTIPLE && containsOption(this.options, inputText))
    );
  };

  renderActionButton = (): ItemDescriptor | undefined => {
    if (this.shouldShowRenderActionButton()) {
      return {
        content: 'Add "' + this.state.inputText + '"',
        icon: 'circlePlus',
        onAction: () => this.addTag(this.state.inputText),
      };
    }
    return undefined;
  };

  // getListTitle = (): string | undefined => {
  //   if (this.shouldShowRenderActionButton()) {
  //     return undefined;
  //   }
  //   return 'Frequently Used Tags';
  // };

  render() {
    console.log(this.renderActionButton());

    return (
      <AppProvider>
        <Page title="Demo Tags Autocomplete">
          <br />
          <TextContainer>
            <Stack>{this.renderTags()}</Stack>
          </TextContainer>
          <br />
          <Autocomplete
            options={this.state.options}
            selected={this.state.selected}
            textField={
              <Autocomplete.ComboBox.TextField
                onChange={this.updateText}
                label=""
                value={this.state.inputText}
                placeholder="Vintage, cotton, summer"
                // prefix={<Icon source="search" color="inkLighter" />}
              />
            }
            onSelect={this.updateSelection}
            allowMultiple={this.ALLOW_MULTIPLE}
            loading={this.state.loading}
            willLoadMoreResults
            onLoadMoreResults={this.loadMoreResults}
            // actionBefore={this.renderActionButton()}
            // listTitle={this.getListTitle()}
          />
        </Page>
      </AppProvider>
    );
  }

  filterAndUpdateOptions = (inputString: string) => {
    if (inputString === '') {
      this.setState({
        options: this.options.slice(0, this.RESULT_PAGE_LENGTH),
        filteredOptions: this.options.slice(
          this.RESULT_PAGE_LENGTH,
          this.options.length,
        ),
      });
      return;
    }

    const filterRegex = new RegExp(inputString, 'i');
    const resultOptions = this.options.filter((option) =>
      option.label.match(filterRegex),
    );
    let endIndex = resultOptions.length - 1;
    if (resultOptions.length === 0) {
      endIndex = 0;
    }
    this.setState({
      options: resultOptions.slice(0, this.RESULT_PAGE_LENGTH),
      filteredOptions: resultOptions.slice(this.RESULT_PAGE_LENGTH, endIndex),
    });
  };

  updateSelection = (updatedSelection: string[]) => {
    const selectedText = updatedSelection.map((selectedItem: string) => {
      const matchedOption = this.options.filter((option) => {
        return option.value.match(selectedItem);
      });
      return matchedOption[0] && matchedOption[0].label;
    });
    if (this.ALLOW_MULTIPLE) {
      this.setState({selected: updatedSelection});
    } else {
      this.setState({selected: selectedText, inputText: selectedText});
    }
  };
}

function containsOption(a: any, optionString: string) {
  for (var i = 0; i < a.length; i++) {
    const filterRegex = new RegExp(
      '^' + optionString.replace(' ', '_') + '$',
      'i',
    );
    if (a[i].value.match(filterRegex)) {
      return true;
    }
  }
  return false;
}

/* eslint-enable */

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
