### PR TITLE
[TextField] Remove deprecated lifecycle method

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,7 +6,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-- `EventListener` no longer uses `componentWillUpdate` ([#628](https://github.com/Shopify/polaris-react/pull/628))
+- `TextField` no longer uses `componentWillReceiveProps`([#628](https://github.com/Shopify/polaris-react/pull/628))
+- EventListener`no longer uses`componentWillUpdate` ([#628](https://github.com/Shopify/polaris-react/pull/628))
 - Allowed `Icon` to accept a React Node as a source ([#635](https://github.com/Shopify/polaris-react/pull/635)) (thanks to [@mbriggs](https://github.com/mbriggs) for the [original issue](https://github.com/Shopify/polaris-react/issues/449))
 
 ### Bug fixes

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -115,6 +115,10 @@ export type Props = NonMutuallyExclusiveProps &
 const getUniqueID = createUniqueIDFactory('TextField');
 
 export default class TextField extends React.PureComponent<Props, State> {
+  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+    return {id: nextProps.id || prevState.id};
+  }
+
   private input: HTMLElement;
 
   constructor(props: Props) {
@@ -135,13 +139,6 @@ export default class TextField extends React.PureComponent<Props, State> {
     ) {
       this.input.focus();
     }
-  }
-
-  // eslint-disable-next-line react/no-deprecated
-  componentWillReceiveProps(newProps: Props) {
-    this.setState((prevState) => ({
-      id: newProps.id || prevState.id,
-    }));
   }
 
   render() {

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -124,12 +124,21 @@ describe('<TextField />', () => {
       expect(id).toBeTruthy();
     });
 
-    it('updates with new id from props', () => {
+    it('updates with the new id from props', () => {
       const id = 'input field';
       const textField = mountWithAppProvider(
         <TextField label="TextField" onChange={noop} />,
       );
       textField.setProps({id});
+      expect(textField.find('input').prop('id')).toBe(id);
+    });
+
+    it('updates with the previous id after the id prop has been removed', () => {
+      const id = 'input field';
+      const textField = mountWithAppProvider(
+        <TextField label="TextField" id={id} onChange={noop} />,
+      );
+      textField.setProps({});
       expect(textField.find('input').prop('id')).toBe(id);
     });
   });

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -123,6 +123,15 @@ describe('<TextField />', () => {
       expect(typeof id).toBe('string');
       expect(id).toBeTruthy();
     });
+
+    it('updates with new id from props', () => {
+      const id = 'input field';
+      const textField = mountWithAppProvider(
+        <TextField label="TextField" onChange={noop} />,
+      );
+      textField.setProps({id});
+      expect(textField.find('input').prop('id')).toBe(id);
+    });
   });
 
   describe('autoComplete', () => {


### PR DESCRIPTION
### WHY are these changes introduced?
Part of https://github.com/Shopify/polaris-react/issues/519

### WHAT is this pull request doing?
* Replaces lifecycle method
* Add test

### How to 🎩
Add a `console.log` to textfield render to check it's current id during render. Check the console, onChange will trigger the id switch.
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {TextField} from '@shopify/polaris';

interface State {
  id: string | undefined;
}

export default class TextFieldExample extends React.Component {
  state = {
    id: undefined,
  };

  handleChange = () => {
    this.setState(({id}) => ({
      id: id
        ? undefined
        : Math.random()
            .toString(36)
            .substring(7),
    }));
  };

  render() {
    const {id} = this.state;
    const props = {
      label: 'Store name',
      value: '',
      onChange: this.handleChange,
      id,
    };
    console.log(`Current id: ${id}`);
    return <TextField {...props} />;
  }
}
```

</details>

