### PR TITLE
Fix top bar links

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,7 +10,7 @@ We've released a suite of new components that, when combined, form the applicati
 
 #### [Frame](https://polaris.shopify.com/components/structure/frame)
 
-The frame component, while not visible in the user interface itself, provides the structure for any non-embedded application. It wraps the main elements and houses the primary [navigation](https://polaris.shopify.com/components/navigation/navigation), [top bar](https://polaris.shopify.com/components/structure/topbar), [toast](https://polaris.shopify.com/components/structure/toast), [loading](https://polaris.shopify.com/components/structure/loading), and [contextual save bar](https://polaris.shopify.com/components/structure/contextual-save-bar) components.
+The frame component, while not visible in the user interface itself, provides the structure for any non-embedded application. It wraps the main elements and houses the primary [navigation](https://polaris.shopify.com/components/navigation/navigation), [top bar](https://polaris.shopify.com/components/structure/top-bar), [toast](https://polaris.shopify.com/components/structure/toast), [loading](https://polaris.shopify.com/components/structure/loading), and [contextual save bar](https://polaris.shopify.com/components/structure/contextual-save-bar) components.
 
 #### [Navigation](https://polaris.shopify.com/components/navigation/navigation)
 

--- a/src/components/AppProvider/README.md
+++ b/src/components/AppProvider/README.md
@@ -169,7 +169,7 @@ class ProviderLinkExample extends React.Component {
 
 ### With theme
 
-With a `theme`, the app provider component will set light, dark, and text colors for the [top bar](/components/structure/topbar) component when given a `background` color, as well as a logo for the top bar and [contextual save bar](/components/structure/contextual-save-bar) components.
+With a `theme`, the app provider component will set light, dark, and text colors for the [top bar](/components/structure/top-bar) component when given a `background` color, as well as a logo for the top bar and [contextual save bar](/components/structure/contextual-save-bar) components.
 
 ```jsx
 class ProviderThemeExample extends React.Component {
@@ -257,7 +257,7 @@ class ProviderThemeExample extends React.Component {
 
 ### With theme using all theme keys
 
-Provide specific keys and corresponding colors to the [top bar](/components/structure/topbar) component theme for finer control. When giving more than just the `background`, providing all keys is necessary to prevent falling back to default colors.
+Provide specific keys and corresponding colors to the [top bar](/components/structure/top-bar) component theme for finer control. When giving more than just the `background`, providing all keys is necessary to prevent falling back to default colors.
 
 ```jsx
 class ProviderThemeExample extends React.Component {

--- a/src/components/Frame/README.md
+++ b/src/components/Frame/README.md
@@ -20,7 +20,7 @@ fullSizeExamples: true
 
 # Frame
 
-The frame component, while not visible in the user interface itself, provides the structure for any non-embedded application. It wraps the main elements and houses the primary [navigation](/components/navigation/navigation), [top bar](/components/structure/topbar), [toast](/components/feedback-indicators/toast), and [contextual save bar](/components/structure/contextual-save-bar) components.
+The frame component, while not visible in the user interface itself, provides the structure for any non-embedded application. It wraps the main elements and houses the primary [navigation](/components/navigation/navigation), [top bar](/components/structure/top-bar), [toast](/components/feedback-indicators/toast), and [contextual save bar](/components/structure/contextual-save-bar) components.
 
 ---
 
@@ -28,7 +28,7 @@ The frame component, while not visible in the user interface itself, provides th
 
 For the best experience when creating an application frame, use the following components:
 
-- [Top bar](/components/structure/topbar)
+- [Top bar](/components/structure/top-bar)
 - [Navigation](/components/navigation/navigation)
 - [Contextual save bar](/components/structure/contextual-save-bar)
 - [Toast](/components/feedback-indicators/toast)
@@ -377,7 +377,7 @@ class FrameExample extends React.Component {
 
 ## Related components
 
-- To display the navigation component on small screens, to provide search and a user menu, or to style the [frame](/components/structure/frame) component to reflect an application’s brand, use the [top bar](/components/structure/topbar) component.
+- To display the navigation component on small screens, to provide search and a user menu, or to style the [frame](/components/structure/frame) component to reflect an application’s brand, use the [top bar](/components/structure/top-bar) component.
 - To display the primary navigation within the frame of a non-embedded application, use the [navigation](/components/structure/navigation) component.
 - To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](/components/structure/contextual-save-bar) component.
 - To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](/components/feedback-indicators/toast) component.

--- a/src/components/Navigation/README.md
+++ b/src/components/Navigation/README.md
@@ -20,7 +20,7 @@ The navigation component is used to display the primary navigation in the sideba
 
 ## Components dependencies
 
-The navigation component must be passed to the [frame](/components/structure/frame) component. The mobile version of the navigation component appears in the [topbar](/components/structure/topbar) component.
+The navigation component must be passed to the [frame](/components/structure/frame) component. The mobile version of the navigation component appears in the [topbar](/components/structure/top-bar) component.
 
 ---
 
@@ -453,7 +453,7 @@ Use to add a horizontal line between sections.
 ## Related components
 
 - To provide the structure for the navigation component, including the left sidebar and the top bar use the [frame](/components/structure/frame) component.
-- To display the navigation component on small screens, to provide search and a user menu, or to theme the [frame](/components/structure/frame) component to reflect an application’s brand, use the [top bar](/components/structure/topbar) component.
+- To display the navigation component on small screens, to provide search and a user menu, or to theme the [frame](/components/structure/frame) component to reflect an application’s brand, use the [top bar](/components/structure/top-bar) component.
 - To tell merchants their options once they have made changes to a form on the page use the {contextual save bar} component.
 - To provide quick, at-a-glance feedback on the outcome of an action, use the {toast} component.
 - To indicate to merchants that a page is loading or an upload is processing use the {loading} component.


### PR DESCRIPTION
Fixes links to top bar docs which is causing 404 checks to fail in https://github.com/Shopify/polaris-styleguide/pull/2346
