### PR TITLE
[ResourceList] Remove extra tabstop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed the new variant of the `Badge` component so that it is simpler and easier to read ([#751](https://github.com/Shopify/polaris-react/pull/751))
 - Reverted a change that set the `autocomplete` property on `TextField` to `nope` when it was `false` ([#761](https://github.com/Shopify/polaris-react/pull/761))
 - Added dismiss button for `CalloutCard` ([#353](https://github.com/Shopify/polaris-react/issues/353))
+- Removed an extra tab stop from `ResourceList.Item` and make it unactionable while loading ([#XXX](https://github.com/Shopify/polaris-react/pull/XXX))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Reverted a change that set the `autocomplete` property on `TextField` to `nope` when it was `false` ([#761](https://github.com/Shopify/polaris-react/pull/761))
 - Added dismiss button for `CalloutCard` ([#353](https://github.com/Shopify/polaris-react/issues/353))
 - Removed an extra tab stop from `ResourceList.Item` and make it unactionable while loading ([#XXX](https://github.com/Shopify/polaris-react/pull/XXX))
+- Removed an extra tab stop from `ResourceList.Item` and make it unactionable while loading ([#745](https://github.com/Shopify/polaris-react/pull/745))
 
 ### Documentation
 

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -597,12 +597,11 @@ export class ResourceList extends React.Component<CombinedProps, State> {
 
   @autobind
   private renderItem(item: any, index: number) {
-    const {renderItem, idForItem = defaultIdForItem, loading} = this.props;
+    const {renderItem, idForItem = defaultIdForItem} = this.props;
     const id = idForItem(item, index);
-    const tabIndex = loading ? -1 : 0;
 
     return (
-      <li key={id} className={styles.ItemWrapper} tabIndex={tabIndex}>
+      <li key={id} className={styles.ItemWrapper}>
         {renderItem(item, id)}
       </li>
     );

--- a/src/components/ResourceList/components/Item/Item.tsx
+++ b/src/components/ResourceList/components/Item/Item.tsx
@@ -156,12 +156,15 @@ export class Item extends React.PureComponent<CombinedProps, State> {
     let actionsMarkup: React.ReactNode | null = null;
     let disclosureMarkup: React.ReactNode | null = null;
 
-    if (shortcutActions) {
+    if (shortcutActions && !loading) {
       if (persistActions) {
         actionsMarkup = (
           <div className={styles.Actions} onClick={stopPropagation}>
             <ButtonGroup>
-              {buttonsFrom(shortcutActions, {size: 'slim', plain: true})}
+              {buttonsFrom(shortcutActions, {
+                size: 'slim',
+                plain: true,
+              })}
             </ButtonGroup>
           </div>
         );
@@ -190,7 +193,9 @@ export class Item extends React.PureComponent<CombinedProps, State> {
         actionsMarkup = (
           <div className={styles.Actions} onClick={stopPropagation}>
             <ButtonGroup segmented testID="ShortcutActions">
-              {buttonsFrom(shortcutActions, {size: 'slim'})}
+              {buttonsFrom(shortcutActions, {
+                size: 'slim',
+              })}
             </ButtonGroup>
           </div>
         );
@@ -214,6 +219,8 @@ export class Item extends React.PureComponent<CombinedProps, State> {
       </div>
     );
 
+    const tabIndex = loading ? -1 : 0;
+
     const accessibleMarkup = url ? (
       <UnstyledLink
         aria-describedby={this.props.id}
@@ -222,6 +229,7 @@ export class Item extends React.PureComponent<CombinedProps, State> {
         url={url}
         onFocus={this.handleAnchorFocus}
         onBlur={this.handleFocusedBlur}
+        tabIndex={tabIndex}
       />
     ) : (
       <button
@@ -232,6 +240,7 @@ export class Item extends React.PureComponent<CombinedProps, State> {
         onClick={this.handleClick}
         onFocus={this.handleAnchorFocus}
         onBlur={this.handleFocusedBlur}
+        tabIndex={tabIndex}
       />
     );
 

--- a/src/components/ResourceList/components/Item/tests/Item.test.tsx
+++ b/src/components/ResourceList/components/Item/tests/Item.test.tsx
@@ -371,5 +371,49 @@ describe('<Item />', () => {
       );
       expect(wrapper.find(ButtonGroup).exists()).toBe(true);
     });
+
+    it('does not render while loading', () => {
+      const wrapper = mountWithAppProvider(
+        <Provider value={{...mockLoadingContext}}>
+          <Item
+            id={itemId}
+            url={url}
+            shortcutActions={[{content: 'action'}]}
+            persistActions
+          />
+        </Provider>,
+      );
+      expect(wrapper.find(ButtonGroup)).toHaveLength(0);
+    });
+  });
+
+  describe('accessibleMarkup', () => {
+    it('renders with a tab index of -1 when loading is true', () => {
+      const wrapper = mountWithAppProvider(
+        <Provider value={mockLoadingContext}>
+          <Item
+            id={itemId}
+            url={url}
+            shortcutActions={[{content: 'action'}]}
+            persistActions
+          />
+        </Provider>,
+      );
+      expect(wrapper.find(UnstyledLink).prop('tabIndex')).toBe(-1);
+    });
+
+    it('renders with a tab index of 0 when loading is false', () => {
+      const wrapper = mountWithAppProvider(
+        <Provider value={mockDefaultContext}>
+          <Item
+            id={itemId}
+            url={url}
+            shortcutActions={[{content: 'action'}]}
+            persistActions
+          />
+        </Provider>,
+      );
+      expect(wrapper.find(UnstyledLink).prop('tabIndex')).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?
* Extra tabstop breaking interaction states
* Items are interact-able while loading

### WHAT is this pull request doing?
* Removing the tabstop
* Items are not interact-able while loading

### How to 🎩
Playground stolen from Solona's loading PR 😄 

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
/* eslint-disable */
import React from 'react';
import {
  Avatar,
  Card,
  ResourceList,
  FilterType,
  TextStyle,
  Page,
  AppProvider,
} from '@shopify/polaris';

interface State {
  searchValue: string;
  appliedFilters: object;
}

export default class ResourceListExample extends React.Component<never, State> {
  state: State = {
    searchValue: '',
    appliedFilters: [
      {
        key: 'accountStatusFilter',
        value: 'Account enabled',
      },
    ],
  };

  handleSearchChange = (searchValue: string) => {
    this.setState({searchValue});
  };

  handleFiltersChange = (appliedFilters: any) => {
    console.log('**** You added a new filter - Current applied filters are ', {
      appliedFilters,
    });
    this.setState({appliedFilters});
  };

  renderItem = (item: any) => {
    const {id, url, name, location} = item;
    const media = <Avatar customer size="medium" name={name} />;

    return (
      <ResourceList.Item id={id} url={url} media={media}>
        <h3>
          <TextStyle variation="strong">{name}</TextStyle>
        </h3>
        <div>{location}</div>
      </ResourceList.Item>
    );
  };

  render() {
    const resourceName = {
      singular: 'customer',
      plural: 'customers',
    };

    const items = [
      {
        id: 341,
        url: 'customers/341',
        name: 'Mae Jemison',
        location: 'Decatur, USA',
      },
      {
        id: 256,
        url: 'customers/256',
        name: 'Ellen Ochoa',
        location: 'Los Angeles, USA',
      },
      {
        id: 190,
        url: 'customers/190',
        name: 'Ellen Ochoa',
        location: 'Los Angeles, USA',
      },
    ];

    const filters = [
      {
        key: 'accountStatusFilter',
        label: 'Account status',
        operatorText: 'is',
        type: FilterType.Select,
        options: ['Enabled', 'Invited', 'Not invited', 'Declined'],
      },
    ];

    const filterControl = (
      <ResourceList.FilterControl
        filters={filters}
        appliedFilters={this.state.appliedFilters}
        onFiltersChange={this.handleFiltersChange}
        searchValue={this.state.searchValue}
        onSearchChange={this.handleSearchChange}
        additionalAction={{
          content: 'Save',
          onAction: () => console.log('New filter saved'),
        }}
      />
    );

    return (
      <AppProvider>
        <Page title="Playground">
          <Card>
            <ResourceList
              resourceName={resourceName}
              items={items}
              renderItem={this.renderItem}
              filterControl={filterControl}
              loading={true}
            />
          </Card>
        </Page>
      </AppProvider>
    );
  }
}

/* eslint-enable */

```

</details>

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
