### PR TITLE
Tophat updates

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -1,15 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <title>Playground</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <title>Playground</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script src="/assets/main.js"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script src="/assets/vendors.js"></script>
+    <script src="/assets/polaris.js"></script>
+    <script src="/assets/main.js"></script>
+  </body>
 </html>

--- a/playground/webpack.config.js
+++ b/playground/webpack.config.js
@@ -27,6 +27,31 @@ module.exports = {
     path: path.resolve(__dirname, 'build/assets'),
     publicPath: '/assets/',
   },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'vendors',
+          chunks: 'all',
+          priority: -20,
+        },
+        polaris: {
+          // test accepts a regex. The replace escapes any special characters
+          // in the path so they are treated literally
+          // see https://github.com/benjamingr/RegExp.escape/blob/master/polyfill.js
+          test: new RegExp(
+            path
+              .resolve(__dirname, '..', 'src')
+              .replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'),
+          ),
+          name: 'polaris',
+          priority: -15,
+          chunks: 'all',
+        },
+      },
+    },
+  },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.json'],
     modules: ['node_modules', path.resolve(__dirname, '..', 'src')],

--- a/playground/webpack.config.js
+++ b/playground/webpack.config.js
@@ -89,7 +89,6 @@ module.exports = {
             loader: 'url-loader',
             options: {
               limit: 10000,
-              emitFile: true,
             },
           },
         ],

--- a/playground/webpack.config.shrink-ray.js
+++ b/playground/webpack.config.shrink-ray.js
@@ -12,7 +12,7 @@ const IMAGE_PATH_REGEX = /\.(jpe?g|png|gif|svg)$/;
 module.exports = {
   target: 'web',
   mode: 'production',
-  devtool: 'eval',
+  devtool: 'source-map',
   stats: {warnings: false},
   entry: [
     '@shopify/polaris/styles/global.scss',
@@ -22,6 +22,31 @@ module.exports = {
     filename: '[name].js',
     path: path.resolve(__dirname, 'build/assets'),
     publicPath: '/assets/',
+  },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'vendors',
+          chunks: 'all',
+          priority: -20,
+        },
+        polaris: {
+          // test accepts a regex. The replace escapes any special characters
+          // in the path so they are treated literally
+          // see https://github.com/benjamingr/RegExp.escape/blob/master/polyfill.js
+          test: new RegExp(
+            path
+              .resolve(__dirname, '..', 'src')
+              .replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'),
+          ),
+          name: 'polaris',
+          priority: -15,
+          chunks: 'all',
+        },
+      },
+    },
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.json'],

--- a/scripts/build-shrink-ray.js
+++ b/scripts/build-shrink-ray.js
@@ -12,7 +12,7 @@ const sha = process.env.CIRCLE_SHA1;
 
 const postWebpackReportURL = `https://shrink-ray.shopifycloud.com/repos/${repo}/commits/${sha}/reports`;
 
