### PR TITLE
[Layout] Adds oneHalf and oneThird props

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Moved icons to a separate npm package ([#686](https://github.com/Shopify/polaris-react/pull/686))
+- Added `oneHalf` and `oneThird` props to `Layout` component ([#724](https://github.com/Shopify/polaris-react/pull/724))
 
 ### Bug fixes
 

--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -1,5 +1,7 @@
 $secondary-basis: layout-width(secondary, min);
 $primary-basis: layout-width(primary, min);
+$one-half-basis: layout-width(one-half-width, base);
+$one-third-basis: layout-width(one-third-width, base);
 $relative-size: $primary-basis / $secondary-basis;
 
 .Layout {
@@ -23,6 +25,16 @@ $relative-size: $primary-basis / $secondary-basis;
 
 .Section-fullWidth {
   flex: 1 1 100%;
+}
+
+.Section-oneHalf {
+  flex: 1 1 $one-half-basis;
+  min-width: 0;
+}
+
+.Section-oneThird {
+  flex: 1 1 $one-third-basis;
+  min-width: 0;
 }
 
 .AnnotatedSection {

--- a/src/components/Layout/README.md
+++ b/src/components/Layout/README.md
@@ -219,7 +219,7 @@ Use to create a ½ + ½ layout. Can be used to display content of equal importan
 
 ```jsx
 <Layout>
-  <Layout.Section secondary>
+  <Layout.Section oneHalf>
     <Card title="Florida" actions={[{content: 'Manage'}]}>
       <Card.Section>
         <TextStyle variation="subdued">455 units available</TextStyle>
@@ -277,7 +277,7 @@ Use to create a ½ + ½ layout. Can be used to display content of equal importan
       </Card.Section>
     </Card>
   </Layout.Section>
-  <Layout.Section secondary>
+  <Layout.Section oneHalf>
     <Card title="Nevada" actions={[{content: 'Manage'}]}>
       <Card.Section>
         <TextStyle variation="subdued">301 units available</TextStyle>
@@ -344,7 +344,7 @@ Use to create a ⅓ + ⅓ + ⅓ layout. Can be used to display content of equal 
 
 ```jsx
 <Layout>
-  <Layout.Section secondary>
+  <Layout.Section oneThird>
     <Card title="Florida" actions={[{content: 'Manage'}]}>
       <Card.Section>
         <TextStyle variation="subdued">455 units available</TextStyle>
@@ -402,7 +402,7 @@ Use to create a ⅓ + ⅓ + ⅓ layout. Can be used to display content of equal 
       </Card.Section>
     </Card>
   </Layout.Section>
-  <Layout.Section secondary>
+  <Layout.Section oneThird>
     <Card title="Nevada" actions={[{content: 'Manage'}]}>
       <Card.Section>
         <TextStyle variation="subdued">301 units available</TextStyle>
@@ -460,7 +460,7 @@ Use to create a ⅓ + ⅓ + ⅓ layout. Can be used to display content of equal 
       </Card.Section>
     </Card>
   </Layout.Section>
-  <Layout.Section secondary>
+  <Layout.Section oneThird>
     <Card title="Minneapolis" actions={[{content: 'Manage'}]}>
       <Card.Section>
         <TextStyle variation="subdued">1931 units available</TextStyle>

--- a/src/components/Layout/components/Section/Section.tsx
+++ b/src/components/Layout/components/Section/Section.tsx
@@ -6,13 +6,23 @@ export interface Props {
   children?: React.ReactNode;
   secondary?: boolean;
   fullWidth?: boolean;
+  oneHalf?: boolean;
+  oneThird?: boolean;
 }
 
-export default function Section({children, secondary, fullWidth}: Props) {
+export default function Section({
+  children,
+  secondary,
+  fullWidth,
+  oneHalf,
+  oneThird,
+}: Props) {
   const className = classNames(
     styles.Section,
     secondary && styles['Section-secondary'],
     fullWidth && styles['Section-fullWidth'],
+    oneHalf && styles['Section-oneHalf'],
+    oneThird && styles['Section-oneThird'],
   );
 
   return <div className={className}>{children}</div>;

--- a/src/components/Layout/tests/Layout.test.tsx
+++ b/src/components/Layout/tests/Layout.test.tsx
@@ -42,6 +42,18 @@ describe('<Layout />', () => {
 
       expect(section.prop('secondary')).toBe(true);
     });
+
+    it('renders a half width section', () => {
+      const section = mountWithAppProvider(<Layout.Section oneHalf />);
+
+      expect(section.prop('oneHalf')).toBe(true);
+    });
+
+    it('renders a third width section', () => {
+      const section = mountWithAppProvider(<Layout.Section oneThird />);
+
+      expect(section.prop('oneThird')).toBe(true);
+    });
   });
 
   describe('<Layout.AnnotatedSection />', () => {

--- a/src/styles/foundation/layout.scss
+++ b/src/styles/foundation/layout.scss
@@ -14,6 +14,12 @@ $layout-width-data: (
     min: rem(240px),
     max: rem(320px),
   ),
+  one-half-width: (
+    base: rem(450px),
+  ),
+  one-third-width: (
+    base: rem(240px),
+  ),
   nav: (
     base: rem($navigation-width),
   ),


### PR DESCRIPTION
### WHY are these changes introduced?
These changes are introduced to allow us to properly achieve an even 2 or 3 column layout. This replaces the old recommendation of using two `secondary` sections. 

### WHAT is this pull request doing?
This PR adds `oneHalf` and `oneThird` props to `Layout.Section` that adds styles for even width columns. 

### What does it look like?
**Wide screen**
<img width="1134" alt="screen shot 2018-12-14 at 10 56 33 am" src="https://user-images.githubusercontent.com/4441303/50013788-1d7e7380-ff90-11e8-90de-3c3d356265e8.png">

**Narrow screen**
<img width="623" alt="screen shot 2018-12-14 at 11 05 27 am" src="https://user-images.githubusercontent.com/4441303/50013817-3850e800-ff90-11e8-9866-7cbdf5d05cdc.png">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Try viewing this layout at multiple viewport widths. Make sure that the columns do not become too narrow before wrapping.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Layout, Banner, Card, FooterHelp} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page
        title="Playground"
        primaryAction={{content: 'View Examples', url: '/examples'}}
      >
        <Layout>
          <Layout.Section fullWidth>
            <Card>
              <Banner title="Successfully created" status="success" />
            </Card>
          </Layout.Section>
          <Layout.Section oneHalf>
            <Card title="Half" sectioned>
              <p>Some content</p>
            </Card>
          </Layout.Section>
          <Layout.Section oneHalf>
            <Card title="Half" sectioned>
              <p>Some content</p>
            </Card>
          </Layout.Section>
          <Layout.Section oneThird>
            <Card title="Third" sectioned>
              <p>Some content</p>
            </Card>
          </Layout.Section>
          <Layout.Section oneThird>
            <Card title="Third" sectioned>
              <p>Some content</p>
            </Card>
          </Layout.Section>
          <Layout.Section oneThird>
            <Card title="Third" sectioned>
              <p>Some content</p>
            </Card>
          </Layout.Section>
          <Layout.Section fullWidth>
            <FooterHelp>Learn more</FooterHelp>
          </Layout.Section>
        </Layout>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
