### PR TITLE
Bump javascript-utilities to 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
   "dependencies": {
     "@shopify/app-bridge": "^0.7.3",
     "@shopify/images": "^1.1.0",
-    "@shopify/javascript-utilities": "^2.2.0",
+    "@shopify/javascript-utilities": "^2.2.1",
     "@shopify/polaris-tokens": "^1.2.0",
     "@shopify/react-compose": "^0.1.6",
     "@shopify/react-html": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,10 +288,10 @@
     lodash "^4.17.4"
     lodash-decorators "^4.3.5"
 
-"@shopify/javascript-utilities@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@shopify/javascript-utilities/-/javascript-utilities-2.2.0.tgz#948d44d4068d602136b0d72de66eed49820e2374"
-  integrity sha512-TdHeNyAva/GayAF9NzAO+AZiM3d6SDhtK8WqOCbvEz9mwTGAL8FHHHwITvs/HUUuuFPZwAVm+0GZnwMURSxisQ==
+"@shopify/javascript-utilities@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@shopify/javascript-utilities/-/javascript-utilities-2.2.1.tgz#7f699d414d2784d176e5d8d6ba1113e0838086e6"
+  integrity sha512-szqIv9Sg7IJ3M/6uBh+yDvaaQ1wUAoBTx60I+hExnI3WhaRz03FQK+jnR3eNoisRZFmbsglxVVYUHJHlZoSvqQ==
   dependencies:
     "@types/lodash" "^4.14.65"
     "@types/react" "^16.0.2"


### PR DESCRIPTION
Bump [`@shopify/javascript-utilities`](https://github.com/Shopify/javascript-utilities/) to 2.2.1 

It fixes specific usecase of Datepicker when `start` and `end` date are the same but different references.

Here is the fix commit: https://github.com/Shopify/javascript-utilities/commit/86f8a7ccb63e322bfc087450e3b8e5c9e72e9c55
It will help https://github.com/Shopify/web/pull/8192 to move forward.