### PR TITLE
Move coverage into build/coverage

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,5 @@
 node_modules
 /build
-/coverage
 /build-intermediate
 /build-esnext
 /docs

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ node_modules
 /build-intermediate
 /build-esnext
 /docs
-/coverage
 /esnext
 /types
 /index.*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,5 @@
 node_modules
 /build
-/coverage
 /build-intermediate
 /build-esnext
 /docs

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,6 +1,5 @@
 node_modules
 /build
-/coverage
 /build-intermediate
 /build-esnext
 /docs

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "check": "npm-run-all lint ts test",
     "check:ci": "npm-run-all lint ts test:ci",
     "clean": "rimraf build build-esnext esnext styles types docs 'build-intermediate' 'index.*' './src/styles/polaris-tokens' './tophat/.cache' './tophat/assets' 'styles.{css,scss}'",
-    "clean:build": "rimraf 'build/!(cache)' build-esnext esnext styles types docs 'build-intermediate' 'index.*' './src/styles/polaris-tokens' './tophat/.cache' './tophat/assets' 'styles.{css,scss}'",
+    "clean:build": "rimraf 'build/!(cache|coverage)' build-esnext esnext styles types docs 'build-intermediate' 'index.*' './src/styles/polaris-tokens' './tophat/.cache' './tophat/assets' 'styles.{css,scss}'",
     "optimize": "node ./scripts/optimize.js",
     "prebuild": "npm-run-all clean:build optimize copy-polaris-tokens",
     "build": "babel-node ./scripts/build.js",

--- a/sewing-kit.config.ts
+++ b/sewing-kit.config.ts
@@ -35,11 +35,9 @@ export default function sewingKitConfig(
         };
 
         // Code coverage
-        config.coverageDirectory = 'coverage';
-        config.coverageReporters = ['text-summary', 'html'];
-        if (env.isCI) {
-          config.coverageReporters.push('lcov');
-        }
+        config.coverageDirectory = 'build/coverage';
+        config.coverageReporters = ['text-summary', 'html', 'lcovonly'];
+
         config.collectCoverageFrom = [
           'src/**/*.{ts,tsx}',
           '!src/test-utilities/**/*.*',


### PR DESCRIPTION
Move code coverage into an already ignored top level folder to avoid
proliferation of top-level ignored files

Simplify the logic for what reporters to use slightly

### Tophat

* Confirm that codecov still picks up the coverage report in the new location, by seeing the codecov check in this PR.
* Run `yarn run test . --no-watch --coverage` and see that:
  * A text summary is shown
  * An lcov report is generated at build/coverage/lcov.info
  * A html report is generated and you can open it with `open build/coverage/index.html`