### PR TITLE
Static string literal types

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -24,7 +24,7 @@ import * as styles from './Modal.scss';
 
 const IFRAME_LOADING_HEIGHT = 200;
 
-export type Size = keyof typeof AppBridgeModal.Size;
+export type Size = 'Small' | 'Medium' | 'Large' | 'Full';
 
 export interface Props extends FooterProps {
   /** Whether the modal is open or not */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,9 @@
 import * as PropTypes from 'prop-types';
 import {ValidationMap} from 'react';
-import {Redirect} from '@shopify/app-bridge/actions';
 import {IconProps} from './components';
 
 export type HeadingTagName = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p';
-export type AppBridgeTarget = Exclude<
-  keyof typeof Redirect.Action,
-  'ADMIN_SECTION'
->;
+export type AppBridgeTarget = 'ADMIN_PATH' | 'REMOTE' | 'APP';
 
 export type Error =
   | string


### PR DESCRIPTION
I was dynamically generating these string literal types in an effort to stay in sync with app bridge, but this breaks the props explorer in the style guide.

We will get this fixed in the style guide (https://github.com/Shopify/polaris-styleguide/issues/2359), but in the meantime let’s just use static string literal types.