### PR TITLE
[Autocomplete] Adds emptyState prop

### DIFF
--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -30,6 +30,8 @@ export interface Props {
   loading?: boolean;
   /** Indicates if more results will load dynamically */
   willLoadMoreResults?: boolean;
+  /** Is rendered when there are no options */
+  emptyState?: React.ReactNode;
   /** Callback when the selection of options is changed */
   onSelect(selected: string[]): void;
   /** Callback when the end of the list is reached */
@@ -58,6 +60,7 @@ export class Autocomplete extends React.PureComponent<CombinedProps, never> {
       loading,
       actionBefore,
       willLoadMoreResults,
+      emptyState,
       onSelect,
       onLoadMoreResults,
       polaris: {intl},
@@ -91,6 +94,7 @@ export class Autocomplete extends React.PureComponent<CombinedProps, never> {
         actionsBefore={conditionalAction}
         onSelect={onSelect}
         onEndReached={onLoadMoreResults}
+        emptyState={emptyState}
       />
     );
   }

--- a/src/components/Autocomplete/README.md
+++ b/src/components/Autocomplete/README.md
@@ -302,6 +302,98 @@ class AutocompleteExample extends React.Component {
 
 ---
 
+### Autocomplete with empty state
+
+Use to indicate there are no search results.
+
+```jsx
+class AutocompleteExample extends React.Component {
+  options = [
+    {value: 'rustic', label: 'Rustic'},
+    {value: 'antique', label: 'Antique'},
+    {value: 'vinyl', label: 'Vinyl'},
+    {value: 'vintage', label: 'Vintage'},
+    {value: 'refurbished', label: 'Refurbished'},
+  ];
+
+  state = {
+    selected: [],
+    inputText: '',
+    options: this.options,
+    loading: false,
+  };
+
+  render() {
+    return (
+      <div style={{height: '225px'}}>
+        <Autocomplete
+          options={this.state.options}
+          selected={this.state.selected}
+          onSelect={this.updateSelection}
+          emptyState={
+            <React.Fragment>
+              <Icon source="search" />
+              <div style={{textAlign: 'center'}}>
+                <TextContainer>Could not find any results</TextContainer>
+              </div>
+            </React.Fragment>
+          }
+          loading={this.state.loading}
+          textField={
+            <Autocomplete.TextField
+              onChange={this.updateText}
+              label=""
+              value={this.state.inputText}
+              prefix={<Icon source="search" color="inkLighter" />}
+              placeholder="Search"
+            />
+          }
+        />
+      </div>
+    );
+  }
+
+  updateText = (newValue) => {
+    this.setState({inputText: newValue});
+    this.filterAndUpdateOptions(newValue);
+  };
+
+  filterAndUpdateOptions = (inputString) => {
+    if (!this.state.loading) {
+      this.setState({loading: true});
+    }
+
+    setTimeout(() => {
+      if (inputString === '') {
+        this.setState({
+          options: this.options,
+          loading: false,
+        });
+        return;
+      }
+      const filterRegex = new RegExp(inputString, 'i');
+      const resultOptions = this.options.filter((option) =>
+        option.label.match(filterRegex),
+      );
+      this.setState({
+        options: resultOptions,
+        loading: false,
+      });
+    }, 300);
+  };
+
+  updateSelection = (updatedSelection) => {
+    const selectedText = updatedSelection.map((selectedItem) => {
+      const matchedOption = this.options.filter((option) => {
+        return option.value.match(selectedItem);
+      });
+      return matchedOption[0] && matchedOption[0].label;
+    });
+    this.setState({selected: selectedText, inputText: selectedText});
+  };
+}
+```
+
 ## Related components
 
 - For an input field without suggested options, [use the text field component](/components/forms/text-field)

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.scss
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.scss
@@ -1,0 +1,3 @@
+.EmptyState {
+  padding: spacing(tight) spacing();
+}

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -14,6 +14,8 @@ import {contextTypes} from '../types';
 import {TextField} from './components';
 import KeypressListener from '../../../KeypressListener';
 
+import * as styles from './ComboBox.scss';
+
 const getUniqueId = createUniqueIDFactory('ComboBox');
 
 export interface State {
@@ -48,6 +50,8 @@ export interface Props {
   contentBefore?: React.ReactNode;
   /** Content to be displayed after the list of options */
   contentAfter?: React.ReactNode;
+  /** Is rendered when there are no options */
+  emptyState?: React.ReactNode;
   /** Callback when the selection of options is changed */
   onSelect(selected: string[]): void;
   /** Callback when the end of the list is reached */
@@ -154,7 +158,7 @@ export default class ComboBox extends React.PureComponent<Props, State> {
   }
 
   componentDidUpdate(_: Props, prevState: State) {
-    const {contentBefore, contentAfter} = this.props;
+    const {contentBefore, contentAfter, emptyState} = this.props;
     const {navigableOptions, popoverActive} = this.state;
     this.subscriptions.forEach((subscriberCallback) => subscriberCallback());
 
@@ -173,7 +177,8 @@ export default class ComboBox extends React.PureComponent<Props, State> {
       navigableOptions &&
       navigableOptions.length === 0 &&
       !contentBefore &&
-      !contentAfter
+      !contentAfter &&
+      !emptyState
     ) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({popoverActive: false});
@@ -203,6 +208,7 @@ export default class ComboBox extends React.PureComponent<Props, State> {
       contentBefore,
       contentAfter,
       onEndReached,
+      emptyState,
     } = this.props;
 
     const actionsBeforeMarkup = actionsBefore &&
@@ -230,6 +236,13 @@ export default class ComboBox extends React.PureComponent<Props, State> {
     const scrollListenerMarkup = onEndReached && (
       <div ref={this.popoverScrollContainer} />
     );
+
+    const emptyStateMarkup = !actionsAfter &&
+      !actionsBefore &&
+      !contentAfter &&
+      !contentBefore &&
+      options.length === 0 &&
+      emptyState && <div className={styles.EmptyState}>{emptyState}</div>;
 
     return (
       <div
@@ -272,6 +285,7 @@ export default class ComboBox extends React.PureComponent<Props, State> {
             {optionsMarkup}
             {actionsAfterMarkup}
             {contentAfter}
+            {emptyStateMarkup}
           </div>
         </Popover>
       </div>

--- a/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
+++ b/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
@@ -89,7 +89,7 @@ describe('<ComboBox/>', () => {
         />,
       );
       comboBox.simulate('click');
-      expect(comboBox.find('#CustomNode').exists()).toBe(true);
+      expect(comboBox.find('#CustomNode')).toHaveLength(1);
     });
 
     it('renders content passed into contentAfter', () => {
@@ -103,7 +103,7 @@ describe('<ComboBox/>', () => {
         />,
       );
       comboBox.simulate('click');
-      expect(comboBox.find('#CustomNode').exists()).toBe(true);
+      expect(comboBox.find('#CustomNode')).toHaveLength(1);
     });
   });
 
@@ -283,7 +283,7 @@ describe('<ComboBox/>', () => {
           onSelect={noop}
         />,
       );
-      expect(comboBox.find(TextField).exists()).toBe(true);
+      expect(comboBox.find(TextField)).toHaveLength(1);
     });
 
     it('renders a custom given input', () => {
@@ -295,8 +295,8 @@ describe('<ComboBox/>', () => {
           onSelect={noop}
         />,
       );
-      expect(comboBox.find('input').exists()).toBe(true);
-      expect(comboBox.find(TextField).exists()).toBe(false);
+      expect(comboBox.find('input')).toHaveLength(1);
+      expect(comboBox.find(TextField)).toHaveLength(0);
     });
 
     it('is passed to Popover as the activator', () => {
@@ -309,12 +309,7 @@ describe('<ComboBox/>', () => {
         />,
       );
 
-      expect(
-        comboBox
-          .find(Popover)
-          .find(TextField)
-          .exists(),
-      ).toBe(true);
+      expect(comboBox.find(Popover).find(TextField)).toHaveLength(1);
     });
   });
 
@@ -363,7 +358,7 @@ describe('<ComboBox/>', () => {
         />,
       );
       comboBox.simulate('click');
-      expect(comboBox.find('button').exists()).toBe(true);
+      expect(comboBox.find('button')).toHaveLength(options.length);
     });
 
     it('renders a checkbox if the prop is set to true', () => {
@@ -377,7 +372,9 @@ describe('<ComboBox/>', () => {
         />,
       );
       comboBox.simulate('click');
-      expect(comboBox.find('input[type="checkbox"]').exists()).toBe(true);
+      expect(comboBox.find('input[type="checkbox"]')).toHaveLength(
+        options.length,
+      );
     });
   });
 
@@ -497,6 +494,89 @@ describe('<ComboBox/>', () => {
         listenerMap.keyup({keyCode: Key.Escape});
         await expect(comboBox.state('popoverActive')).toBe(false);
       };
+    });
+  });
+
+  describe('empty state', () => {
+    const EmptyState = () => <div>No results</div>;
+
+    it('renders an empty state when no options are passed in', () => {
+      const comboBox = mountWithAppProvider(
+        <ComboBox
+          options={[]}
+          selected={[]}
+          textField={renderTextField()}
+          onSelect={noop}
+          emptyState={<EmptyState />}
+        />,
+      );
+
+      comboBox.simulate('click');
+      expect(comboBox.find(EmptyState)).toHaveLength(1);
+    });
+
+    it('does not render empty state if actionsBefore exist', () => {
+      const comboBox = mountWithAppProvider(
+        <ComboBox
+          options={[]}
+          selected={[]}
+          textField={renderTextField()}
+          onSelect={noop}
+          actionsBefore={[{image: '../image/path', role: 'option'}]}
+          emptyState={<EmptyState />}
+        />,
+      );
+
+      comboBox.simulate('click');
+      expect(comboBox.find(EmptyState)).toHaveLength(0);
+    });
+
+    it('does not render empty state if actionsAfter exist', () => {
+      const comboBox = mountWithAppProvider(
+        <ComboBox
+          options={[]}
+          selected={[]}
+          textField={renderTextField()}
+          onSelect={noop}
+          actionsAfter={[{image: '../image/path', role: 'option'}]}
+          emptyState={<EmptyState />}
+        />,
+      );
+
+      comboBox.simulate('click');
+      expect(comboBox.find(EmptyState)).toHaveLength(0);
+    });
+
+    it('does not render empty state if contentAfter exist', () => {
+      const comboBox = mountWithAppProvider(
+        <ComboBox
+          options={[]}
+          selected={[]}
+          textField={renderTextField()}
+          onSelect={noop}
+          contentAfter={<div>Content after</div>}
+          emptyState={<EmptyState />}
+        />,
+      );
+
+      comboBox.simulate('click');
+      expect(comboBox.find(EmptyState)).toHaveLength(0);
+    });
+
+    it('does not render empty state if contentBefore exist', () => {
+      const comboBox = mountWithAppProvider(
+        <ComboBox
+          options={[]}
+          selected={[]}
+          textField={renderTextField()}
+          onSelect={noop}
+          contentBefore={<div>Content before</div>}
+          emptyState={<EmptyState />}
+        />,
+      );
+
+      comboBox.simulate('click');
+      expect(comboBox.find(EmptyState)).toHaveLength(0);
     });
   });
 });

