### PR TITLE
Update sewing-kit

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@
   "extends": [
     "plugin:shopify/typescript",
     "plugin:shopify/react",
+    "plugin:shopify/eslint-comments",
     "plugin:shopify/jest",
     "plugin:shopify/node",
     "plugin:shopify/polaris",

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "plugin:shopify/typescript-react",
+    "plugin:shopify/typescript",
+    "plugin:shopify/react",
     "plugin:shopify/jest",
     "plugin:shopify/node",
     "plugin:shopify/polaris",
@@ -51,15 +52,17 @@
   },
   "overrides": [
     {
-      "files": ["*.js"],
+      "files": ["examples/**/*.js"],
       "rules": {
-        "typescript/no-var-requires": "off"
+        "import/no-extraneous-dependencies": "off",
+        "import/no-unresolved": "off"
       }
     },
     {
       "files": ["playground/Playground.tsx"],
       "rules": {
-        "react/prefer-stateless-function": "off"
+        "react/prefer-stateless-function": "off",
+        "shopify/react-initialize-state": "off"
       }
     }
   ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@
     "plugin:shopify/jest",
     "plugin:shopify/node",
     "plugin:shopify/polaris",
-    "plugin:shopify/typescript-prettier"
+    "plugin:shopify/prettier"
   ],
   "settings": {
     "react": {
@@ -26,9 +26,12 @@
         "allowBlockStart": false
       }
     ],
+    "import/no-cycle": "off",
+    "import/no-named-as-default": "off",
     "react/button-has-type": "off",
     "react/no-array-index-key": "off",
     "shopify/jest/no-vague-titles": "off",
