### PR TITLE
[Page][Prototype] ✨ add `forceRender` to force render of the title, actions & breadcrumbs to be in page vs in the top bar.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added `onKeyPress`, `onKeyDown`, and `onKeyUp` to `Button` ([#860](https://github.com/Shopify/polaris-react/pull/860))
 - Added `monochrome` prop to `Button` and `Link` component ([#821](https://github.com/Shopify/polaris-react/pull/821))
 - Updated `Frame` layout and made `TopBar.UserMenu` visible on mobile ([#852](https://github.com/Shopify/polaris-react/pull/852))
+- Added a `forceRender` prop to `Page` to not delegate to the app bridge TitleBar action ([#695](https://github.com/Shopify/polaris-react/pull/695))
 - Changed `Tabs` example to contain children so the `Panel` renders for accessibility ([#893](https://github.com/Shopify/polaris-react/pull/893))
 - Fixed timezone not being accounted for in `ResourceList` date filter control ([#710](https://github.com/Shopify/polaris-react/pull/710))
 

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -23,6 +23,13 @@ export interface Props extends HeaderProps {
   fullWidth?: boolean;
   /** Decreases the maximum layout width. Intended for single-column layouts */
   singleColumn?: boolean;
+  /**
+   * Force render in page and do not delegate to the app bridge TitleBar action
+   * @default false
+   * @embeddedAppOnly
+   * @see {@link https://polaris.shopify.com/components/structure/page#section-use-in-an-embedded-application|Shopify Page Component docs}
+   * */
+  forceRender?: boolean;
 }
 
 export type ComposedProps = Props & WithAppProviderProps;
@@ -39,7 +46,7 @@ export class Page extends React.PureComponent<ComposedProps, never> {
   private titlebar: AppBridgeTitleBar.TitleBar | undefined;
 
   componentDidMount() {
-    if (this.props.polaris.appBridge == null) {
+    if (this.delegateToAppbridge === false) {
       return;
     }
 
@@ -50,7 +57,7 @@ export class Page extends React.PureComponent<ComposedProps, never> {
   }
 
   componentDidUpdate(prevProps: ComposedProps) {
-    if (this.props.polaris.appBridge == null || this.titlebar == null) {
+    if (this.titlebar == null || this.delegateToAppbridge === false) {
       return;
     }
 
@@ -64,7 +71,7 @@ export class Page extends React.PureComponent<ComposedProps, never> {
   }
 
   componentWillUnmount() {
-    if (this.props.polaris.appBridge == null || this.titlebar == null) {
+    if (this.titlebar == null || this.delegateToAppbridge === false) {
       return;
     }
 
@@ -81,8 +88,7 @@ export class Page extends React.PureComponent<ComposedProps, never> {
     );
 
     const headerMarkup =
-      this.props.polaris.appBridge ||
-      this.hasHeaderContent() === false ? null : (
+      this.delegateToAppbridge || this.hasHeaderContent() === false ? null : (
         <Header {...rest} />
       );
 
@@ -94,7 +100,16 @@ export class Page extends React.PureComponent<ComposedProps, never> {
     );
   }
 
-  private hasHeaderContent() {
+  private get delegateToAppbridge(): boolean {
+    const {
+      polaris: {appBridge},
+      forceRender = false,
+    } = this.props;
+
+    return appBridge != null && forceRender === false;
+  }
+
+  private hasHeaderContent(): boolean {
     const {
       title,
       primaryAction,

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -42,6 +42,20 @@ describe('<Page />', () => {
     };
   }
 
+  describe('forceRender renders children in page', () => {
+    const {
+      createSpy: titleBarCreateSpy,
+      restore: restoreTitleBarCreateMock,
+    } = mockTitleBarCreate();
+    const {page} = mountWithAppBridge(
+      <Page {...mockProps} title="new title" forceRender />,
+    );
+
+    expect(page.find(Header).exists()).toBeTruthy();
+    expect(titleBarCreateSpy).not.toHaveBeenCalled();
+    restoreTitleBarCreateMock();
+  });
+
   describe('children', () => {
     it('renders its children', () => {
       const card = <Card />;


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris-react/issues/669#issuecomment-442485366

### WHAT is this pull request doing?

Added `forceRender` to title, breadcrumbs, and actions render in the app when app-bridge is use

Default using app bridge 
ie. `<AppProvider apiKey={YOUR_API_KEY}>`
<img width="896" alt="by default" src="https://user-images.githubusercontent.com/1610169/49246386-c2228200-f3e2-11e8-98c6-61f3e279f8bf.png">

Default without app bridge
ie. `<AppProvider apiKey={undefined}>`
<img width="898" alt="with both" src="https://user-images.githubusercontent.com/1610169/49246402-d0709e00-f3e2-11e8-97d8-b959c3e748d9.png">

Using app bridge & forceRenderTitle
ie. `<AppProvider apiKey={YOUR_API_KEY}><Page title="test title" forceRenderTitle /></AppProvider>`
<img width="899" alt="with forcerendertitle" src="https://user-images.githubusercontent.com/1610169/49246453-f5fda780-f3e2-11e8-819e-4dbc66111874.png">

Using app bridge & forceRenderActions
ie. `<AppProvider apiKey={YOUR_API_KEY}><Page title="" primaryAction={{content: 'Save'}} forceRenderActions /></AppProvider>`
<img width="896" alt="with forcerenderactions" src="https://user-images.githubusercontent.com/1610169/49246503-1299df80-f3e3-11e8-93b1-aa7953b99273.png">

Using app bridge, forceRenderTitle, and forceRenderActions
ie. `<AppProvider apiKey={YOUR_API_KEY}><Page title="test title" primaryAction={{content: 'Save'}} forceRenderTitle forceRenderActions /></AppProvider>`
<img width="898" alt="with both" src="https://user-images.githubusercontent.com/1610169/49246522-1d547480-f3e3-11e8-9beb-78ae3ec05bc3.png">

Using app bridge, forceRender
ie. `<AppProvider apiKey={YOUR_API_KEY}><Page title="test title" primaryAction={{content: 'Save'}} forceRender /></AppProvider>`
<img width="898" alt="with both" src="https://user-images.githubusercontent.com/1610169/49246522-1d547480-f3e3-11e8-9beb-78ae3ec05bc3.png">

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <AppProvider apiKey={YOUR_API_KEY}>
          <Page title="Playground" breadcrumbs={[{content: 'previous page'}]} primaryAction={{content: 'Save'}}>
            {/* Add the code you want to test here */}
          </Page>
      </AppProvider>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
