### PR TITLE
[AppProvider] Fix SSR support

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,7 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - `TextField` no longer uses `componentWillReceiveProps`([#628](https://github.com/Shopify/polaris-react/pull/628))
-- EventListener`no longer uses`componentWillUpdate` ([#628](https://github.com/Shopify/polaris-react/pull/628))
+- `EventListener` no longer uses `componentWillUpdate` ([#628](https://github.com/Shopify/polaris-react/pull/628))
 - Allowed `Icon` to accept a React Node as a source ([#635](https://github.com/Shopify/polaris-react/pull/635)) (thanks to [@mbriggs](https://github.com/mbriggs) for the [original issue](https://github.com/Shopify/polaris-react/issues/449))
 - Added `alignContentFlush` prop to ContextualSaveBar ([#654](https://github.com/Shopify/polaris-react/pull/654))
 
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Removed min-width from `FormLayout` `Items` and applying it only to `Items` used inside a `FormLayout.Group` ([#650](https://github.com/Shopify/polaris-react/pull/650))
 - Removed added space in `ChoiceList` when choice has children on selection but is not selected ([#665](https://github.com/Shopify/polaris-react/issues/665))
+- Fixed `AppProvider` server side rendering support ([#694](https://github.com/Shopify/polaris-react/pull/694)) (thanks [@sbstnmsch](https://github.com/sbstnmsch) for the [original issue](https://github.com/Shopify/polaris-react/issues/372))
 
 - Updated the `InlineError` text color, the error border-color on form fields and the error Icon color to be the same red. ([#676](https://github.com/Shopify/polaris-react/pull/676))
 

--- a/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
+++ b/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
@@ -17,7 +17,7 @@ export default function createAppProviderContext({
   i18n,
   linkComponent,
   apiKey,
-  shopOrigin,
+  shopOrigin = '',
   forceRedirect,
   stickyManager,
   scrollLockManager,
@@ -26,10 +26,16 @@ export default function createAppProviderContext({
 }: CreateAppProviderContext = {}): Context {
   const intl = new Intl(i18n);
   const link = new Link(linkComponent);
+  let origin = shopOrigin;
+
+  if (!shopOrigin && typeof window !== undefined) {
+    origin = getShopOrigin();
+  }
+
   const appBridge = apiKey
     ? createApp({
         apiKey,
-        shopOrigin: shopOrigin || getShopOrigin(),
+        shopOrigin: origin,
         forceRedirect,
       })
     : undefined;


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes #372 

### WHAT is this pull request doing?
Currently, if the app provider component's `shopOrigin` prop is unset, it's utility function `createAppProviderContext` calls the App Bridge utility `getShopOrigin` which returns `window.location`. This PR sets a default value for shopOrigin and only calls `getShopOrigin` if `window` exists. 

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

- `git checkout app-provider-ssr && yarn run build-consumer {YOUR-APPS-REPO-NAME}`**

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->

### Notes

**In order to tophat this change, you need a test embedded app with server side rendering.
