### PR TITLE
[Card] Rearrange primary & secondary footer actions

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -59,6 +59,7 @@ The autocomplete component is an input field that provides selectable suggestion
 - Fixed `RangeSlider` linear-gradient so it doesn't break the css build (thanks [@Ankitjasoliya](https://github.com/Ankitjasoliya) and [@nerfologist](https://github.com/nerfologist) for the [original issue](https://github.com/Shopify/polaris-react/issues/441))
 - Fixed issue in `Page`, where styling wasn't being applied correctly to Page Actions
 - Removed unnecessary bindings on `Modal`s `onClose` prop. [original issue](https://github.com/Shopify/polaris-react/issues/441))
+- Rearranged `primaryFooterAction` and `secondaryFooterAction` in `Card` (thanks [@sivakumar-kailasam](https://github.com/sivakumar-kailasam) for the [original issue](https://github.com/Shopify/polaris-react/issues/551))
 
 ### Breaking changes
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -67,8 +67,8 @@ export default class Card extends React.PureComponent<Props, never> {
       primaryFooterActionMarkup || secondaryFooterActionMarkup ? (
         <div className={styles.Footer}>
           <ButtonGroup>
-            {primaryFooterActionMarkup}
             {secondaryFooterActionMarkup}
+            {primaryFooterActionMarkup}
           </ButtonGroup>
         </div>
       ) : null;


### PR DESCRIPTION


<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves #551 <!-- link to issue if one exists -->
The existing implementation differs from all the other components having a primary & secondary button.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR rearranges the primary & secondary footer actions on the card component to their expected order.

Before:
<img width="968" alt="screenshot 2018-11-07 12 24 56" src="https://user-images.githubusercontent.com/604117/48115210-25a80c80-e288-11e8-9948-e74a77544df5.png">

After:
<img width="997" alt="screenshot 2018-11-07 12 24 30" src="https://user-images.githubusercontent.com/604117/48115214-2ccf1a80-e288-11e8-869e-101cf95deeed.png">
