### PR TITLE
Export ContextualSaveBarProps from src/components/index

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed `Page` header component to only render actions wrapper when actions are present ([#732](https://github.com/Shopify/polaris-react/pull/732))
+- Fixed `ContextualSaveBarProps` type not being exported ([#734](https://github.com/Shopify/polaris-react/pull/734))
 
 ### Documentation
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -135,6 +135,7 @@ export {default as FormLayout, Props as FormLayoutProps} from './FormLayout';
 export {
   default as Frame,
   Props as FrameProps,
+  ContextualSaveBarProps,
   ToastProps,
   DEFAULT_TOAST_DURATION,
 } from './Frame';


### PR DESCRIPTION
266f1297 accidentally removed this import as part of refactoring

---

#698 Stopped exporting ToastProps and ContextualSaveBarProps. This was my bad as I didn't understand enough about how and where these props are used and didn't realize they are part of our public API. 

#722 Brought back ToastProps. This finishes the job.
