### PR TITLE
[FormLayout] min-width added to Item only when in Group. 

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Removed min-width from `FormLayout` `Items` and applying it only to `Items` used inside a `FormLayout.Group` ([#650](https://github.com/Shopify/polaris-react/pull/650))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/FormLayout/FormLayout.scss
+++ b/src/components/FormLayout/FormLayout.scss
@@ -5,11 +5,6 @@ $item-min-size: rem(220px);
   margin-left: -1 * spacing(loose);
 }
 
-.condensed .Item {
-  flex-basis: (0.5 * $item-min-size);
-  min-width: (0.5 * $item-min-size);
-}
-
 .Title {
   margin-bottom: -1 * spacing(tight);
   padding: spacing() spacing(loose) 0;
@@ -29,6 +24,14 @@ $item-min-size: rem(220px);
   flex: 1 1 $item-min-size;
   margin-top: spacing();
   margin-left: spacing(loose);
-  min-width: $item-min-size;
   max-width: calc(100% - #{spacing(loose)});
+
+  .grouped & {
+    min-width: $item-min-size;
+  }
+
+  .condensed & {
+    flex-basis: (0.5 * $item-min-size);
+    min-width: (0.5 * $item-min-size);
+  }
 }

--- a/src/components/FormLayout/components/Group/Group.tsx
+++ b/src/components/FormLayout/components/Group/Group.tsx
@@ -16,7 +16,7 @@ export interface Props {
 const getUniqueID = createUniqueIDFactory('FormLayoutGroup');
 
 export default function Group({children, condensed, title, helpText}: Props) {
-  const className = classNames(condensed && styles.condensed);
+  const className = classNames(condensed ? styles.condensed : styles.grouped);
 
   const id = getUniqueID();
 


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/web/issues/4902

There's a min-width set on FormLayout Items t


hat is used for wrapping of items when inside a group. In the side column however that min-width is too wide.

### WHAT is this pull request doing?

Adding the min-width to items when in groups only.

Before | After
------------ | -------------
Content from cell 1 | Content from cell 2
![formgroupmaxwidth-b4](https://user-images.githubusercontent.com/1229901/48783138-ad8d0e00-ecad-11e8-8738-27c71d2f2452.gif) | ![formgroupmaxwidth](https://user-images.githubusercontent.com/1229901/48783125-a6fe9680-ecad-11e8-9001-c4ee142707a6.gif)
![screen shot 2018-11-20 at 10 12 07 am](https://user-images.githubusercontent.com/1229901/48782795-f42e3880-ecac-11e8-8445-e54c15d160f8.png) | ![screen shot 2018-11-20 at 9 46 00 am](https://user-images.githubusercontent.com/1229901/48782837-060fdb80-ecad-11e8-99f7-81283a37b93b.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩


1. Below is the Polaris-React Playground
2. `yarn build-consumer web` to 🎩 in web

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, FormLayout, TextField} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        <FormLayout>
          <FormLayout.Group>
            <TextField label="Length" onChange={() => {}} />
            <TextField label="Width" onChange={() => {}} />
            <TextField label="Height" onChange={() => {}} />
            <TextField label="Unit" onChange={() => {}} />
          </FormLayout.Group>
          <FormLayout.Group condensed>
            <TextField label="Length" onChange={() => {}} />
            <TextField label="Width" onChange={() => {}} />
            <TextField label="Height" onChange={() => {}} />
            <TextField label="Unit" onChange={() => {}} />
          </FormLayout.Group>
        </FormLayout>
      </Page>
    );
  }
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
