### PR TITLE
[AppProvider] Fix SSR

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed added space in `ChoiceList` when choice has children on selection but is not selected ([#665](https://github.com/Shopify/polaris-react/issues/665))
 - Fixed `errorOverlayText` on `Dropzone` ([#671](https://github.com/Shopify/polaris-react/pull/671))
 - Updated the `InlineError` text color, the error border-color on form fields and the error `Icon` color to be the same red. ([#676](https://github.com/Shopify/polaris-react/pull/676))
+- Fixed `AppProvider` server side rendering support ([#696](https://github.com/Shopify/polaris-react/pull/696)) (thanks [@sbstnmsch](https://github.com/sbstnmsch) for the [original issue](https://github.com/Shopify/polaris-react/issues/372))
 
 ### Documentation
 

--- a/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
+++ b/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
@@ -1,5 +1,6 @@
 import {noop} from '@shopify/javascript-utilities/other';
 import createApp, {getShopOrigin} from '@shopify/app-bridge';
+import {isServer} from '@shopify/react-utilities/target';
 import {AppProviderProps, Context} from '../../types';
 import {StickyManager} from '../withSticky';
 import ScrollLockManager from '../ScrollLockManager';
@@ -26,13 +27,14 @@ export default function createAppProviderContext({
 }: CreateAppProviderContext = {}): Context {
   const intl = new Intl(i18n);
   const link = new Link(linkComponent);
-  const appBridge = apiKey
-    ? createApp({
-        apiKey,
-        shopOrigin: shopOrigin || getShopOrigin(),
-        forceRedirect,
-      })
-    : undefined;
+  const appBridge =
+    apiKey && !isServer
+      ? createApp({
+          apiKey,
+          shopOrigin: shopOrigin || getShopOrigin(),
+          forceRedirect,
+        })
+      : undefined;
 
   return {
     polaris: {

--- a/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
+++ b/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import createApp from '@shopify/app-bridge';
 import {noop} from '@shopify/javascript-utilities/other';
+import * as targets from '@shopify/react-utilities/target';
 import createAppProviderContext from '../createAppProviderContext';
 import Intl from '../../Intl';
 import Link from '../../Link';
@@ -10,9 +11,19 @@ import ScrollLockManager from '../../ScrollLockManager';
 jest.mock('@shopify/app-bridge');
 (createApp as jest.Mock<{}>).mockImplementation((args) => args);
 
+const actualIsServer = targets.isServer;
+
+function mockIsServer(value: boolean) {
+  (targets as any).isServer = value;
+}
+
 describe('createAppProviderContext()', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mockIsServer(actualIsServer);
   });
 
   it('returns the right context without properties', () => {
@@ -66,6 +77,25 @@ describe('createAppProviderContext()', () => {
           forceRedirect: undefined,
           shopOrigin: undefined,
         },
+      },
+    };
+
+    expect(context).toEqual(mockContext);
+  });
+
+  it('does not instantiate app bridge if server side rendering', () => {
+    mockIsServer(true);
+    const apiKey = '4p1k3y';
+    const context = createAppProviderContext({apiKey});
+    const mockContext = {
+      polaris: {
+        intl: new Intl(undefined),
+        link: new Link(),
+        stickyManager: new StickyManager(),
+        scrollLockManager: new ScrollLockManager(),
+        subscribe: noop,
+        unsubscribe: noop,
+        appBridge: undefined,
       },
     };
 


### PR DESCRIPTION
### WHY are these changes introduced?
To prevent server side rendering from failing, which fixes #372.

### WHAT is this pull request doing?

Not instantiating app bridge if server side. The specific culprit is `getShopOrigin()` which ultimately reads `window.location`

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

The setup here is fairly involved. I worked through this with @katiedavis and confirmed this fixes the issue with AppProvider. There still may be other components where we are missing a server side check. If you would like to 🎩 please reach out to one of us.

Because this is hard to 🎩 I at least committed a test first which fails then committed the changes which satisfies the test.

### Checklist

* [x] 🎩  

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
