### PR TITLE
[DataTable] Update class targeting to data attribute targeting

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed `DataTable` fixed column in production enviroments by using a data-attribute target instead of class based targeting ([#615](https://github.com/Shopify/polaris-react/pull/615))
 - Fixed `Navigation.Item` not calling `onClick` on small screens when `onNavigationDismiss` is undefined ([#603](https://github.com/Shopify/polaris-react/pull/603))
 - Fixed `Autocomplete` empty state example Markdown not parsing correctly ([#592](https://github.com/Shopify/polaris-react/pull/592))
 - Fixed `TopBar`’s `UserMenu` alignment so it is now right-aligned when `TopBar` isn't passed a `searchField` prop ([#597](https://github.com/Shopify/polaris-react/pull/597))

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -10,6 +10,7 @@ import {measureColumn, getPrevAndCurrentColumns} from './utilities';
 import {Cell, CellProps, Navigation} from './components';
 
 import * as styles from './DataTable.scss';
+import {headerCell} from 'components/shared';
 
 export type CombinedProps = Props & WithAppProviderProps;
 export type TableRow = Props['headings'] | Props['rows'] | Props['totals'];
@@ -328,7 +329,7 @@ export class DataTable extends React.PureComponent<CombinedProps, State> {
     } = this;
     if (collapsed && table && scrollContainer && dataTable) {
       const headerCells = table.querySelectorAll(
-        '[data-polaris-headercell]',
+        headerCell.selector,
       ) as NodeListOf<HTMLElement>;
       const collapsedHeaderCells = Array.from(headerCells).slice(1);
       const fixedColumnWidth = headerCells[0].offsetWidth;

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -328,7 +328,7 @@ export class DataTable extends React.PureComponent<CombinedProps, State> {
     } = this;
     if (collapsed && table && scrollContainer && dataTable) {
       const headerCells = table.querySelectorAll(
-        '[class*=header]',
+        '[data-polaris-headercell]',
       ) as NodeListOf<HTMLElement>;
       const collapsedHeaderCells = Array.from(headerCells).slice(1);
       const fixedColumnWidth = headerCells[0].offsetWidth;

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -3,11 +3,10 @@ import {autobind, debounce} from '@shopify/javascript-utilities/decorators';
 import {classNames} from '@shopify/react-utilities/styles';
 import isEqual from 'lodash/isEqual';
 
+import {Cell, CellProps, Navigation} from './components';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import EventListener from '../EventListener';
 import {measureColumn, getPrevAndCurrentColumns} from './utilities';
-
-import {Cell, CellProps, Navigation} from './components';
 
 import * as styles from './DataTable.scss';
 import {headerCell} from 'components/shared';

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -3,13 +3,13 @@ import {autobind, debounce} from '@shopify/javascript-utilities/decorators';
 import {classNames} from '@shopify/react-utilities/styles';
 import isEqual from 'lodash/isEqual';
 
-import {Cell, CellProps, Navigation} from './components';
+import {headerCell} from 'components/shared';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import EventListener from '../EventListener';
+import {Cell, CellProps, Navigation} from './components';
 import {measureColumn, getPrevAndCurrentColumns} from './utilities';
 
 import * as styles from './DataTable.scss';
-import {headerCell} from 'components/shared';
 
 export type CombinedProps = Props & WithAppProviderProps;
 export type TableRow = Props['headings'] | Props['rows'] | Props['totals'];

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -99,6 +99,7 @@ function Cell({
 
   const headingMarkup = header ? (
     <th
+      data-polaris-headercell
       className={className}
       scope="col"
       aria-sort={sortDirection}

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 
+import {headerCell} from 'components/shared';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 import Icon, {IconSource} from '../../../Icon';
 import {SortDirection} from '../../DataTable';
@@ -99,7 +100,7 @@ function Cell({
 
   const headingMarkup = header ? (
     <th
-      data-polaris-header-cell
+      {...headerCell.props}
       className={className}
       scope="col"
       aria-sort={sortDirection}

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -99,7 +99,7 @@ function Cell({
 
   const headingMarkup = header ? (
     <th
-      data-polaris-headercell
+      data-polaris-header-cell
       className={className}
       scope="col"
       aria-sort={sortDirection}

--- a/src/components/shared.ts
+++ b/src/components/shared.ts
@@ -23,6 +23,11 @@ export const dataPolarisTopBar = {
   selector: '[data-polaris-top-bar]',
 };
 
+export const headerCell = {
+  props: {'data-polaris-header-cell': true},
+  selector: '[data-polaris-header-cell]',
+};
+
 // these match our values in duration.scss
 export enum Duration {
   Instant = 0,


### PR DESCRIPTION
### Problem

Currently, our DataTable looks for `class*=header` when calculating column visibility. This doesn't work in a production environment where class names are obfuscated, hence this working in a development environment, but not a production environment like an embedded app.

### Solution
This PR changes the way we target the `headerCells`, from the class-based targeting mentioned above to a data attribute system using `data-polaris-headercell`.

#### Alternative solution
The other option here would be to use `refs` instead of data attributes, but with `Cell` being a subcomponent inside of `DataTable`, we would need to do a ref callback, and that seemed like more trouble than what it was worth.

### How to 🔝 👒 

 - Load up the `DataTable` component with some dummy data
 - Make sure classes are obfuscated in the DOM
 - Confirm that the fixed column works, and there is no `offsetWidth` error in the console

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

