### PR TITLE
Update Avatar and Image component to handle onError with images.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- `Avatar` falls back to `initials` when the image fails to load ([#557](https://github.com/Shopify/polaris-react/pull/557))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Avatar/Avatar.scss
+++ b/src/components/Avatar/Avatar.scss
@@ -19,6 +19,10 @@ $large-size: rem(60px);
   }
 }
 
+.hidden {
+  visibility: hidden;
+}
+
 .sizeSmall {
   width: $small-size;
 }

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
+import {autobind} from '@shopify/javascript-utilities/decorators';
 
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import Image from '../Image';
@@ -34,83 +35,124 @@ export interface Props {
   accessibilityLabel?: string;
 }
 
+export interface State {
+  hasError: boolean;
+  hasLoaded: boolean;
+}
+
 export type CombinedProps = Props & WithAppProviderProps;
 
-function Avatar({
-  name,
-  source,
-  initials,
-  customer,
-  size = 'medium',
-  accessibilityLabel,
-  polaris: {intl},
-}: CombinedProps) {
-  const nameString = name || initials;
+export class Avatar extends React.PureComponent<CombinedProps, State> {
+  state: State = {
+    hasError: false,
+    hasLoaded: false,
+  };
 
-  let finalSource: string | undefined;
-  let label: string | undefined;
-
-  if (accessibilityLabel) {
-    label = accessibilityLabel;
-  } else if (name) {
-    label = name;
-  } else if (initials) {
-    const splitInitials = initials.split('').join(' ');
-    label = intl.translate('Polaris.Avatar.labelWithInitials', {
-      initials: splitInitials,
-    });
-  } else {
-    label = intl.translate('Polaris.Avatar.label');
+  ComponentDidUpdate({source: previousSource}: Props) {
+    const {source} = this.props;
+    const {hasError, hasLoaded} = this.state;
+    if (previousSource === source || (!hasError && !hasLoaded)) {
+      return;
+    }
+    this.setState({hasError: false, hasLoaded: false});
   }
 
-  if (source) {
-    finalSource = source;
-  } else if (customer) {
-    finalSource = customerPlaceholder(nameString);
+  render() {
+    const {
+      name,
+      source,
+      initials,
+      customer,
+      size = 'medium',
+      accessibilityLabel,
+      polaris: {intl},
+    } = this.props;
+
+    const {hasError, hasLoaded} = this.state;
+
+    const hasImage = (source || customer) && !hasError;
+
+    const nameString = name || initials;
+
+    let finalSource: string | undefined;
+    let label: string | undefined;
+
+    if (accessibilityLabel) {
+      label = accessibilityLabel;
+    } else if (name) {
+      label = name;
+    } else if (initials) {
+      const splitInitials = initials.split('').join(' ');
+      label = intl.translate('Polaris.Avatar.labelWithInitials', {
+        initials: splitInitials,
+      });
+    } else {
+      label = intl.translate('Polaris.Avatar.label');
+    }
+
+    if (source) {
+      finalSource = source;
+    } else if (customer) {
+      finalSource = customerPlaceholder(nameString);
+    }
+
+    const className = classNames(
+      styles.Avatar,
+      styles[variationName('style', styleClass(nameString))],
+      size && styles[variationName('size', size)],
+      hasImage && !hasLoaded && styles.hidden,
+      hasImage && styles.hasImage,
+    );
+
+    const imageMarkUp = finalSource ? (
+      <Image
+        className={styles.Image}
+        source={finalSource}
+        alt=""
+        role="presentation"
+        onLoad={this.handleLoad}
+        onError={this.handleError}
+      />
+    ) : null;
+
+    // Use `dominant-baseline: central` instead of `dy` when Edge supports it.
+    const verticalOffset = '0.35em';
+
+    const initialsMarkup =
+      initials && !hasImage ? (
+        <span className={styles.Initials}>
+          <svg className={styles.Svg} viewBox="0 0 48 48">
+            <text
+              x="50%"
+              y="50%"
+              dy={verticalOffset}
+              fill="currentColor"
+              fontSize="26"
+              textAnchor="middle"
+            >
+              {initials}
+            </text>
+          </svg>
+        </span>
+      ) : null;
+
+    return (
+      <span aria-label={label} role="img" className={className}>
+        {initialsMarkup}
+        {imageMarkUp}
+      </span>
+    );
   }
 
-  const className = classNames(
-    styles.Avatar,
-    styles[variationName('style', styleClass(nameString))],
-    size && styles[variationName('size', size)],
-    finalSource && styles.hasImage,
-  );
+  @autobind
+  handleError() {
+    this.setState({hasError: true, hasLoaded: false});
+  }
 
-  const imageMarkUp = finalSource ? (
-    <Image
-      className={styles.Image}
-      source={finalSource}
-      alt=""
-      role="presentation"
-    />
-  ) : null;
-
-  // Use `dominant-baseline: central` instead of `dy` when Edge supports it.
-  const verticalOffset = '0.35em';
-
-  const initialsMarkup = initials ? (
-    <span className={styles.Initials}>
-      <svg className={styles.Svg} viewBox="0 0 48 48">
-        <text
-          x="50%"
-          y="50%"
-          dy={verticalOffset}
-          fill="currentColor"
-          fontSize="26"
-          textAnchor="middle"
-        >
-          {initials}
-        </text>
-      </svg>
-    </span>
-  ) : null;
-
-  return (
-    <span aria-label={label} role="img" className={className}>
-      {initialsMarkup}
-      {imageMarkUp}
-    </span>
-  );
+  @autobind
+  handleLoad() {
+    this.setState({hasLoaded: true, hasError: false});
+  }
 }
 
 function styleClass(name?: string) {

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -29,7 +29,7 @@ export interface Props {
   initials?: string;
   /** Whether the avatar is for a customer */
   customer?: boolean;
-  /** URL of the avatar image */
+  /** URL of the avatar image which falls back to initials if the image fails to load */
   source?: string;
   /** Accessible label for the avatar image */
   accessibilityLabel?: string;

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -48,12 +48,13 @@ export class Avatar extends React.PureComponent<CombinedProps, State> {
     hasLoaded: false,
   };
 
-  ComponentDidUpdate({source: previousSource}: Props) {
+  componentDidUpdate({source: previousSource}: Props) {
     const {source} = this.props;
     const {hasError, hasLoaded} = this.state;
     if (previousSource === source || (!hasError && !hasLoaded)) {
       return;
     }
+    // eslint-disable-next-line react/no-did-update-set-state
     this.setState({hasError: false, hasLoaded: false});
   }
 

--- a/src/components/Avatar/tests/Avatar.test.tsx
+++ b/src/components/Avatar/tests/Avatar.test.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import {mountWithAppProvider, trigger} from 'test-utilities';
+import {Image} from 'components';
+import Avatar from '../Avatar';
+
+describe('<Avatar />', () => {
+  describe('intials', () => {
+    it('renders intials if the image is not provided ', () => {
+      const avatar = mountWithAppProvider(<Avatar initials="DL" />);
+      expect(avatar.find('span[role="img"] span svg')).toHaveLength(1);
+    });
+  });
+
+  describe('source', () => {
+    it('renders an Image component with the Avatar source if one is provided', () => {
+      const src = 'image/path/';
+      const avatar = mountWithAppProvider(<Avatar source={src} />);
+      const image = avatar.find(Image);
+      expect(image.prop('source')).toBe(src);
+    });
+  });
+
+  describe('customer', () => {
+    it('renders an Image component with a customer Avatar if the customer prop is true ', () => {
+      const avatar = mountWithAppProvider(<Avatar customer />);
+      const image = avatar.find(Image);
+      expect(image.prop('source')).toContain('avatar-');
+    });
+
+    it('does not render a customer Avatar if a source is provided', () => {
+      const src = 'image/path/';
+      const avatar = mountWithAppProvider(<Avatar customer source={src} />);
+      const image = avatar.find(Image);
+      expect(image.prop('source')).not.toContain('avatar-');
+    });
+  });
+
+  describe('on Error with Intials', () => {
+    it('renders initials if the Image onError prop is triggered and the Intials are provided.', () => {
+      const src = 'image/path/';
+      const avatar = mountWithAppProvider(
+        <Avatar size="large" initials="DL" source={src} />,
+      );
+      expect(avatar.find('span[role="img"] span svg')).toHaveLength(0);
+      trigger(avatar.find(Image), 'onError');
+      expect(avatar.find('span[role="img"] span svg')).toHaveLength(1);
+    });
+  });
+});

--- a/src/components/Avatar/tests/Avatar.test.tsx
+++ b/src/components/Avatar/tests/Avatar.test.tsx
@@ -5,7 +5,7 @@ import Avatar from '../Avatar';
 
 describe('<Avatar />', () => {
   describe('intials', () => {
-    it('renders intials if the image is not provided ', () => {
+    it('renders intials if the image is not provided', () => {
       const avatar = mountWithAppProvider(<Avatar initials="DL" />);
       expect(avatar.find('span[role="img"] span svg')).toHaveLength(1);
     });
@@ -18,10 +18,18 @@ describe('<Avatar />', () => {
       const image = avatar.find(Image);
       expect(image.prop('source')).toBe(src);
     });
+
+    it('safely updates', () => {
+      const src = 'image/path/';
+      const avatar = mountWithAppProvider(<Avatar source={src} />);
+      expect(() => {
+        avatar.setProps({source: 'image/new/path'});
+      }).not.toThrow();
+    });
   });
 
   describe('customer', () => {
-    it('renders an Image component with a customer Avatar if the customer prop is true ', () => {
+    it('renders an Image component with a customer Avatar if the customer prop is true', () => {
       const avatar = mountWithAppProvider(<Avatar customer />);
       const image = avatar.find(Image);
       expect(image.prop('source')).toContain('avatar-');
@@ -36,7 +44,7 @@ describe('<Avatar />', () => {
   });
 
   describe('on Error with Intials', () => {
-    it('renders initials if the Image onError prop is triggered and the Intials are provided.', () => {
+    it('renders initials if the Image onError prop is triggered and the Intials are provided', () => {
       const src = 'image/path/';
       const avatar = mountWithAppProvider(
         <Avatar size="large" initials="DL" source={src} />,
@@ -44,6 +52,41 @@ describe('<Avatar />', () => {
       expect(avatar.find('span[role="img"] span svg')).toHaveLength(0);
       trigger(avatar.find(Image), 'onError');
       expect(avatar.find('span[role="img"] span svg')).toHaveLength(1);
+    });
+  });
+
+  describe('on Load', () => {
+    it('safely triggers onLoad', () => {
+      const avatar = mountWithAppProvider(<Avatar source="image/path/" />);
+      expect(() => {
+        trigger(avatar.find(Image), 'onLoad');
+      }).not.toThrow();
+    });
+  });
+
+  describe('accessibilityLabel', () => {
+    it('is passed to the aria-label', () => {
+      const avatar = mountWithAppProvider(
+        <Avatar accessibilityLabel="Hello World" />,
+      );
+      expect(
+        avatar
+          .find('span')
+          .first()
+          .prop('aria-label'),
+      ).toBe('Hello World');
+    });
+  });
+
+  describe('name', () => {
+    it('is passed to the aria-label', () => {
+      const avatar = mountWithAppProvider(<Avatar name="Hello World" />);
+      expect(
+        avatar
+          .find('span')
+          .first()
+          .prop('aria-label'),
+      ).toBe('Hello World');
     });
   });
 });

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -11,6 +11,8 @@ export interface Props extends React.HTMLProps<HTMLImageElement> {
   alt: string;
   source: string;
   sourceSet?: SourceSet[];
+  onLoad?(): void;
+  onError?(): void;
 }
 
 export default function Image({

--- a/src/components/Image/tests/Image.test.tsx
+++ b/src/components/Image/tests/Image.test.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
-import {mountWithAppProvider} from 'test-utilities';
+import {mountWithAppProvider, trigger} from 'test-utilities';
 import Image from '../Image';
 
 describe('<Image />', () => {
-  describe('accessibilityLabel', () => {
+  describe('img attributes', () => {
     let src: string;
     let image: any;
 
     beforeAll(() => {
       src =
         'https://cdn.shopify.com/s/assets/admin/checkout/settings-customizecart-705f57c725ac05be5a34ec20c05b94298cb8afd10aac7bd9c7ad02030f48cfa0.svg';
-      image = mountWithAppProvider(<Image alt="alt text" source={src} />);
+      image = mountWithAppProvider(
+        <Image alt="alt text" source={src} crossOrigin="Anonymous" />,
+      );
     });
 
     it('renders the src', () => {
@@ -19,6 +21,34 @@ describe('<Image />', () => {
 
     it('renders the alt text', () => {
       expect(image.find('img').prop('alt')).toBe('alt text');
+    });
+
+    it('renders the crossOrigin', () => {
+      expect(image.find('img').prop('crossOrigin')).toBe('Anonymous');
+    });
+  });
+
+  describe('onError', () => {
+    it('calls the onError callback when the image onError is triggered', () => {
+      const spy = jest.fn();
+      const image = mountWithAppProvider(
+        <Image alt="alt text" source="404" onError={spy} />,
+      );
+
+      trigger(image.find('img'), 'onError');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onLoad', () => {
+    it('calls the onLoad callback when the image on onLoad is triggered', () => {
+      const spy = jest.fn();
+      const image = mountWithAppProvider(
+        <Image alt="alt text" source="/path/to/image" onLoad={spy} />,
+      );
+
+      trigger(image.find('img'), 'onLoad');
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/shopify/issues/174824

The default option we want for our Avatar component is to show the  logged in user initials if an avatar image is not found. Gravatar gives us the possibility of providing a default image when an image is not found or to return a 404. 

In this [pr](https://github.com/Shopify/web/pull/5377) we attempted to return a transparent image. This was done with the following option in the query:

```
avatar(fallback: TRANSPARENT) {
      src
    }
```

The idea being that if the fallback was a transparent image it would simply lay over the Initials and wouldn't be visible.

However the Initials are in circle coloured background. As a result when an image was present it would show through [pr](https://github.com/Shopify/polaris-react-deprecated/pull/1157)

### WHAT is this pull request doing?

This PR is taking the is relying on gravatar returning a 404.

```
avatar(fallback: NOT_FOUND) {
      src
    }
```

Both the Image component and Avatar component have an onError prop now. If an image requested returns a 404 the onError attribute of the image tag will trigger the onError and no image will be outputted.

This is one approach. Another approach would be to have web check for the image, or to have the graphQl return a boolean. identifying if the fall back was used. I see some benefits of making the change in Polaris as well as web. 

I'm putting up this PR for discussion on the approach. I will polish and update tests if we chose to go this route.



## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Avatar, Image, Stack} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        <Stack>
          <Avatar size="large" initials="DL" customer />
          <Avatar
            size="large"
            initials="DL"
            source="https://avatars2.githubusercontent.com/u/1229901?s=80&v=4"
          />
          <Avatar size="large" initials="DL" source="https://bla" />
        </Stack>
        <br />
        <Image
          alt="Just an image"
          source="https://avatars2.githubusercontent.com/u/1229901?s=80&v=4"
        />
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
