### PR TITLE
Don't fail CI when PERCY_TOKEN is absent

### DIFF
--- a/tophat/snapshots.js
+++ b/tophat/snapshots.js
@@ -3,6 +3,16 @@ const puppeteer = require('puppeteer');
 const {Percy, FileSystemAssetLoader} = require('@percy/puppeteer');
 
 (async () => {
+  // If a build is from a forked repository, CircleCI does not pass environment
+  // environment variables into the build to prevent credential leakage.
+  // In that case, exit cleanly so the build does not fail.
+  // Once we start using @percy/puppeteer v1 this can be removed as it is
+  // checked within Percy. See https://github.com/percy/percy-puppeteer/pull/3
+  if (!process.env.PERCY_TOKEN) {
+    console.log('No PERCY_TOKEN provided. Skipping snapshots.');
+    process.exit();
+  }
+
   const percy = new Percy({
     loaders: [
       new FileSystemAssetLoader({


### PR DESCRIPTION

### WHY are these changes introduced?

Partial fix for #565

### WHAT is this pull request doing?

Ensures PERCY_TOKEN is set before running snapshots

### Tophat

This PR is from a forked repo. Ensure that the "ci/circleci: percy" build step passes as a no-op.