### PR TITLE
[TextStyle] Change <b> to <span>

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `Navigation.Item` not calling `onClick` on small screens when `onNavigationDismiss` is undefined ([#603](https://github.com/Shopify/polaris-react/pull/603))
 - Fixed `Autocomplete` empty state example Markdown not parsing correctly ([#592](https://github.com/Shopify/polaris-react/pull/592))
 - Removed erroneous scss file import that rendered Polaris unable to be used in typescript projects without scss support ([#609](https://github.com/Shopify/polaris-react/pull/609))
+- Fixed `Popover` inconsistent `border-radius` values ([#605](https://github.com/Shopify/polaris-react/pull/605))
+- `TextStyle` "strong" variant now uses a `span` tag instead of `b` ([#606](https://github.com/Shopify/polaris-react/pull/606))
 
 ### Documentation
 

--- a/src/components/TextStyle/TextStyle.tsx
+++ b/src/components/TextStyle/TextStyle.tsx
@@ -25,19 +25,10 @@ export default function TextStyle({variation, children}: Props) {
     variation === VariationValue.Code && styles.code,
   );
   const Element = variationElement(variation);
+
   return <Element className={className}>{children}</Element>;
 }
 
 function variationElement(variation?: Variation) {
-  switch (variation) {
-    case VariationValue.Code:
-      return 'code';
-    case VariationValue.Strong:
-      return 'b';
-    case VariationValue.Positive:
-    case VariationValue.Negative:
-    case VariationValue.Subdued:
-    default:
-      return 'span';
-  }
+  return variation === VariationValue.Code ? 'code' : 'span';
 }

--- a/src/components/TextStyle/tests/TextStyle.test.tsx
+++ b/src/components/TextStyle/tests/TextStyle.test.tsx
@@ -43,17 +43,17 @@ describe('<TextStyle />', () => {
     expect(textStyle.find('span')).toHaveLength(1);
   });
 
+  it('renders a span tag when the strong variant is provided', () => {
+    const textStyle = mountWithAppProvider(
+      <TextStyle variation="strong">Hello Polaris</TextStyle>,
+    );
+    expect(textStyle.find('span')).toHaveLength(1);
+  });
+
   it('renders a code tag when the code variant is provided', () => {
     const textStyle = mountWithAppProvider(
       <TextStyle variation="code">Hello Polaris</TextStyle>,
     );
     expect(textStyle.find('code')).toHaveLength(1);
-  });
-
-  it('renders a strong tag when the strong variant is provided', () => {
-    const textStyle = mountWithAppProvider(
-      <TextStyle variation="strong">Hello Polaris</TextStyle>,
-    );
-    expect(textStyle.find('b')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
~`<b>` tags have gone the way of powdered wigs. Out with the old, in with the new. `TextStyle > strong` now uses a `<strong>` tag!~

We do not want to use `b` for "strong" variants... so using `span` tag instead.