### PR TITLE
[Icon] updating source prop to accept a react node

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Allowed `Icon` to accept a React Node as a source ([#635](https://github.com/Shopify/polaris-react/pull/635)) (thanks to [@mbriggs](https://github.com/mbriggs) for the [original issue](https://github.com/Shopify/polaris-react/issues/449))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -161,9 +161,15 @@ const COLORS_WITH_BACKDROPS = [
   'inkLighter',
 ];
 
-export type IconSource = SVGSource | 'placeholder' | keyof typeof BUNDLED_ICONS;
+export type BundledIcon = keyof typeof BUNDLED_ICONS;
+
+export type IconSource =
+  | React.ReactNode
+  | SVGSource
+  | 'placeholder'
+  | BundledIcon;
 export interface Props {
-  /** The SVG contents to display in the icon */
+  /** The SVG contents to display in the icon. Icons should be in a 20 X 20 pixel viewbox */
   source: IconSource;
   /** Sets the color for the SVG fill */
   color?: Color;
@@ -200,12 +206,15 @@ function Icon({
   );
 
   let contentMarkup: React.ReactNode;
-
   if (source === 'placeholder') {
     contentMarkup = <div className={styles.Placeholder} />;
+  } else if (React.isValidElement(source)) {
+    contentMarkup = source;
   } else {
     const iconSource =
-      typeof source === 'string' ? BUNDLED_ICONS[source] : source;
+      typeof source === 'string' && isBundledIcon(source)
+        ? BUNDLED_ICONS[source]
+        : source;
     contentMarkup = iconSource &&
       iconSource.viewBox &&
       iconSource.body && (
@@ -224,6 +233,10 @@ function Icon({
       {contentMarkup}
     </span>
   );
+}
+
+function isBundledIcon(key: string | BundledIcon): key is BundledIcon {
+  return Object.keys(BUNDLED_ICONS).includes(key);
 }
 
 export default withAppProvider<Props>()(Icon);

--- a/src/components/Icon/tests/Icon.test.tsx
+++ b/src/components/Icon/tests/Icon.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import {shallowWithAppProvider} from 'test-utilities';
+import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import Icon from '../Icon';
+import Button from '../../Button';
 
 describe('<Icon />', () => {
   describe('accessibilityLabel', () => {
@@ -9,6 +10,33 @@ describe('<Icon />', () => {
         <Icon source="placeholder" accessibilityLabel="This is an icon" />,
       );
       expect(element.prop('aria-label')).toBe('This is an icon');
+    });
+  });
+  describe('source', () => {
+    it("renders a placeholder div when source is set to 'placeholder'", () => {
+      const element = mountWithAppProvider(<Icon source="placeholder" />);
+      expect(element.find('div')).toHaveLength(1);
+    });
+
+    it('renders an SVG when source is given a BundledIcon', () => {
+      const element = shallowWithAppProvider(<Icon source="add" />);
+      expect(element.find('svg')).toHaveLength(1);
+    });
+
+    it('renders an SVG when source is given an SVG', () => {
+      const svg = {
+        body:
+          "<path d='M17 9h-6V3a1 1 0 1 0-2 0v6H3a1 1 0 1 0 0 2h6v6a1 1 0 1 0 2 0v-6h6a1 1 0 1 0 0-2'  fill-rule='evenodd'/>",
+        viewBox: '0 0 20 20',
+      };
+      const element = shallowWithAppProvider(<Icon source={svg} />);
+      expect(element.find('svg')).toHaveLength(1);
+    });
+
+    it('renders a React Component when source is given a React Component', () => {
+      const component = <Button>Icon</Button>;
+      const element = shallowWithAppProvider(<Icon source={component} />);
+      expect(element.find(Button)).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
fixes: https://github.com/Shopify/polaris-react/issues/449

### WHY are these changes introduced?

In create-react-app 2, svg are loaded as components. This break our Icon component.

### WHAT is this pull request doing?

Allows to use a React Component at the source of the icon.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Icon} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    const svg = {
      body:
        "<path d='M17 9h-6V3a1 1 0 1 0-2 0v6H3a1 1 0 1 0 0 2h6v6a1 1 0 1 0 2 0v-6h6a1 1 0 1 0 0-2'  fill-rule='evenodd'/>",
      viewBox: '0 0 20 20',
    };
    return (
      <Page title="Playground">
        <Icon source="placeholder" />
        <Icon source="add" />
        <Icon source={<Icon source="delete" />} />
        <Icon source={svg} />
      </Page>
    );
  }
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
