### PR TITLE
Remove binds from modal onClose

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -12,7 +12,6 @@ import {transformActions} from '../../utilities/app-bridge-transformers';
 import {contentContextTypes} from '../../types';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import {Scrollable, Spinner, Portal, Backdrop} from '../../components';
-import memoizedBind from '../../utilities/memoized-bind';
 import {
   CloseButton,
   Dialog,
@@ -191,7 +190,6 @@ export class Modal extends React.Component<CombinedProps, State> {
 
     const {
       children,
-      onClose,
       title,
       src,
       iFrameName,
@@ -201,6 +199,7 @@ export class Modal extends React.Component<CombinedProps, State> {
       loading,
       large,
       limitHeight,
+      onClose,
       footer,
       primaryAction,
       secondaryActions,
@@ -210,8 +209,6 @@ export class Modal extends React.Component<CombinedProps, State> {
     const {iframeHeight} = this.state;
 
     const iframeTitle = intl.translate('Polaris.Modal.iFrameTitle');
-
-    const handleClose = memoizedBind(onClose);
 
     let dialog: React.ReactNode;
     let backdrop: React.ReactNode;
@@ -254,12 +251,12 @@ export class Modal extends React.Component<CombinedProps, State> {
       );
 
       const headerMarkup = title ? (
-        <Header id={this.headerId} onClose={handleClose} testID="ModalHeader">
+        <Header id={this.headerId} onClose={onClose} testID="ModalHeader">
           {title}
         </Header>
       ) : (
         <CloseButton
-          onClick={handleClose}
+          onClick={onClose}
           title={false}
           testID="ModalCloseButton"
         />
@@ -269,7 +266,7 @@ export class Modal extends React.Component<CombinedProps, State> {
         <Dialog
           instant={instant}
           labelledBy={this.headerId}
-          onClose={handleClose}
+          onClose={onClose}
           onEntered={this.handleEntered}
           onExited={this.handleExited}
           large={large}

--- a/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/src/components/Modal/components/Dialog/Dialog.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import {Transition, CSSTransition} from 'react-transition-group';
 import {KeypressListener, TrapFocus} from '../../../../components';
-import memoizedBind from '../../../../utilities/memoized-bind';
 import {Duration} from '../../../shared';
 import {AnimationProps, Key} from '../../../../types';
 import * as styles from './Dialog.scss';
@@ -44,7 +43,6 @@ export default function Dialog({
     large && styles.sizeLarge,
     limitHeight && styles.limitHeight,
   );
-  const handleClose = memoizedBind(onClose);
   const TransitionChild = instant ? Transition : FadeUp;
 
   return (
@@ -66,7 +64,7 @@ export default function Dialog({
           >
             <KeypressListener
               keyCode={Key.Escape}
-              handler={handleClose}
+              handler={onClose}
               testID="CloseKeypressListener"
             />
             {children}

--- a/src/components/Modal/components/Header/Header.tsx
+++ b/src/components/Modal/components/Header/Header.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {DisplayText} from '../../../../components';
-import memoizedBind from '../../../../utilities/memoized-bind';
 import CloseButton from '../CloseButton';
 import * as styles from './Header.scss';
 
@@ -11,8 +10,6 @@ export interface Props {
 }
 
 export default function Header({id, children, onClose}: Props) {
-  const handleClose = memoizedBind(onClose);
-
   return (
     <div className={styles.Header}>
       <div id={id} className={styles.Title}>
@@ -21,7 +18,7 @@ export default function Header({id, children, onClose}: Props) {
         </DisplayText>
       </div>
 
-      <CloseButton onClick={handleClose} />
+      <CloseButton onClick={onClose} />
     </div>
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

As @GoodForOneFare pointed out in #501, the Modal component appears to be causing memory leaks when server side rendered.

Looking through the code I saw several unnecessary memoized binds on the modals onClose and the ones it passes around to the child components.

### WHAT is this pull request doing?

This removes all the bindings from the `onClose` callback.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

I'm not sure how best to test this resolves the memory leak. I have tested with the following playground to verify the `onClose` still works as expected with these removed.

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Modal, Button, TextContainer, AppProvider} from '@shopify/polaris';

interface State {
  active: boolean;
}

export default class Playground extends React.Component<never, State> {
  state = {
    active: true,
  };

  render() {
    const {active} = this.state;

    return (
      <AppProvider>
        <div>
          <Button onClick={this.handleChange}>Open</Button>
          <Modal
            open={active}
            onClose={this.handleChange}
            title="Reach more shoppers with Instagram product tags"
            primaryAction={{
              content: 'Add Instagram',
              onAction: this.handleChange,
            }}
            secondaryActions={[
              {
                content: 'Learn more',
                onAction: this.handleChange,
              },
            ]}
          >
            <Modal.Section>
              <TextContainer>
                <p>
                  Use Instagram posts to share your products with millions of
                  people. Let shoppers buy from your store without leaving
                  Instagram.
                </p>
              </TextContainer>
            </Modal.Section>
          </Modal>
        </div>
      </AppProvider>
    );
  }

  handleChange = () => {
    this.setState(({active}) => ({active: !active}));
  };
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