+    "shopify/jsx-no-complex-expressions": "off",
     "jsx-a11y/label-has-for": [
       2,
       {

--- a/config/rollup/plugins/styles.js
+++ b/config/rollup/plugins/styles.js
@@ -1,6 +1,6 @@
+import {resolve as resolvePath, dirname} from 'path';
 import postcss from 'postcss';
 import {readFileSync, ensureDirSync, writeFile} from 'fs-extra';
-import {resolve as resolvePath, dirname} from 'path';
 import {render} from 'node-sass';
 import {createFilter} from 'rollup-pluginutils';
 import cssnano from 'cssnano';

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@shopify/jest-dom-mocks": "^2.0.5",
     "@shopify/js-uploader": "github:shopify/js-uploader",
     "@shopify/react-serialize": "^1.0.6",
-    "@shopify/sewing-kit": "^0.61.0",
+    "@shopify/sewing-kit": "0.62.0",
     "@types/enzyme": "^3.1.14",
     "@types/enzyme-adapter-react-16": "^1.0.3",
     "@types/lodash": "^4.14.108",
@@ -178,7 +178,6 @@
     "react-dom": "^16.3.1"
   },
   "resolutions": {
-    "ts-jest": "~23.10.4",
     "typescript-eslint-parser": "17.0.1"
   },
   "files": [

--- a/playground/index.tsx
+++ b/playground/index.tsx
@@ -5,7 +5,6 @@ import {AppContainer} from 'react-hot-loader';
 import {AppProvider} from '@shopify/polaris';
 
 function renderPlayground() {
-  // eslint-disable-next-line no-require-imports
   const Playground = require('./Playground').default;
   render(
     <AppContainer>

--- a/playground/webpack.config.js
+++ b/playground/webpack.config.js
@@ -12,7 +12,6 @@ module.exports = {
   target: 'web',
   devtool: 'eval',
   devServer: {
-    // eslint-disable-next-line no-process-env
     port: process.env.PORT || 8080,
     disableHostCheck: true,
   },

--- a/scripts/build-consumer.js
+++ b/scripts/build-consumer.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 
-import {cp, mkdir, rm} from 'shelljs';
 import {resolve} from 'path';
+import {cp, mkdir, rm} from 'shelljs';
 
 import packageJSON from '../package.json';
 

--- a/scripts/build-shrink-ray.js
+++ b/scripts/build-shrink-ray.js
@@ -8,7 +8,7 @@ const {existsSync, readFileSync} = require('fs-extra');
 
 const BASE_BRANCH = 'master';
 const repo = 'polaris-react';
-const sha = process.env.CIRCLE_SHA1; // eslint-disable-line no-process-env
+const sha = process.env.CIRCLE_SHA1;
 
 const postWebpackReportURL = `https://shrink-ray.shopifycloud.com/repos/${repo}/commits/${sha}/reports`;
 

--- a/scripts/build-shrink-ray.js
+++ b/scripts/build-shrink-ray.js
@@ -3,8 +3,8 @@
 require('isomorphic-fetch');
 
 const {resolve} = require('path');
-const {existsSync, readFileSync} = require('fs-extra');
 const {execSync} = require('child_process');
+const {existsSync, readFileSync} = require('fs-extra');
 
 const BASE_BRANCH = 'master';
 const repo = 'polaris-react';

--- a/scripts/build-shrink-ray.js
+++ b/scripts/build-shrink-ray.js
@@ -25,10 +25,10 @@ if (sha) {
   console.log(
     'sha is not available, building bundle without pinging shrink-ray',
   );
-  buildPackages(false);
+  buildPackages();
 }
 
-function buildPackages(includeReport) {
+function buildPackages() {
   execSync('yarn run webpack --config shrink-ray-build/webpack.config.js', {
     stdio: 'inherit',
   });
@@ -41,7 +41,7 @@ function setupShrinkRay() {
       console.log(`[shrink-ray] status: ${response.status}`);
       console.log(`[shrink-ray] statusText: ${response.statusText}`);
       console.log('[shrink-ray] shrink-ray prebuild script completed.');
-      buildPackages(true);
+      buildPackages();
       return postReportToShrinkRay();
     })
     .then((response) => {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,15 +1,15 @@
 /* eslint-disable no-console */
 
 import {execSync} from 'child_process';
-import {ensureDirSync, writeFileSync, readFileSync} from 'fs-extra';
 import {join, resolve as resolvePath} from 'path';
+import {ensureDirSync, writeFileSync, readFileSync} from 'fs-extra';
 import {rollup} from 'rollup';
 import {cp, mv, rm} from 'shelljs';
 import copyfiles from 'copyfiles';
 
 import createRollupConfig from '../config/rollup';
-import generateSassBuild from './sass-build';
 import packageJSON from '../package.json';
+import generateSassBuild from './sass-build';
 
 const root = resolvePath(__dirname, '..');
 const build = resolvePath(root, 'build');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -38,9 +38,6 @@ rm('-rf', resolvePath(root, 'types/src'));
 
 mv(resolvePath(intermediateBuild, 'src/*'), intermediateBuild);
 
-const srcReadme = resolvePath(root, './src/components/README.md');
-const destinationReadme = resolvePath(docs, './components/README.md');
-
 copy(['./src/**/*.md', docs], {up: 1}).catch((error) => {
   console.error(error);
   process.exit(1);

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -5,7 +5,7 @@ const {resolve} = require('path');
 const Uploader = require('@shopify/js-uploader');
 const {S3} = require('aws-sdk');
 const semver = require('semver');
-const awsConfig = require('../secrets.json').aws; // eslint-disable-line import/no-unresolved
+const awsConfig = require('../secrets.json').aws;
 const currentVersion = require('../package.json').version;
 
 // Check if the current version is stable

--- a/scripts/optimize.js
+++ b/scripts/optimize.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
 
+const {resolve: resolvePath, basename, dirname} = require('path');
 const SVGO = require('svgo');
 const glob = require('glob');
 const {paramCase} = require('change-case');
-const {resolve: resolvePath, basename, dirname} = require('path');
 const {readFileSync, writeFileSync, removeSync} = require('fs-extra');
 
 const {svgOptions} = require('@shopify/images/optimize');

--- a/scripts/pa11y-utilities.js
+++ b/scripts/pa11y-utilities.js
@@ -26,12 +26,12 @@ function shitlistCheck(results, immutableShitlist) {
   });
 
   Object.keys(mutableShitlist).forEach((key) => {
-    mutableShitlist[key].length
-      ? remainingIssues.push({
-          pageUrl: key,
-          issues: mutableShitlist[key],
-        })
-      : undefined;
+    if (mutableShitlist[key].length) {
+      remainingIssues.push({
+        pageUrl: key,
+        issues: mutableShitlist[key],
+      });
+    }
   });
 
   return {

--- a/scripts/pa11y.js
+++ b/scripts/pa11y.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 const puppeteer = require('puppeteer');
 const pa11y = require('pa11y');
-const fs = require('fs');
 const shitlistCheck = require('./pa11y-utilities.js').shitlistCheck;
 
 const shitlist = require('./../a11y_shitlist.json');
@@ -62,7 +61,7 @@ async function runPa11y() {
     ),
   );
 
-  urls.map((path) => {
+  urls.forEach((path) => {
     const currentBrowser = browsers[browserIndex % NUMBER_OF_BROWSERS];
     browserIndex++;
     currentBrowser.taken = currentBrowser.taken.then(async () => {

--- a/scripts/readme-update-version.js
+++ b/scripts/readme-update-version.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 
+const {resolve} = require('path');
 const {execSync} = require('child_process');
 const {writeFileSync, readFileSync} = require('fs-extra');
-const {resolve} = require('path');
 const {version: newVersion} = require('../package.json');
 const {semverRegExp, readmes} = require('./utilities');
 

--- a/scripts/sass-build.js
+++ b/scripts/sass-build.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 
+import {basename, resolve, join, relative} from 'path';
 import glob from 'glob';
 import {
   writeFileSync,
@@ -10,7 +11,6 @@ import {
   lstatSync,
   existsSync,
 } from 'fs-extra';
-import {basename, resolve, join, relative} from 'path';
 import {cp, mkdir} from 'shelljs';
 import archiver from 'archiver';
 

--- a/sewing-kit.config.ts
+++ b/sewing-kit.config.ts
@@ -1,6 +1,5 @@
-import {ConfigurationCallback, Env, Plugins} from '@shopify/sewing-kit';
 import {join} from 'path';
-import {pathsToModuleNameMapper} from 'ts-jest/utils';
+import {ConfigurationCallback, Env, Plugins} from '@shopify/sewing-kit';
 
 const tests = join(__dirname, 'tests');
 
@@ -10,14 +9,10 @@ export default function sewingKitConfig(
 ): ReturnType<ConfigurationCallback> {
   return {
     name: 'polaris',
+    library: true,
     plugins: [
       plugins.jest((config) => {
         config.roots = [join(__dirname, 'src'), join(__dirname, 'tests')];
-        config.modulePaths = [
-          '<rootDir>/node_modules/',
-          '<rootDir>/src/',
-          '<rootDir>/tests/',
-        ];
 
         config.setupFiles.push(join(tests, 'setup.ts'));
 
@@ -52,15 +47,6 @@ export default function sewingKitConfig(
           '!src/**/*.d.ts',
           '!src/**/*.test.{ts,tsx}',
         ];
-
-        // Can be removed once SK is updated to latest ts-jest
-        config.transform = {
-          ...config.transform,
-          '\\.tsx?$': 'ts-jest',
-        };
-
-        // Can be removed once SK is updated to latest ts-jest
-        delete config.globals['ts-jest'].useBabelrc;
 
         return config;
       }),

--- a/src/components/AccountConnection/AccountConnection.tsx
+++ b/src/components/AccountConnection/AccountConnection.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import {Avatar, buttonFrom, Card, Stack, TextStyle} from '../../components';
-import SettingAction from '../../components/SettingAction';
+import {Avatar, buttonFrom, Card, Stack, TextStyle} from '..';
+import SettingAction from '../SettingAction';
 import {Action} from '../../types';
 import * as styles from './AccountConnection.scss';
 

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -4,13 +4,13 @@ import {ClientApplication} from '@shopify/app-bridge';
 
 import {LinkLikeComponent} from '../UnstyledLink';
 
+import ThemeProvider, {Theme} from '../ThemeProvider';
 import Intl from './Intl';
 import Link from './Link';
 import StickyManager from './StickyManager';
 import ScrollLockManager from './ScrollLockManager';
 import {createAppProviderContext} from './utils';
 import {polarisAppProviderContextTypes, TranslationDictionary} from './types';
-import ThemeProvider, {Theme} from '../ThemeProvider';
 
 export interface Props {
   /** A locale object or array of locale objects that overrides default translations */

--- a/src/components/AppProvider/types.ts
+++ b/src/components/AppProvider/types.ts
@@ -1,16 +1,16 @@
 import * as PropTypes from 'prop-types';
 import {ValidationMap} from 'react';
 import {ClientApplication} from '@shopify/app-bridge';
-import {Props as AppProviderProps} from '../AppProvider';
 
-import Intl from './Intl';
-import Link from './Link';
-import StickyManager from './StickyManager';
-import ScrollLockManager from './ScrollLockManager';
 import {
   THEME_CONTEXT_TYPES as polarisTheme,
   ThemeContext,
 } from '../ThemeProvider';
+import Intl from './Intl';
+import Link from './Link';
+import StickyManager from './StickyManager';
+import ScrollLockManager from './ScrollLockManager';
+import {Props as AppProviderProps} from '.';
 
 export const polarisAppProviderContextTypes: ValidationMap<any> = {
   polaris: PropTypes.any,

--- a/src/components/AppProvider/utils/index.tsx
+++ b/src/components/AppProvider/utils/index.tsx
@@ -67,7 +67,6 @@ export function withAppProvider<OwnProps>() {
       | React.ComponentClass<OwnProps & WithAppProviderProps> & C
       | React.SFC<OwnProps & WithAppProviderProps> & C,
   ): React.ComponentClass<OwnProps> & C {
-    // eslint-disable-next-line react/prefer-stateless-function
     class WithProvider extends React.Component<OwnProps, never> {
       static contextTypes = WrappedComponent.contextTypes
         ? merge(WrappedComponent.contextTypes, polarisAppProviderContextTypes)

--- a/src/components/AppProvider/utils/index.tsx
+++ b/src/components/AppProvider/utils/index.tsx
@@ -139,6 +139,7 @@ export function withSticky() {
       | React.ComponentClass<OwnProps & WithAppProviderProps> & C
       | React.SFC<OwnProps & WithAppProviderProps> & C,
   ): any & C {
+    // eslint-disable-next-line shopify/react-initialize-state
     class WithStickyManager extends React.Component<
       {},
       OwnProps & WithAppProviderProps

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
-import {ComboBox} from './components';
 import {PreferredPosition} from '../PositionedOverlay';
 import {OptionDescriptor} from '../OptionList';
 import {ActionListItemDescriptor} from '../../types';
-import {TextFieldProps, Spinner} from '../../components';
+import {TextFieldProps, Spinner} from '..';
+import {ComboBox} from './components';
 
 import * as styles from './Autocomplete.scss';
 

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -11,8 +11,8 @@ import Popover from '../../../Popover';
 import {PreferredPosition} from '../../../PositionedOverlay';
 import {ActionListItemDescriptor, Key} from '../../../../types';
 import {contextTypes} from '../types';
-import {TextField} from './components';
 import KeypressListener from '../../../KeypressListener';
+import {TextField} from './components';
 
 const getUniqueId = createUniqueIDFactory('ComboBox');
 

--- a/src/components/Autocomplete/components/ComboBox/components/TextField/TextField.tsx
+++ b/src/components/Autocomplete/components/ComboBox/components/TextField/TextField.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import {autobind} from '@shopify/javascript-utilities/decorators';
 
-import {
-  TextField as BaseTextField,
-  TextFieldProps,
-} from '../../../../../../components';
+import {TextField as BaseTextField, TextFieldProps} from '../../../../..';
 import {contextTypes} from '../../../types';
 
 export default class TextField extends React.PureComponent<

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -11,6 +11,8 @@ export type Size = 'small' | 'medium' | 'large';
 
 const STYLE_CLASSES = ['one', 'two', 'three', 'four', 'five', 'six'];
 const AVATAR_IMAGES = Object.keys(avatars).map(
+  // import/namespace does not allow computed values by default
+  // eslint-disable-next-line import/namespace
   (key: keyof typeof avatars) => avatars[key],
 );
 

--- a/src/components/Backdrop/Backdrop.tsx
+++ b/src/components/Backdrop/Backdrop.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import {classNames} from '@shopify/react-utilities';
 
-import * as styles from './Backdrop.scss';
 import ScrollLock from '../ScrollLock';
+import * as styles from './Backdrop.scss';
 
 export interface Props {
   onClick?(): void;

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -53,9 +53,6 @@ export default class Breadcrumbs extends React.PureComponent<Props, never> {
         </button>
       );
 
-    return (
-      // eslint-disable-next-line jsx-a11y/no-redundant-roles
-      <nav role="navigation">{breadcrumbMarkup}</nav>
-    );
+    return <nav role="navigation">{breadcrumbMarkup}</nav>;
   }
 }

--- a/src/components/Button/utils.tsx
+++ b/src/components/Button/utils.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import Button, {Props} from './Button';
 import {ComplexAction} from '../../types';
+import Button, {Props} from './Button';
 
 export function buttonsFrom(
   action: ComplexAction,

--- a/src/components/ButtonGroup/components/Item/Item.tsx
+++ b/src/components/ButtonGroup/components/Item/Item.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {autobind} from '@shopify/javascript-utilities/decorators';
 import {classNames} from '@shopify/react-utilities/styles';
-import {ButtonProps} from '../../../../components';
+import {ButtonProps} from '../../..';
 import * as styles from '../../ButtonGroup.scss';
 
 export interface Props {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -123,7 +123,7 @@ function Checkbox({
         </span>
       </span>
     </Choice>
-    /* eslint-disable jsx-a11y/no-redundant-roles, jsx-a11y/role-has-required-aria-props */
+    /* eslint-enable jsx-a11y/no-redundant-roles, jsx-a11y/role-has-required-aria-props */
   );
 }
 

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -42,7 +42,6 @@ export default class ColorPicker extends React.PureComponent<Props, State> {
       return;
     }
 
-    // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({pickerSize: colorNode.clientWidth});
 
     if (process.env.NODE_ENV === 'development') {

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import {clamp} from '@shopify/javascript-utilities/math';
 import {autobind} from '@shopify/javascript-utilities/decorators';
 
-import {HSBColor, HSBAColor} from './types';
 import {hsbToRgb} from '../../utilities/color-transformers';
+import {HSBColor, HSBAColor} from './types';
 import {AlphaPicker, HuePicker, Slidable, Position} from './components';
 import * as styles from './ColorPicker.scss';
 

--- a/src/components/ColorPicker/components/AlphaPicker/AlphaPicker.tsx
+++ b/src/components/ColorPicker/components/AlphaPicker/AlphaPicker.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import {autobind} from '@shopify/javascript-utilities/decorators';
-import {calculateDraggerY, alphaForDraggerY} from './utilities';
 import Slidable, {Position} from '../Slidable';
 import {HSBColor} from '../../types';
 import {hsbToRgb} from '../../../../utilities/color-transformers';
 import * as styles from '../../ColorPicker.scss';
+import {calculateDraggerY, alphaForDraggerY} from './utilities';
 
 export interface State {
   sliderHeight: number;

--- a/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
+++ b/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import {mountWithAppProvider, trigger} from 'test-utilities';
 import {noop} from '@shopify/javascript-utilities/other';
+import {mountWithAppProvider, trigger} from 'test-utilities';
 import {calculateDraggerY, alphaForDraggerY} from '../utilities';
 import Slidable from '../../Slidable';
 import AlphaPicker from '../AlphaPicker';

--- a/src/components/ColorPicker/components/HuePicker/HuePicker.tsx
+++ b/src/components/ColorPicker/components/HuePicker/HuePicker.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import {autobind} from '@shopify/javascript-utilities/decorators';
-import {calculateDraggerY, hueForDraggerY} from './utilities';
 import Slidable, {Position} from '../Slidable';
 import * as styles from '../../ColorPicker.scss';
+import {calculateDraggerY, hueForDraggerY} from './utilities';
 
 export interface State {
   sliderHeight: number;

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -4,8 +4,8 @@ import {classNames} from '@shopify/react-utilities/styles';
 import isEqual from 'lodash/isEqual';
 
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
-import {measureColumn, getPrevAndCurrentColumns} from './utilities';
 import EventListener from '../EventListener';
+import {measureColumn, getPrevAndCurrentColumns} from './utilities';
 
 import {Cell, CellProps, Navigation} from './components';
 

--- a/src/components/DatePicker/components/Month/tests/Month.test.tsx
+++ b/src/components/DatePicker/components/Month/tests/Month.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {Weekdays} from '@shopify/javascript-utilities/dates';
 import {mountWithAppProvider} from 'test-utilities';
-import {Weekday} from '../../../components';
+import {Weekday} from '../..';
 import Month from '../Month';
 
 describe('<Month />', () => {

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -302,7 +302,7 @@ export class DropZone extends React.Component<CombinedProps, State> {
 
   componentDidMount() {
     this.dragTargets = [];
-    // eslint-disable-next-line react/no-did-mount-set-state
+
     this.setState({error: this.props.error});
 
     if (!this.dropNode) {

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -4,14 +4,7 @@ import {classNames} from '@shopify/react-utilities/styles';
 import compose from '../../../../utilities/react-compose';
 import withRef from '../../../WithRef';
 
-import {
-  Link,
-  Icon,
-  Stack,
-  Button,
-  Caption,
-  TextStyle,
-} from '../../../../components';
+import {Link, Icon, Stack, Button, Caption, TextStyle} from '../../..';
 import withContext from '../../../WithContext';
 import {Consumer} from '../Context';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';

--- a/src/components/ExceptionList/ExceptionList.tsx
+++ b/src/components/ExceptionList/ExceptionList.tsx
@@ -3,7 +3,7 @@ import {classNames, variationName} from '@shopify/react-utilities/styles';
 
 import Icon from '../Icon';
 import Truncate from '../Truncate';
-import {IconProps} from '../../components';
+import {IconProps} from '..';
 
 import * as styles from './ExceptionList.scss';
 

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 
 import {autobind} from '@shopify/javascript-utilities/decorators';
 import {Button, Image, Stack, ContextualSaveBarProps} from '../../..';
-import {DiscardConfirmationModal} from './components';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 import {getWidth} from '../../../../utilities/getWidth';
+import {DiscardConfirmationModal} from './components';
 
 import * as styles from './ContextualSaveBar.scss';
 

--- a/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/DiscardConfirmationModal.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/DiscardConfirmationModal.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
 
-import {
-  Modal,
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../../../../../components';
+import {Modal, withAppProvider, WithAppProviderProps} from '../../../../..';
 
 export interface Props {
   open: boolean;

--- a/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import {mountWithAppProvider, trigger} from 'test-utilities';
-// eslint-disable-next-line shopify/strict-component-boundaries
+import {polarisAppProviderContextTypes} from 'components/AppProvider';
 import {createThemeContext, ThemeContext} from 'components/ThemeProvider';
 import {createAppProviderContext, Button, Image, Modal} from 'components';
-// eslint-disable-next-line shopify/strict-component-boundaries
-import {polarisAppProviderContextTypes} from 'components/AppProvider';
 import ContextualSaveBar from '../ContextualSaveBar';
 
 describe('<ContextualSaveBar />', () => {

--- a/src/components/Frame/components/Toast/Toast.tsx
+++ b/src/components/Frame/components/Toast/Toast.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
 import {classNames} from '@shopify/react-utilities';
-import {
-  KeypressListener,
-  ToastProps,
-  DEFAULT_TOAST_DURATION,
-} from '../../../../components';
+import {KeypressListener, ToastProps, DEFAULT_TOAST_DURATION} from '../../..';
 import Icon from '../../../Icon';
 import {Key} from '../../../../types';
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -11,7 +11,7 @@ import {Modal as AppBridgeModal} from '@shopify/app-bridge/actions';
 import {transformActions} from '../../utilities/app-bridge-transformers';
 import {contentContextTypes} from '../../types';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
-import {Scrollable, Spinner, Portal, Backdrop} from '../../components';
+import {Scrollable, Spinner, Portal, Backdrop} from '..';
 import {
   CloseButton,
   Dialog,

--- a/src/components/Modal/components/CloseButton/CloseButton.tsx
+++ b/src/components/Modal/components/CloseButton/CloseButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {classNames} from '@shopify/react-utilities';
-import {Icon} from '../../../../components';
+import {Icon} from '../../..';
 import * as styles from './CloseButton.scss';
 
 export interface Props {

--- a/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/src/components/Modal/components/Dialog/Dialog.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import {Transition, CSSTransition} from 'react-transition-group';
-import {KeypressListener, TrapFocus} from '../../../../components';
+import {KeypressListener, TrapFocus} from '../../..';
 import {Duration} from '../../../shared';
 import {AnimationProps, Key} from '../../../../types';
 import * as styles from './Dialog.scss';

--- a/src/components/Modal/components/Footer/Footer.tsx
+++ b/src/components/Modal/components/Footer/Footer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {buttonsFrom, ButtonGroup, Stack} from '../../../../components';
+import {buttonsFrom, ButtonGroup, Stack} from '../../..';
 import {ComplexAction, AppBridgeAction} from '../../../../types';
 import * as styles from './Footer.scss';
 

--- a/src/components/Modal/components/Header/Header.tsx
+++ b/src/components/Modal/components/Header/Header.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {DisplayText} from '../../../../components';
+import {DisplayText} from '../../..';
 import CloseButton from '../CloseButton';
 import * as styles from './Header.scss';
 

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {Scrollable} from '../../components';
+import {Scrollable} from '..';
 
 import {UserMenu, Section, Item} from './components';
 import {contextTypes, SectionType} from './types';

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -4,11 +4,11 @@ import {classNames} from '@shopify/react-utilities/styles';
 import {autobind, memoize} from '@shopify/javascript-utilities/decorators';
 import {navigationBarCollapsed} from '../../../../utilities/breakpoints';
 
-import {Secondary} from './components';
-import {Icon, IconProps, UnstyledLink, Badge} from '../../../../components';
+import {Icon, IconProps, UnstyledLink, Badge} from '../../..';
 import {Context, contextTypes} from '../../types';
 
 import * as styles from '../../Navigation.scss';
+import {Secondary} from './components';
 
 interface ItemURLDetails {
   url?: string;

--- a/src/components/Navigation/components/Item/components/Secondary/Secondary.tsx
+++ b/src/components/Navigation/components/Item/components/Secondary/Secondary.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
-import {Collapsible} from '../../../../../../components';
+import {Collapsible} from '../../../../..';
 
 import styles from '../../../../Navigation.scss';
 

--- a/src/components/Navigation/components/Section/Section.tsx
+++ b/src/components/Navigation/components/Section/Section.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import {autobind, memoize} from '@shopify/javascript-utilities/decorators';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
-import {Collapsible, Icon, IconProps} from '../../../../components';
+import {Collapsible, Icon, IconProps} from '../../..';
 import {contextTypes} from '../../types';
 
 import {ellipsis} from '../../../../icons';

--- a/src/components/Navigation/components/Section/tests/Section.test.tsx
+++ b/src/components/Navigation/components/Section/tests/Section.test.tsx
@@ -8,7 +8,6 @@ import {findByTestID, trigger, mountWithAppProvider} from 'test-utilities';
 import Item from '../../Item';
 import Section from '../Section';
 
-// eslint-disable-next-line shopify/strict-component-boundaries
 import channelResults from './fixtures/AdminNavQuery/multiple-channels.json';
 
 interface Context {

--- a/src/components/Navigation/components/UserMenu/UserMenu.tsx
+++ b/src/components/Navigation/components/UserMenu/UserMenu.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import {autobind, memoize} from '@shopify/javascript-utilities/decorators';
 
-import {Avatar, AvatarProps, Icon, UnstyledLink} from '../../../../components';
+import {Avatar, AvatarProps, Icon, UnstyledLink} from '../../..';
 import {IconableAction} from '../../../../types';
 import MessageIndicator from '../../../MessageIndicator';
 import Message, {Props as MessageProps} from '../Message';

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -3,9 +3,9 @@ import {autobind} from '@shopify/javascript-utilities/decorators';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 
+import {arraysAreEqual} from '../../utilities/arrays';
 import {Option} from './components';
 import {IconProps, ThumbnailProps, AvatarProps} from '..';
-import {arraysAreEqual} from '../../utilities/arrays';
 
 import * as styles from './OptionList.scss';
 

--- a/src/components/OptionList/components/Option/Option.tsx
+++ b/src/components/OptionList/components/Option/Option.tsx
@@ -2,10 +2,9 @@ import * as React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import {autobind} from '@shopify/javascript-utilities/decorators';
 
-import {IconProps, ThumbnailProps, AvatarProps} from '../../..';
+import {IconProps, ThumbnailProps, AvatarProps, Scrollable} from '../../..';
 
 import {Checkbox} from '..';
-import {Scrollable} from '../../../../components';
 
 import * as styles from './Option.scss';
 

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -7,7 +7,7 @@ import {
   TitleBar as AppBridgeTitleBar,
 } from '@shopify/app-bridge/actions';
 
-import {withAppProvider, WithAppProviderProps} from '../../components';
+import {withAppProvider, WithAppProviderProps} from '..';
 import {
   transformActions,
   generateRedirect,

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -10,7 +10,7 @@ import {
   Popover,
   ActionList,
   BreadcrumbsProps,
-} from '../../../../components';
+} from '../../..';
 import {PaginationDescriptor} from '../../../Pagination';
 import {
   DisableableAction,

--- a/src/components/Page/components/Header/components/Action/Action.tsx
+++ b/src/components/Page/components/Header/components/Action/Action.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {classNames} from '@shopify/react-utilities';
 import {handleMouseUpByBlurring} from '../../../../../../utilities/focus';
 import Indicator from '../../../../../Indicator';
-import {Icon, UnstyledLink} from '../../../../../../components';
+import {Icon, UnstyledLink} from '../../../../..';
 import {IconableAction, DisableableAction} from '../../../../../../types';
 import * as styles from './Action.scss';
 

--- a/src/components/Page/components/Header/components/ActionGroup/ActionGroup.tsx
+++ b/src/components/Page/components/Header/components/ActionGroup/ActionGroup.tsx
@@ -34,18 +34,13 @@ class ActionGroup extends React.Component<Props, never> {
               hasIndicator={active}
               disclosure
               icon={icon}
-              // eslint-disable-next-line react/jsx-no-bind
               onAction={this.handleOpen}
             >
               {title}
             </Action>
           }
         >
-          <ActionList
-            items={actions}
-            // eslint-disable-next-line react/jsx-no-bind
-            onActionAnyItem={this.handleClose}
-          />
+          <ActionList items={actions} onActionAnyItem={this.handleClose} />
           {detailsMarkup}
         </Popover>
       </div>

--- a/src/components/Page/components/Header/components/ActionGroup/ActionGroup.tsx
+++ b/src/components/Page/components/Header/components/ActionGroup/ActionGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {autobind} from '@shopify/javascript-utilities/decorators';
-import {Popover, ActionList} from '../../../../../../components';
+import {Popover, ActionList} from '../../../../..';
 import {hasNewStatus} from '../../utilities';
 import Action from '../Action';
 import {ActionGroupDescriptor} from './types';

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -5,7 +5,9 @@ import {Page, DisplayText, Card} from 'components';
 import {noop} from '../../../utilities/other';
 import {LinkAction} from '../../../types';
 import {Header} from '../components';
+// eslint-disable-next-line shopify/strict-component-boundaries
 import {SecondaryAction, PrimaryActionProps} from '../components/Header/Header';
+// eslint-disable-next-line shopify/strict-component-boundaries
 import {ActionGroupDescriptor} from '../components/Header/components';
 
 jest.mock('../../../utilities/app-bridge-transformers', () => ({

--- a/src/components/PageActions/tests/PageActions.test.tsx
+++ b/src/components/PageActions/tests/PageActions.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
-import PageActions from '../../PageActions';
+import PageActions from '..';
 import ButtonGroup from '../../ButtonGroup';
 import Stack from '../../Stack';
 import {buttonsFrom} from '../../Button';

--- a/src/components/ResourceList/components/BulkActions/BulkActions.tsx
+++ b/src/components/ResourceList/components/BulkActions/BulkActions.tsx
@@ -7,7 +7,7 @@ import {Duration} from '../../../shared';
 import {ActionList, Popover, Button, EventListener} from '../../..';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 import CheckableButton from '../CheckableButton';
-import BulkActionButton from './components/BulkActionButton';
+import {BulkActionButton} from './components';
 import * as styles from './BulkActions.scss';
 
 export type BulkAction = DisableableAction;

--- a/src/components/ResourceList/components/BulkActions/BulkActions.tsx
+++ b/src/components/ResourceList/components/BulkActions/BulkActions.tsx
@@ -147,7 +147,6 @@ export class BulkActions extends React.PureComponent<CombinedProps, State> {
       : 0;
 
     if (this.containerNode) {
-      // eslint-disable-next-line react/no-did-mount-set-state
       this.setState({
         containerWidth: this.containerNode.getBoundingClientRect().width,
         measuring: false,

--- a/src/components/ResourceList/components/BulkActions/tests/BulkActions.test.tsx
+++ b/src/components/ResourceList/components/BulkActions/tests/BulkActions.test.tsx
@@ -3,7 +3,7 @@ import {Transition, CSSTransition} from 'react-transition-group';
 import {mountWithAppProvider, findByTestID} from 'test-utilities';
 import {Popover} from 'components';
 import CheckableButton from '../../CheckableButton';
-import BulkActionButton from '../components/BulkActionButton';
+import {BulkActionButton} from '../components';
 import BulkActions, {BulkAction} from '../BulkActions';
 
 export interface Props {

--- a/src/components/ResourceList/components/FilterControl/FilterControl.tsx
+++ b/src/components/ResourceList/components/FilterControl/FilterControl.tsx
@@ -5,11 +5,11 @@ import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 import {ComplexAction, WithContextTypes} from '../../../../types';
 import {buttonsFrom, TextField, Icon, Tag, FormLayout} from '../../..';
 
-import {AppliedFilter, Filter, FilterType, Operator} from './types';
-import * as styles from './FilterControl.scss';
 import {ResourceListContext} from '../../ResourceList';
 import {Consumer} from '../Context';
 import withContext from '../../../WithContext';
+import * as styles from './FilterControl.scss';
+import {AppliedFilter, Filter, FilterType, Operator} from './types';
 
 import {FilterCreator} from './components';
 

--- a/src/components/ResourceList/components/FilterControl/FilterControl.tsx
+++ b/src/components/ResourceList/components/FilterControl/FilterControl.tsx
@@ -5,12 +5,13 @@ import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 import {ComplexAction, WithContextTypes} from '../../../../types';
 import {buttonsFrom, TextField, Icon, Tag, FormLayout} from '../../..';
 
-import FilterCreator from './components/FilterCreator';
 import {AppliedFilter, Filter, FilterType, Operator} from './types';
 import * as styles from './FilterControl.scss';
 import {ResourceListContext} from '../../ResourceList';
 import {Consumer} from '../Context';
 import withContext from '../../../WithContext';
+
+import {FilterCreator} from './components';
 
 export interface Props {
   searchValue?: string;

--- a/src/components/ResourceList/components/FilterControl/components/index.ts
+++ b/src/components/ResourceList/components/FilterControl/components/index.ts
@@ -1,6 +1,7 @@
 export {
   default as DateSelector,
   Props as DateSelectorProps,
+  DateFilterOption,
 } from './DateSelector';
 
 export {

--- a/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
@@ -11,8 +11,7 @@ import {
   FilterDateSelector,
 } from '../types';
 import FilterControl, {Props} from '../FilterControl';
-import FilterCreator from '../components/FilterCreator';
-import {DateFilterOption} from '../components/DateSelector';
+import {FilterCreator, DateFilterOption} from '../components';
 
 describe('<FilterControl />', () => {
   const mockDefaultProps: Props = {

--- a/src/components/ResourceList/components/Item/Item.tsx
+++ b/src/components/ResourceList/components/Item/Item.tsx
@@ -15,10 +15,10 @@ import Button, {buttonsFrom} from '../../../Button';
 import {SELECT_ALL_ITEMS} from '../../types';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 
-import * as styles from './Item.scss';
 import {ResourceListContext} from '../../ResourceList';
 import withContext from '../../../WithContext';
 import {Consumer} from '../Context';
+import * as styles from './Item.scss';
 
 export type ExceptionStatus = 'neutral' | 'warning' | 'critical';
 export type MediaSize = 'small' | 'medium' | 'large';

--- a/src/components/ResourcePicker/ResourcePicker.tsx
+++ b/src/components/ResourcePicker/ResourcePicker.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import isEqual from 'lodash/isEqual';
 import {ResourcePicker as AppBridgeResourcePicker} from '@shopify/app-bridge/actions';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../components/AppProvider';
+import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 
 export interface SelectPayload {
   /** The selected resources

--- a/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
+++ b/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {ResourcePicker as AppBridgeResourcePicker} from '@shopify/app-bridge/actions';
-import {mountWithAppProvider} from 'test-utilities';
 import {noop} from '@shopify/javascript-utilities/other';
+import {mountWithAppProvider} from 'test-utilities';
 import ResourcePicker from '../ResourcePicker';
 
 describe('<ResourcePicker />', () => {

--- a/src/components/SettingToggle/SettingToggle.tsx
+++ b/src/components/SettingToggle/SettingToggle.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import SettingAction from '../../components/SettingAction';
-import {buttonFrom, Card} from '../../components';
+import SettingAction from '../SettingAction';
+import {buttonFrom, Card} from '..';
 import {ComplexAction} from '../../types';
 
 export interface Props {

--- a/src/components/SettingToggle/tests/SettingToggle.test.tsx
+++ b/src/components/SettingToggle/tests/SettingToggle.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
-// eslint-disable-next-line shopify/strict-component-boundaries
 import SettingAction from 'components/SettingAction';
 import SettingToggle from '../SettingToggle';
 

--- a/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/src/components/SkeletonPage/SkeletonPage.tsx
@@ -4,8 +4,8 @@ import DisplayText from '../DisplayText';
 import SkeletonDisplayText from '../SkeletonDisplayText';
 import SkeletonBodyText from '../SkeletonBodyText';
 
-import * as styles from './SkeletonPage.scss';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
+import * as styles from './SkeletonPage.scss';
 
 export interface Props {
   /** Page title, in large type */

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -6,8 +6,8 @@ import {classNames} from '@shopify/react-utilities/styles';
 import Labelled, {Action, helpTextID, labelID} from '../Labelled';
 import Connected from '../Connected';
 
-import {Resizer, Spinner} from './components';
 import {Error, Key} from '../../types';
+import {Resizer, Spinner} from './components';
 import * as styles from './TextField.scss';
 
 export type Type =

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -9,7 +9,7 @@ import {
   UnstyledLink,
   withAppProvider,
   WithAppProviderProps,
-} from '../../components';
+} from '..';
 import {SearchField, UserMenu, Search, SearchProps, Menu} from './components';
 
 import * as styles from './TopBar.scss';

--- a/src/components/TopBar/components/Menu/Menu.tsx
+++ b/src/components/TopBar/components/Menu/Menu.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import {Message, MessageProps} from './components';
 import {ActionList, ActionListProps, Popover} from '../../..';
+import {Message, MessageProps} from './components';
 import styles from './Menu.scss';
 
 export interface Props {

--- a/src/components/TopBar/components/Menu/components/Message/Message.tsx
+++ b/src/components/TopBar/components/Menu/components/Message/Message.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import {
+  Badge,
+  BadgeProps,
   TextContainer,
   Heading,
   Link,
   Stack,
   Popover,
   Button,
-} from '../../../../../../components';
-import {Badge, BadgeProps} from '../../../../..';
+} from '../../../../..';
 import styles from './Message.scss';
 
 export interface Props {

--- a/src/components/TopBar/components/SearchField/SearchField.tsx
+++ b/src/components/TopBar/components/SearchField/SearchField.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import {autobind} from '@shopify/javascript-utilities/decorators';
 import {noop} from '../../../../utilities/other';
-import {Icon} from '../../../../components';
+import {Icon} from '../../..';
 
 import * as styles from './SearchField.scss';
 

--- a/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {IconableAction} from '../../../../types';
 
-import {Avatar, AvatarProps} from '../../../../components';
+import {Avatar, AvatarProps} from '../../..';
 import {MessageProps} from '../Menu';
 import {Menu} from '..';
 import MessageIndicator from '../../../MessageIndicator';

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -7,7 +7,7 @@ import {
   focusLastFocusableNode,
 } from '@shopify/javascript-utilities/focus';
 
-import {EventListener, Focus} from '../../components';
+import {EventListener, Focus} from '..';
 
 export interface Props {
   trapping?: boolean;

--- a/src/components/WithRef/WithRef.tsx
+++ b/src/components/WithRef/WithRef.tsx
@@ -13,7 +13,6 @@ export default function withRef<OriginalProps>() {
   return function addForwardRef<C>(
     WrappedComponent: ReactComponent<OriginalProps & Ref> & C,
   ): React.ComponentClass<OriginalProps> {
-    // eslint-disable-next-line react/prefer-stateless-function
     class WithRef extends React.Component<OriginalProps, never> {
       render() {
         return (

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -4,7 +4,7 @@ import {
   ToastProps,
   AppProviderContext,
   ThemeProviderContext,
-} from '../components';
+} from '.';
 
 export interface PolarisContext
   extends AppProviderContext,

--- a/src/utilities/app-bridge-transformers.ts
+++ b/src/utilities/app-bridge-transformers.ts
@@ -1,12 +1,12 @@
 import {ClientApplication} from '@shopify/app-bridge';
 import {Redirect, Button, ButtonGroup} from '@shopify/app-bridge/actions';
+// eslint-disable-next-line shopify/strict-component-boundaries
 import {ActionGroupDescriptor} from 'components/Page/components/Header/components/ActionGroup';
 import {
   AppBridgeTarget,
   ComplexAction,
   ActionListItemDescriptor,
 } from '../types';
-// eslint-disable-next-line shopify/strict-component-boundaries
 
 export function generateRedirect(
   appBridge: ClientApplication<{}>,

--- a/src/utilities/other.ts
+++ b/src/utilities/other.ts
@@ -1,2 +1,1 @@
-// tslint:disable-next-line:no-empty
 export function noop() {}

--- a/src/utilities/react-compose.tsx
+++ b/src/utilities/react-compose.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {ReactComponent} from '@shopify/react-utilities/types';
 import reactCompose from '@shopify/react-compose';
+// eslint-disable-next-line shopify/strict-component-boundaries
 import {Provider as RefProvider} from '../components/WithRef';
 
 export type ComponentClass = React.ComponentClass<any>;

--- a/src/utilities/tests/app-bridge-transformers.test.ts
+++ b/src/utilities/tests/app-bridge-transformers.test.ts
@@ -1,6 +1,6 @@
 import {ClientApplication} from '@shopify/app-bridge';
 import {Button, ButtonGroup, Redirect} from '@shopify/app-bridge/actions';
-import {noop} from '../../utilities/other';
+import {noop} from '../other';
 import {generateRedirect, transformActions} from '../app-bridge-transformers';
 
 describe('app bridge transformers', () => {

--- a/tophat/Example.tsx
+++ b/tophat/Example.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-unresolved */
 import * as React from 'react';
 import * as Polaris from '@shopify/polaris';
 import {parse} from '@babel/parser';

--- a/tophat/ExampleContainer.tsx
+++ b/tophat/ExampleContainer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-unresolved */
 import * as React from 'react';
 
 export interface ExampleProps {

--- a/tophat/parseMarkdown.js
+++ b/tophat/parseMarkdown.js
@@ -133,7 +133,7 @@ function parseCodeExamples(data, file) {
     );
   }
 
-  examples.map((example) => {
+  examples.forEach((example) => {
     if (example.code === '') {
       throw new Error(
         chalk`🚨 {red [${matter.data.name}]} Example “${

--- a/tophat/snapshots.js
+++ b/tophat/snapshots.js
@@ -54,7 +54,7 @@ const {Percy, FileSystemAssetLoader} = require('@percy/puppeteer');
 
     const urls = [...batchComponentExamples, ...individualModalExamples];
 
-    urls.map((path) => {
+    urls.forEach((path) => {
       const currentBrowser = browsers[browserIndex % 2];
       browserIndex++;
       currentBrowser.taken = currentBrowser.taken.then(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,12 +318,13 @@
     classnames "^2.2.5"
     core-js "^2.5.6"
 
-"@shopify/sewing-kit@^0.61.0":
-  version "0.61.0"
-  resolved "https://registry.yarnpkg.com/@shopify/sewing-kit/-/sewing-kit-0.61.0.tgz#3e941a738626cceeb1fc780727e7d00cc8993f64"
-  integrity sha512-USBtyG5i2x+1mmxm9XOgbGmdLKAlCvKmdqtFzi9UwwTLwdKGFt2mO8uiwP26haceybMhusTLjwLrO58srWhXkA==
+"@shopify/sewing-kit@0.62.0":
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/@shopify/sewing-kit/-/sewing-kit-0.62.0.tgz#87e13cb8a5432bbde87f13d92521c82605a88021"
+  integrity sha512-HX9+McQ6KC74KqJ22JH+rWNQSqE3ts1VoC8s7Ol2cZs8DDt0fEhtw6oSoTZJKeiYyeSCuGiM2hnbpQzajGMAvg==
   dependencies:
     "@shopify/images" "^1.1.4"
+    "@types/graphql" "^0.13.0"
     "@types/jest" "^23.3.1"
     app-root-dir "^1.0.2"
     awesome-typescript-loader "3.1.3"
@@ -342,17 +343,19 @@
     css-loader "^0.28.11"
     element-dataset "^2.2.6"
     eslint "^5.6.0"
-    eslint-plugin-shopify "^25.1.0"
+    eslint-plugin-shopify "^26.1.1"
     express "^4.16.3"
     file-loader "^1.1.6"
     fs-extra "^6.0.0"
     get-port "^3.2.0"
     glob "^7.1.2"
+    graphql "0.13.2"
+    graphql-config "2.1.1"
     graphql-tag "^2.9.1"
-    graphql-tool-utilities "^0.9.0"
+    graphql-tool-utilities "^0.9.1"
     graphql-typed "^0.2.0"
-    graphql-typescript-definitions "^0.13.0"
-    graphql-validate-fixtures "^0.10.0"
+    graphql-typescript-definitions "^0.13.2"
+    graphql-validate-fixtures "^0.10.1"
     happypack "^5.0.0"
     hard-source-webpack-plugin "~0.10.1"
     identity-obj-proxy "^3.0.0"
@@ -385,12 +388,13 @@
     sass-loader "^7.0.3"
     sass-resources-loader "^1.3.2"
     source-map-support "^0.5.6"
+    strip-ansi "^4.0.0"
     style-loader "^0.21.0"
     stylelint "^9.5.0"
-    stylelint-config-shopify "^7.0.2"
+    stylelint-config-shopify "^7.0.4"
     svgo "^1.0.5"
     temp "^0.8.3"
-    ts-jest "^21.2.3"
+    ts-jest "~23.10.4"
     ts-loader "^4.4.1"
     uglifyjs-webpack-plugin "^1.2.7"
     url-loader "^1.0.1"
@@ -479,6 +483,11 @@
   version "23.3.5"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.5.tgz#870a1434208b60603745bfd214fc3fc675142364"
   integrity sha512-3LI+vUC3Wju28vbjIjsTKakhMB8HC4l+tMz+Z8WRzVK+kmvezE5jcOvKtBpznWSI5KDLFo+FouUhpTKoekadCA==
+
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
 "@types/lodash-decorators@^4.0.0":
   version "4.0.0"
@@ -3897,7 +3906,7 @@ core-js@^2.0.0, core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.1:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
   integrity sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=
 
-core-js@^2.4.1, core-js@^2.5.3, core-js@^2.5.6:
+core-js@^2.5.3, core-js@^2.5.6, core-js@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
   integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
@@ -4525,6 +4534,11 @@ deep-strict-equal@^0.2.0:
   integrity sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=
   dependencies:
     core-assert "^0.2.0"
+
+deepmerge@^2.0.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
 default-gateway@^2.6.0:
   version "2.7.2"
@@ -5278,6 +5292,15 @@ eslint-import-resolver-node@^0.3.1:
     debug "^2.6.8"
     resolve "^1.2.0"
 
+eslint-import-resolver-typescript@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-1.1.1.tgz#e6d42172b95144ef16610fe104ef38340edea591"
+  integrity sha512-jqSfumQ+H5y3FUJ6NjRkbOQSUOlbBucGTN3ELymOtcDBbPjVdm/luvJuCfCaIXGh8sEF26ma1qVdtDgl9ndhUg==
+  dependencies:
+    debug "^4.0.1"
+    resolve "^1.4.0"
+    tsconfig-paths "^3.6.0"
+
 eslint-module-utils@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz#abaec824177613b8a95b299639e1b6facf473449"
@@ -5330,6 +5353,14 @@ eslint-plugin-es@^1.3.1:
     eslint-utils "^1.3.0"
     regexpp "^2.0.0"
 
+eslint-plugin-eslint-comments@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.0.1.tgz#baafb713584c0de7ee588710720e580bcc28cfbb"
+  integrity sha512-7zU6gCulKVmfG3AZdnvDxzfHaGdvkA8tsLiKbneeI/TlVaulJsRzOyMCctH9QTobKVJ6LIsiJbrkSKkgcFLHxw==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^3.3.8"
+
 eslint-plugin-flowtype@2.41.0:
   version "2.41.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.41.0.tgz#fd5221c60ba917c059d7ef69686a99cca09fd871"
@@ -5337,10 +5368,10 @@ eslint-plugin-flowtype@2.41.0:
   dependencies:
     lodash "^4.15.0"
 
-eslint-plugin-graphql@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-graphql/-/eslint-plugin-graphql-2.1.1.tgz#dae5d597080075320ea8e98795056309ffe73a18"
-  integrity sha512-JT2paUyu3e9ZDnroSshwUMc6pKcnkfXTsZInX1+/rPotvqOLVLtdrx/cmfb7PTJwjiEAshwcpm3/XPdTpsKJPw==
+eslint-plugin-graphql@2.1.0-0:
+  version "2.1.0-0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-graphql/-/eslint-plugin-graphql-2.1.0-0.tgz#49eb0126f4aef142ecb0b444baece5d481388361"
+  integrity sha512-BSLC0/LpCW+LEFnCWaM7UQ5sBJzxO1WtsS+8nmtErkFULvF76yVzVW8LdJ6ZRKE8W/gakJIh21VlaXjhUuqyqQ==
   dependencies:
     graphql-config "^2.0.1"
     lodash "^4.11.1"
@@ -5406,21 +5437,12 @@ eslint-plugin-node@7.0.1:
     resolve "^1.8.1"
     semver "^5.5.0"
 
-eslint-plugin-prettier@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz#33e4e228bdb06142d03c560ce04ec23f6c767dd7"
-  integrity sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==
+eslint-plugin-prettier@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.0.tgz#f6b823e065f8c36529918cdb766d7a0e975ec30c"
+  integrity sha512-4g11opzhqq/8+AMmo5Vc2Gn7z9alZ4JqrbZ+D4i8KlSyxeQhZHlmIrY8U9Akf514MoEhogPa87Jgkq87aZ2Ohw==
   dependencies:
-    fast-diff "^1.1.1"
-    jest-docblock "^21.0.0"
-
-eslint-plugin-prettier@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz#71998c60aedfa2141f7bfcbf9d1c459bf98b4fad"
-  integrity sha512-tGek5clmW5swrAx1mdPYM8oThrBE83ePh7LeseZHBWfHVGrHPhKn7Y5zgRMbU/9D5Td9K4CEmUPjGxA7iw98Og==
-  dependencies:
-    fast-diff "^1.1.1"
-    jest-docblock "^21.0.0"
+    prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-promise@4.0.0:
   version "4.0.0"
@@ -5438,26 +5460,28 @@ eslint-plugin-react@7.11.1:
     jsx-ast-utils "^2.0.1"
     prop-types "^15.6.2"
 
-eslint-plugin-shopify@^25.1.0:
-  version "25.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-shopify/-/eslint-plugin-shopify-25.1.0.tgz#93f810584b767437c334e3771277d4ba116ffc27"
-  integrity sha512-tff2vDuQDQId6QJUKF0QRPP3RxvJfmbND1TkcwZoUTlNtSY3gEtRy3LB9TwTZJj6YLOJG+vvHxzLfpUQOk4xXg==
+eslint-plugin-shopify@^26.1.1:
+  version "26.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-shopify/-/eslint-plugin-shopify-26.1.1.tgz#8e2b3af7de246145b45df6bec130922d2b642866"
+  integrity sha512-tuXjwTonJMcKheAApf2So/BlN0vvZnKSrFGOz0dO3txeLYzeKR7hkFj65SHspcDcTB3oGTByuqhQ35BqnRDusw==
   dependencies:
     babel-eslint "9.0.0"
     eslint-config-prettier "3.0.1"
+    eslint-import-resolver-typescript "^1.1.1"
     eslint-module-utils "2.1.1"
     eslint-plugin-ava "5.1.0"
     eslint-plugin-babel "5.1.0"
     eslint-plugin-chai-expect "1.1.1"
+    eslint-plugin-eslint-comments "3.0.1"
     eslint-plugin-flowtype "2.41.0"
-    eslint-plugin-graphql "2.1.1"
+    eslint-plugin-graphql "2.1.0-0"
     eslint-plugin-import "2.14.0"
     eslint-plugin-jest "21.22.0"
     eslint-plugin-jsx-a11y "6.1.1"
     eslint-plugin-lodash "2.6.1"
     eslint-plugin-mocha "5.2.0"
     eslint-plugin-node "7.0.1"
-    eslint-plugin-prettier "2.6.0"
+    eslint-plugin-prettier "3.0.0"
     eslint-plugin-promise "4.0.0"
     eslint-plugin-react "7.11.1"
     eslint-plugin-sort-class-members "1.3.1"
@@ -5466,7 +5490,7 @@ eslint-plugin-shopify@^25.1.0:
     pascal-case "^2.0.1"
     pkg-dir "2.0.0"
     pluralize "^7.0.0"
-    typescript-eslint-parser "19.0.2"
+    typescript-eslint-parser "20.0.0"
 
 eslint-plugin-sort-class-members@1.3.1:
   version "1.3.1"
@@ -6044,10 +6068,10 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-diff@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
-  integrity sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.0.2:
   version "2.2.2"
@@ -6980,14 +7004,14 @@ graphql-tag@^2.9.1:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.0.tgz#87da024be863e357551b2b8700e496ee2d4353ae"
   integrity sha512-9FD6cw976TLLf9WYIUPCaaTpniawIjHWZSwIRZSjrfufJamcXbVVYfN2TWvJYbw0Xf2JjYbl1/f2+wDnBVw3/w==
 
-graphql-tool-utilities@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/graphql-tool-utilities/-/graphql-tool-utilities-0.9.0.tgz#15ec0b17f983c03637851bf6c71a7517f800389d"
-  integrity sha512-cjj9BzeefXz0p5fhljAAzA5bDFuENFK+Rt48SMmTnH+79uJwYc50MX4/BJnGLemyCdyuW1MqB0TjB2CKVeMWkA==
+graphql-tool-utilities@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/graphql-tool-utilities/-/graphql-tool-utilities-0.9.1.tgz#2710fb7315b06cf875b5e28a435571c6043a7b2f"
+  integrity sha512-cnJ3uodlAZ7DENgbj5r/Aqhvb4vOsCPA+u2oNI173+0fE8ft2xaQEw5htQhoGYjAZKWsBNJ/kZO9hXHNpE9sEw==
   dependencies:
     "@types/graphql" "^0.13.0"
     apollo-codegen-core "0.28.1"
-    core-js "^2.4.1"
+    core-js "^2.5.7"
     graphql "0.13.2"
     graphql-config "2.1.1"
 
@@ -6996,10 +7020,10 @@ graphql-typed@^0.2.0:
   resolved "https://registry.yarnpkg.com/graphql-typed/-/graphql-typed-0.2.0.tgz#626863bbc8d0f1562db08508601dc2439bf00dd7"
   integrity sha512-cBy1vxabkmx3G0IURSbav7Rww/eQesKvHrSWa0SJy866JyHhxUJehp7m4sgTJt5J1vNFsEaJeHA4xLZmICKHnw==
 
-graphql-typescript-definitions@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/graphql-typescript-definitions/-/graphql-typescript-definitions-0.13.0.tgz#bb6437b0d7f5175c1ca00d6ebef13dbbd07b7365"
-  integrity sha512-es2tYBrUfDkkPaRmFIP45LP50uRc6jt5Tplxw44i+KOAXxFpdXRXCVG8ANKlMeLXl5czUR7m4MYitfTvW5pD2A==
+graphql-typescript-definitions@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/graphql-typescript-definitions/-/graphql-typescript-definitions-0.13.2.tgz#2bc0b41344341129f139e056d64bfac6309cd141"
+  integrity sha512-1lw3xt8vxDAJ9pD9n/Z7jAjwQL86jVJ2UEEVV+1ygXNQS6rvC8Y00NswZRw99NbKyMqVG5SECT1t8wohxbNmqA==
   dependencies:
     "@babel/generator" "^7.0.0-beta.46"
     "@babel/types" "^7.0.0-beta.46"
@@ -7010,17 +7034,17 @@ graphql-typescript-definitions@^0.13.0:
     chokidar "^2.0.3"
     fs-extra "^6.0.0"
     glob "^7.1.2"
-    graphql-tool-utilities "^0.9.0"
+    graphql-tool-utilities "^0.9.1"
 
-graphql-validate-fixtures@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/graphql-validate-fixtures/-/graphql-validate-fixtures-0.10.0.tgz#7561c867a5c8611488445ebb048a65febde46aea"
-  integrity sha512-A7orOvxzns9n2mxBNZ2fwP7bFOtuuO3oDf9hoEJX9xWHIcC8EDHVnb+2qb6A7y6BjIVMGlB/+G4ov22J3Sj9xQ==
+graphql-validate-fixtures@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/graphql-validate-fixtures/-/graphql-validate-fixtures-0.10.1.tgz#17922cc03027f5bdff9bc0dca0a58b8c89c5d5d9"
+  integrity sha512-z44X2WjZQ8XG5p+AH6s4yWEY7TxqO1+KlvAwT6sKq3xZfIRRn+vqOTrcy/X1HFFgy5kWebrFUbA3KxAOzmDHTA==
   dependencies:
     chalk "^2.4.1"
     fs-extra "^6.0.0"
     glob "^7.1.2"
-    graphql-tool-utilities "^0.9.0"
+    graphql-tool-utilities "^0.9.1"
     yargs "^11.0.0"
 
 graphql@0.13.2:
@@ -7616,7 +7640,7 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.3.5:
+ignore@^3.3.5, ignore@^3.3.8:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
@@ -8737,11 +8761,6 @@ jest-diff@^23.6.0:
     jest-get-type "^22.1.0"
     pretty-format "^23.6.0"
 
-jest-docblock@^21.0.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
-  integrity sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==
-
 jest-docblock@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
@@ -9170,6 +9189,13 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
+
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  dependencies:
+    minimist "^1.2.0"
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -12191,6 +12217,13 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
 prettier@^1.13.5:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
@@ -14603,15 +14636,15 @@ stylelint-config-prettier@^4.0.0:
   resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-4.0.0.tgz#8c712977be13bd25191ab8b986b5c07a3342a5dc"
   integrity sha512-cwh3QbBC2+3zBeMvuxFjT8XsbSdyoyELOY9BZqMuvphUKEQ+srkPWoN60FlvRwLB014TOke4Y12KvTtfKnaHhg==
 
-stylelint-config-shopify@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/stylelint-config-shopify/-/stylelint-config-shopify-7.0.2.tgz#7640b6b324b645276742fedbaec8063d2719139a"
-  integrity sha512-kmTPkEvbEZywDV6H3l45Kz6V14mfffUZa/BVn1TifjeIwNd5OlhzMFpMsj3juv4IoJPB236BzN0jLMCnS3pgyQ==
+stylelint-config-shopify@^7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/stylelint-config-shopify/-/stylelint-config-shopify-7.0.4.tgz#7d412a4c1cfe89f6dcf3c41f63b328c5608a6689"
+  integrity sha512-LUrUEmLEC2PjkXflILGZZbfqKakdzwvsHp/gMiPpe55gQsyVlfwmut55W/9xk0qseW9T/+5o2O+5LMnu5cZIVw==
   dependencies:
     merge "1.2.x"
     stylelint-config-prettier "^4.0.0"
     stylelint-order "1.0.0"
-    stylelint-prettier "1.0.1"
+    stylelint-prettier "1.0.3"
     stylelint-scss "3.3.0"
 
 stylelint-order@1.0.0:
@@ -14623,12 +14656,12 @@ stylelint-order@1.0.0:
     postcss "^7.0.2"
     postcss-sorting "^4.0.0"
 
-stylelint-prettier@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-1.0.1.tgz#991f0bd639f7dc11648b553cef85db6301aaf4f1"
-  integrity sha512-qM4Cs7JEWw/eLNsP04WDkQ2xCu3YXIjMivG/Pb+Nn91FbhRWVw5WbwucJKPnI1tciVesdXOT9x7AoiWp+thm1g==
+stylelint-prettier@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-1.0.3.tgz#d7b1e8c331045dc1fd9d792dd8a1a5afc5304018"
+  integrity sha512-yzlhOKg2AmzGmKfWN9LPONr7/8O15QkGLtofhDsbpiEHCXMS5fZbQ0lcjopOAm6iU7vzETRFbOSHrDNJCRepbA==
   dependencies:
-    eslint-plugin-prettier "^2.6.2"
+    prettier-linter-helpers "^1.0.0"
 
 stylelint-scss@3.3.0:
   version "3.3.0"
@@ -15140,7 +15173,7 @@ tryer@^1.0.0:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.0.tgz#027b69fa823225e551cace3ef03b11f6ab37c1d7"
   integrity sha1-Antp+oIyJeVRys4+8DsR9qs3wdc=
 
-ts-jest@^21.2.3, ts-jest@~23.10.4:
+ts-jest@~23.10.4:
   version "23.10.4"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.10.4.tgz#a7a953f55c9165bcaa90ff91014a178e87fe0df8"
   integrity sha512-oV/wBwGUS7olSk/9yWMiSIJWbz5xO4zhftnY3gwv6s4SMg6WHF1m8XZNBvQOKQRiTAexZ9754Z13dxBq3Zgssw==
@@ -15164,6 +15197,17 @@ ts-loader@^4.4.1:
     loader-utils "^1.0.2"
     micromatch "^3.1.4"
     semver "^5.0.1"
+
+tsconfig-paths@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.6.0.tgz#f14078630d9d6e8b1dc690c1fc0cfb9cd0663891"
+  integrity sha512-mrqQIP2F4e03aMTCiPdedCIT300//+q0ET53o5WqqtQjmEICxP9yfz/sHTpPqXpssuJEzODsEzJaLRaf5J2X1g==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    deepmerge "^2.0.1"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tslib@^1.6.1, tslib@^1.7.1, tslib@^1.8.0:
   version "1.8.0"
@@ -15225,7 +15269,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript-eslint-parser@17.0.1, typescript-eslint-parser@19.0.2:
+typescript-eslint-parser@17.0.1, typescript-eslint-parser@20.0.0:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-17.0.1.tgz#ddc681a3afa51a9baa6746a001eb5f29fb1365d3"
   integrity sha512-EPCOjxjnGqu9kQwH3CAwa1Jjty2Dn0FnehksVEmfZxXtkEK2Jerb2lnd/htsj1XooqEkKC5AzCaK+qOxHaBDBQ==


### PR DESCRIPTION
### WHY are these changes introduced?

* Keeping up to date
* Removes the need for some overrides in our jest configuration
* Improves our linting, by using an updated version of eslint-plugin-shopify
  * fixes some cases where linting rules were mistakenly disabled thanks to the typescript and react configs having precedence fights. We thought these rules were always enabled but they weren't. Now they are.
  * import linting rules now work within typescript files. This enforces the order of imports (node builtins, then node module, then parent imports, then siblings), and ensures [paths are a simple as possible](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-useless-path-segments.md).

### WHAT is this pull request doing?

Updates to the latest version of sewing-kit
Updates files to comply with linting rules.

Review this PR one commit at a time as about half the size of this pr comes from 7f835d3d which is the result of running `yarn format` rather than any manual changes.


### How to 🎩

`yarn lint` and `yarn test` should both pass. 

Change around the ordering of imports so sibling imports come before parent imports and see `yarn lint` complain

