### PR TITLE
Support opening a new tab or window with embedded app actions

### DIFF
--- a/src/utilities/app-bridge-transformers.ts
+++ b/src/utilities/app-bridge-transformers.ts
@@ -19,17 +19,30 @@ export function generateRedirect(
   }
 
   const redirect = Redirect.create(appBridge);
-  const inferredTarget = external === true ? 'REMOTE' : target;
+  const payload =
+    external === true
+      ? {
+          url,
+          newContext: true,
+        }
+      : url;
 
   return () => {
-    redirect.dispatch(redirectAction(inferredTarget), url);
+    redirect.dispatch(redirectAction(target, external), payload);
   };
 }
 
 function redirectAction(target: AppBridgeTarget): Redirect.Action.APP;
 function redirectAction(target: AppBridgeTarget): Redirect.Action.ADMIN_PATH;
-function redirectAction(target: AppBridgeTarget): Redirect.Action.REMOTE;
-function redirectAction(target: AppBridgeTarget) {
+function redirectAction(
+  target: AppBridgeTarget,
+  external?: boolean,
+): Redirect.Action.REMOTE;
+function redirectAction(target: AppBridgeTarget, external?: boolean) {
+  if (external === true) {
+    return Redirect.Action.REMOTE;
+  }
+
   return Redirect.Action[target];
 }
 

--- a/src/utilities/tests/app-bridge-transformers.test.ts
+++ b/src/utilities/tests/app-bridge-transformers.test.ts
@@ -35,13 +35,16 @@ describe('app bridge transformers', () => {
       expect(dispatch).toHaveBeenCalledWith(Redirect.Action.APP, '/path');
     });
 
-    it('action is REMOTE when external is true', () => {
+    it('action is REMOTE with newContext when external is true', () => {
       const callback = generateRedirect(appBridge, '/path', undefined, true);
       if (callback != null) {
         callback.call(this);
       }
       expect(dispatch).toHaveBeenCalledTimes(1);
-      expect(dispatch).toHaveBeenCalledWith(Redirect.Action.REMOTE, '/path');
+      expect(dispatch).toHaveBeenCalledWith(Redirect.Action.REMOTE, {
+        url: '/path',
+        newContext: true,
+      });
     });
 
     it('action is REMOTE when target is REMOTE', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

We want actions used with embedded apps to be able to open a new tab or window.

### WHAT is this pull request doing?

When `external` is true, the redirect callback will pass the proper payload with `newContext: true` along with `Redirect.Action.REMOTE` per the [Shopify App Bridge Redirect docs](https://help.shopify.com/en/api/embedded-apps/app-bridge/actions/navigation/redirect#redirect-to-an-absolute-url-outside-of-the-app-and-outside-of-shopify-admin).

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

1. Create an embedded app
1. run `yarn build-cosumer your-embedded-app-directory`
1. Add a `Page` component and pass a primary action with `external: true`

### 🎩 checklist

* [x] I have [tophatted](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md) this change
