### PR TITLE
[SkeletonPage] Add primaryAction as a prop to SkeletonPage

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added `primaryAction` prop to `SkeletonPage` ([#488](https://github.com/Shopify/polaris-react/pull/488))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/SkeletonPage/README.md
+++ b/src/components/SkeletonPage/README.md
@@ -63,7 +63,7 @@ Use placeholder content that will change when the page fully loads. This will co
 Use this component to compose a loading version of a page where the page title and header content are dynamic, meaning, the content changes.
 
 ```jsx
-<SkeletonPage secondaryActions={2}>
+<SkeletonPage primaryAction secondaryActions={2}>
   <Layout>
     <Layout.Section>
       <Card sectioned>
@@ -115,7 +115,7 @@ Use this component to compose a loading version of a page where the page title a
 Use this component to compose a loading version of a page where the page title and header content are known and stay the same.
 
 ```jsx
-<SkeletonPage title="Products" secondaryActions={2}>
+<SkeletonPage title="Products" primaryAction secondaryActions={2}>
   <Layout>
     <Layout.Section>
       <Card sectioned>

--- a/src/components/SkeletonPage/SkeletonPage.scss
+++ b/src/components/SkeletonPage/SkeletonPage.scss
@@ -1,4 +1,6 @@
 $action-text-spacing: rem(24px);
+$primary-action-button-height: rem(36px);
+$primary-action-button-width: rem(100px);
 
 .Page {
   @include page-layout;
@@ -32,6 +34,45 @@ $action-text-spacing: rem(24px);
   margin-bottom: (-1 * spacing(extra-tight));
 }
 
+.TitleAndPrimaryAction {
+  display: flex;
+
+  @include page-content-when-partially-condensed {
+    display: block;
+  }
+}
+
+.Title {
+  flex: 1 1 0%;
+}
+
+.PrimaryAction {
+  align-self: stretch;
+
+  > * {
+    height: $primary-action-button-height;
+    min-width: $primary-action-button-width;
+  }
+
+  @include page-content-when-layout-stacked {
+    margin-top: spacing(base);
+    margin-bottom: (-1 * spacing(tight));
+  }
+
+  @include page-content-when-not-fully-condensed {
+    margin-top: $actions-vertical-spacing;
+    margin-bottom: (-1 * spacing(tight));
+  }
+
+  @include page-content-when-not-partially-condensed {
+    margin-top: 0;
+  }
+
+  @include page-content-when-layout-not-stacked {
+    margin-top: 0;
+  }
+}
+
 .Actions {
   @include skeleton-page-secondary-actions-layout;
 }
@@ -44,7 +85,7 @@ $action-text-spacing: rem(24px);
   padding-right: $action-text-spacing;
   margin-top: (-1 * spacing(extra-tight));
   margin-bottom: (-1 * spacing(extra-tight));
-  padding-top: rem(16px);
+  padding-top: spacing();
 
   &:first-child {
     padding-right: 0;

--- a/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/src/components/SkeletonPage/SkeletonPage.tsx
@@ -14,6 +14,8 @@ export interface Props {
   fullWidth?: boolean;
   /** Decreases the maximum layout width. Intended for single-column layouts */
   singleColumn?: boolean;
+  /** Shows a skeleton over the primary action */
+  primaryAction?: boolean;
   /** Number of secondary page-level actions to display */
   secondaryActions?: number;
   /** Shows a skeleton over the breadcrumb */
@@ -30,6 +32,7 @@ export class SkeletonPage extends React.PureComponent<CombinedProps, never> {
       children,
       fullWidth,
       singleColumn,
+      primaryAction,
       secondaryActions,
       title = '',
       breadcrumbs,
@@ -49,6 +52,12 @@ export class SkeletonPage extends React.PureComponent<CombinedProps, never> {
 
     const titleMarkup = title !== null ? renderTitle(title) : null;
 
+    const primaryActionMarkup = primaryAction ? (
+      <div className={styles.PrimaryAction}>
+        <SkeletonDisplayText size="large" />
+      </div>
+    ) : null;
+
     const secondaryActionsMarkup = secondaryActions
       ? renderSecondaryActions(secondaryActions)
       : null;
@@ -62,7 +71,10 @@ export class SkeletonPage extends React.PureComponent<CombinedProps, never> {
     const headerMarkup = !this.props.polaris.appBridge ? (
       <div className={headerClassName}>
         {breadcrumbMarkup}
-        {titleMarkup}
+        <div className={styles.TitleAndPrimaryAction}>
+          {titleMarkup}
+          {primaryActionMarkup}
+        </div>
         {secondaryActionsMarkup}
       </div>
     ) : null;

--- a/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
+++ b/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
-import {Layout, Card, SkeletonBodyText, DisplayText} from 'components';
+import {
+  Layout,
+  Card,
+  SkeletonBodyText,
+  DisplayText,
+  SkeletonDisplayText,
+} from 'components';
 import SkeletonPage from '../SkeletonPage';
 
 describe('<SkeletonPage />', () => {
@@ -24,12 +30,42 @@ describe('<SkeletonPage />', () => {
     expect(skeletonPage.contains(children)).toBe(true);
   });
 
-  it('renders the title', () => {
-    const skeletonPage = mountWithAppProvider(
-      <SkeletonPage title="Products" />,
-    );
-    expect(skeletonPage.find(DisplayText)).toHaveLength(1);
-    expect(skeletonPage.find(DisplayText).contains('Products')).toBe(true);
+  describe('title', () => {
+    it('renders title when a title is provided', () => {
+      const skeletonPage = mountWithAppProvider(
+        <SkeletonPage title="Products" />,
+      );
+      const displayText = skeletonPage.find(DisplayText);
+      expect(displayText).toHaveLength(1);
+      expect(displayText.text()).toBe('Products');
+    });
+
+    it('passes large to the size prop of DisplayText', () => {
+      const skeletonPage = mountWithAppProvider(
+        <SkeletonPage title="Products" />,
+      );
+      const displayText = skeletonPage.find(DisplayText);
+      expect(displayText.prop('size')).toBe('large');
+    });
+
+    it('passes h1 to the element prop of DisplayText', () => {
+      const skeletonPage = mountWithAppProvider(
+        <SkeletonPage title="Products" />,
+      );
+      const displayText = skeletonPage.find(DisplayText);
+      expect(displayText.prop('element')).toBe('h1');
+    });
+
+    it('renders a SkeletonDisplayText when the title is an empty string', () => {
+      const skeletonPage = mountWithAppProvider(<SkeletonPage title="" />);
+      expect(skeletonPage.find(SkeletonDisplayText)).toHaveLength(1);
+    });
+
+    it('passes large to the size prop of SkeletonDisplayText', () => {
+      const skeletonPage = mountWithAppProvider(<SkeletonPage title="" />);
+      const skeletonDisplayText = skeletonPage.find(SkeletonDisplayText);
+      expect(skeletonDisplayText.prop('size')).toBe('large');
+    });
   });
 
   it('renders the correct number of secondary actions as SkeletonBodyText', () => {
@@ -42,5 +78,14 @@ describe('<SkeletonPage />', () => {
   it('renders breadcrumbs', () => {
     const skeletonPage = mountWithAppProvider(<SkeletonPage breadcrumbs />);
     expect(skeletonPage.find(SkeletonBodyText)).toHaveLength(1);
+  });
+
+  describe('primaryAction', () => {
+    it('renders SkeletonDisplayText if true', () => {
+      const skeletonPage = mountWithAppProvider(
+        <SkeletonPage title="Title" primaryAction />,
+      );
+      expect(skeletonPage.find(SkeletonDisplayText)).toHaveLength(1);
+    });
   });
 });


### PR DESCRIPTION
[Link to deprecated PR](https://github.com/Shopify/polaris-react-deprecated/pull/2416)
### WHY are these changes introduced?

closes https://github.com/Shopify/polaris-react/issues/2372
Original feature request: https://github.com/Shopify/polaris/issues/443

### WHAT is this pull request doing?

Added a primaryAction SkeletonDisplayText to mimic primaryAction Button on Page

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://vault.shopify.com/developers/Tophatting)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-pasta this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
/* eslint-disable */

import * as React from 'react';
import {
  Button,
  Layout,
  SkeletonPage,
  Page,
  AppProvider,
  Card,
  SkeletonBodyText,
} from '@shopify/polaris';

interface State {
  loading: boolean;
}

export default class Playground extends React.Component<never, State> {
  state: State = {
    loading: true,
  };

  toggleLoading = () => {
    this.setState(({loading}) => {
      return {loading: !loading};
    });
  };

  render() {
    const pageMarkup = this.state.loading ? (
      <SkeletonPage title="Products" primaryAction={true}>
        <Layout>
          <Layout.Section>
            <Card sectioned title="Images">
              <SkeletonBodyText />
            </Card>
            <Card sectioned title="Variants">
              <SkeletonBodyText />
            </Card>
          </Layout.Section>
          <Layout.Section secondary>
            <Card title="Sales channels">
              <Card.Section>
                <SkeletonBodyText lines={2} />
              </Card.Section>
              <Card.Section>
                <SkeletonBodyText lines={1} />
              </Card.Section>
            </Card>
            <Card title="Organization" subdued>
              <Card.Section>
                <SkeletonBodyText lines={2} />
              </Card.Section>
              <Card.Section>
                <SkeletonBodyText lines={2} />
              </Card.Section>
            </Card>
          </Layout.Section>
        </Layout>
      </SkeletonPage>
    ) : (
      <Page title="Products" primaryAction={{content: 'Save', disabled: true}}>
        <Card sectioned title="Card">
          <p>Page content</p>
        </Card>
      </Page>
    );

    return (
      <AppProvider>
        <React.Fragment>
          <Button onClick={this.toggleLoading}>Toggle loading</Button>
          {pageMarkup}
        </React.Fragment>
      </AppProvider>
    );
  }
}

/* eslint-enable */

```

</details>

### 🎩 checklist

* [x] Tested on mobile
* [x] Tested on multiple browsers
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
