### PR TITLE
[DatePicker] Fix date comparision when different references

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed `Datepicker` ranges when `start` and `end` dates are similar but have different references ([#601](https://github.com/Shopify/polaris-react/pull/601))
 - Fixed `DataTable` fixed column in production enviroments by using a data-attribute target instead of class based targeting ([#615](https://github.com/Shopify/polaris-react/pull/615))
 - Fixed `Navigation.Item` not calling `onClick` on small screens when `onNavigationDismiss` is undefined ([#603](https://github.com/Shopify/polaris-react/pull/603))
 - Fixed `Autocomplete` empty state example Markdown not parsing correctly ([#592](https://github.com/Shopify/polaris-react/pull/592))

--- a/src/components/DatePicker/components/Month/Month.tsx
+++ b/src/components/DatePicker/components/Month/Month.tsx
@@ -142,7 +142,7 @@ function hoveringDateIsInRange(
     return false;
   }
   const {start, end} = range;
-  return Boolean(start === end && day > start && day <= hoverEndDate);
+  return Boolean(isSameDay(start, end) && day > start && day <= hoverEndDate);
 }
 
 function getWeekdaysOrdered(weekStartsOn: Weekdays): Weekdays[] {

--- a/src/components/DatePicker/components/Month/tests/Month.test.tsx
+++ b/src/components/DatePicker/components/Month/tests/Month.test.tsx
@@ -3,6 +3,7 @@ import {Weekdays} from '@shopify/javascript-utilities/dates';
 import {mountWithAppProvider} from 'test-utilities';
 import {Weekday} from '../..';
 import Month from '../Month';
+import Day from '../../Day';
 
 describe('<Month />', () => {
   describe('title', () => {
@@ -64,6 +65,28 @@ describe('<Month />', () => {
           .first()
           .prop('current'),
       ).toBe(false);
+    });
+  });
+
+  describe('with allowRange prop to true', () => {
+    it('range can be created even if start and end have different references', () => {
+      const hoverDate = new Date('05 Jan 2018 00:00:00 GMT');
+      const month = mountWithAppProvider(
+        <Month
+          month={0}
+          year={2018}
+          weekStartsOn={Weekdays.Monday}
+          allowRange
+          hoverDate={hoverDate}
+          selected={{
+            start: new Date('01 Jan 2018 00:00:00 GMT'),
+            end: new Date('01 Jan 2018 00:00:00 GMT'),
+          }}
+        />,
+      );
+
+      expect(month.find(Day).get(2).props.inHoveringRange).toBeTruthy();
+      expect(month.find(Day).get(10).props.inHoveringRange).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

When DatePicker allow ranges but `start` and `end` dates are different references `start === end` will return false even if they are the same date.

### WHAT is this pull request doing?

Compare date instead of references.

### How to 🎩

Best way to tophat is to try this PR with and without the changes:
https://github.com/Shopify/web/pull/8192

Before: 

![before](https://user-images.githubusercontent.com/445045/48356440-44c9e400-e664-11e8-8a44-2545b8e24578.gif)


After:

![after](https://user-images.githubusercontent.com/445045/48356366-1815cc80-e664-11e8-92fe-1af41a44d35f.gif)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
