### PR TITLE
fixes app bridge type imports

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,9 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed App Brige import issues in the `enzyme` utility and `AppProvider`.
+- Fixed missing color utility and type exports.
+
 ### Documentation
 
 ### Development workflow

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,8 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
-- Fixed App Brige import issues in the `enzyme` utility and `AppProvider`.
-- Fixed missing color utility and type exports.
+- Fixed Shopify App Bridge import issues in `AppProvider` and `enzyme` test utilities ([#720](https://github.com/Shopify/polaris-react/pull/720))
 
 ### Documentation
 

--- a/src/components/AppProvider/utilities/createPolarisContext/createPolarisContext.ts
+++ b/src/components/AppProvider/utilities/createPolarisContext/createPolarisContext.ts
@@ -24,7 +24,7 @@ export function createPolarisContext(
 export default function createPolarisContext(
   contextOne?: CreateAppProviderContext | CreateThemeContext,
   contextTwo?: CreateAppProviderContext | CreateThemeContext,
-) {
+): PolarisContext {
   let appProviderContext: CreateAppProviderContext | undefined;
   let themeContext: CreateThemeContext | undefined;
   if (contextOne && 'logo' in contextOne) {

--- a/src/test-utilities/enzyme.tsx
+++ b/src/test-utilities/enzyme.tsx
@@ -10,6 +10,7 @@ import {
 import * as React from 'react';
 import get from 'lodash/get';
 import merge from 'lodash/merge';
+import {PolarisContext} from '../components/types';
 
 // eslint-disable-next-line shopify/strict-component-boundaries
 import {
@@ -171,7 +172,7 @@ export function shallowWithAppProvider<P>(
   return shallow(node, mergeAppProviderOptions(options)).dive(options);
 }
 
-export function createPolarisProps() {
+export function createPolarisProps(): PolarisContext {
   const {polaris} = createAppProviderContext();
   const theme = createThemeContext().polarisTheme;
   const polarisContext = {...polaris, theme};


### PR DESCRIPTION
### WHY are these changes introduced?
`@shopify/app-bridge` imports in the generated types were relative imports which lead to a non-existent node_module when `app-bridge` was not installed.

### WHAT is this pull request doing?
Explicitly defines a `PolarisContext` return type on the functions that caused issues.

### How to 🎩
1. Run `yarn build`.
2. In `types` ensure that all `app-bridge` imports are absolute.