### PR TITLE
Add eslint shopify/jest plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,7 +26,6 @@
         "allowBlockStart": false
       }
     ],
-    "jest/no-disabled-tests": "off",
     "react/button-has-type": "off",
     "react/no-array-index-key": "off",
     "shopify/jest/no-vague-titles": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,10 +1,9 @@
 {
   "extends": [
-    "plugin:shopify/esnext",
+    "plugin:shopify/typescript-react",
+    "plugin:shopify/jest",
     "plugin:shopify/node",
     "plugin:shopify/polaris",
-    "plugin:shopify/typescript",
-    "plugin:shopify/typescript-react",
     "plugin:shopify/typescript-prettier"
   ],
   "settings": {
@@ -27,8 +26,10 @@
         "allowBlockStart": false
       }
     ],
+    "jest/no-disabled-tests": "off",
     "react/button-has-type": "off",
     "react/no-array-index-key": "off",
+    "shopify/jest/no-vague-titles": "off",
     "jsx-a11y/label-has-for": [
       2,
       {

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -111,7 +111,7 @@ The autocomplete component is an input field that provides selectable suggestion
 - Move to use sewing-kit for test running, updating to Jest 23 in the process. This gives us working sourcemaps for code coverage
 - Improved accessibility testing checklist
 - Updated development node environment to 8.12.0
-- Added shopify/jest plugin to eslint config.
+- Added shopify/jest plugin to eslint config
 
 #### Open development
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -111,6 +111,7 @@ The autocomplete component is an input field that provides selectable suggestion
 - Move to use sewing-kit for test running, updating to Jest 23 in the process. This gives us working sourcemaps for code coverage
 - Improved accessibility testing checklist
 - Updated development node environment to 8.12.0
+- Added shopify/jest plugin to eslint config.
 
 #### Open development
 

--- a/examples/create-react-app/src/tests/App.test.js
+++ b/examples/create-react-app/src/tests/App.test.js
@@ -6,7 +6,7 @@ import App from '../App';
 import {mountWithAppProvider} from './utils/enzyme';
 
 // Sample test to demonstrate how you should test with AppProvider context
-it('renders page', () => {
+test('renders page', () => {
   const wrapper = mountWithAppProvider(<App />);
   expect(wrapper.find(Page).exists()).toBe(true);
 });

--- a/src/components/ActionList/components/Section/tests/Section.test.tsx
+++ b/src/components/ActionList/components/Section/tests/Section.test.tsx
@@ -77,7 +77,7 @@ describe('<Section />', () => {
   });
 
   it('passes the onActionAnyItem callback to Item', () => {
-    const callback = () => {};
+    const mockOnActionAnyItem = jest.fn();
     const section = mountWithAppProvider(
       <Section
         hasMultipleSections
@@ -87,15 +87,15 @@ describe('<Section />', () => {
             {content: 'Export file', onAction: noop},
           ],
         }}
-        onActionAnyItem={callback}
+        onActionAnyItem={mockOnActionAnyItem}
       />,
     );
 
-    expect(
-      section
-        .find(Item)
-        .first()
-        .prop('onAction'),
-    );
+    section
+      .find('Item button')
+      .first()
+      .simulate('click');
+
+    expect(mockOnActionAnyItem).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ActionList/components/Section/tests/Section.test.tsx
+++ b/src/components/ActionList/components/Section/tests/Section.test.tsx
@@ -18,7 +18,7 @@ describe('<Section />', () => {
       />,
     );
 
-    expect(section.find(Item).length).toBe(2);
+    expect(section.find(Item)).toHaveLength(2);
   });
 
   it('renders items as li when hasMultipleSections is false', () => {
@@ -34,7 +34,7 @@ describe('<Section />', () => {
       />,
     );
 
-    expect(section.find('li').length).toBe(2);
+    expect(section.find('li')).toHaveLength(2);
   });
 
   it('wraps items in an li when hasMultipleSections is true', () => {
@@ -50,7 +50,7 @@ describe('<Section />', () => {
       />,
     );
 
-    expect(section.find('li').length).toBe(3);
+    expect(section.find('li')).toHaveLength(3);
   });
 
   it('passes content to Item', () => {

--- a/src/components/ActionList/components/Section/tests/Section.test.tsx
+++ b/src/components/ActionList/components/Section/tests/Section.test.tsx
@@ -77,7 +77,7 @@ describe('<Section />', () => {
   });
 
   it('passes the onActionAnyItem callback to Item', () => {
-    const mockOnActionAnyItem = jest.fn();
+    const spy = jest.fn();
     const section = mountWithAppProvider(
       <Section
         hasMultipleSections
@@ -87,7 +87,7 @@ describe('<Section />', () => {
             {content: 'Export file', onAction: noop},
           ],
         }}
-        onActionAnyItem={mockOnActionAnyItem}
+        onActionAnyItem={spy}
       />,
     );
 
@@ -96,6 +96,6 @@ describe('<Section />', () => {
       .first()
       .simulate('click');
 
-    expect(mockOnActionAnyItem).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/CalloutCard/tests/CalloutCard.test.tsx
+++ b/src/components/CalloutCard/tests/CalloutCard.test.tsx
@@ -19,7 +19,12 @@ describe('<CalloutCard />', () => {
   );
 
   it('renders its children', () => {
-    expect(calloutCard.contains('<p>Content</p>'));
+    expect(
+      calloutCard
+        .find('p')
+        .first()
+        .contains('Content'),
+    ).toBe(true);
   });
 
   it('renders the title as an h2 element', () => {

--- a/src/components/Caption/tests/Caption.test.tsx
+++ b/src/components/Caption/tests/Caption.test.tsx
@@ -11,6 +11,6 @@ describe('<Caption />', () => {
   it('renders its children', () => {
     const captionMarkup = 'Caption text';
     const caption = mountWithAppProvider(<Caption>{captionMarkup}</Caption>);
-    expect(caption.contains(captionMarkup));
+    expect(caption.contains(captionMarkup)).toBe(true);
   });
 });

--- a/src/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/Checkbox/tests/Checkbox.test.tsx
@@ -137,7 +137,7 @@ describe('<Checkbox />', () => {
         .find('input')
         .prop<string>('aria-describedby')
         .split(' ');
-      expect(descriptions.length).toBe(2);
+      expect(descriptions).toHaveLength(2);
       expect(checkbox.find(`#${descriptions[0]}`).text()).toBe('Some error');
       expect(checkbox.find(`#${descriptions[1]}`).text()).toBe('Some help');
     });

--- a/src/components/ChoiceList/tests/ChoiceList.test.tsx
+++ b/src/components/ChoiceList/tests/ChoiceList.test.tsx
@@ -258,13 +258,13 @@ describe('<ChoiceList />', () => {
       let element = shallowWithAppProvider(
         <ChoiceList selected={[]} choices={choices} />,
       );
-      expect(element.find(RadioButton).length).toBe(choices.length);
+      expect(element.find(RadioButton)).toHaveLength(choices.length);
       expect(element.find(Checkbox).exists()).toBe(false);
 
       element = shallowWithAppProvider(
         <ChoiceList selected={[]} choices={choices} allowMultiple={false} />,
       );
-      expect(element.find(RadioButton).length).toBe(choices.length);
+      expect(element.find(RadioButton)).toHaveLength(choices.length);
       expect(element.find(Checkbox).exists()).toBe(false);
     });
 
@@ -273,7 +273,7 @@ describe('<ChoiceList />', () => {
         <ChoiceList allowMultiple selected={[]} choices={choices} />,
       );
       expect(element.find(RadioButton).exists()).toBe(false);
-      expect(element.find(Checkbox).length).toBe(choices.length);
+      expect(element.find(Checkbox)).toHaveLength(choices.length);
     });
   });
 

--- a/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -27,8 +27,6 @@ describe('<ColorPicker />', () => {
         expect(spy).toHaveBeenCalled();
       });
 
-      it.skip('is called on mousemove when dragging', () => {});
-
       it('is not called on mousemove when not dragging', () => {
         const spy = jest.fn();
         mountWithAppProvider(<ColorPicker color={red} onChange={spy} />);
@@ -50,8 +48,6 @@ describe('<ColorPicker />', () => {
 
         expect(spy).toHaveBeenCalled();
       });
-
-      it.skip('is called on mousemove when dragging', () => {});
 
       it('is not called on mousemove when not dragging', () => {
         const spy = jest.fn();

--- a/src/components/DataTable/components/Navigation/tests/Navigation.test.tsx
+++ b/src/components/DataTable/components/Navigation/tests/Navigation.test.tsx
@@ -18,6 +18,6 @@ describe('<Navigation />', () => {
         isScrolledFarthestRight={false}
       />,
     );
-    expect(navigation.find(Button).length).toEqual(2);
+    expect(navigation.find(Button)).toHaveLength(2);
   });
 });

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -56,17 +56,17 @@ describe('<DataTable />', () => {
   it('renders a table, thead and all table body rows', () => {
     const {dataTable} = setup();
 
-    expect(dataTable.find('table').length).toEqual(1);
-    expect(dataTable.find('thead').length).toEqual(1);
-    expect(dataTable.find('thead th').length).toEqual(5);
-    expect(dataTable.find('tbody tr').length).toEqual(3);
+    expect(dataTable.find('table')).toHaveLength(1);
+    expect(dataTable.find('thead')).toHaveLength(1);
+    expect(dataTable.find('thead th')).toHaveLength(5);
+    expect(dataTable.find('tbody tr')).toHaveLength(3);
   });
 
   it('defaults to non-sorting column headings', () => {
     const {dataTable} = setup();
     const sortableHeadings = dataTable.find(Cell).filter({sortable: true});
 
-    expect(sortableHeadings.length).toEqual(0);
+    expect(sortableHeadings).toHaveLength(0);
   });
 
   it('initial sort column defaults to first column if not specified', () => {

--- a/src/components/DatePicker/components/Day/tests/Day.test.tsx
+++ b/src/components/DatePicker/components/Day/tests/Day.test.tsx
@@ -43,7 +43,7 @@ describe('<Day />', () => {
         />,
       );
       day.simulate('click');
-      expect(spy).toHaveBeenCalled;
+      expect(spy).toHaveBeenCalled();
     });
 
     it('does not get called if button is disabled', () => {
@@ -53,7 +53,7 @@ describe('<Day />', () => {
         <Day focused day={currentDay} selected disabled onClick={spy} />,
       );
       day.simulate('click');
-      expect(spy).not.toHaveBeenCalled;
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/DatePicker/components/Day/tests/Day.test.tsx
+++ b/src/components/DatePicker/components/Day/tests/Day.test.tsx
@@ -8,7 +8,7 @@ describe('<Day />', () => {
     const day = mountWithAppProvider(
       <Day focused day={currentDay} selected disabled={false} />,
     );
-    expect(day.find('button').length).toBe(1);
+    expect(day.find('button')).toHaveLength(1);
   });
 
   describe('tabIndex', () => {

--- a/src/components/DatePicker/components/Day/tests/Day.test.tsx
+++ b/src/components/DatePicker/components/Day/tests/Day.test.tsx
@@ -43,7 +43,7 @@ describe('<Day />', () => {
         />,
       );
       day.simulate('click');
-      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('does not get called if button is disabled', () => {
@@ -65,7 +65,7 @@ describe('<Day />', () => {
         <Day day={currentDay} selected onFocus={spy} />,
       );
       day.simulate('focus');
-      expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/components/DatePicker/tests/DatePicker.test.tsx
+++ b/src/components/DatePicker/tests/DatePicker.test.tsx
@@ -70,14 +70,14 @@ describe('<DatePicker />', () => {
       const datePicker = mountWithAppProvider(
         <DatePicker month={month} year={year} multiMonth />,
       );
-      expect(datePicker.find(Month).length).toBe(2);
+      expect(datePicker.find(Month)).toHaveLength(2);
     });
 
     it('shows only one month when false', () => {
       const datePicker = mountWithAppProvider(
         <DatePicker month={month} year={year} />,
       );
-      expect(datePicker.find(Month).length).toBe(1);
+      expect(datePicker.find(Month)).toHaveLength(1);
     });
   });
 

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -12,9 +12,9 @@ describe('<FileUpload />', () => {
       </Provider>,
     );
 
-    expect(fileUpload.find('img').length).toBe(1);
-    expect(fileUpload.find(Button).length).toBe(1);
-    expect(fileUpload.find(TextStyle).length).toBe(1);
+    expect(fileUpload.find('img')).toHaveLength(1);
+    expect(fileUpload.find(Button)).toHaveLength(1);
+    expect(fileUpload.find(TextStyle)).toHaveLength(1);
   });
 
   it('renders medium view', () => {
@@ -24,8 +24,8 @@ describe('<FileUpload />', () => {
       </Provider>,
     );
 
-    expect(fileUpload.find(Link).length).toBe(1);
-    expect(fileUpload.find(Caption).length).toBe(1);
+    expect(fileUpload.find(Link)).toHaveLength(1);
+    expect(fileUpload.find(Caption)).toHaveLength(1);
   });
 
   it('renders small view', () => {
@@ -35,6 +35,6 @@ describe('<FileUpload />', () => {
       </Provider>,
     );
 
-    expect(fileUpload.find(Icon).length).toBe(1);
+    expect(fileUpload.find(Icon)).toHaveLength(1);
   });
 });

--- a/src/components/ExceptionList/tests/ExceptionList.test.tsx
+++ b/src/components/ExceptionList/tests/ExceptionList.test.tsx
@@ -20,7 +20,7 @@ describe('<ExceptionList />', () => {
         ]}
       />,
     );
-    expect(exceptionList.find('li').length).toBe(2);
+    expect(exceptionList.find('li')).toHaveLength(2);
   });
 
   it('renders its items icon as an <Icon />', () => {
@@ -35,6 +35,6 @@ describe('<ExceptionList />', () => {
         ]}
       />,
     );
-    expect(exceptionList.find(Icon).length).toBe(1);
+    expect(exceptionList.find(Icon)).toHaveLength(1);
   });
 });

--- a/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
+++ b/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
@@ -25,9 +25,11 @@ describe('<ToastManager />', () => {
       />,
     );
 
-    toastManager.setProps({
-      toastMessages: [{id: '1', content: 'World!', onDismiss: noop}],
-    });
+    expect(() => {
+      toastManager.setProps({
+        toastMessages: [{id: '1', content: 'World!', onDismiss: noop}],
+      });
+    }).not.toThrow();
   });
 });
 

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -174,6 +174,7 @@ describe('<Frame />', () => {
   // JSDOM 11.12.0 does not support setting/reading custom properties so we are
   // unable to assert that we set a custom property
   // See https://github.com/jsdom/jsdom/issues/1895
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip('sets a root property with global ribbon height if passed', () => {
     mountWithAppProvider(<Frame globalRibbon={<div />} />);
     expect(documentHasStyle('--global-ribbon-height', '0px')).toBe(true);
@@ -182,6 +183,7 @@ describe('<Frame />', () => {
   // JSDOM 11.12.0 does not support setting/reading custom properties so we are
   // unable to assert that we set a custom property
   // See https://github.com/jsdom/jsdom/issues/1895
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip('sets a root property with global ribbon height if new props are passed', () => {
     const frame = mountWithAppProvider(<Frame />);
     frame.setProps({globalRibbon: <div />});
@@ -191,6 +193,7 @@ describe('<Frame />', () => {
   // JSDOM 11.12.0 does not support setting/reading custom properties so we are
   // unable to assert that we set a custom property
   // See https://github.com/jsdom/jsdom/issues/1895
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip('sets a root property with global ribbon height of 0 if there is no globalRibbon prop', () => {
     mountWithAppProvider(<Frame />);
     expect(documentHasStyle('--global-ribbon-height', '0px')).toBe(true);

--- a/src/components/InlineError/tests/InlineError.test.tsx
+++ b/src/components/InlineError/tests/InlineError.test.tsx
@@ -24,7 +24,7 @@ describe('<InlineError />', () => {
       );
 
       error.setProps({message: ''});
-      expect(error.find('#ProductTitleError')).toBeNull;
+      expect(error.find('#ProductTitleError')).toHaveLength(0);
     });
   });
 });

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -91,7 +91,7 @@ describe('<Modal>', () => {
         </Modal>,
       );
 
-      expect(modal.find(Dialog).prop('instant')).toBe(undefined);
+      expect(modal.find(Dialog).prop('instant')).toBeUndefined();
     });
   });
 
@@ -113,7 +113,7 @@ describe('<Modal>', () => {
         </Modal>,
       );
 
-      expect(modal.find(Dialog).prop('large')).toBe(undefined);
+      expect(modal.find(Dialog).prop('large')).toBeUndefined();
     });
   });
 
@@ -135,7 +135,7 @@ describe('<Modal>', () => {
         </Modal>,
       );
 
-      expect(modal.find(Dialog).prop('limitHeight')).toBe(undefined);
+      expect(modal.find(Dialog).prop('limitHeight')).toBeUndefined();
     });
   });
 

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -483,15 +483,6 @@ describe('<Modal>', () => {
       modal.unmount();
       expect(appBridgeModalMock.unsubscribe).toHaveBeenCalledTimes(1);
     });
-
-    it('unsubscribes on unmount', () => {
-      const {modal} = mountWithAppBridge(
-        <Modal src="/test" open onClose={noop} />,
-      );
-
-      modal.unmount();
-      expect(appBridgeModalMock.unsubscribe).toHaveBeenCalledTimes(1);
-    });
   });
 });
 

--- a/src/components/RangeSlider/tests/RangeSlider.test.tsx
+++ b/src/components/RangeSlider/tests/RangeSlider.test.tsx
@@ -197,7 +197,7 @@ describe('<RangeSlider />', () => {
         .prop<string>('aria-describedby')
         .split(' ');
 
-      expect(descriptions.length).toBe(2);
+      expect(descriptions).toHaveLength(2);
       expect(element.find(`#${descriptions[1]}`).text()).toBe('Some help');
       expect(element.find(`#${descriptions[0]}`).text()).toBe('Some error');
     });

--- a/src/components/ResourceList/components/BulkActions/tests/BulkActions.test.tsx
+++ b/src/components/ResourceList/components/BulkActions/tests/BulkActions.test.tsx
@@ -97,7 +97,7 @@ describe('<BulkActions />', () => {
         <BulkActions {...bulkActionProps} />,
       );
       const popover = bulkActionsElement.find(Popover);
-      expect(popover.length).toBe(1);
+      expect(popover).toHaveLength(1);
     });
   });
 
@@ -226,7 +226,7 @@ describe('<BulkActions />', () => {
           <BulkActions {...bulkActionProps} />,
         );
         const bulkActionButtons = bulkActions.find(BulkActionButton);
-        expect(bulkActionButtons.length).toBe(4);
+        expect(bulkActionButtons).toHaveLength(4);
       });
     });
 