-const build = resolve(__dirname, '..', 'playground/build');
+const build = resolve(__dirname, '..', 'tophat/build');
 const report = resolve(build, 'bundle-analysis', 'report.html');
 
 process.on('unhandledRejection', (reason) => {
@@ -29,10 +29,9 @@ if (sha) {
 }
 
 function buildPackages() {
-  execSync(
-    'yarn run webpack --config playground/webpack.config.shrink-ray.js',
-    {stdio: 'inherit'},
-  );
+  execSync('yarn run webpack --config tophat/webpack.config.shrink-ray.js', {
+    stdio: 'inherit',
+  });
 }
 
 function setupShrinkRay() {

--- a/tophat/Example.tsx
+++ b/tophat/Example.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
 import * as Polaris from '@shopify/polaris';
-import {parse} from '@babel/parser';
-import generate from '@babel/generator';
-import {transform} from '@babel/standalone';
 
 export interface ExampleProps {
   name: string;
@@ -17,11 +14,13 @@ export default function Example(props: ExampleProps) {
     tempScope.push(scope[scopeProp]);
   });
 
-  const ast = astFromCode(props.code);
-  const compiledCode = compileCode(scope, ast);
+  const code = props.code.replace(
+    'SCOPE_VARIABLES_PLACEHOLDER',
+    Object.keys(scope).join(', '),
+  );
 
   // eslint-disable-next-line no-eval
-  const Component = eval(compiledCode)(...tempScope);
+  const Component = eval(code)(...tempScope);
 
   return (
     <React.Fragment>
@@ -29,58 +28,4 @@ export default function Example(props: ExampleProps) {
       <Component />
     </React.Fragment>
   );
-}
-
-function astFromCode(code: string): File {
-  const ast = parse(code, {
-    sourceType: 'module',
-    plugins: ['jsx', 'classProperties', 'objectRestSpread'],
-  });
-
-  return ast;
-}
-
-function unicodeToChar(text: string) {
-  return text.replace(/\\u[\dA-F]{4}/gi, (match) => {
-    return String.fromCharCode(parseInt(match.replace(/\\u/g, ''), 16));
-  });
-}
-
-function compileCode(scope, ast) {
-  const code = generate(ast)
-    .code.replace(/;$/, '')
-    .replace(/\\\\/, '\\');
-
-  const rawCode = unicodeToChar(code);
-
-  const classPattern = /class (\w+) extends React.Component/g;
-  const classMatch = classPattern.exec(code);
-
-  if (classMatch) {
-    return transform(
-      `
-        ((${Object.keys(scope).join(', ')}, mountNode) => {
-          ${rawCode}
-          return ${classMatch[1]};
-        });
-      `,
-      {presets: ['es2015', 'react', ['stage-1', {decoratorsLegacy: true}]]},
-    ).code;
-  } else {
-    return transform(
-      `
-      ((${Object.keys(scope).join(', ')}, mountNode) => {
-        class Comp extends React.Component {
-          render() {
-            return (
-              ${rawCode}
-            );
-          }
-        }
-        return Comp;
-      });
-    `,
-      {presets: ['es2015', 'react', ['stage-1', {decoratorsLegacy: true}]]},
-    ).code;
-  }
 }

--- a/tophat/index.js
+++ b/tophat/index.js
@@ -17,7 +17,14 @@ const port = process.env.PORT || 3000;
 const codeExamples = readMarkDownFiles();
 
 function appMiddleware(req, res, next) {
-  const html = render([{path: '/assets/main.js'}], {codeExamples});
+  const html = render(
+    [
+      {path: '/assets/vendors.js'},
+      {path: '/assets/polaris.js'},
+      {path: '/assets/main.js'},
+    ],
+    {codeExamples},
+  );
 
   res.send(html);
   next();
@@ -37,6 +44,10 @@ if (argv.watch) {
 
   app.use((req, res, next) => buildPromise.then(next, next));
 }
+
+app.use('/favicon.ico', (req, res) => {
+  res.status(404).end();
+});
 
 app.use(
   '/assets/',

--- a/tophat/parseMarkdown.js
+++ b/tophat/parseMarkdown.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import glob from 'glob';
 import chalk from 'chalk';
 import grayMatter from 'gray-matter';
+import transpileExample from './transpileExample';
 
 const exampleForRegExp = /<!-- example-for: ([\w\s,]+) -->/u;
 
@@ -119,9 +120,12 @@ function parseCodeExamples(data, file) {
     const nameMatches = example.match(/(.)*/);
     const codeBlock = example.match(/```jsx(.|\n)*?```/g);
 
+    const hasName = nameMatches !== null;
+    const hasCodeBlock = codeBlock !== null;
+
     return {
-      name: nameMatches === null ? '' : nameMatches[0].trim(),
-      code: codeBlock === null ? '' : stripCodeBlock(codeBlock[0]),
+      name: hasName ? nameMatches[0].trim() : '',
+      code: hasCodeBlock ? transpileExample(stripCodeBlock(codeBlock[0])) : '',
     };
   });
 

--- a/tophat/transpileExample.js
+++ b/tophat/transpileExample.js
@@ -1,0 +1,69 @@
+import {parse} from '@babel/parser';
+import generate from '@babel/generator';
+import {transform} from '@babel/standalone';
+
+export default function transpileExample(string) {
+  const scope = {SCOPE_VARIABLES_PLACEHOLDER: ''};
+  const tempScope: Object[] = [];
+
+  Object.keys(scope).forEach((scopeProp) => {
+    tempScope.push(scope[scopeProp]);
+  });
+
+  const ast = astFromCode(string);
+  return transpiledCodeFromAst(scope, ast);
+}
+
+function astFromCode(code: string): File {
+  const ast = parse(code, {
+    sourceType: 'module',
+    plugins: ['jsx', 'classProperties', 'objectRestSpread'],
+  });
+
+  return ast;
+}
+
+function transpiledCodeFromAst(scope, ast) {
+  const code = generate(ast)
+    .code.replace(/;$/, '')
+    .replace(/\\\\/, '\\');
+
+  const rawCode = unicodeToChar(code);
+
+  const classPattern = /class (\w+) extends React.Component/g;
+  const classMatch = classPattern.exec(code);
+
+  if (classMatch) {
+    return transform(
+      `
+        ((${Object.keys(scope).join(', ')}, mountNode) => {
+          ${rawCode}
+          return ${classMatch[1]};
+        });
+      `,
+      {presets: ['es2015', 'react', ['stage-1', {decoratorsLegacy: true}]]},
+    ).code;
+  } else {
+    return transform(
+      `
+      ((${Object.keys(scope).join(', ')}, mountNode) => {
+        class Comp extends React.Component {
+          render() {
+            return (
+              ${rawCode}
+            );
+          }
+        }
+        return Comp;
+      });
+    `,
+      {presets: ['es2015', 'react', ['stage-1', {decoratorsLegacy: true}]]},
+    ).code;
+  }
+}
+
+function unicodeToChar(text: string) {
+  return text.replace(/\\u[\dA-F]{4}/gi, (match) => {
+    return String.fromCharCode(parseInt(match.replace(/\\u/g, ''), 16));
+  });
+}

--- a/tophat/webpack.config.js
+++ b/tophat/webpack.config.js
@@ -21,6 +21,31 @@ module.exports = {
     path: path.resolve(__dirname, 'build/assets'),
     publicPath: '/assets/',
   },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'vendors',
+          chunks: 'all',
+          priority: -20,
+        },
+        polaris: {
+          // test accepts a regex. The replace escapes any special characters
+          // in the path so they are treated literally
+          // see https://github.com/benjamingr/RegExp.escape/blob/master/polyfill.js
+          test: new RegExp(
+            path
+              .resolve(__dirname, '..', 'src')
+              .replace(/[\\^$*+?.()|[\]{}]/g, '\\$&'),
+          ),
+          name: 'polaris',
+          priority: -15,
+          chunks: 'all',
+        },
+      },
+    },
+  },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.json'],
     modules: ['node_modules', path.resolve(__dirname, '..', 'src')],

