### PR TITLE
Prevent polaris-react 3.0.x hotfixes from getting deployed under the 'latest' tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "url": "https://github.com/Shopify/polaris-react/issues"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "web"
   },
   "sideEffects": [
     "**/*.css",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -4,8 +4,13 @@
 const {resolve} = require('path');
 const Uploader = require('@shopify/js-uploader');
 const {S3} = require('aws-sdk');
+const semver = require('semver');
 const awsConfig = require('../secrets.json').aws;
 const currentVersion = require('../package.json').version;
+
+// Check if the current version is stable
+// and doesn’t include -alpha.x, -beta.x, -rc.x tags
+const isStableVersion = !semver.prerelease(currentVersion);
 
 const files = [
   resolve(__dirname, '../build/polaris.css'),
@@ -27,10 +32,14 @@ const uploader = new Uploader({
   s3: awsS3,
   destination: 'polaris',
   version: currentVersion,
+  // Upload assets to the /latest/ directory
+  // only when the version is stable (no alpha, beta, rc…)
+
+  // ⚠️ ️TEMPORARILY SET TO 'false' - DO NOT MERGE TO MASTER ⚠️
   // Don't upload assets to the /latest/ directory
   // as this version is currently used in Shopify/web only,
   // while newer versions of polaris-react already exist in the wild
-  latest: false,
+  latest: false && isStableVersion,
 });
 
 uploader.deployStaticFiles().catch((err) => {

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -4,13 +4,8 @@
 const {resolve} = require('path');
 const Uploader = require('@shopify/js-uploader');
 const {S3} = require('aws-sdk');
-const semver = require('semver');
 const awsConfig = require('../secrets.json').aws;
 const currentVersion = require('../package.json').version;
-
-// Check if the current version is stable
-// and doesn’t include -alpha.x, -beta.x, -rc.x tags
-const isStableVersion = !semver.prerelease(currentVersion);
 
 const files = [
   resolve(__dirname, '../build/polaris.css'),
@@ -32,9 +27,10 @@ const uploader = new Uploader({
   s3: awsS3,
   destination: 'polaris',
   version: currentVersion,
-  // Upload assets to the /latest/ directory
-  // only when the version is stable (no alpha, beta, rc…)
-  latest: isStableVersion,
+  // Don't upload assets to the /latest/ directory
+  // as this version is currently used in Shopify/web only,
+  // while newer versions of polaris-react already exist in the wild
+  latest: false,
 });
 
 uploader.deployStaticFiles().catch((err) => {

--- a/shipit.yml
+++ b/shipit.yml
@@ -16,3 +16,5 @@ merge:
 
 deploy:
   max_commits: false
+  override:
+    - npm publish


### PR DESCRIPTION
### WHY are these changes introduced?

- Versions published from the `web` branch should not overwrite the version available on CDN via the `/latest/` release tag.
- `npm publish`, by default, publishes packages under the `latest` tag.

### WHAT is this pull request doing?

- Prevents `web` branch deploys from getting uploaded to S3 in the `/latest/` directory.
- Prevents `npm publish` from overriding the `latest` dist-tag when deploying from the `web` branch.

(Not sure how to test this without creating a whole new package, stack, s3 bucket, etc… probably not worth the hassle)