### PR TITLE
[Avatar] - fixed proportion on non-square images

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed Popover not opening in a small Scrollable container ([#658](https://github.com/Shopify/polaris-react/pull/658))
 - Fixed `Page` header component to only render actions wrapper when actions are present ([#732](https://github.com/Shopify/polaris-react/pull/732))
 - Fixed `ContextualSaveBarProps` type not being exported ([#734](https://github.com/Shopify/polaris-react/pull/734))
+- Fixed `Avatar` proportions when image is not square ([#740](https://github.com/Shopify/polaris-react/pull/740))
 
 ### Documentation
 

--- a/src/components/Avatar/Avatar.scss
+++ b/src/components/Avatar/Avatar.scss
@@ -68,8 +68,10 @@ $large-size: rem(60px);
   top: 50%;
   left: 50%;
   width: 100%;
+  height: 100%;
   border-radius: $large-size / 2;
   transform: translate(-50%, -50%);
+  object-fit: cover;
 }
 
 .Initials {


### PR DESCRIPTION
### WHY are these changes introduced?

When non-square images were added as a an avatar, it would result in them becoming pill-shaped blobs. This fixes that problem.

### WHAT is this pull request doing?
Adds `height: 100%` and [`object-fit: cover`](https://caniuse.com/#feat=object-fit) as styles to the image generated by the `Avatar` component.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Avatar, Image, Stack} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        <Stack>
          <Avatar size="large" initials="DL" customer />
          <Avatar
            size="large"
            initials="DL"
            source="https://cdn.pixabay.com/photo/2017/08/03/14/17/nature-2576508_960_720.jpg"
          />
          <Avatar
            size="large"
            initials="DL"
            source="https://images.unsplash.com/photo-1486875862166-34751ccac396?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=934&q=80"
          />
          <Avatar size="large" initials="DL" source="https://avatars2=80&v=4" />
        </Stack>
      </Page>
    );
  }
}
```

</details>
