### PR TITLE
[ContextualSaveBar]: Add prop to extend contents flush with left edge.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - `TextField` no longer uses `componentWillReceiveProps`([#628](https://github.com/Shopify/polaris-react/pull/628))
 - EventListener`no longer uses`componentWillUpdate` ([#628](https://github.com/Shopify/polaris-react/pull/628))
 - Allowed `Icon` to accept a React Node as a source ([#635](https://github.com/Shopify/polaris-react/pull/635)) (thanks to [@mbriggs](https://github.com/mbriggs) for the [original issue](https://github.com/Shopify/polaris-react/issues/449))
+- Added `alignContentFlush` prop to ContextualSaveBar ([#654](https://github.com/Shopify/polaris-react/pull/654))
 
 ### Bug fixes
 

--- a/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -23,6 +23,8 @@ interface DiscardActionProps {
 type CombinedActionProps = DiscardActionProps & Action;
 
 export interface Props {
+  /** Extend the contents section to be flush with the left edge  */
+  alignContentFlush?: boolean;
   /** Accepts a string of content that will be rendered to the left of the actions */
   message?: string;
   /** Save or commit contextual save bar action with text defaulting to 'Save' */

--- a/src/components/ContextualSaveBar/README.md
+++ b/src/components/ContextualSaveBar/README.md
@@ -132,7 +132,38 @@ Use the save action to provide an opportunity to save a newly-created resource. 
       />
     </Frame>
   </AppProvider>
-  );
+</div>
+```
+
+### Contextual save bar with flush contents
+
+Use the alignContentFlush flag when you want to omit the logo from the contextual save bar and
+repurpose that space to extend the message contents fully to the left side of the container.
+
+```jsx
+<div style={{height: '250px'}}>
+  <AppProvider
+    theme={{
+      logo: {
+        width: 124,
+        contextualSaveBarSource:
+          'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
+      },
+    }}
+  >
+    <Frame>
+      <ContextualSaveBar
+        alignContentFlush
+        message="Unsaved changes"
+        saveAction={{
+          onAction: () => console.log('add form submit logic'),
+        }}
+        discardAction={{
+          onAction: () => console.log('add clear form logic'),
+        }}
+      />
+    </Frame>
+  </AppProvider>
 </div>
 ```
 

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -29,6 +29,7 @@ class ContextualSaveBar extends React.PureComponent<CombinedProps, State> {
     const {discardConfirmationModalVisible} = this.state;
 
     const {
+      alignContentFlush,
       message,
       discardAction,
       saveAction,
@@ -100,12 +101,16 @@ class ContextualSaveBar extends React.PureComponent<CombinedProps, State> {
       />
     );
 
+    const logoMarkup = alignContentFlush ? null : (
+      <div className={styles.LogoContainer} style={{width}}>
+        {imageMarkup}
+      </div>
+    );
+
     return (
       <React.Fragment>
         <div className={styles.ContextualSaveBar}>
-          <div className={styles.LogoContainer} style={{width}}>
-            {imageMarkup}
-          </div>
+          {logoMarkup}
           <div className={styles.Contents}>
             <h2 className={styles.Message}>{message}</h2>
             <Stack spacing="tight" wrap={false}>

--- a/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -167,6 +167,22 @@ describe('<ContextualSaveBar />', () => {
         '104px',
       );
     });
+
+    it('will not render the logo when content is aligned flush left', () => {
+      const contextualSaveBar = mountWithAppProvider(
+        <ContextualSaveBar alignContentFlush />,
+        addPolarisContext({
+          logo: {
+            contextualSaveBarSource: './assets/monochrome_shopify.svg',
+            width: 200,
+          },
+          subscribe: () => {},
+          unsubscribe: () => {},
+        }),
+      );
+
+      expect(contextualSaveBar.find(Image).exists()).toBeFalsy();
+    });
   });
 });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Related to: https://github.com/Shopify/business-platform/issues/684

We are currently presenting a separate TopBar in specific scenarios. When they make changes within `web`, the context bar shows the old logo. We are looking to simply hide the logo in this dirty state.

![image](https://user-images.githubusercontent.com/1929696/48802748-21dfa580-ecde-11e8-9308-17010c8977e4.png)

### WHAT is this pull request doing?

This PR adds a `hideLogo` prop to the ContextualSaveBar component which essentially eliminates the markup for the Logo section in the ContextualSaveBar. Existing CSS for the `message` allows that section to fill in the remaining space out of the box.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Essentially, loading the ContextualSaveBar and toggling the `alignContentFlush` prop between `true | false` should be enough to see the results. Stretching the viewport to smaller dimensions and observing the behaviour should remain consistent.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {AppProvider, ContextualSaveBar, Frame} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <div style={{height: '250px'}}>
        <AppProvider
          theme={{
            logo: {
              width: 124,
              contextualSaveBarSource:
                'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
            },
          }}
        >
          <Frame>
            <ContextualSaveBar
              alignContentFlush
              message="Unsaved changes"
              saveAction={{
                onAction: () => console.log('add form submit logic'),
                loading: false,
                disabled: false,
              }}
              discardAction={{
                onAction: () => console.log('add clear form logic'),
              }}
            />
          </Frame>
        </AppProvider>
      </div>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)
