### PR TITLE
[Autocomplete] Move props into their own variables in examples

### DIFF
--- a/src/components/Autocomplete/README.md
+++ b/src/components/Autocomplete/README.md
@@ -55,21 +55,22 @@ class AutocompleteExample extends React.Component {
   };
 
   render() {
+    const textField = (
+      <Autocomplete.TextField
+        onChange={this.updateText}
+        label=""
+        value={this.state.inputText}
+        prefix={<Icon source="search" color="inkLighter" />}
+        placeholder="Search"
+      />
+    );
     return (
       <div style={{height: '225px'}}>
         <Autocomplete
           options={this.state.options}
           selected={this.state.selected}
           onSelect={this.updateSelection}
-          textField={
-            <Autocomplete.TextField
-              onChange={this.updateText}
-              label=""
-              value={this.state.inputText}
-              prefix={<Icon source="search" color="inkLighter" />}
-              placeholder="Search"
-            />
-          }
+          textField={textField}
         />
       </div>
     );
@@ -130,6 +131,14 @@ class MultiAutocompleteExample extends React.Component {
   };
 
   render() {
+    const textField = (
+      <Autocomplete.TextField
+        onChange={this.updateText}
+        label=""
+        value={this.state.inputText}
+        placeholder="Vintage, cotton, summer"
+      />
+    );
     return (
       <div style={{height: '325px'}}>
         <TextContainer>
@@ -140,14 +149,7 @@ class MultiAutocompleteExample extends React.Component {
           allowMultiple
           options={this.state.options}
           selected={this.state.selected}
-          textField={
-            <Autocomplete.TextField
-              onChange={this.updateText}
-              label=""
-              value={this.state.inputText}
-              placeholder="Vintage, cotton, summer"
-            />
-          }
+          textField={textField}
           onSelect={this.updateSelection}
           listTitle="Suggested Tags"
         />
@@ -238,6 +240,15 @@ class AutocompleteExample extends React.Component {
   };
 
   render() {
+    const textField = (
+      <Autocomplete.TextField
+        onChange={this.updateText}
+        label=""
+        value={this.state.inputText}
+        prefix={<Icon source="search" color="inkLighter" />}
+        placeholder="Search"
+      />
+    );
     return (
       <div style={{height: '225px'}}>
         <Autocomplete
@@ -245,15 +256,7 @@ class AutocompleteExample extends React.Component {
           selected={this.state.selected}
           onSelect={this.updateSelection}
           loading={this.state.loading}
-          textField={
-            <Autocomplete.TextField
-              onChange={this.updateText}
-              label=""
-              value={this.state.inputText}
-              prefix={<Icon source="search" color="inkLighter" />}
-              placeholder="Search"
-            />
-          }
+          textField={textField}
         />
       </div>
     );
@@ -322,30 +325,32 @@ class AutocompleteExample extends React.Component {
   };
 
   render() {
+    const textField = (
+      <Autocomplete.TextField
+        onChange={this.updateText}
+        label=""
+        value={this.state.inputText}
+        prefix={<Icon source="search" color="inkLighter" />}
+        placeholder="Search"
+      />
+    );
+    const emptyState = (
+      <React.Fragment>
+        <Icon source="search" />
+        <div style={{textAlign: 'center'}}>
+          <TextContainer>Could not find any results</TextContainer>
+        </div>
+      </React.Fragment>
+    );
     return (
       <div style={{height: '225px'}}>
         <Autocomplete
           options={this.state.options}
           selected={this.state.selected}
           onSelect={this.updateSelection}
-          emptyState={
-            <React.Fragment>
-              <Icon source="search" />
-              <div style={{textAlign: 'center'}}>
-                <TextContainer>Could not find any results</TextContainer>
-              </div>
-            </React.Fragment>
-          }
+          emptyState={emptyState}
           loading={this.state.loading}
-          textField={
-            <Autocomplete.TextField
-              onChange={this.updateText}
-              label=""
-              value={this.state.inputText}
-              prefix={<Icon source="search" color="inkLighter" />}
-              placeholder="Search"
-            />
-          }
+          textField={textField}
         />
       </div>
     );


### PR DESCRIPTION
### WHY are these changes introduced?

Partly addresses https://github.com/Shopify/polaris-react/issues/590 and addresses [these comments](https://github.com/Shopify/polaris-react/pull/503#discussion_r230201606).

### WHAT is this pull request doing?

Moves `textField` and `emptyState` markup into their own variables in the README examples. 

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

- `yarn run build-consumer polaris-styleguide`

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
