### PR TITLE
[Page] Fix types for actions

### DIFF
--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -17,16 +17,21 @@ import {
   LoadableAction,
   DestructableAction,
   IconableAction,
+  AppBridgeAction,
+  AppBridgeActionTarget,
 } from '../../../../types';
 import {hasNewStatus} from './utilities';
 import {Action, ActionGroup, ActionGroupDescriptor} from './components';
 import * as styles from './Header.scss';
 
-type SecondaryAction = IconableAction & DisableableAction;
+export type SecondaryAction = IconableAction &
+  DisableableAction &
+  AppBridgeActionTarget;
 
-interface PrimaryActionProps
+export interface PrimaryActionProps
   extends DisableableAction,
     LoadableAction,
+    AppBridgeAction,
     DestructableAction {
   /** Provides extra visual weight and identifies the primary action in a set of buttons */
   primary?: boolean;

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -5,6 +5,8 @@ import {Page, DisplayText, Card} from 'components';
 import {noop} from '../../../utilities/other';
 import {LinkAction} from '../../../types';
 import {Header} from '../components';
+import {SecondaryAction, PrimaryActionProps} from '../components/Header/Header';
+import {ActionGroupDescriptor} from '../components/Header/components';
 
 jest.mock('../../../utilities/app-bridge-transformers', () => ({
   ...require.requireActual('../../../utilities/app-bridge-transformers'),
@@ -84,14 +86,18 @@ describe('<Page />', () => {
     });
 
     it('creates a title bar', () => {
-      const primaryAction = {
+      const primaryAction: PrimaryActionProps = {
         content: 'Foo',
+        url: '/foo',
+        target: 'APP',
       };
-      const secondaryActions = [{content: 'Bar'}];
-      const actionGroups = [
+      const secondaryActions: SecondaryAction[] = [
+        {content: 'Bar', url: '/bar', target: 'ADMIN_PATH'},
+      ];
+      const actionGroups: ActionGroupDescriptor[] = [
         {
           title: 'Baz',
-          actions: [{content: 'Qux'}],
+          actions: [{content: 'Qux', url: 'https://qux.com', target: 'REMOTE'}],
         },
       ];
 


### PR DESCRIPTION
The updated types for `Page` to support Shopify App Bridge were undone when merging `master` into the beta branch.