### PR TITLE
[Pagination] Fixed event from being called when has previous or next is false

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - `TextField` no longer uses `componentWillReceiveProps`([#628](https://github.com/Shopify/polaris-react/pull/628))
+- Fixed `Pagination` from calling `onNext` and `onPrevious` while `hasNext` and `hasPrevious` are false for key press events ([#643](https://github.com/Shopify/polaris-react/pull/643))
 - `EventListener` no longer uses `componentWillUpdate` ([#628](https://github.com/Shopify/polaris-react/pull/628))
 - Allowed `Icon` to accept a React Node as a source ([#635](https://github.com/Shopify/polaris-react/pull/635)) (thanks to [@mbriggs](https://github.com/mbriggs) for the [original issue](https://github.com/Shopify/polaris-react/issues/449))
 - Added `alignContentFlush` prop to ContextualSaveBar ([#654](https://github.com/Shopify/polaris-react/pull/654))

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -24,15 +24,9 @@ export interface PaginationDescriptor {
   nextURL?: string;
   /** The URL of the previous page */
   previousURL?: string;
-  /**
-   * Whether there is a next page to show
-   * @default true
-   */
+  /** Whether there is a next page to show */
   hasNext?: boolean;
-  /**
-   * Whether there is a previous page to show
-   * @default true
-   */
+  /** Whether there is a previous page to show */
   hasPrevious?: boolean;
   /** Accessible label for the pagination */
   accessibilityLabel?: string;
@@ -50,8 +44,8 @@ export interface Props extends PaginationDescriptor {
 export type CombinedProps = Props & WithAppProviderProps;
 
 function Pagination({
-  hasNext = true,
-  hasPrevious = true,
+  hasNext,
+  hasPrevious,
   nextURL,
   previousURL,
   onNext,

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -24,9 +24,15 @@ export interface PaginationDescriptor {
   nextURL?: string;
   /** The URL of the previous page */
   previousURL?: string;
-  /** Whether there is a next page to show */
+  /**
+   * Whether there is a next page to show
+   * @default true
+   */
   hasNext?: boolean;
-  /** Whether there is a previous page to show */
+  /**
+   * Whether there is a previous page to show
+   * @default true
+   */
   hasPrevious?: boolean;
   /** Accessible label for the pagination */
   accessibilityLabel?: string;
@@ -44,8 +50,8 @@ export interface Props extends PaginationDescriptor {
 export type CombinedProps = Props & WithAppProviderProps;
 
 function Pagination({
-  hasNext,
-  hasPrevious,
+  hasNext = true,
+  hasPrevious = true,
   nextURL,
   previousURL,
   onNext,
@@ -130,6 +136,7 @@ function Pagination({
   const previousButtonEvents =
     previousKeys &&
     (previousURL || onPrevious) &&
+    hasPrevious &&
     previousKeys.map((key) => (
       <KeypressListener
         key={key}
@@ -145,6 +152,7 @@ function Pagination({
   const nextButtonEvents =
     nextKeys &&
     (nextURL || onNext) &&
+    hasNext &&
     nextKeys.map((key) => (
       <KeypressListener
         key={key}

--- a/src/components/Pagination/tests/Pagination.test.tsx
+++ b/src/components/Pagination/tests/Pagination.test.tsx
@@ -139,6 +139,24 @@ describe('<Pagination />', () => {
 
       expect(spy).toHaveBeenCalledTimes(1);
     });
+
+    it('does not navigate the browser when hasNext or hasPrevious is false', () => {
+      const spy = jest.fn();
+      pagination = mountWithAppProvider(
+        <Pagination
+          hasPrevious={false}
+          previousKeys={[Key.KeyJ]}
+          previousTooltip="j"
+          previousURL="https://www.google.com"
+        />,
+      );
+
+      const anchor = pagination.find('a').getDOMNode() as HTMLAnchorElement;
+      anchor.click = spy;
+      listenerMap.keyup({keyCode: Key.KeyJ});
+
+      expect(spy).toHaveBeenCalledTimes(0);
+    });
   });
 });
 

--- a/src/components/Pagination/tests/Pagination.test.tsx
+++ b/src/components/Pagination/tests/Pagination.test.tsx
@@ -62,7 +62,7 @@ describe('<Pagination />', () => {
   it('adds a keypress event for nextKeys', () => {
     const spy = jest.fn();
     mountWithAppProvider(
-      <Pagination nextKeys={[Key.KeyK]} onNext={spy} nextTooltip="k" />,
+      <Pagination hasNext nextKeys={[Key.KeyK]} onNext={spy} nextTooltip="k" />,
     );
 
     listenerMap.keyup({keyCode: Key.KeyK});
@@ -74,6 +74,7 @@ describe('<Pagination />', () => {
     const spy = jest.fn();
     mountWithAppProvider(
       <Pagination
+        hasPrevious
         previousKeys={[Key.KeyJ]}
         onPrevious={spy}
         previousTooltip="j"
@@ -127,6 +128,7 @@ describe('<Pagination />', () => {
       const spy = jest.fn();
       pagination = mountWithAppProvider(
         <Pagination
+          hasPrevious
           previousKeys={[Key.KeyJ]}
           previousTooltip="j"
           previousURL="https://www.google.com"
@@ -141,7 +143,7 @@ describe('<Pagination />', () => {
     });
 
     it('does not navigate the browser when hasNext or hasPrevious is false', () => {
-      const spy = jest.fn();
+      const anchorClickSpy = jest.fn();
       pagination = mountWithAppProvider(
         <Pagination
           hasPrevious={false}
@@ -152,10 +154,10 @@ describe('<Pagination />', () => {
       );
 
       const anchor = pagination.find('a').getDOMNode() as HTMLAnchorElement;
-      anchor.click = spy;
+      anchor.click = anchorClickSpy;
       listenerMap.keyup({keyCode: Key.KeyJ});
 
-      expect(spy).toHaveBeenCalledTimes(0);
+      expect(anchorClickSpy).toHaveBeenCalledTimes(0);
     });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?
Key events can't be disabled like buttons and will currently fire when `hasNext` or `hasPrevious` are true

### WHAT is this pull request doing?
* Add default of true for `hasNext` and `hasPrevious`
* Don't add key events if `hasNext` or `hasPrevious` are true
* Add tests
* Add changelog

### How to 🎩
Use the playground code to toggle `hasNext` and `hasPrevious`

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Pagination, Button} from '@shopify/polaris';

interface State {
  next: boolean;
  prev: boolean;
  [key: string]: any;
}

export default class Playground extends React.Component<never, State> {
  state = {
    next: true,
    prev: true,
  };

  toggleState = (key: string) => () => this.setState({[key]: !this.state[key]});

  render() {
    const {next, prev} = this.state;

    return (
      <Page title="Playground">
        <Button onClick={this.toggleState('prev')}>Toggle Previous</Button>

        <Button onClick={this.toggleState('next')}>Toggle Next</Button>

        <Pagination
          hasPrevious={prev}
          previousKeys={[74]}
          previousTooltip="j"
          onPrevious={() => {
            console.log('Previous');
          }}
          hasNext={next}
          nextKeys={[75]}
          nextTooltip="k"
          onNext={() => {
            console.log('Next');
          }}
        />
      </Page>
    );
  }
}
```

</details>

#### Notes
* base to be changed when we create a feature branch to merge to during the code freeze