### PR TITLE
Provide better error messaging when README examples have syntax errors

### DIFF
--- a/documentation/Component READMEs.md
+++ b/documentation/Component READMEs.md
@@ -132,16 +132,27 @@ Example description.
 
 ## Troubleshooting
 
-When running `yarn tophat` or CI tests, when you see:
+When running `yarn tophat` or CI tests you may run into errors.
+Here are some common fixes.
+
+### No examples found
 
 ```console
 🚨 [Top bar] No examples found in src/components/TopBar/README.md
 ```
 
-A `---` may be missing before the `## Examples` heading:
+A `---` may be missing before the `## Examples` heading. Add it so that our parsers know where the Examples section begins.
 
 ```diff
 + ---
 +
   ## Examples
 ```
+
+### Syntax errors
+
+```console
+🚨 Example "Autocomplete with loading" contains a syntax error in src/components/Autocomplete/README.md: Unexpected token (18:20)
+```
+
+This error is reported when an example does not contain valid JavaScript. The values at the end denote the line and character offset of the error. In this example `18:20` denotes that the error is on line 18, character 20 of the "Autocomplete with loading" example. Look for typos or other invalid syntax in that area.

--- a/tophat/parseMarkdown.js
+++ b/tophat/parseMarkdown.js
@@ -120,13 +120,24 @@ function parseCodeExamples(data, file) {
     const nameMatches = example.match(/(.)*/);
     const codeBlock = example.match(/```jsx(.|\n)*?```/g);
 
-    const hasName = nameMatches !== null;
-    const hasCodeBlock = codeBlock !== null;
+    const name = nameMatches !== null ? nameMatches[0].trim() : '';
 
-    return {
-      name: hasName ? nameMatches[0].trim() : '',
-      code: hasCodeBlock ? transpileExample(stripCodeBlock(codeBlock[0])) : '',
-    };
+    let code = '';
+    if (codeBlock !== null) {
+      try {
+        code = transpileExample(stripCodeBlock(codeBlock[0]));
+      } catch (err) {
+        throw new Error(
+          chalk`🚨 {red [${
+            matter.data.name
+          }]} Example "${name}" contains a syntax error in ${filePath}: ${
+            err.message
+          }`,
+        );
+      }
+    }
+
+    return {name, code};
   });
 
   if (examples.filter((example) => example.code).length === 0) {


### PR DESCRIPTION

### WHY are these changes introduced?

If you fatfingered an example in a README then `yarn tophat` can give a cryptic error message. Make it less cryptic by adding more information.

### WHAT is this pull request doing?

Throw an error message that contains the file and example name that the problem occurs in.

What was:

```
Unexpected token, expected "{" (6:24)
```

Is now:

```
🚨 [Text field] Example "Default text field" contains a syntax error in src/components/TextField/README.md: Unexpected token, expected "{" (6:24)
```

### How to 🎩

* Go make a syntax error in an example. For instance change `handleChange = (value) =>` to `handleChange (value) =>` in TextField/README.md's "Default text field" example.
* Run `yarn tophat`
* See that the console reports the file and example name within which the error occurs. It'll look something like:

```
   🚨 [Text field] Example "Default text field" contains a syntax error in src/components/TextField/README.md: Unexpected token, expected "{" (6:24)
```
