### PR TITLE
[EventListener] Remove deprecated lifecycle method

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- `EventListener` no longer uses `componentWillUpdate` ([#628](https://github.com/Shopify/polaris-react/pull/628))
 - Allowed `Icon` to accept a React Node as a source ([#635](https://github.com/Shopify/polaris-react/pull/635)) (thanks to [@mbriggs](https://github.com/mbriggs) for the [original issue](https://github.com/Shopify/polaris-react/issues/449))
 
 ### Bug fixes

--- a/src/components/EventListener/EventListener.tsx
+++ b/src/components/EventListener/EventListener.tsx
@@ -4,11 +4,14 @@ import {
   removeEventListener,
 } from '@shopify/javascript-utilities/events';
 
-export interface Props {
+export interface BaseEventProps {
   event: string;
   capture?: boolean;
-  passive?: boolean;
   handler(event: Event): void;
+}
+
+export interface Props extends BaseEventProps {
+  passive?: boolean;
 }
 
 // see https://github.com/oliviertassinari/react-event-listener/
@@ -17,12 +20,8 @@ export default class EventListener extends React.PureComponent<Props, never> {
     this.attachListener();
   }
 
-  // eslint-disable-next-line react/no-deprecated
-  componentWillUpdate() {
-    this.detachListener();
-  }
-
-  componentDidUpdate() {
+  componentDidUpdate({passive, ...detachProps}: Props) {
+    this.detachListener(detachProps);
     this.attachListener();
   }
 
@@ -39,8 +38,8 @@ export default class EventListener extends React.PureComponent<Props, never> {
     addEventListener(window, event, handler, {capture, passive});
   }
 
-  private detachListener() {
-    const {event, handler, capture} = this.props;
+  private detachListener(prevProps?: BaseEventProps) {
+    const {event, handler, capture} = prevProps || this.props;
     removeEventListener(window, event, handler, capture);
   }
 }

--- a/src/components/EventListener/tests/EventListener.test.tsx
+++ b/src/components/EventListener/tests/EventListener.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
+import {noop} from '@shopify/javascript-utilities/other';
 import EventListener from '../EventListener';
 
 describe('<EventListener />', () => {
@@ -13,6 +14,16 @@ describe('<EventListener />', () => {
   it('does not call handler when a different event is fired', () => {
     const spy = jest.fn();
     mountWithAppProvider(<EventListener event="click" handler={spy} />);
+    window.dispatchEvent(new Event('resize'));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('removes listener on update', () => {
+    const spy = jest.fn();
+    const eventListener = mountWithAppProvider(
+      <EventListener event="resize" handler={spy} />,
+    );
+    eventListener.setProps({event: 'scroll', handler: noop});
     window.dispatchEvent(new Event('resize'));
     expect(spy).not.toHaveBeenCalled();
   });

--- a/src/components/EventListener/tests/EventListener.test.tsx
+++ b/src/components/EventListener/tests/EventListener.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import {mountWithAppProvider} from 'test-utilities';
 import {noop} from '@shopify/javascript-utilities/other';
+import {mountWithAppProvider} from 'test-utilities';
 import EventListener from '../EventListener';
 
 describe('<EventListener />', () => {


### PR DESCRIPTION
### WHY are these changes introduced?
Part of https://github.com/Shopify/polaris-react/issues/519

### WHAT is this pull request doing?
* Replaces lifecycle method
* Add test

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, AppProvider, Button, EventListener} from '@shopify/polaris';

interface State {
  event: 'resize' | 'scroll';
}

export default class CollapsibleExample extends React.Component<never, State> {
  state: State = {
    event: 'resize',
  };

  render() {
    const {event} = this.state;
    const lines = Array.from({length: 100}, (n: number) => <br key={n} />);

    return (
      <AppProvider>
        <Page title="test">
          <EventListener event={event} handler={() => console.log(event)} />
          <Button onClick={this.handleToggleClick}>
            Current listener {event}
            <br />
            Previous listener {this.getEvent()}
          </Button>
          {lines}
        </Page>
      </AppProvider>
    );
  }

  handleToggleClick = () => {
    this.setState({event: this.getEvent()});
  };

  getEvent() {
    const {event} = this.state;
    return event === 'scroll' ? 'resize' : 'scroll';
  }
}
```

</details>

