### PR TITLE
Use `!important` in print-hidden mixin

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -60,6 +60,7 @@ The autocomplete component is an input field that provides selectable suggestion
 - Fixed `Portal` rendering by using `componentDidMount` lifecycle hook as opposed to `componentWillMount`;
 - Fixed an issue where clicking a `Link` without a `url` in a form would implicitly submit the form. `Link` can no longer submit forms. Use `<Button submit>` instead.
 - Renamed the `Keys` enum to align with Shopify naming standards. It is now singular and the properties are in PascalCase. Replace `import {Keys} from '@shopify/polaris'` with `import {Key} from '@shopify/polaris'` and change the casing of the properties, e.g. replace `Keys.DOWN_ARROW` with `Key.DownArrow`
+- Added !important to `display: none` in `@print-hidden` mixin
 
 #### Embedded apps
 

--- a/src/styles/shared/typography.scss
+++ b/src/styles/shared/typography.scss
@@ -171,6 +171,7 @@ $typography-condensed: em(640px);
 
 @mixin print-hidden {
   @media print {
+    // stylelint-disable-next-line declaration-no-important
     display: none !important;
   }
 }

--- a/src/styles/shared/typography.scss
+++ b/src/styles/shared/typography.scss
@@ -171,6 +171,6 @@ $typography-condensed: em(640px);
 
 @mixin print-hidden {
   @media print {
-    display: none;
+    display: none !important;
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

In Shopify/web#7574 we start using the shared `print-hidden` mixin in more places. It was pointed out there that mixins are usually added at the top of selectors so specificity may become a problem.

### WHAT is this pull request doing?

Adds `!important` to `print-hidden` directly. The thinking is that there should be no reason to ever show an item in print media that you have already explicitly said "hide this during printing".

### How to 🎩

Pull it down and test various pages in both screen and print. Note how the app chrome and classes with `print-hidden` disappear during printing. You can't test the other case where someone needs to override the `!important` because it currently does not exist in the app.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)
