### PR TITLE
[TextField / Labelled] Add character count

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- `TextField` accepts a `showCharacterCount` prop to enable the display of character count ([#709](https://github.com/Shopify/polaris-react/pull/709))
+
 ### Bug fixes
 
 - Fixed vertical misalignment in `Banner.Header`([#870](https://github.com/Shopify/polaris-react/pull/870))

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -497,7 +497,7 @@ class HelpTextExample extends React.Component {
 
 Use as a special form of help text that works best inline.
 
-- Use a prefix for things like currency symbols (e.g. “$”, “¥”, “£”).
+- Use a prefix for things like currency symbols (e.g. “\$”, “¥”, “£”).
 - Use suffix for things like units of measure (e.g. “in”, “cm”).
 
 ```jsx
@@ -735,6 +735,36 @@ Use to show that a textfield is not available for interaction. Most often used i
 
 ```jsx
 <TextField label="Store name" disabled />
+```
+
+### Text field with character count
+
+<!-- example-for: web -->
+
+Use to display the current number of characters in a text field. Use in conjunction with max length to display the current remaining number of characters in the text field.
+
+```jsx
+class TextFieldExample extends React.Component {
+  state = {
+    value: 'Jaded Pixel',
+  };
+
+  handleChange = (value) => {
+    this.setState({value});
+  };
+
+  render() {
+    return (
+      <TextField
+        label="Store name"
+        value={this.state.value}
+        onChange={this.handleChange}
+        maxLength={20}
+        showCharacterCount
+      />
+    );
+  }
+}
 ```
 
 ---

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -170,6 +170,18 @@ $stacking-order: (
   pointer-events: none;
 }
 
+.CharacterCount {
+  @include text-emphasis-subdued;
+  z-index: z-index(contents, $stacking-order);
+  margin-right: $backdrop-horizontal-spacing;
+  line-height: control-height();
+  pointer-events: none;
+}
+
+.AlignFieldBottom {
+  align-self: flex-end;
+}
+
 .Spinner {
   z-index: z-index(contents, $stacking-order);
   display: flex;

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -7,6 +7,7 @@ import Labelled, {Action, helpTextID, labelID} from '../Labelled';
 import Connected from '../Connected';
 
 import {Error, Key} from '../../types';
+import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import {Resizer, Spinner} from './components';
 import * as styles from './TextField.scss';
 
@@ -96,6 +97,8 @@ export interface BaseProps {
   ariaActiveDescendant?: string;
   /** Indicates what kind of user input completion suggestions are provided */
   ariaAutocomplete?: string;
+  /** Indicates whether or not the character count should be displayed */
+  showCharacterCount?: boolean;
   /** Callback when value is changed */
   onChange?(value: string, id: string): void;
   /** Callback when input is focused */
@@ -112,17 +115,19 @@ export type Props = NonMutuallyExclusiveProps &
     | {disabled: true}
     | {onChange(value: string, id: string): void});
 
+export type CombinedProps = Props & WithAppProviderProps;
+
 const getUniqueID = createUniqueIDFactory('TextField');
 
-export default class TextField extends React.PureComponent<Props, State> {
-  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+class TextField extends React.PureComponent<CombinedProps, State> {
+  static getDerivedStateFromProps(nextProps: CombinedProps, prevState: State) {
     return {id: nextProps.id || prevState.id};
   }
 
   private input: HTMLElement;
   private buttonPressTimer: number;
 
-  constructor(props: Props) {
+  constructor(props: CombinedProps) {
     super(props);
 
     this.state = {
@@ -132,7 +137,7 @@ export default class TextField extends React.PureComponent<Props, State> {
     };
   }
 
-  componentDidUpdate({focused}: Props) {
+  componentDidUpdate({focused}: CombinedProps) {
     if (
       this.input &&
       focused !== this.props.focused &&
@@ -177,6 +182,8 @@ export default class TextField extends React.PureComponent<Props, State> {
       ariaActiveDescendant,
       ariaAutocomplete,
       ariaControls,
+      showCharacterCount,
+      polaris: {intl},
     } = this.props;
 
     const {height} = this.state;
@@ -202,6 +209,35 @@ export default class TextField extends React.PureComponent<Props, State> {
     const suffixMarkup = suffix ? (
       <div className={styles.Suffix} id={`${id}Suffix`}>
         {suffix}
+      </div>
+    ) : null;
+
+    const characterCount = value.length;
+    const characterCountLabel = intl.translate(
+      maxLength
+        ? 'Polaris.TextField.characterCountWithMaxLength'
+        : 'Polaris.TextField.characterCount',
+      {count: characterCount, limit: maxLength},
+    );
+
+    const characterCountClassName = classNames(
+      styles.CharacterCount,
+      multiline && styles.AlignFieldBottom,
+    );
+
+    const characterCountText = !maxLength
+      ? characterCount
+      : `${characterCount}/${maxLength}`;
+
+    const characterCountMarkup = showCharacterCount ? (
+      <div
+        id={`${id}CharacterCounter`}
+        className={characterCountClassName}
+        aria-label={characterCountLabel}
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {characterCountText}
       </div>
     ) : null;
 
@@ -231,6 +267,9 @@ export default class TextField extends React.PureComponent<Props, State> {
     }
     if (helpText) {
       describedBy.push(helpTextID(id));
+    }
+    if (showCharacterCount) {
+      describedBy.push(`${id}CharacterCounter`);
     }
 
     const labelledBy = [labelID(id)];
@@ -303,6 +342,7 @@ export default class TextField extends React.PureComponent<Props, State> {
             {prefixMarkup}
             {input}
             {suffixMarkup}
+            {characterCountMarkup}
             {spinnerMarkup}
             <div className={styles.Backdrop} />
             {resizer}
@@ -414,3 +454,5 @@ function normalizeAutoComplete(autoComplete?: boolean) {
   }
   return autoComplete ? 'on' : 'off';
 }
+
+export default withAppProvider<Props>()(TextField);

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -305,6 +305,41 @@ describe('<TextField />', () => {
     });
   });
 
+  describe('characterCount', () => {
+    it('displays number of characters entered in input field', () => {
+      const textField = mountWithAppProvider(
+        <TextField
+          value="test"
+          showCharacterCount
+          label="TextField"
+          id="MyField"
+          onChange={noop}
+        />,
+      );
+
+      const characterCount = textField.find('#MyFieldCharacterCounter');
+
+      expect(characterCount.text()).toBe('4');
+    });
+
+    it('displays remaining characters as fraction in input field with maxLength', () => {
+      const textField = mountWithAppProvider(
+        <TextField
+          value="test"
+          maxLength={10}
+          showCharacterCount
+          label="TextField"
+          id="MyField"
+          onChange={noop}
+        />,
+      );
+
+      const characterCount = textField.find('#MyFieldCharacterCounter');
+
+      expect(characterCount.text()).toBe('4/10');
+    });
+  });
+
   describe('type', () => {
     it('sets the type on the input', () => {
       const type = shallowWithAppProvider(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -192,6 +192,11 @@
 
     "Tag": {
       "ariaLabel": "Remove {children}"
+    },
+
+    "TextField": {
+      "characterCount": "{count} characters",
+      "characterCountWithMaxLength": "{count} of {limit} characters used"
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #491

TextField lacks the ability to display the remaining characters available when the TextField has a max character length. This PR adds that ability.

### WHAT is this pull request doing?

Adds in the prop `showCharacterCount` to TextField to enable the displaying of the remaining character count.

The `Labelled` component will then display the number of characters out of the total allowed characters that have been inputted into the TextField.

<img width="331" alt="screen shot 2018-12-03 at 4 21 40 pm" src="https://user-images.githubusercontent.com/11445215/49402881-2dd55980-f719-11e8-8768-2844b220bd65.png">

One item of note is that things can get a little busy as can be seen below:

<img width="962" alt="screen shot 2018-11-29 at 4 20 26 pm" src="https://user-images.githubusercontent.com/11445215/49403510-f1a2f880-f71a-11e8-8c71-8ab1ff49daf9.png">

@dpersing was giving insight into this on the issue.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, TextField} from '@shopify/polaris';

interface State {
  value: string;
}

export default class Playground extends React.Component<{}, State> {
  state = {
    value: '',
  };

  onChange = (value: string) => {
    this.setState({value});
  };

  render() {
    const {value} = this.state;
    return (
      <Page
        title="Playground"
        primaryAction={{content: 'View Examples', url: '/examples'}}
      >
        <TextField
          label="This is where the label lives"
          value={value}
          onChange={this.onChange}
          maxLength={10}
          showCharacterCount
        />
        <TextField
          label="This is where the label lives"
          value={value}
          onChange={this.onChange}
          maxLength={10}
          multiline         
          showCharacterCount
        />
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated [UNRELEASED.md](https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
