### PR TITLE
[DateSelector] Take timezone into account

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Changed `Tabs` example to contain children so the `Panel` renders for accessibility ([#893](https://github.com/Shopify/polaris-react/pull/893))
+- Fixed timezone not being accounted for in `ResourceList` date filter control ([#710](https://github.com/Shopify/polaris-react/pull/710))
 
 ### Documentation
 

--- a/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
@@ -44,6 +44,17 @@ describe('<DateSelector />', () => {
     ],
   };
 
+  let getTimezoneOffset: jest.SpyInstance;
+
+  beforeEach(() => {
+    getTimezoneOffset = jest.spyOn(Date.prototype, 'getTimezoneOffset');
+    getTimezoneOffset.mockImplementation(() => -540);
+  });
+
+  afterEach(() => {
+    getTimezoneOffset.mockRestore();
+  });
+
   describe('dateOptionType', () => {
     it('builds date filters Select options for past option type', () => {
       const wrapper = mountWithAppProvider(
@@ -158,6 +169,79 @@ describe('<DateSelector />', () => {
         />,
       );
       expect(wrapper.find(Select).prop('value')).toBe('on_or_before');
+    });
+  });
+
+  describe('timezones adjustments', () => {
+    it('sets the correct selected date with negative timezone offset on DatePicker and TextField', () => {
+      const nextUserInputDate = '2019-01-01';
+      const timezoneOffset = -540;
+      const timezoneOffsetInHours = Math.abs(timezoneOffset / 60);
+      getTimezoneOffset.mockImplementation(() => timezoneOffset);
+
+      const wrapper = mountWithAppProvider(
+        <DateSelector
+          {...mockDefaultProps}
+          filterValue={DateFilterOption.OnOrBefore}
+        />,
+      );
+
+      trigger(wrapper.find(TextField), 'onChange', nextUserInputDate);
+      trigger(wrapper.find(TextField), 'onBlur');
+
+      const selectedDate = wrapper.find(DatePicker).prop('selected') as Date;
+      const selectedInputDate = wrapper.find(TextField).prop('value');
+
+      expect(selectedDate.toISOString()).toBe(
+        `2019-01-01T0${timezoneOffsetInHours}:00:00.000Z`,
+      );
+      expect(selectedInputDate).toBe(nextUserInputDate);
+    });
+
+    it('sets the correct selected date with fringe timezone offset on DatePicker and TextField', () => {
+      const nextUserInputDate = '2019-01-01';
+      getTimezoneOffset.mockImplementation(() => -720);
+
+      const wrapper = mountWithAppProvider(
+        <DateSelector
+          {...mockDefaultProps}
+          filterValue={DateFilterOption.OnOrBefore}
+        />,
+      );
+
+      trigger(wrapper.find(TextField), 'onChange', nextUserInputDate);
+      trigger(wrapper.find(TextField), 'onBlur');
+
+      const selectedDate = wrapper.find(DatePicker).prop('selected') as Date;
+      const selectedInputDate = wrapper.find(TextField).prop('value');
+
+      expect(selectedDate.toISOString()).toContain(nextUserInputDate);
+      expect(selectedInputDate).toBe(nextUserInputDate);
+    });
+
+    it('sets the correct selected date with positive timezone offset on DatePicker and TextField', () => {
+      const nextUserInputDate = '2019-01-01';
+      const timezoneOffset = 300;
+      const timezoneOffsetInHours = Math.abs(timezoneOffset / 60);
+      getTimezoneOffset.mockImplementation(() => timezoneOffset);
+
+      const wrapper = mountWithAppProvider(
+        <DateSelector
+          {...mockDefaultProps}
+          filterValue={DateFilterOption.OnOrBefore}
+        />,
+      );
+
+      trigger(wrapper.find(TextField), 'onChange', nextUserInputDate);
+      trigger(wrapper.find(TextField), 'onBlur');
+
+      const selectedDate = wrapper.find(DatePicker).prop('selected') as Date;
+      const selectedInputDate = wrapper.find(TextField).prop('value');
+
+      expect(selectedDate.toISOString()).toBe(
+        `2019-01-01T0${timezoneOffsetInHours}:00:00.000Z`,
+      );
+      expect(selectedInputDate).toBe(nextUserInputDate);
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
This PR will fix an issue with the `<DateSelector />` component where it display the incorrect date in the `<TextField />` due to it not taking into account the timezone offset.

The issue is that when passing a date without time, e.g `new Date("2018-12-04").toISOString()` it doesn't take the time zone offset into account.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
This PR fixes the issue by taking the timezone into account when adding a date either in the `<TextField />` component, or by clicking in the `<DatePicker />`. This PR also fixes https://github.com/Shopify/polaris-react/issues/688.

**Before (computer located in Sweden)**
![tz-before](https://user-images.githubusercontent.com/1921046/49437757-ae00cb00-f7bc-11e8-8621-b22af2d4a11b.gif)

**After (computer located in Sweden)**
![tz-after](https://user-images.githubusercontent.com/1921046/49437758-ae996180-f7bc-11e8-86f0-0d7447a1a638.gif)


<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';
import {noop} from '@shopify/javascript-utilities/other';
import DateSelector from '../src/components/ResourceList/components/FilterControl/components/DateSelector';
interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        <DateSelector
          onFilterValueChange={noop}
          onFilterKeyChange={noop}
          filterValue="on_or_before"
          filterKey="starts"
          filterMinKey="starts_min"
          filterMaxKey="starts_max"
        />
      </Page>
    );
  }
}
```

</details>

I've tested this in multiple browsers, as well as multiple time zones (setting them manually in my Mac's system preferences) and everything seems to work as intended. I'd suggest changing the time zone and clicking through the date picker and adding a date manually in the textbox.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
