### PR TITLE
[WIP] [Modal] Add `fullScreen` prop

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -55,6 +55,8 @@ export interface Props extends FooterProps {
   limitHeight?: boolean;
   /** Replaces modal content with a spinner while a background action is being performed (stand-alone app use only) */
   loading?: boolean;
+  /** Sets the modal to take up the entire screen */
+  fullScreen?: boolean;
   /**
    * Controls the size of the modal
    * @default 'Small'
@@ -209,6 +211,7 @@ export class Modal extends React.Component<CombinedProps, State> {
       footer,
       primaryAction,
       secondaryActions,
+      fullScreen,
       polaris: {intl},
     } = this.props;
 
@@ -277,6 +280,7 @@ export class Modal extends React.Component<CombinedProps, State> {
           onExited={this.handleExited}
           large={large}
           limitHeight={limitHeight}
+          fullScreen={fullScreen}
         >
           {headerMarkup}
           <div className={styles.BodyWrapper}>{bodyMarkup}</div>

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -616,6 +616,63 @@ class ModalExample extends React.Component {
 }
 ```
 
+### Full screen modal
+
+<!-- example-for: web -->
+
+When you need a modal that will take up the entire screen.
+
+```jsx
+class ModalExample extends React.Component {
+  state = {
+    active: true,
+  };
+
+  render() {
+    const {active} = this.state;
+
+    return (
+      <div style={{height: '500px'}}>
+        <Button onClick={this.handleChange}>Open</Button>
+        <Modal
+          fullScreen
+          open={active}
+          onClose={this.handleChange}
+          title="Build custom apps with App Bridge"
+          primaryAction={{
+            content: 'Done',
+            onAction: this.handleChange,
+          }}
+          secondaryActions={[
+            {
+              content: 'Learn more',
+              onAction: this.handleChange,
+            },
+          ]}
+        >
+          <Modal.Section>
+            <TextContainer>
+              <p>
+                Use Shopify App Bridge to embed apps and channels directly into
+                the Shopify admin, Shopify Mobile, and Shopify POS. Shopify App
+                Bridge helps to reduce your development time by accessing native
+                Shopify features across different platforms, and makes sure that
+                the user experience is consistent wherever merchants are using
+                your app.
+              </p>
+            </TextContainer>
+          </Modal.Section>
+        </Modal>
+      </div>
+    );
+  }
+
+  handleChange = () => {
+    this.setState(({active}) => ({active: !active}));
+  };
+}
+```
+
 ### Warning modal
 
 <!-- example-for: android, ios -->

--- a/src/components/Modal/components/Dialog/Dialog.scss
+++ b/src/components/Modal/components/Dialog/Dialog.scss
@@ -66,6 +66,13 @@ $large-width: rem(980px);
       max-width: $large-width;
     }
   }
+
+  &.fullScreen {
+    border-radius: 0;
+    height: 100vh;
+    max-height: 100vh;
+    max-width: 100vw;
+  }
 }
 
 .animateFadeUp {

--- a/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/src/components/Modal/components/Dialog/Dialog.tsx
@@ -15,6 +15,7 @@ export interface DialogProps {
   instant?: boolean;
   children?: React.ReactNode;
   limitHeight?: boolean;
+  fullScreen?: boolean;
   large?: boolean;
   onClose(): void;
   onEntered?(): void;
@@ -40,12 +41,14 @@ export default function Dialog({
   onEntered,
   large,
   limitHeight,
+  fullScreen,
   ...props
 }: Props) {
   const classes = classNames(
     styles.Modal,
     large && styles.sizeLarge,
     limitHeight && styles.limitHeight,
+    fullScreen && styles.fullScreen,
   );
   const TransitionChild = instant ? Transition : FadeUp;
 

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -139,6 +139,28 @@ describe('<Modal>', () => {
     });
   });
 
+  describe('fullScreen', () => {
+    it('passes fullScreen to Dialog if true', () => {
+      const modal = mountWithAppProvider(
+        <Modal fullScreen onClose={jest.fn()} open>
+          <Badge />
+        </Modal>,
+      );
+
+      expect(modal.find(Dialog).prop('fullScreen')).toBe(true);
+    });
+
+    it('does not pass fullScreen to Dialog by default', () => {
+      const modal = mountWithAppProvider(
+        <Modal onClose={jest.fn()} open>
+          <Badge />
+        </Modal>,
+      );
+
+      expect(modal.find(Dialog).prop('fullScreen')).toBeUndefined();
+    });
+  });
+
   describe('open', () => {
     it('renders <Portal /> with idPrefix modal', () => {
       const modal = mountWithAppProvider(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

In App Bridge, `Full` is available as an option for modal `size`, used to display full screen modals: [public docs](https://help.shopify.com/en/api/embedded-apps/app-bridge/actions/modal#set-modal-size).

When **displaying** the full size modal on the host side (`web`), we are consuming the `Modal` component from `polaris-next`, which is a slightly different modal component with an additional `fullScreen` prop.

App Bridge is in the process of extracting re-usable components out of `web`, and hoping to move away from `polaris-next` and directly consume the public version instead. This change will allow us to do so.

#### Additional context

I'm not sure if there were previous discussions regarding making `fullScreen` prop available to the public. I've spoken to @dleroux briefly regarding this prop, and from my understanding the API is safe.

### WHAT is this pull request doing?

Move `fullScreen` prop and related styles from `polaris-next` in `web`, add to docs and tests.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Button, Modal, TextContainer} from '@shopify/polaris';

interface State {
  active: boolean;
}

export default class Playground extends React.Component<{}, State> {
  state = {
    active: false,
  };

  render() {
    const {active} = this.state;

    return (
      <Page
        title="Playground - Full screen modal demo"
        primaryAction={{content: 'View Examples', url: '/examples'}}
      >
        <div style={{height: '500px'}}>
          <Button onClick={this.handleChange}>Open full screen modal</Button>
          <Modal
            fullScreen
            open={active}
            onClose={this.handleChange}
            title="Build custom apps with App Bridge"
            primaryAction={{
              content: 'OK',
              onAction: this.handleChange,
            }}
          >
            <Modal.Section>
              <TextContainer>
                <p>
                  Use Shopify App Bridge to embed apps and channels directly
                  into the Shopify admin, Shopify Mobile, and Shopify POS.
                  Shopify App Bridge helps to reduce your development time by
                  accessing native Shopify features across different platforms,
                  and makes sure that the user experience is consistent wherever
                  merchants are using your app.
                </p>
              </TextContainer>
            </Modal.Section>
          </Modal>
        </div>
      </Page>
    );
  }

  handleChange = () => {
    const {active} = this.state;
    this.setState({active: !active});
  };
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
