### PR TITLE
[Autocomplete] Fix section break placement in README

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed `Autocomplete` empty state example Markdown not parsing correctly ([#592](https://github.com/Shopify/polaris-react/pull/592))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Autocomplete/README.md
+++ b/src/components/Autocomplete/README.md
@@ -300,8 +300,6 @@ class AutocompleteExample extends React.Component {
 }
 ```
 
----
-
 ### Autocomplete with empty state
 
 Use to indicate there are no search results.
@@ -393,6 +391,8 @@ class AutocompleteExample extends React.Component {
   };
 }
 ```
+
+---
 
 ## Related components
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Closes #590 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Fixes misplacement of the Markdown horizontal rule so that the last example gets parsed properly.

| Before        | After           |
| ------------- |:-------------:|
|![2018-11-09 13 48 13](https://user-images.githubusercontent.com/18447883/48292774-bae60500-e430-11e8-8f2d-e2b015cc67e5.gif)|![2018-11-09 13 51 08](https://user-images.githubusercontent.com/18447883/48292789-cafde480-e430-11e8-8987-a3feb4ce3f68.gif)|

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

- `git checkout fix-autocomplete-readme && yarn run build-consumer polaris-styleguide`
- The empty state example should parse properly and be listed as the last option in the Examples select input.

### 🎩 checklist

* [x] Tested in the style guide
* [x] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
