### PR TITLE
fixes prop-types import

### DIFF
--- a/src/components/AppProvider/types.ts
+++ b/src/components/AppProvider/types.ts
@@ -1,6 +1,6 @@
 import {ClientApplication} from '@shopify/app-bridge';
 import {ValidationMap} from 'react';
-import PropTypes from 'prop-types';
+import * as PropTypes from 'prop-types';
 import {LinkLikeComponent} from '../UnstyledLink';
 import {Theme, THEME_CONTEXT_TYPES as polarisTheme} from '../ThemeProvider';
 import {


### PR DESCRIPTION
### WHY are these changes introduced?
fixes https://github.com/Shopify/polaris-react/pull/524#issuecomment-441637376

### WHAT is this pull request doing?
Changes the `prop-types` import to fix the build.

### How to 🎩
1. Dev up in Web.
2. In `polaris-react` switch to this branch and run `yarn build-consumer web`.
3. In Web start the server.
4. Make sure everything compiles without errors.