--- a/src/components/Autocomplete/tests/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/tests/Autocomplete.test.tsx
@@ -48,6 +48,8 @@ describe('<Autocomplete/>', () => {
         },
       ];
 
+      const EmptyState = () => <span>No results</span>;
+
       const autocomplete = mountWithAppProvider(
         <Autocomplete
           id="Autocomplete-ID"
@@ -63,6 +65,7 @@ describe('<Autocomplete/>', () => {
             id: 'ComboBox3-0',
           }}
           onSelect={handleOnSelect}
+          emptyState={<EmptyState />}
         />,
       );
 
@@ -83,6 +86,9 @@ describe('<Autocomplete/>', () => {
         actionBefore,
       );
       expect(autocomplete.find(ComboBox).prop('onSelect')).toBe(handleOnSelect);
+      expect(autocomplete.find(ComboBox).prop('emptyState')).toEqual(
+        <EmptyState />,
+      );
     });
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?
This PR allows developers to render an optional empty state if there are no results for their search query.

### WHAT is this pull request doing?
This PR adds the `emptyState` prop. This prop takes a function that renders some JSX. `emptyState` is called when `options` is empty and there are no before or after actions.

![empty state](https://user-images.githubusercontent.com/4441303/47738604-db9ca680-dc49-11e8-9799-f78c213c0ea5.gif)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Include the following snippet in the Playground file. Try searching for something that does not return any results. You should see the empty state.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
/* eslint-disable */

import * as React from 'react';
import {Page, AppProvider} from '@shopify/polaris';
import {Autocomplete} from '../src/components';

interface State {}

export default class Playground extends React.Component<never, State> {
  state = {
    query: '',
  };

  options = [
    {label: 'One', value: '1'},
    {label: 'Two', value: '2'},
    {label: 'Three', value: '3'},
  ];

  render() {
    const {query} = this.state;
    return (
      <AppProvider>
        <Page title="Playground">
          <Autocomplete
            selected={[]}
            options={this.getOptions()}
            onSelect={() => {
              return;
            }}
            allowMultiple
            emptyState={<span>No results</span>}
            textField={
              <Autocomplete.TextField
                label="Search"
                value={query}
                onChange={(value) => this.setState({query: value})}
              />
            }
          />
        </Page>
      </AppProvider>
    );
  }

  getOptions() {
    const {query} = this.state;

    if (query.length === 0) {
      return this.options;
    }

    return this.options.filter((option) =>
      option.label.toLowerCase().includes(query.toLowerCase()),
    );
  }
}

/* eslint-enable */
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
