### PR TITLE
[WIP] Added a11y section to the Button Readme.md

### DIFF
--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -30,7 +30,7 @@ keywords:
 
 # Button
 
-Buttons are used to make common actions immediately visible and easy to perform with one click or tap. Merchants can use it to navigate, or take action.
+Buttons are used to make common actions immediately visible and easy to perform with one click, tap, or keypress. Merchants can use it to navigate, or take action.
 
 ---
 
@@ -99,6 +99,59 @@ Add menu item
 Add a menu item
 
 <!-- end -->
+
+<!-- content-for: web -->
+
+---
+
+## Accessibility
+
+### Labeling
+
+The `accessibilityLabel` prop adds an `aria-label` attribute to the button, which can be accessed by assistive technologies like screen readers. Typically, this text will replace the visible text on the button for assistive technology users.
+
+For a button, `accessibilityLabel` should be used if:
+
+- The visible text of the button is not enough for non-visual users to understand the purpose of the Button in the context of the page.
+- The button has no text and relies on an icon alone to convey its purpose.
+
+To help support people who use speech activation software and sighted screen reader users, make sure that the `aria-label` text includes any button text that is visible. Mismatches in visible and programmatic labeling can cause confusion, and can cause voice recognition commands to not work.
+
+When possible, give the button visible text that clearly conveys its purpose without the use of `accessibilityLabel`. Duplicating the Button text with `accessibilityLabel` when no additional content is needed is not necessary.
+
+<!-- usagelist -->
+
+#### Do
+
+Do
+
+```
+<button>Edit shipping address</button>
+```
+
+```
+<button aria-label="Edit shipping address">Edit</button>
+```
+
+#### Don’t
+
+Don't
+
+```
+<button aria-label="Change your shipping address">Edit</button>
+```
+
+```
+<button aria-label="Edit">Edit</button>
+```
+
+<!-- end -->
+
+### Keyboard support
+
+Keyboard users will expect to be able to give buttons keyboard focus with the `tab` key, and to activate them with the `enter`/`return` and `space` keys.
+
+<!-- /content-for -->
 
 ---
 

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -149,7 +149,7 @@ Don't
 
 ### Keyboard support
 
-Keyboard users will expect to be able to give buttons keyboard focus with the `tab` key, and to activate them with the `enter`/`return` and `space` keys.
+Keyboard users will expect to be able to give buttons keyboard focus with the <kbd>tab</kbd> key, and to activate them with the <kbd>enter</kbd>/<kbd>return</kbd> and <kbd>space</kbd> keys.
 
 <!-- /content-for -->
 

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -100,8 +100,6 @@ Add a menu item
 
 <!-- end -->
 
-<!-- content-for: web -->
-
 ---
 
 ## Accessibility
@@ -119,11 +117,9 @@ To help support people who use speech activation software and sighted screen rea
 
 When possible, give the button visible text that clearly conveys its purpose without the use of `accessibilityLabel`. Duplicating the Button text with `accessibilityLabel` when no additional content is needed is not necessary.
 
-<!-- usagelist -->
+<!-- usageblock -->
 
 #### Do
-
-Do
 
 ```
 <button>Edit shipping address</button>
@@ -134,8 +130,6 @@ Do
 ```
 
 #### Don’t
-
-Don't
 
 ```
 <button aria-label="Change your shipping address">Edit</button>
@@ -150,8 +144,6 @@ Don't
 ### Keyboard support
 
 Keyboard users will expect to be able to give buttons keyboard focus with the <kbd>tab</kbd> key, and to activate them with the <kbd>enter</kbd>/<kbd>return</kbd> and <kbd>space</kbd> keys.
-
-<!-- /content-for -->
 
 ---
 


### PR DESCRIPTION
Currently marked as WIP since this PR has an issue where the section displays for Web, iOS, and Android in the style guide, although it should only be visible for Web. (See issue: https://github.com/Shopify/polaris-styleguide/issues/2421)

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Adds accessibility documentation and guidance for the Button component for consumption by the style guide.

![Screenshot of button content displaying in the style guide](https://user-images.githubusercontent.com/1462085/49313639-bbf0dc00-f49c-11e8-9874-9da6ceeeadcf.png)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Tweaked language around how buttons are activated to include keyboard users.
- Added best practices around using the accessibilityLabel prop and keyboard support.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->