### PR TITLE
[Page] Change SecondaryAction to an interface

### DIFF
--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -24,9 +24,10 @@ import {hasNewStatus} from './utilities';
 import {Action, ActionGroup, ActionGroupDescriptor} from './components';
 import * as styles from './Header.scss';
 
-export type SecondaryAction = IconableAction &
-  DisableableAction &
-  AppBridgeActionTarget;
+export interface SecondaryAction
+  extends IconableAction,
+    DisableableAction,
+    AppBridgeActionTarget {}
 
 export interface PrimaryActionProps
   extends DisableableAction,


### PR DESCRIPTION
The props explorer in the style guide did not render this composed type correctly. This should be an extended interface anyways imo.
