### PR TITLE
Use 'import * as styles' format for all imports

### DIFF
--- a/src/components/EmptySearchResult/EmptySearchResult.tsx
+++ b/src/components/EmptySearchResult/EmptySearchResult.tsx
@@ -7,7 +7,7 @@ import Image from '../Image';
 import Stack from '../Stack';
 
 import emptySearch from './illustrations/empty-search.svg';
-import styles from './EmptySearchResult.scss';
+import * as styles from './EmptySearchResult.scss';
 
 export interface Props {
   title: string;

--- a/src/components/Navigation/components/Item/components/Secondary/Secondary.tsx
+++ b/src/components/Navigation/components/Item/components/Secondary/Secondary.tsx
@@ -3,7 +3,7 @@ import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 
 import Collapsible from '../../../../../Collapsible';
 
-import styles from '../../../../Navigation.scss';
+import * as styles from '../../../../Navigation.scss';
 
 const createSecondaryNavigationId = createUniqueIDFactory(
   'SecondaryNavigation',

--- a/src/components/Navigation/components/Message/Message.tsx
+++ b/src/components/Navigation/components/Message/Message.tsx
@@ -7,7 +7,7 @@ import Link from '../../../Link';
 import Stack from '../../../Stack';
 import TextContainer from '../../../TextContainer';
 
-import styles from './Message.scss';
+import * as styles from './Message.scss';
 
 export interface Props {
   title: string;

--- a/src/components/TopBar/components/Menu/Menu.tsx
+++ b/src/components/TopBar/components/Menu/Menu.tsx
@@ -4,7 +4,7 @@ import ActionList, {Props as ActionListProps} from '../../../ActionList';
 import Popover from '../../../Popover';
 
 import {Message, MessageProps} from './components';
-import styles from './Menu.scss';
+import * as styles from './Menu.scss';
 
 export interface Props {
   /** Accepts an activator component that renders inside of a button that opens the menu */

--- a/src/components/TopBar/components/Menu/components/Message/Message.tsx
+++ b/src/components/TopBar/components/Menu/components/Message/Message.tsx
@@ -8,7 +8,7 @@ import Popover from '../../../../../Popover';
 import Stack from '../../../../../Stack';
 import TextContainer from '../../../../../TextContainer';
 
-import styles from './Message.scss';
+import * as styles from './Message.scss';
 
 export interface Props {
   title: string;

--- a/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -6,7 +6,7 @@ import MessageIndicator from '../../../MessageIndicator';
 
 import Menu, {MessageProps} from '../Menu';
 
-import styles from './UserMenu.scss';
+import * as styles from './UserMenu.scss';
 
 export interface Props {
   /** An array of action objects that are rendered inside of a popover triggered by this menu */


### PR DESCRIPTION
### WHY are these changes introduced?

Using a consistent format form importing styles

### WHAT is this pull request doing?

Changes some instances of `import styles from 'blah.scss'` to `import * as styles from 'blah.scss'`.

Honestly I'm suprised this ever worked in the first place.

### How to 🎩

Ensure the `Frame` tophat example keeps its styling for the affected components.

Compare the build output by comparing master to this PR

* Checkout master and run `yarn build && yarn mv build build-master`
* Checkout this branch and run `yarn build && diff -r -u build-master build` to compare the build folders. The sass zip is expected to be different (as it includes metadata on file modified times, which differ between the builds). Assert that no other changes in the JS or css files occur.