--- a/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
@@ -134,9 +134,7 @@ describe('<DateSelector />', () => {
 
       expect(wrapper.find(DatePicker).exists()).toBe(false);
     });
-  });
 
-  describe('filterValue', () => {
     it('is used to calculate dateFilterOption and gets passed to Select as value', () => {
       const filterValue = 'filter value';
       const wrapper = mountWithAppProvider(

--- a/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/tests/FilterValueSelector.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/tests/FilterValueSelector.test.tsx
@@ -407,7 +407,7 @@ describe('<FilterValueSelector />', () => {
         expect(operatorsSelect.exists()).toBe(false);
       });
 
-      it('calls onFilterKeyChange when the filter key was changed', () => {
+      it('calls onChange when the filter key was changed', () => {
         const onChange = jest.fn();
         const wrapper = shallowWithAppProvider(
           <FilterValueSelector

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -38,7 +38,7 @@ describe('<ResourceList />', () => {
       const resourceList = shallowWithAppProvider(
         <ResourceList items={itemsWithID} renderItem={shallowRenderItem} />,
       );
-      expect(resourceList.find('li').length).toBe(3);
+      expect(resourceList.find('li')).toHaveLength(3);
     });
 
     it('renders custom markup', () => {

--- a/src/components/Select/tests/Select.test.tsx
+++ b/src/components/Select/tests/Select.test.tsx
@@ -128,6 +128,8 @@ describe('<Select />', () => {
       }
     }
 
+    // Expectations are ran within the call to testOptions()
+    // eslint-disable-next-line jest/expect-expect
     it('translates grouped options into optgroup tags', () => {
       const optionOrOptgroupElements = shallowWithAppProvider(
         <Select label="Select" options={optionsAndGroups} />,
@@ -141,6 +143,8 @@ describe('<Select />', () => {
       });
     });
 
+    // Expectations are ran within the call to testOptions()
+    // eslint-disable-next-line jest/expect-expect
     it('translates legacy groups into optgroup tags', () => {
       const optionOrOptgroupElements = shallowWithAppProvider(
         <Select label="Select" groups={optionsAndGroups} />,

--- a/src/components/Select/tests/Select.test.tsx
+++ b/src/components/Select/tests/Select.test.tsx
@@ -308,7 +308,7 @@ describe('<Select />', () => {
         .find('select')
         .prop<string>('aria-describedby')
         .split(' ');
-      expect(descriptions.length).toBe(2);
+      expect(descriptions).toHaveLength(2);
       expect(select.find(`#${descriptions[0]}`).text()).toBe('Some help');
       expect(select.find(`#${descriptions[1]}`).text()).toBe('Some error');
     });

--- a/src/components/SkeletonBodyText/tests/SkeletonBodyText.test.tsx
+++ b/src/components/SkeletonBodyText/tests/SkeletonBodyText.test.tsx
@@ -11,8 +11,8 @@ describe('<SkeletonBodyText />', () => {
       skeletonBodyText
         .find('div')
         .first()
-        .children().length,
-    ).toBe(2);
+        .children(),
+    ).toHaveLength(2);
   });
 
   it('renders 3 lines if none are provided', () => {
@@ -21,7 +21,7 @@ describe('<SkeletonBodyText />', () => {
       skeletonBodyText
         .find('div')
         .first()
-        .children().length,
-    ).toBe(3);
+        .children(),
+    ).toHaveLength(3);
   });
 });

--- a/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
+++ b/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
@@ -28,7 +28,7 @@ describe('<SkeletonPage />', () => {
     const skeletonPage = mountWithAppProvider(
       <SkeletonPage title="Products" />,
     );
-    expect(skeletonPage.find(DisplayText).length).toBe(1);
+    expect(skeletonPage.find(DisplayText)).toHaveLength(1);
     expect(skeletonPage.find(DisplayText).contains('Products')).toBe(true);
   });
 
@@ -36,11 +36,11 @@ describe('<SkeletonPage />', () => {
     const skeletonPage = mountWithAppProvider(
       <SkeletonPage secondaryActions={3} />,
     );
-    expect(skeletonPage.find(SkeletonBodyText).length).toBe(3);
+    expect(skeletonPage.find(SkeletonBodyText)).toHaveLength(3);
   });
 
   it('renders breadcrumbs', () => {
     const skeletonPage = mountWithAppProvider(<SkeletonPage breadcrumbs />);
-    expect(skeletonPage.find(SkeletonBodyText).length).toBe(1);
+    expect(skeletonPage.find(SkeletonBodyText)).toHaveLength(1);
   });
 });

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -55,7 +55,7 @@ describe('<TextField />', () => {
       />,
     ).find('input');
 
-    expect(input.prop('prefix')).toBe(undefined);
+    expect(input.prop('prefix')).toBeUndefined();
   });
 
   it('focuses input and calls onFocus() when focused prop has been updated to true', () => {
@@ -221,7 +221,7 @@ describe('<TextField />', () => {
         .find('input')
         .prop<string>('aria-describedby')
         .split(' ');
-      expect(descriptions.length).toBe(2);
+      expect(descriptions).toHaveLength(2);
       expect(textField.find(`#${descriptions[0]}`).text()).toBe('Some error');
       expect(textField.find(`#${descriptions[1]}`).text()).toBe('Some help');
     });
@@ -252,7 +252,7 @@ describe('<TextField />', () => {
         .find('input')
         .prop<string>('aria-labelledby')
         .split(' ');
-      expect(labels.length).toBe(2);
+      expect(labels).toHaveLength(2);
       expect(textField.find(`#${labels[0]}`).text()).toBe('TextField');
       expect(textField.find(`#${labels[1]}`).text()).toBe('$');
     });
@@ -265,7 +265,7 @@ describe('<TextField />', () => {
         .find('input')
         .prop<string>('aria-labelledby')
         .split(' ');
-      expect(labels.length).toBe(3);
+      expect(labels).toHaveLength(3);
       expect(textField.find(`#${labels[0]}`).text()).toBe('TextField');
       expect(textField.find(`#${labels[1]}`).text()).toBe('$');
       expect(textField.find(`#${labels[2]}`).text()).toBe('.00');
@@ -281,7 +281,7 @@ describe('<TextField />', () => {
         .find('input')
         .prop<string>('aria-labelledby')
         .split(' ');
-      expect(labels.length).toBe(2);
+      expect(labels).toHaveLength(2);
       expect(textField.find(`#${labels[0]}`).text()).toBe('TextField');
       expect(textField.find(`#${labels[1]}`).text()).toBe('kg');
     });
@@ -484,7 +484,7 @@ describe('<TextField />', () => {
           />,
         );
         const buttons = element.find('[role="button"]');
-        expect(buttons.length).toBe(0);
+        expect(buttons).toHaveLength(0);
       });
 
       it('increments correctly when a value step or both are float numbers', () => {
@@ -580,7 +580,7 @@ describe('<TextField />', () => {
         />,
       );
 
-      expect(textField.find(Labelled).length).toEqual(1);
+      expect(textField.find(Labelled)).toHaveLength(1);
       expect(textField.find(Labelled).prop('label')).toBe('TextField');
       expect(textField.find(Labelled).prop('id')).toBe('MyField');
       expect(textField.find(Labelled).prop('helpText')).toBe('Help text');
@@ -627,7 +627,7 @@ describe('<TextField />', () => {
         />,
       );
 
-      expect(textField.find(Connected).length).toEqual(1);
+      expect(textField.find(Connected)).toHaveLength(1);
       expect(textField.find(Connected).prop('left')).toEqual(connectedLeft);
       expect(textField.find(Connected).prop('right')).toEqual(connectedRight);
     });

--- a/src/components/ThemeProvider/tests/utils.test.ts
+++ b/src/components/ThemeProvider/tests/utils.test.ts
@@ -16,7 +16,7 @@ describe('setTextColor', () => {
 });
 
 describe('setTheme', () => {
-  it.only('returns a base theme', () => {
+  it('returns a base theme', () => {
     const theme = setTheme(
       {hue: 184, saturation: 100, lightness: 28},
       'topBar',

--- a/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -14,13 +14,13 @@ describe('<TrapFocus />', () => {
     expect(trapFocus.exists()).toBe(true);
 
     // Render children
-    expect(trapFocus.find(TextContainer).length).toBe(1);
+    expect(trapFocus.find(TextContainer)).toHaveLength(1);
 
     // Renders Focus
-    expect(trapFocus.find(Focus).length).toBe(1);
+    expect(trapFocus.find(Focus)).toHaveLength(1);
 
     // Renders an event listener
-    expect(trapFocus.find(EventListener).length).toBe(1);
+    expect(trapFocus.find(EventListener)).toHaveLength(1);
     expect(trapFocus.find(EventListener).prop('event')).toBe('focusout');
   });
 

--- a/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
+++ b/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
@@ -15,7 +15,7 @@ describe('<UnstyledLink />', () => {
         mockContext,
       ).find(CustomLinkComponent);
 
-      expect(anchorElement.length).toBe(1);
+      expect(anchorElement).toHaveLength(1);
     });
 
     it('doesn’t have polaris prop', () => {

--- a/src/utilities/tests/compose.test.ts
+++ b/src/utilities/tests/compose.test.ts
@@ -20,7 +20,7 @@ const toScreamingCaseSnake = compose(
 
 describe('compose', () => {
   it('will return a function', () => {
-    expect(typeof toScreamingCaseSnake === 'function').toBe(true);
+    expect(typeof toScreamingCaseSnake).toBe('function');
   });
 
   it('will compose arguments from right to left', () => {

--- a/src/utilities/tests/compose.test.ts
+++ b/src/utilities/tests/compose.test.ts
@@ -20,7 +20,7 @@ const toScreamingCaseSnake = compose(
 
 describe('compose', () => {
   it('will return a function', () => {
-    expect(typeof toScreamingCaseSnake === 'function');
+    expect(typeof toScreamingCaseSnake === 'function').toBe(true);
   });
 
   it('will compose arguments from right to left', () => {

--- a/src/utilities/tests/pluckDeep.test.ts
+++ b/src/utilities/tests/pluckDeep.test.ts
@@ -43,13 +43,13 @@ describe('pluckDeep', () => {
       },
       'hello',
     );
-    expect(pluckedValue).toBe(null);
+    expect(pluckedValue).toBeNull();
   });
 
   describe('obj argument', () => {
     it('will return null if null is supplied', () => {
       const pluckedValue = pluckDeep(null, 'hello');
-      expect(pluckedValue).toBe(null);
+      expect(pluckedValue).toBeNull();
     });
   });
 });

--- a/src/utilities/tests/setRootProperty.test.ts
+++ b/src/utilities/tests/setRootProperty.test.ts
@@ -5,6 +5,7 @@ describe('setRootProperty', () => {
   // JSDOM 11.12.0 does not support setting/reading custom properties so we are
   // unable to assert that we set a custom property
   // See https://github.com/jsdom/jsdom/issues/1895
+  // eslint-disable-next-line jest/no-disabled-tests
   it.skip('sets styles on the document element', () => {
     setRootProperty('topBar', '#eee', null);
     expect(documentHasStyle('topBar', '#eee')).toBe(true);

--- a/tests/pa11y-utilities.test.js
+++ b/tests/pa11y-utilities.test.js
@@ -30,7 +30,7 @@ describe('shitlistCheck', () => {
     expect(results[0].issues.findIndex(({code}) => code === '風の戦士')).toBe(
       0,
     );
-    expect(results[0].issues.length).toBe(1);
+    expect(results[0].issues).toHaveLength(1);
   });
 
   it('leaves errors not on the shitlist', () => {
@@ -43,7 +43,7 @@ describe('shitlistCheck', () => {
 
     const {results} = shitlistCheck(issueList, shitlist);
 
-    expect(results[0].issues.length).toBe(2);
+    expect(results[0].issues).toHaveLength(2);
   });
 
   it('removes entries with no issues from the list', () => {
@@ -56,7 +56,7 @@ describe('shitlistCheck', () => {
 
     const {results} = shitlistCheck(issueList, shitlist);
 
-    expect(results.length).toBe(0);
+    expect(results).toHaveLength(0);
   });
 
   it('returns a list with errors that werent found', () => {
@@ -69,8 +69,8 @@ describe('shitlistCheck', () => {
 
     const {remainingIssues} = shitlistCheck(issueList, shitlist);
 
-    expect(remainingIssues.length).toBe(1);
-    expect(remainingIssues[0].issues.length).toBe(1);
+    expect(remainingIssues).toHaveLength(1);
+    expect(remainingIssues[0].issues).toHaveLength(1);
     expect(remainingIssues[0].issues[0].code).toBe('Pyxis');
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

To ensure our tests follow best practices. This caught a few places where we didn't remember to make assertions in our tests.

### WHAT is this pull request doing?

Adds the shopify/jest eslint plugin (along with some reordering of plugins to make them not stamp over each other).
Runs `yarn format` to autofix several items
Makes manual fixes where required


I suggest reviewing this per-commit, as the first commit contains all the autofixes which are pretty brainless, while the second commit is code I had to modify myself