### PR TITLE
Fix for typedoc parsing script

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -24,7 +24,7 @@ import * as styles from './Modal.scss';
 
 const IFRAME_LOADING_HEIGHT = 200;
 
-export type Size = keyof typeof AppBridgeModal.Size;
+export type Size = 'Small' | 'Medium' | 'Large' | 'Full';
 
 export interface Props extends FooterProps {
   /** Whether the modal is open or not */


### PR DESCRIPTION
### WHY are these changes introduced?

There's a bug in the type parsing script for the props explorer in th…e styleguide that causes it to break on this type. We're investigating how to fix this for a better long-term solution but in the meantime using a static type instead of a reference solves the issue

### WHAT is this pull request doing?

Using the types this compiles to instead of a reference type

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Build and consume on the styleguide
Run the styleguide and go to https://polaris.myshopify.io/components/overlays/modal
Make sure Size shows up properly in the Props Explorer