### PR TITLE
[Popover] Fix inconsistent border-radius

### DIFF
--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -49,14 +49,14 @@ $content-max-width: rem(400px);
   position: relative;
   overflow: hidden;
   background-color: color('white');
-  border-radius: border-radius(large);
+  border-radius: border-radius();
 }
 
 .Content {
   position: relative;
   display: flex;
   flex-direction: column;
-  border-radius: border-radius(large);
+  border-radius: border-radius();
   max-width: $content-max-width;
   max-height: $content-max-height;
 


### PR DESCRIPTION
A quick ~one~ two-liner.

I noticed that the `border-radius` for `<Popover />` was funky, and tracked it down to inconsistent `border-radius` values.

This PR resolves the visual issue.

### Before

Here you can see some of the `Popover` background poking through in the top left and right corner:

<img width="271" alt="before" src="https://user-images.githubusercontent.com/643944/48427479-cbe78c80-e736-11e8-8113-b20d5df5980b.png">


### After

Top corners now resolved:

<img width="273" alt="after" src="https://user-images.githubusercontent.com/643944/48427495-d4d85e00-e736-11e8-845f-369ad67d025f.png">
