### PR TITLE
[Playground] Add Google Analytics tracking back

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -1,12 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
     <title>Playground</title>
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-49178120-48"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-49178120-48');
+    </script>
 
     <script>
       // When transpiling TS using isolatedModules, the compiler doesn't strip


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Tracking used to be present in the `yarn tophat` developer tool, but was recently removed (probably when /tophat and /playground got merged).

### WHAT is this pull request doing?

- Adds tracking back to the playground (and /examples)
- Puts `utf-8` in lowercase, not sure it has an impact but it seems to be the norm