### PR TITLE
Fix focus invariant error

### DIFF
--- a/src/components/Focus/Focus.tsx
+++ b/src/components/Focus/Focus.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
-import {write} from '@shopify/javascript-utilities/fastdom';
 
 export interface Props {
   children?: React.ReactNode;
@@ -14,20 +13,17 @@ export default class Focus extends React.PureComponent<Props, never> {
       return;
     }
 
-    write(() => {
-      const root = ReactDOM.findDOMNode(this) as HTMLElement | null;
-      if (root) {
-        if (!root.querySelector('[autofocus]')) {
-          focusFirstFocusableNode(root, false);
-        }
+    const root = ReactDOM.findDOMNode(this) as HTMLElement | null;
+    if (root) {
+      if (!root.querySelector('[autofocus]')) {
+        focusFirstFocusableNode(root, false);
       }
-    });
+    }
   }
 
   render() {
-    const Fragment = (React as any).Fragment;
     const {children} = this.props;
 
-    return <Fragment>{children}</Fragment>;
+    return <React.Fragment>{children}</React.Fragment>;
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?
Resolves #507

### WHAT is this pull request doing?
Previously `Focus` had it self focusing logic in a called back passed to `write` which uses `requestAnimationFrame` under the hood. It's an unneeded optimization which was causing the calledback to be invoked after the component has unmounted causing an invariant error.

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

Check the console for errors

```jsx
/* eslint-disable */

import * as React from 'react';
import {Page, AppProvider, Focus, TextStyle} from '@shopify/polaris';

interface State {
  toggle: boolean;
}

export default class Playground extends React.Component<never, State> {
  state = {
    toggle: true,
  };

  componentDidMount() {
    this.setState({toggle: false});
  }

  render() {
    const {toggle} = this.state;

    const focusMarkup = toggle && (
      <Focus>
        <TextStyle>Polaris</TextStyle>
      </Focus>
    );

    return (
      <AppProvider>
        <Page title="Playground">{focusMarkup}</Page>
      </AppProvider>
    );
  }
}

/* eslint-enable */
```

</details>

#### Notes
* Focus is not exposed so a changelog entry is not needed