### PR TITLE
Updating red colour for errors

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed min-width from `FormLayout` `Items` and applying it only to `Items` used inside a `FormLayout.Group` ([#650](https://github.com/Shopify/polaris-react/pull/650))
 - Removed added space in `ChoiceList` when choice has children on selection but is not selected ([#665](https://github.com/Shopify/polaris-react/issues/665))
 
+- Updated the `InlineError` text color, the error border-color on form fields and the error Icon color to be the same red. ([#676](https://github.com/Shopify/polaris-react/pull/676))
+
 ### Documentation
 
 - Updated documentation links to match the new style guide link structure ([#478](https://github.com/Shopify/polaris-react/pull/478))

--- a/src/components/InlineError/InlineError.scss
+++ b/src/components/InlineError/InlineError.scss
@@ -6,7 +6,7 @@ $error-icon-adjustment: rem(2px);
 }
 
 .Icon {
-  @include recolor-icon(color('red'));
+  @include recolor-icon(color('red', 'dark'));
   margin-left: -1 * $error-icon-adjustment;
   margin-right: spacing(extra-tight) + $error-icon-adjustment;
 }

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -53,7 +53,7 @@ $stacking-order: (
   // stylelint-disable-next-line selector-max-class, selector-max-combinators
   > .Input ~ .Backdrop {
     background-color: color('red', 'lighter');
-    border-color: color('red');
+    border-color: color('red', 'dark');
     box-shadow: none;
   }
 

--- a/src/styles/shared/controls.scss
+++ b/src/styles/shared/controls.scss
@@ -69,7 +69,7 @@
       }
     }
   } @else if $style == error {
-    background: color('red');
+    background: color('red', 'dark');
     box-shadow: 0 0 0 1px transparent;
 
     &::after {


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris-react/issues/651

### WHAT is this pull request doing?

Updating `InlineError`, borders on our form fields and the Error Icon to be the same red. 

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, TextField, Checkbox} from '@shopify/polaris';

interface State {
  value: string;
  checked: boolean;
}

export default class Playground extends React.Component<never, State> {
  state = {
    value: 'Jaded Pixel',
    checked: false,
  };

  handleTextFieldChange = (value) => {
    this.setState({value});
  };

  handleCheckboxChange = (checked) => {
    this.setState({checked});
  };

  render() {
    const {value, checked, selected} = this.state;

    return (
      <Page
        title="Playground"
        primaryAction={{content: 'View Examples', url: '/examples'}}
      >
        <TextField
          label="Store name"
          value={value}
          onChange={this.handleTextFieldChange}
          error="error"
        />

        <Checkbox
          checked={checked}
          label="Basic checkbox"
          onChange={this.handleCheckboxChange}
          error="error"
        />
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