--- a/tophat/webpack.config.js
+++ b/tophat/webpack.config.js
@@ -93,7 +93,6 @@ module.exports = {
           {
             loader: 'awesome-typescript-loader',
             options: {
-              sourceMap: true,
               silent: true,
               useBabel: true,
               useCache: true,

--- a/tophat/webpack.config.shrink-ray.js
+++ b/tophat/webpack.config.shrink-ray.js
@@ -99,7 +99,6 @@ module.exports = {
             loader: 'url-loader',
             options: {
               limit: 10000,
-              emitFile: true,
             },
           },
         ],


### PR DESCRIPTION
### WHY are these changes introduced?

More tidying of playground / shrink-ray / tophat on the road to unification

### WHAT is this pull request doing?

* In tophat, compile examples as part of the markdown parsing stage. This means we don't need to include babel in our JS output, which knocks about 4mb off our total size.
* Enables code splitting for all three builds. This means we can easily see the size of polaris, without including overheads like react and application code.

### How to 🎩

Check playground, shrink-ray and `yarn tophat` all still work as expected.

Shrink ray changes are expected due to splitting out items. This does however make it obvious that Webpack 4 does dead code elimination by default so the shrink-ray size isn't representative of our total bundle size (long term this shall be fixed by a move to use sewing-kit to build the tophat environment, and using the shrink-ray build from that, which contains many modules).