### PR TITLE
Change paths to images to match the style guide's folder structure

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Modified image paths to fit the [style guide](https://polaris.shopify.com)’s new image parsing rules ([#753](https://github.com/Shopify/polaris-react/pull/753)
+
 ### Development workflow
 
 - Added a slight delay to the Percy screenshot script to give time for components to render fully ([#704](https://github.com/Shopify/polaris-react/pull/704))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,7 +14,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
-- Modified image paths to fit the [style guide](https://polaris.shopify.com)’s new image parsing rules ([#753](https://github.com/Shopify/polaris-react/pull/753)
+- Modified image paths to fit the [style guide](https://polaris.shopify.com)’s new Markdown parsing rules ([#753](https://github.com/Shopify/polaris-react/pull/753))
 
 ### Development workflow
 

--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -67,13 +67,13 @@ Use to present an avatar for a merchant, customer, or business.
 
 <!-- content-for: android -->
 
-![Default avatar](components/Avatar/android/default.png)
+![Default avatar](/public_images/components/Avatar/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default avatar](components/Avatar/ios/default.png)
+![Default avatar](/public_images/components/Avatar/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Badge/README.md
+++ b/src/components/Badge/README.md
@@ -88,13 +88,13 @@ Use to give a non-critical status update on a piece of information or action.
 
 <!-- content-for: android -->
 
-![Default badge with gray background](components/Badge/android/default.png)
+![Default badge with gray background](/public_images/components/Badge/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default badge with gray background](components/Badge/ios/default.png)
+![Default badge with gray background](/public_images/components/Badge/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -108,13 +108,13 @@ Use to call out an object or action as having an important attribute. For exampl
 
 <!-- content-for: android -->
 
-![Informational badge with blue background](components/Badge/android/informational.png)
+![Informational badge with blue background](/public_images/components/Badge/android/informational@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Informational badge with blue background](components/Badge/ios/informational.png)
+![Informational badge with blue background](/public_images/components/Badge/ios/informational@2x.png)
 
 <!-- /content-for -->
 
@@ -128,13 +128,13 @@ Use to indicate a successful, completed, or desirable state when it’s importan
 
 <!-- content-for: android -->
 
-![Success badge with green background](components/Badge/android/success.png)
+![Success badge with green background](/public_images/components/Badge/android/success@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Success badge with green background](components/Badge/ios/success.png)
+![Success badge with green background](/public_images/components/Badge/ios/success@2x.png)
 
 <!-- /content-for -->
 
@@ -148,13 +148,13 @@ Use when something requires merchants’ attention but the issue isn’t critica
 
 <!-- content-for: android -->
 
-![Attention badge with yellow background](components/Badge/android/attention.png)
+![Attention badge with yellow background](/public_images/components/Badge/android/attention@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Attention badge with yellow background](components/Badge/ios/attention.png)
+![Attention badge with yellow background](/public_images/components/Badge/ios/attention@2x.png)
 
 <!-- /content-for -->
 
@@ -170,13 +170,13 @@ Keep in mind that seeing this badge can feel stressful for merchants so it shoul
 
 <!-- content-for: android -->
 
-![Warning badge with orange background](components/Badge/android/warning.png)
+![Warning badge with orange background](/public_images/components/Badge/android/warning@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Warning badge with orange background](components/Badge/ios/warning.png)
+![Warning badge with orange background](/public_images/components/Badge/ios/warning@2x.png)
 
 <!-- /content-for -->
 
@@ -190,13 +190,13 @@ Keep in mind that seeing this badge can feel stressful for merchants so it shoul
 
 <!-- content-for: android -->
 
-![Critical badge with red background](components/Badge/android/critical.png)
+![Critical badge with red background](/public_images/components/Badge/android/critical@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Critical badge with red background](components/Badge/ios/critical.png)
+![Critical badge with red background](/public_images/components/Badge/ios/critical@2x.png)
 
 <!-- /content-for -->
 
@@ -210,13 +210,13 @@ Use to indicate when a given task has not yet been completed. For example, when 
 
 <!-- content-for: android -->
 
-![Incomplete badge. Default badge with incomplete status](components/Badge/android/incomplete.png)
+![Incomplete badge. Default badge with incomplete status](/public_images/components/Badge/android/incomplete@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Incomplete badge. Default badge with incomplete status](components/Badge/ios/incomplete.png)
+![Incomplete badge. Default badge with incomplete status](/public_images/components/Badge/ios/incomplete@2x.png)
 
 <!-- /content-for -->
 
@@ -230,13 +230,13 @@ Use to indicate when a given task has been partially completed. For example, whe
 
 <!-- content-for: android -->
 
-![Partially complete badge. Default badge with partially complete status](components/Badge/android/partially-complete.png)
+![Partially complete badge. Default badge with partially complete status](/public_images/components/Badge/android/partially-complete@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Partially complete badge. Default badge with partially complete status](components/Badge/ios/partially-complete.png)
+![Partially complete badge. Default badge with partially complete status](/public_images/components/Badge/ios/partially-complete@2x.png)
 
 <!-- /content-for -->
 
@@ -250,13 +250,13 @@ Use to indicate when a given task has been completed. For example, when merchant
 
 <!-- content-for: android -->
 
-![Complete badge. Default badge with complete status](components/Badge/android/complete.png)
+![Complete badge. Default badge with complete status](/public_images/components/Badge/android/complete@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Complete badge. Default badge with complete status](components/Badge/ios/complete.png)
+![Complete badge. Default badge with complete status](/public_images/components/Badge/ios/complete@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Banner/README.md
+++ b/src/components/Banner/README.md
@@ -270,13 +270,13 @@ including packaging.
 
 <!-- content-for: android -->
 
-![Default banner for Android](components/Banner/android/default.png)
+![Default banner for Android](/public_images/components/Banner/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default banner for iOS](components/Banner/ios/default.png)
+![Default banner for iOS](/public_images/components/Banner/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -315,13 +315,13 @@ Use when you want merchants to take an action after reading the banner.
 
 <!-- content-for: android -->
 
-![Banner with footer call-to-action for Android](components/Banner/android/footer-action.png)
+![Banner with footer call-to-action for Android](/public_images/components/Banner/android/footer-action@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Banner with footer call-to-action for iOS](components/Banner/ios/footer-action.png)
+![Banner with footer call-to-action for iOS](/public_images/components/Banner/ios/footer-action@2x.png)
 
 <!-- /content-for -->
 
@@ -342,13 +342,13 @@ Use to update merchants about a change or give them advice.
 
 <!-- content-for: android -->
 
-![Informational banner for Android](components/Banner/android/informational.png)
+![Informational banner for Android](/public_images/components/Banner/android/informational@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Informational banner for iOS](components/Banner/ios/informational.png)
+![Informational banner for iOS](/public_images/components/Banner/ios/informational@2x.png)
 
 <!-- /content-for -->
 
@@ -368,13 +368,13 @@ Use to update merchants about a change or give them advice.
 
 <!-- content-for: android -->
 
-![Success banner for Android](components/Banner/android/success.png)
+![Success banner for Android](/public_images/components/Banner/android/success@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Success banner for iOS](components/Banner/ios/success.png)
+![Success banner for iOS](/public_images/components/Banner/ios/success@2x.png)
 
 <!-- /content-for -->
 
@@ -400,13 +400,13 @@ Use to update merchants about a change or give them advice.
 
 <!-- content-for: android -->
 
-![Warning banner for Android](components/Banner/android/warning.png)
+![Warning banner for Android](/public_images/components/Banner/android/warning@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Warning banner for iOS](components/Banner/ios/warning.png)
+![Warning banner for iOS](/public_images/components/Banner/ios/warning@2x.png)
 
 <!-- /content-for -->
 
@@ -432,13 +432,13 @@ Use to update merchants about a change or give them advice.
 
 <!-- content-for: android -->
 
-![Critical banner for Android](components/Banner/android/critical.png)
+![Critical banner for Android](/public_images/components/Banner/android/critical@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Critical banner for iOS](components/Banner/ios/critical.png)
+![Critical banner for iOS](/public_images/components/Banner/ios/critical@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -114,13 +114,13 @@ Used most in the interface. Only use another style if a button requires more or 
 
 <!-- content-for: android -->
 
-![Basic button for Android](components/Button/android/basic.png)
+![Basic button for Android](/public_images/components/Button/android/basic@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Basic button for iOS](components/Button/ios/basic.png)
+![Basic button for iOS](/public_images/components/Button/ios/basic@2x.png)
 
 <!-- /content-for -->
 
@@ -144,13 +144,13 @@ Use for less important or less commonly used actions since they’re less promin
 
 <!-- content-for: android -->
 
-![Plain button for Android](components/Button/android/plain.png)
+![Plain button for Android](/public_images/components/Button/android/plain@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Plain button for iOS](components/Button/ios/plain.png)
+![Plain button for iOS](/public_images/components/Button/ios/plain@2x.png)
 
 <!-- /content-for -->
 
@@ -164,13 +164,13 @@ Use to highlight the most important actions in any experience. Don’t use more 
 
 <!-- content-for: android -->
 
-![Primary button for Android](components/Button/android/primary.png)
+![Primary button for Android](/public_images/components/Button/android/primary@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Primary button for iOS](components/Button/ios/primary.png)
+![Primary button for iOS](/public_images/components/Button/ios/primary@2x.png)
 
 <!-- /content-for -->
 
@@ -184,13 +184,13 @@ Use when the action will delete merchant data or be otherwise difficult to recov
 
 <!-- content-for: android -->
 
-![Destrutive plain and destructive basic button for Android](components/Button/android/destructive.png)
+![Destrutive plain and destructive basic button for Android](/public_images/components/Button/android/destructive@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Destrutive plain and destructive basic button for iOS](components/Button/ios/destructive.png)
+![Destrutive plain and destructive basic button for iOS](/public_images/components/Button/ios/destructive@2x.png)
 
 <!-- /content-for -->
 
@@ -234,13 +234,13 @@ Use for actions that aren’t currently available. The surrounding interface sho
 
 <!-- content-for: android -->
 
-![Disabled primary button for Android](components/Button/android/disabled.png)
+![Disabled primary button for Android](/public_images/components/Button/android/disabled@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Disabled primary button for iOS](components/Button/ios/disabled.png)
+![Disabled primary button for iOS](/public_images/components/Button/ios/disabled@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/ButtonGroup/README.md
+++ b/src/components/ButtonGroup/README.md
@@ -68,13 +68,13 @@ Use when you have multiple buttons to space them out evenly.
 
 <!-- content-for: android -->
 
-![Alt text](components/ButtonGroup/android/default.png)
+![Alt text](/public_images/components/ButtonGroup/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Alt text](components/ButtonGroup/ios/default.png)
+![Alt text](/public_images/components/ButtonGroup/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -92,13 +92,13 @@ Use to emphasize several buttons as a thematically-related set among other contr
 
 <!-- content-for: android -->
 
-![Alt text](components/ButtonGroup/android/segmented-button.png)
+![Alt text](/public_images/components/ButtonGroup/android/segmented-button@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Alt text](components/ButtonGroup/ios/segmented-button.png)
+![Alt text](/public_images/components/ButtonGroup/ios/segmented-button@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Caption/README.md
+++ b/src/components/Caption/README.md
@@ -49,7 +49,7 @@ Captions are primarily used in [data visualizations](/design/data-visualizations
 #### Do
 
 - Use caption for labelling data visualizations
-  ![Diagram of using captions to label graphs and other data content](typography/display-styles/do-use-caption-for-labeling-data-visualizations.png)
+  ![Diagram of using captions to label graphs and other data content](/public_images/typography/display-styles/do-use-caption-for-labeling-data-visualizations@2x.png)
 - Received April 21, 2017
 
 #### Don’t
@@ -80,12 +80,12 @@ Use to provide details in situations where content is compact and space is tight
 
 <!-- content-for: android -->
 
-![Default caption](components/Caption/android/default.png)
+![Default caption](/public_images/components/Caption/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default caption](components/Caption/ios/default.png)
+![Default caption](/public_images/components/Caption/ios/default@2x.png)
 
 <!-- /content-for -->

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -206,13 +206,13 @@ Use when you have a simple message to communicate to merchants that doesn’t re
 
 <!-- content-for: android -->
 
-![Default card with a title and a short body](components/Card/android/default.png)
+![Default card with a title and a short body](/public_images/components/Card/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default card with a title and a short body](components/Card/ios/default.png)
+![Default card with a title and a short body](/public_images/components/Card/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -244,13 +244,13 @@ Use for less important card actions, or actions merchants may do before reviewin
 
 <!-- content-for: android -->
 
-![Card with a title (Conditions), a short body and a header action to add a condition](components/Card/android/header-actions.png)
+![Card with a title (Conditions), a short body and a header action to add a condition](/public_images/components/Card/android/header-actions@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Card with a title (Conditions), a short body and a header action to add a condition](components/Card/ios/header-actions.png)
+![Card with a title (Conditions), a short body and a header action to add a condition](/public_images/components/Card/ios/header-actions@2x.png)
 
 <!-- /content-for -->
 
@@ -288,13 +288,13 @@ Use footer actions for a card’s most important actions, or actions merchants s
 
 <!-- content-for: android -->
 
-![Card featuring footer actions: add variant, edit options](components/Card/android/footer-actions.png)
+![Card featuring footer actions: add variant, edit options](/public_images/components/Card/android/footer-actions@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Card featuring footer actions: add variant, edit options](components/Card/ios/footer-actions.png)
+![Card featuring footer actions: add variant, edit options](/public_images/components/Card/ios/footer-actions@2x.png)
 
 <!-- /content-for -->
 
@@ -319,13 +319,13 @@ Use when you have two related but distinct pieces of information to communicate 
 
 <!-- content-for: android -->
 
-![Shipping costs card with multiple sections: domestic, international](components/Card/android/multiple-sections.png)
+![Shipping costs card with multiple sections: domestic, international](/public_images/components/Card/android/multiple-sections@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Shipping costs card with multiple sections: domestic, international](components/Card/ios/multiple-sections.png)
+![Shipping costs card with multiple sections: domestic, international](/public_images/components/Card/ios/multiple-sections@2x.png)
 
 <!-- /content-for -->
 
@@ -350,13 +350,13 @@ Use when you have two related but distinct pieces of information to communicate 
 
 <!-- content-for: android -->
 
-![Customer card with multiple titled sections: note, shipping address](components/Card/android/multiple-titled-sections.png)
+![Customer card with multiple titled sections: note, shipping address](/public_images/components/Card/android/multiple-titled-sections@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Customer card with multiple titled sections: note, shipping address](components/Card/ios/multiple-titled-sections.png)
+![Customer card with multiple titled sections: note, shipping address](/public_images/components/Card/ios/multiple-titled-sections@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Checkbox/README.md
+++ b/src/components/Checkbox/README.md
@@ -133,13 +133,13 @@ class CheckboxExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default checkbox on Android](components/Checkbox/android/default.png)
+![Default checkbox on Android](/public_images/components/Checkbox/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default checkbox on iOS](components/Checkbox/ios/default.png)
+![Default checkbox on iOS](/public_images/components/Checkbox/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/ChoiceList/README.md
+++ b/src/components/ChoiceList/README.md
@@ -208,13 +208,13 @@ class ChoiceListExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Single choice list for Android](components/ChoiceList/android/single-choice.png)
+![Single choice list for Android](/public_images/components/ChoiceList/android/single-choice@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Single choice list for iOS](components/ChoiceList/ios/single-choice.png)
+![Single choice list for iOS](/public_images/components/ChoiceList/ios/single-choice@2x.png)
 
 <!-- /content-for -->
 
@@ -265,13 +265,13 @@ class ChoiceListExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Multi choice list for Android](components/ChoiceList/android/multi-choice.png)
+![Multi choice list for Android](/public_images/components/ChoiceList/android/multi-choice@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Multi choice list for iOS](components/ChoiceList/ios/multi-choice.png)
+![Multi choice list for iOS](/public_images/components/ChoiceList/ios/multi-choice@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Collapsible/README.md
+++ b/src/components/Collapsible/README.md
@@ -97,13 +97,13 @@ class CollapsibleExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Collapsible on Android](components/Collapsible/android/default.png)
+![Collapsible on Android](/public_images/components/Collapsible/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Collapsible on iOS](components/Collapsible/ios/default.png)
+![Collapsible on iOS](/public_images/components/Collapsible/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/DatePicker/README.md
+++ b/src/components/DatePicker/README.md
@@ -93,12 +93,12 @@ class DatePickerExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Date picker on Android](components/DatePicker/android/default.png)
+![Date picker on Android](/public_images/components/DatePicker/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Date picker on iOS](components/DatePicker/ios/default.png)
+![Date picker on iOS](/public_images/components/DatePicker/ios/default@2x.png)
 
 <!-- /content-for -->

--- a/src/components/DescriptionList/README.md
+++ b/src/components/DescriptionList/README.md
@@ -131,13 +131,13 @@ Use when you need to present merchants with a list of items or terms alongside d
 
 <!-- content-for: android -->
 
-![Description list for Android](components/DescriptionList/android/default.png)
+![Description list for Android](/public_images/components/DescriptionList/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Description list for iOS](components/DescriptionList/ios/default.png)
+![Description list for iOS](/public_images/components/DescriptionList/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/DisplayText/README.md
+++ b/src/components/DisplayText/README.md
@@ -80,13 +80,13 @@ Use this size sparingly and never multiple times on the same page.
 
 <!-- content-for: android -->
 
-![Extra large display text](components/DisplayText/android/extra-large.png)
+![Extra large display text](/public_images/components/DisplayText/android/extra-large@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Extra large display text](components/DisplayText/ios/extra-large.png)
+![Extra large display text](/public_images/components/DisplayText/ios/extra-large@2x.png)
 
 <!-- /content-for -->
 
@@ -108,13 +108,13 @@ Use for display text that’s more important than the small size, but less impor
 
 <!-- content-for: android -->
 
-![Medium and large display text](components/DisplayText/android/medium-large.png)
+![Medium and large display text](/public_images/components/DisplayText/android/medium-large@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Medium and large display text](components/DisplayText/ios/medium-large.png)
+![Medium and large display text](/public_images/components/DisplayText/ios/medium-large@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -165,13 +165,13 @@ Use to explain a single feature before merchants have used it.
 
 <!-- content-for: android -->
 
-![Default empty state](components/EmptyState/android/default.png)
+![Default empty state](/public_images/components/EmptyState/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default empty state](components/EmptyState/ios/default.png)
+![Default empty state](/public_images/components/EmptyState/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/ExceptionList/README.md
+++ b/src/components/ExceptionList/README.md
@@ -55,11 +55,11 @@ If placed next to an item in a [resource list](https://polaris.shopify.com/compo
 
 #### Do
 
-- ![Exception list being used inside a resource list item](exception-list/do-exception-list.png)
+- ![Exception list being used inside a resource list item](/public_images/exception-list/do-exception-list@2x.png)
 
 #### Don’t
 
-- ![Exception list being used in place of a banner](exception-list/dont-exception-list.png)
+- ![Exception list being used in place of a banner](/public_images/exception-list/dont-exception-list@2x.png)
 
 <!-- end -->
 

--- a/src/components/FormLayout/README.md
+++ b/src/components/FormLayout/README.md
@@ -128,13 +128,13 @@ Use to stack form fields vertically, which makes them easier to scan and complet
 
 <!-- content-for: android -->
 
-![Default form layout for Android](components/FormLayout/android/default.png)
+![Default form layout for Android](/public_images/components/FormLayout/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default form layout for iOS](components/FormLayout/ios/default.png)
+![Default form layout for iOS](/public_images/components/FormLayout/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -157,13 +157,13 @@ Field groups will wrap automatically on smaller screens.
 
 <!-- content-for: android -->
 
-![Form layout with field group for Android](components/FormLayout/android/field-group.png)
+![Form layout with field group for Android](/public_images/components/FormLayout/android/field-group@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Form layout with field group for iOS](components/FormLayout/ios/field-group.png)
+![Form layout with field group for iOS](/public_images/components/FormLayout/ios/field-group@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Heading/README.md
+++ b/src/components/Heading/README.md
@@ -93,13 +93,13 @@ Use for the title of each top-level page section.
 
 <!-- content-for: android -->
 
-![Typographic heading](components/Heading/android/default.png)
+![Typographic heading](/public_images/components/Heading/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Typographic heading](components/Heading/ios/default.png)
+![Typographic heading](/public_images/components/Heading/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/InlineError/README.md
+++ b/src/components/InlineError/README.md
@@ -72,13 +72,13 @@ Use when the merchant has entered invalid information into multiple fields insid
 
 <!-- content-for: android -->
 
-![Inline error for Android](components/InlineError/android/default.png)
+![Inline error for Android](/public_images/components/InlineError/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Inline error for iOS](components/InlineError/ios/default.png)
+![Inline error for iOS](/public_images/components/InlineError/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/KeyboardAccessories/README.md
+++ b/src/components/KeyboardAccessories/README.md
@@ -41,13 +41,13 @@ Use the action accessories to add actions that are relevant to what merchants ar
 
 <!-- content-for: android -->
 
-![Keyboard accessory with actions](components/KeyboardAccessories/android/toolbar.png)
+![Keyboard accessory with actions](/public_images/components/KeyboardAccessories/android/toolbar@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Keyboard accessory with actions](components/KeyboardAccessories/ios/toolbar.png)
+![Keyboard accessory with actions](/public_images/components/KeyboardAccessories/ios/toolbar@2x.png)
 
 <!-- /content-for -->
 
@@ -59,13 +59,13 @@ Use to make message entry easier in messaging and chat-based products.
 
 <!-- content-for: android -->
 
-![Keyboard accessory with text field](components/KeyboardAccessories/android/text-field.png)
+![Keyboard accessory with text field](/public_images/components/KeyboardAccessories/android/text-field@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Keyboard accessory with text field](components/KeyboardAccessories/ios/text-field.png)
+![Keyboard accessory with text field](/public_images/components/KeyboardAccessories/ios/text-field@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/List/README.md
+++ b/src/components/List/README.md
@@ -95,13 +95,13 @@ Use for a text-only list of related items that don’t need to be in a specific 
 
 <!-- content-for: android -->
 
-![Bulleted list on Android](components/List/android/bullets.png)
+![Bulleted list on Android](/public_images/components/List/android/bullets@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Bulleted list on iOS](components/List/ios/bullets.png)
+![Bulleted list on iOS](/public_images/components/List/ios/bullets@2x.png)
 
 <!-- /content-for -->
 
@@ -119,13 +119,13 @@ Use for a text-only list of related items when an inherent order, priority, or s
 
 <!-- content-for: android -->
 
-![Numbered list on Android](components/List/android/numbered.png)
+![Numbered list on Android](/public_images/components/List/android/numbered@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Numbered list on iOS](components/List/ios/numbered.png)
+![Numbered list on iOS](/public_images/components/List/ios/numbered@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -382,13 +382,13 @@ class ModalExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Modal with primary action on Android](components/Modal/android/information.png)
+![Modal with primary action on Android](/public_images/components/Modal/android/information@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Modal with primary action on iOS](components/Modal/ios/information.png)
+![Modal with primary action on iOS](/public_images/components/Modal/ios/information@2x.png)
 
 <!-- /content-for -->
 
@@ -487,13 +487,13 @@ class ModalExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Modal with primary and secondary actions on Android](components/Modal/android/basic.png)
+![Modal with primary and secondary actions on Android](/public_images/components/Modal/android/basic@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Modal with primary and secondary actions on iOS](components/Modal/ios/basic.png)
+![Modal with primary and secondary actions on iOS](/public_images/components/Modal/ios/basic@2x.png)
 
 <!-- /content-for -->
 
@@ -624,13 +624,13 @@ Use to make it clear to the merchant that the action is potentially dangerous. O
 
 <!-- content-for: android -->
 
-![Warning modal on Android](components/Modal/android/default.png)
+![Warning modal on Android](/public_images/components/Modal/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Warning modal on iOS](components/Modal/ios/default.png)
+![Warning modal on iOS](/public_images/components/Modal/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -42,7 +42,7 @@ Passing an API key to the [app provider component](https://polaris.shopify.com/c
 
 Note in the props table that a number of properties are only available in stand-alone applications, and won't work in an embedded context. Configure your application's icon and navigation in the [Shopify Partner Dashboard](https://partners.shopify.com) app setup section. To help visualize the page component in an embedded application, we've provided the following screenshot.
 
-![Screenshot of page component in an embedded application](embedded/page/page.jpg)
+![Screenshot of page component in an embedded application](/public_images/embedded/page/page@2x.jpg)
 
 ```jsx
 ReactDOM.render(
@@ -201,7 +201,7 @@ Use for detail pages, which should have breadcrumbs, and also often have several
 
 Use for building any page on Android.
 
-![Page on Android](components/Page/android/with-header.png)
+![Page on Android](/public_images/components/Page/android/with-header@2x.png)
 
 <!-- /content-for -->
 
@@ -211,7 +211,7 @@ Use for detail pages, which should have breadcrumbs, and also often have several
 
 Use for building any page on iOS.
 
-![Page on iOS](components/Page/ios/with-header.png)
+![Page on iOS](/public_images/components/Page/ios/with-header@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Pagination/README.md
+++ b/src/components/Pagination/README.md
@@ -110,13 +110,13 @@ Use for lists longer than 25 items. In mobile apps it’s natural to scroll to t
 
 <!-- content-for: android -->
 
-![Infinite scroll pagination on Android](components/Pagination/android/default.png)
+![Infinite scroll pagination on Android](/public_images/components/Pagination/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Infinite scroll pagination on iOS](components/Pagination/ios/default.png)
+![Infinite scroll pagination on iOS](/public_images/components/Pagination/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -159,13 +159,13 @@ class PopoverExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Popover with action list for Android](components/Popover/android/action-list.png)
+![Popover with action list for Android](/public_images/components/Popover/android/action-list@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Popover with action list for iOS](components/Popover/ios/action-list.png)
+![Popover with action list for iOS](/public_images/components/Popover/ios/action-list@2x.png)
 
 <!-- /content-for -->
 
@@ -220,13 +220,13 @@ class PopoverContentExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Popover with content and actions for Android](components/Popover/android/action-content.png)
+![Popover with content and actions for Android](/public_images/components/Popover/android/action-content@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Popover with content and actions for iOS](components/Popover/ios/action-content.png)
+![Popover with content and actions for iOS](/public_images/components/Popover/ios/action-content@2x.png)
 
 <!-- /content-for -->
 
@@ -297,7 +297,7 @@ Use when you have few actions that affects the whole page. Action sheets doesnâ€
 
 <!-- content-for: ios -->
 
-![iOS action sheet](components/Popover/ios/action-sheet.png)
+![iOS action sheet](/public_images/components/Popover/ios/action-sheet@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/RadioButton/README.md
+++ b/src/components/RadioButton/README.md
@@ -134,13 +134,13 @@ class RadioButtonExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default radio button on Android](components/RadioButton/android/default.png)
+![Default radio button on Android](/public_images/components/RadioButton/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default radio button on iOS](components/RadioButton/ios/default.png)
+![Default radio button on iOS](/public_images/components/RadioButton/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -152,13 +152,13 @@ Use toggles when merchants need to make a binary choice (on or off).
 
 <!-- content-for: android -->
 
-![Android toggle with on or off options](components/RadioButton/android/toggle.png)
+![Android toggle with on or off options](/public_images/components/RadioButton/android/toggle@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![iOS toggle with on or off options](components/RadioButton/ios/toggle.png)
+![iOS toggle with on or off options](/public_images/components/RadioButton/ios/toggle@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/RangeSlider/README.md
+++ b/src/components/RangeSlider/README.md
@@ -143,13 +143,13 @@ class RangeSliderExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Range slider for Android](components/RangeSlider/android/default.png)
+![Range slider for Android](/public_images/components/RangeSlider/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Range slider for iOS](components/RangeSlider/ios/default.png)
+![Range slider for iOS](/public_images/components/RangeSlider/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -29,7 +29,7 @@ A resource list displays a collection of objects of the same type, like products
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Resource list anatomy, showing filters, header, and items](resource-list/anatomy-wide.png)
+![Resource list anatomy, showing filters, header, and items](/public_images/resource-list/anatomy-wide@2x.png)
 
 </div>
 
@@ -596,7 +596,7 @@ Because a details page displays all the content and actions for an individual re
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Schematic showing content from a details page being surfaced on a resource list](resource-list/list-surfacing-show.png)
+![Schematic showing content from a details page being surfaced on a resource list](/public_images/resource-list/list-surfacing-show@2x.png)
 
 </div>
 
@@ -688,7 +688,7 @@ See the case study section for [more about customizing and using resource list i
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Resource list item anatomy, showing handle, media and details](resource-list/item-anatomy-wide.png)
+![Resource list item anatomy, showing handle, media and details](/public_images/resource-list/item-anatomy-wide@2x.png)
 
 </div>
 
@@ -702,7 +702,7 @@ A basic resource list item with its details filled in at the point of use.
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Blog post list item](resource-list/item-example-simple.png)
+![Blog post list item](/public_images/resource-list/item-example-simple@2x.png)
 
 </div>
 
@@ -743,7 +743,7 @@ The media element can hold an [avatar](/components/images-and-icons/avatar), [th
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Example customer list item](resource-list/item-example-media.png)
+![Example customer list item](/public_images/resource-list/item-example-media@2x.png)
 
 </div>
 
@@ -787,7 +787,7 @@ Shortcut actions present popular actions from the resource’s details page for 
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Shortcut actions are shown on hover](resource-list/item-example-shortcuts.png)
+![Shortcut actions are shown on hover](/public_images/resource-list/item-example-shortcuts@2x.png)
 
 </div>
 
@@ -891,7 +891,7 @@ Provides a default interface for adding and removing filters. Supports quick fil
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Resource list with filter control](resource-list/filter-control-anatomy.png)
+![Resource list with filter control](/public_images/resource-list/filter-control-anatomy@2x.png)
 
 </div>
 
@@ -905,7 +905,7 @@ Filter control showing a state with applied filters and an additional action (op
 
 <div class="TypeContainerImage">
 
-![Example filter control](resource-list/filter-control-example.png)
+![Example filter control](/public_images/resource-list/filter-control-example@2x.png)
 
 </div>
 
@@ -1030,7 +1030,7 @@ The filter builder itself has three parts: the **label**, the **operator text**,
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Example filter builder in a popover](resource-list/filter-control-filter-builder.png)
+![Example filter builder in a popover](/public_images/resource-list/filter-control-filter-builder@2x.png)
 
 </div>
 
@@ -1044,7 +1044,7 @@ Here’s another example:
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Second filter builder example](resource-list/filter-control-filter-builder-2.png)
+![Second filter builder example](/public_images/resource-list/filter-control-filter-builder-2@2x.png)
 
 </div>
 
@@ -1059,7 +1059,7 @@ In this case, a the **filter input** is a text field, so you only need to consid
 
 <div class="TypeContainerImage">
 
-![Example of applied filter tags](resource-list/filter-control-filter-tags.png)
+![Example of applied filter tags](/public_images/resource-list/filter-control-filter-tags@2x.png)
 
 </div>
 
@@ -1254,7 +1254,7 @@ In this section, we’ll build a custom resource list item for customers:
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Preview of customer list item](resource-list/study-list-item-preview.png)
+![Preview of customer list item](/public_images/resource-list/study-list-item-preview@2x.png)
 
 </div>
 
@@ -1350,7 +1350,7 @@ Whenever possible, use badges conditionally, showing them only when there is an 
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Example of a badge highlighting open orders on an item](resource-list/study-list-item-badges.png)
+![Example of a badge highlighting open orders on an item](/public_images/resource-list/study-list-item-badges@2x.png)
 
 </div>
 
@@ -1548,7 +1548,7 @@ Use the following guidelines:
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Example of column-aligned content](resource-list/study-list-item-column-alignment.png)
+![Example of column-aligned content](/public_images/resource-list/study-list-item-column-alignment@2x.png)
 
 </div>
 
@@ -1560,7 +1560,7 @@ To accommodate smaller screen sizes, follow these guidelines:
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Preview of customer list item](resource-list/study-list-item-content-stacking.png)
+![Preview of customer list item](/public_images/resource-list/study-list-item-content-stacking@2x.png)
 
 </div>
 
@@ -1571,7 +1571,7 @@ When laying out media content:
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Example of resizing media based on screen size](resource-list/study-list-item-media-sizing.png)
+![Example of resizing media based on screen size](/public_images/resource-list/study-list-item-media-sizing@2x.png)
 
 </div>
 
@@ -1720,7 +1720,7 @@ Now we can write our styles:
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Example of conditionally showing customer notes](resource-list/study-list-item-conditional-content.png)
+![Example of conditionally showing customer notes](/public_images/resource-list/study-list-item-conditional-content@2x.png)
 
 </div>
 
@@ -1732,7 +1732,7 @@ Actions can also be presented conditionally, based on the state of the item. For
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Example of conditionally showing a link to open orders](resource-list/study-list-item-conditional-actions.png)
+![Example of conditionally showing a link to open orders](/public_images/resource-list/study-list-item-conditional-actions@2x.png)
 
 </div>
 
@@ -1864,7 +1864,7 @@ We can finish this off with a couple of simple styles:
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Example of a shortcut to a customer’s latest order](resource-list/study-list-item-shortcut-actions.png)
+![Example of a shortcut to a customer’s latest order](/public_images/resource-list/study-list-item-shortcut-actions@2x.png)
 
 </div>
 
@@ -1972,7 +1972,7 @@ Now let’s save our merchants some time by using more features of the resource 
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Image showing bulk selection and actions](resource-list/study-bulk-lead.png)
+![Image showing bulk selection and actions](/public_images/resource-list/study-bulk-lead@2x.png)
 
 </div>
 
@@ -1987,7 +1987,7 @@ Because resource lists prioritize acting on individual items, selection checkbox
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Sequence showing bulk actions on a small device](resource-list/study-bulk-narrow.png)
+![Sequence showing bulk actions on a small device](/public_images/resource-list/study-bulk-narrow@2x.png)
 
 </div>
 
@@ -1995,7 +1995,7 @@ Up to two frequently-used bulk actions may be visually promoted outside of the a
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Promoted actions on wide and narrow screens](resource-list/study-bulk-promoted.png)
+![Promoted actions on wide and narrow screens](/public_images/resource-list/study-bulk-promoted@2x.png)
 
 </div>
 
@@ -2161,7 +2161,7 @@ If you’re new to React or ES2015 you might be wondering about the lines in our
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Detail of the resource list header showing the sort control](resource-list/study-sort-control.png)
+![Detail of the resource list header showing the sort control](/public_images/resource-list/study-sort-control@2x.png)
 
 </div>
 
@@ -2426,7 +2426,7 @@ class App extends Component {
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Filter control example](resource-list/filter-control-example.png)
+![Filter control example](/public_images/resource-list/filter-control-example@2x.png)
 
 </div>
 
@@ -2604,7 +2604,7 @@ As with sorting, exactly how the new items array is generated depends on your ap
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![A resource list with pagination](resource-list/study-pagination.png)
+![A resource list with pagination](/public_images/resource-list/study-pagination@2x.png)
 
 </div>
 
@@ -2616,7 +2616,7 @@ Pagination interacts with bulk actions. When a resource list is paginated, the S
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Selecting across pages in a paginated list](resource-list/study-pagination-bulk.png)
+![Selecting across pages in a paginated list](/public_images/resource-list/study-pagination-bulk@2x.png)
 
 </div>
 

--- a/src/components/ResourcePicker/README.md
+++ b/src/components/ResourcePicker/README.md
@@ -32,7 +32,7 @@ Enable the resource picker component to delegate to the [Shopify App Bridge](htt
 
 Use of the resource picker component is only supported in an embedded application—it will not render in a stand-alone application. To help visualize the resource picker component in an embedded application, we've provided the following screenshot.
 
-![Screenshot product picker - multiple product selection component](embedded/resource-picker/product-picker-multiple.jpg)
+![Screenshot product picker - multiple product selection component](/public_images/embedded/resource-picker/product-picker-multiple@2x.jpg)
 
 ---
 

--- a/src/components/SectionHeader/README.md
+++ b/src/components/SectionHeader/README.md
@@ -78,13 +78,13 @@ Use to group related content together, for example orders received on the same d
 
 <!-- content-for: android -->
 
-![Shipping costs card with multiple sections: domestic, international](components/SectionHeader/android/default.png)
+![Shipping costs card with multiple sections: domestic, international](/public_images/components/SectionHeader/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Shipping costs card with multiple sections: domestic, international](components/SectionHeader/ios/default.png)
+![Shipping costs card with multiple sections: domestic, international](/public_images/components/SectionHeader/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -94,7 +94,7 @@ Use to group related content together, for example orders received on the same d
 
 Use if your list section could be longer than the height of the screen. For example you may need fixed section headers for a list of orders, because merchants may receive many orders in one day.
 
-![Shipping costs card with multiple sections: domestic, international](components/SectionHeader/ios/fixed.png)
+![Shipping costs card with multiple sections: domestic, international](/public_images/components/SectionHeader/ios/fixed@2x.png)
 
 ---
 

--- a/src/components/Select/README.md
+++ b/src/components/Select/README.md
@@ -133,7 +133,7 @@ class SelectExample extends React.Component {
 
 The iOS picker expands in-line. Merchants scroll to select the item they want.
 
-![iOS select, and select with option menu](components/Select/ios/default.png)
+![iOS select, and select with option menu](/public_images/components/Select/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -141,7 +141,7 @@ The iOS picker expands in-line. Merchants scroll to select the item they want.
 
 The Android menu is similar in behavior to the web dropdown.
 
-![Android select, and select with option menu](components/Select/android/default.png)
+![Android select, and select with option menu](/public_images/components/Select/android/default@2x.png)
 
 <!-- /content-for -->
 
@@ -202,13 +202,13 @@ Use for selections that aren’t currently available. The surrounding interface 
 
 <!-- content-for: ios -->
 
-![Disabled select component on iOS](components/Select/ios/disabled.png)
+![Disabled select component on iOS](/public_images/components/Select/ios/disabled@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: android -->
 
-![Disabled select component on Android](components/Select/android/disabled.png)
+![Disabled select component on Android](/public_images/components/Select/android/disabled@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/SkeletonBodyText/README.md
+++ b/src/components/SkeletonBodyText/README.md
@@ -36,12 +36,12 @@ Show static content that never changes on a page and use skeleton loading for dy
 #### Do
 
 Use skeleton body text for dynamic content.
-![Image showing skeleton body text for dynamic content](skeleton/do-use-skeleton-body-for-dynamic-content.png)
+![Image showing skeleton body text for dynamic content](/public_images/skeleton/do-use-skeleton-body-for-dynamic-content@2x.png)
 
 #### Don’t
 
 Use skeleton body text for static content or use placeholder content for dynamic content.
-![Image showing skeleton body text for static content](skeleton/dont-use-skeleton-body-for-static-or-placeholder-for-dynamic-text.png)
+![Image showing skeleton body text for static content](/public_images/skeleton/dont-use-skeleton-body-for-static-or-placeholder-for-dynamic-text@2x.png)
 
 <!-- end -->
 

--- a/src/components/SkeletonDisplayText/README.md
+++ b/src/components/SkeletonDisplayText/README.md
@@ -35,12 +35,12 @@ Show static display text that that never changes on a page. For example, keep pa
 #### Do
 
 Show actual display text for static content and use skeleton display text for dynamic content.
-![Image showing skeleton display text for dynamic content](skeleton/do-show-display-text-for-static-content.png)
+![Image showing skeleton display text for dynamic content](/public_images/skeleton/do-show-display-text-for-static-content@2x.png)
 
 #### Don’t
 
 Use skeleton display text for static content or placeholder content for dynamic content.
-![Image showing skeleton display text for static content and placeholder text for dynamic content](skeleton/dont-use-skeleton-for-static-or-placeholder-content-for-dynamic.png)
+![Image showing skeleton display text for static content and placeholder text for dynamic content](/public_images/skeleton/dont-use-skeleton-for-static-or-placeholder-content-for-dynamic@2x.png)
 
 <!-- end -->
 
@@ -52,7 +52,7 @@ Show skeleton display text for dynamic page titles.
 
 <div class="TypographyUsageBlockImg">
 
-![Image showing skeleton display text for dynamic page title](skeleton/do-use-skeleton-for-dynamic-page-titles.png)
+![Image showing skeleton display text for dynamic page title](/public_images/skeleton/do-use-skeleton-for-dynamic-page-titles@2x.png)
 
 </div>
 

--- a/src/components/SkeletonPage/README.md
+++ b/src/components/SkeletonPage/README.md
@@ -38,7 +38,7 @@ Use skeleton loading for dynamic content, and use actual content for content tha
 
 <div class="TypographyUsageBlockImg">
 
-![Image showing skeleton loading for changing content](skeleton/do-use-skeleton-for-changing-content.png)
+![Image showing skeleton loading for changing content](/public_images/skeleton/do-use-skeleton-for-changing-content@2x.png)
 
 </div>
 
@@ -48,7 +48,7 @@ Use placeholder content that will change when the page fully loads. This will co
 
 <div class="TypographyUsageBlockImg">
 
-![Image showing placeholder content that will change](skeleton/dont-use-placeholder-content-that-will-change.png)
+![Image showing placeholder content that will change](/public_images/skeleton/dont-use-placeholder-content-that-will-change@2x.png)
 
 </div>
 

--- a/src/components/Spinner/README.md
+++ b/src/components/Spinner/README.md
@@ -33,13 +33,13 @@ Use to notify merchants that their requested action is being processed.
 
 <!-- content-for: android -->
 
-![Material design spinner for Android](components/Spinner/android/default.gif)
+![Material design spinner for Android](/public_images/components/Spinner/android/default@2x.gif)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Apple’s spinner for iOS](components/Spinner/ios/default.gif)
+![Apple’s spinner for iOS](/public_images/components/Spinner/ios/default@2x.gif)
 
 <!-- /content-for -->
 

--- a/src/components/Stepper/README.md
+++ b/src/components/Stepper/README.md
@@ -69,13 +69,13 @@ The stepper has two buttons, a minus and a plus button. It’s possible to tap i
 
 <!-- content-for: android -->
 
-![Default stepper with enabled decrease and increase button](components/Stepper/android/default.png)
+![Default stepper with enabled decrease and increase button](/public_images/components/Stepper/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default stepper with enabled decrease and increase button](components/Stepper/ios/default.png)
+![Default stepper with enabled decrease and increase button](/public_images/components/Stepper/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -87,13 +87,13 @@ If you reach the bottom or top value, the appropriate button becomes disabled.
 
 <!-- content-for: android -->
 
-![Disabled stepper](components/Stepper/android/disabled.png)
+![Disabled stepper](/public_images/components/Stepper/android/disabled@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Disabled stepper](components/Stepper/ios/disabled.png)
+![Disabled stepper](/public_images/components/Stepper/ios/disabled@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Subheading/README.md
+++ b/src/components/Subheading/README.md
@@ -76,13 +76,13 @@ Use to structure content in a card.
 
 <!-- content-for: android -->
 
-![Subheading in a card](components/Subheading/android/default.png)
+![Subheading in a card](/public_images/components/Subheading/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Subheading in a card](components/Subheading/ios/default.png)
+![Subheading in a card](/public_images/components/Subheading/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Tabs/README.md
+++ b/src/components/Tabs/README.md
@@ -124,13 +124,13 @@ class TabsExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default tabs on Android](components/Tabs/android/default.png)
+![Default tabs on Android](/public_images/components/Tabs/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default tabs on iOS](components/Tabs/ios/default.png)
+![Default tabs on iOS](/public_images/components/Tabs/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -184,7 +184,7 @@ class FittedTabsExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Fixed tabs on Android](components/Tabs/android/fixed.png)
+![Fixed tabs on Android](/public_images/components/Tabs/android/fixed@2x.png)
 
 <!-- /content-for -->
 
@@ -192,6 +192,6 @@ class FittedTabsExample extends React.Component {
 
 Also known as [Segmented controls](https://developer.apple.com/design/human-interface-guidelines/ios/controls/segmented-controls/) on iOS.
 
-![Fixed tabs on iOS](components/Tabs/ios/fixed.png)
+![Fixed tabs on iOS](/public_images/components/Tabs/ios/fixed@2x.png)
 
 <!-- /content-for -->

--- a/src/components/Tag/README.md
+++ b/src/components/Tag/README.md
@@ -47,13 +47,13 @@ Use to allow merchants to add attributes to, and remove attributes from, an obje
 
 <!-- content-for: android -->
 
-![Tag for Android](components/Tag/android/default.png)
+![Tag for Android](/public_images/components/Tag/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Tag for iOS](components/Tag/ios/default.png)
+![Tag for iOS](/public_images/components/Tag/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/TextContainer/README.md
+++ b/src/components/TextContainer/README.md
@@ -51,13 +51,13 @@ Use this component for default vertical spacing.
 
 <!-- content-for: android -->
 
-![Default text container](components/TextContainer/android/default.png)
+![Default text container](/public_images/components/TextContainer/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text container](components/TextContainer/ios/default.png)
+![Default text container](/public_images/components/TextContainer/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -77,13 +77,13 @@ Use the tight spacing option to relate content topics to each other.
 
 <!-- content-for: android -->
 
-![Tight text container](components/TextContainer/android/tight.png)
+![Tight text container](/public_images/components/TextContainer/android/tight@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Tight text container](components/TextContainer/ios/tight.png)
+![Tight text container](/public_images/components/TextContainer/ios/tight@2x.png)
 
 <!-- /content-for -->
 
@@ -107,13 +107,13 @@ Use the loose spacing option to separate concepts that are independent of each o
 
 <!-- content-for: android -->
 
-![Loose text container](components/TextContainer/android/loose.png)
+![Loose text container](/public_images/components/TextContainer/android/loose@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Loose text container](components/TextContainer/ios/loose.png)
+![Loose text container](/public_images/components/TextContainer/ios/loose@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -196,13 +196,13 @@ class TextFieldExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default text field](components/TextField/android/default.png)
+![Default text field](/public_images/components/TextField/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text field](components/TextField/ios/default.png)
+![Default text field](/public_images/components/TextField/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -237,7 +237,7 @@ class NumberFieldExample extends React.Component {
 
 This will display the right keyboard on mobile devices.
 
-![Number text field with numeric keyboard](components/TextField/android/number.png)
+![Number text field with numeric keyboard](/public_images/components/TextField/android/number@2x.png)
 
 <!-- /content-for -->
 
@@ -245,7 +245,7 @@ This will display the right keyboard on mobile devices.
 
 This will display the right keyboard on mobile devices.
 
-![Number text field with numeric keyboard](components/TextField/ios/number.png)
+![Number text field with numeric keyboard](/public_images/components/TextField/ios/number@2x.png)
 
 <!-- /content-for -->
 
@@ -280,7 +280,7 @@ class EmailFieldExample extends React.Component {
 
 This will display the right keyboard on mobile devices.
 
-![Email field with email keyboard](components/TextField/android/email.png)
+![Email field with email keyboard](/public_images/components/TextField/android/email@2x.png)
 
 <!-- /content-for -->
 
@@ -288,7 +288,7 @@ This will display the right keyboard on mobile devices.
 
 This will display the right keyboard on mobile devices.
 
-![Email field with email keyboard](components/TextField/ios/email.png)
+![Email field with email keyboard](/public_images/components/TextField/ios/email@2x.png)
 
 <!-- /content-for -->
 
@@ -321,13 +321,13 @@ class MultilineFieldExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Multi-line text field](components/TextField/android/multi-line.png)
+![Multi-line text field](/public_images/components/TextField/android/multi-line@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Multi-line text field](components/TextField/ios/multi-line.png)
+![Multi-line text field](/public_images/components/TextField/ios/multi-line@2x.png)
 
 <!-- /content-for -->
 
@@ -443,13 +443,13 @@ class PlaceholderExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default text field with placeholder text hint](components/TextField/android/placeholder-text.png)
+![Default text field with placeholder text hint](/public_images/components/TextField/android/placeholder-text@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text field with placeholder text hint](components/TextField/ios/placeholder-text.png)
+![Default text field with placeholder text hint](/public_images/components/TextField/ios/placeholder-text@2x.png)
 
 <!-- /content-for -->
 
@@ -483,13 +483,13 @@ class HelpTextExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default text field with help text](components/TextField/android/help-text.png)
+![Default text field with help text](/public_images/components/TextField/android/help-text@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text field with help text](components/TextField/ios/help-text.png)
+![Default text field with help text](/public_images/components/TextField/ios/help-text@2x.png)
 
 <!-- /content-for -->
 
@@ -526,13 +526,13 @@ class PrefixExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default text field with prefix and suffix](components/TextField/android/prefix-suffix.png)
+![Default text field with prefix and suffix](/public_images/components/TextField/android/prefix-suffix@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text field with prefix and suffix](components/TextField/ios/prefix-suffix.png)
+![Default text field with prefix and suffix](/public_images/components/TextField/ios/prefix-suffix@2x.png)
 
 <!-- /content-for -->
 
@@ -576,7 +576,7 @@ class ConnectedFieldsExample extends React.Component {
 
 If inputting weight as a number and a separate unit of measurement, use a text field with a selector (e.g. “kg”, “lb”) as a connected field.
 
-![Text field with connected selector](components/TextField/android/connected-fields.png)
+![Text field with connected selector](/public_images/components/TextField/android/connected-fields@2x.png)
 
 <!-- /content-for -->
 
@@ -584,7 +584,7 @@ If inputting weight as a number and a separate unit of measurement, use a text f
 
 If inputting weight as a number and a separate unit of measurement, use a text field with a selector (e.g. “kg”, “lb”) as a connected field.
 
-![Text field with connected selector](components/TextField/ios/connected-fields.png)
+![Text field with connected selector](/public_images/components/TextField/ios/connected-fields@2x.png)
 
 <!-- /content-for -->
 
@@ -598,13 +598,13 @@ For example, tap on a barcode icon to launch the camera and scan barcode for the
 
 <!-- content-for: android -->
 
-![Text field with icon action inside the text field](components/TextField/android/accessory.png)
+![Text field with icon action inside the text field](/public_images/components/TextField/android/accessory@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Text field with icon action inside the text field](components/TextField/ios/accessory.png)
+![Text field with icon action inside the text field](/public_images/components/TextField/ios/accessory@2x.png)
 
 <!-- /content-for -->
 
@@ -637,13 +637,13 @@ class ValidationErrorExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Text field with error](components/TextField/android/error.png)
+![Text field with error](/public_images/components/TextField/android/error@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Text field with error](components/TextField/ios/error.png)
+![Text field with error](/public_images/components/TextField/ios/error@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/TextStyle/README.md
+++ b/src/components/TextStyle/README.md
@@ -54,13 +54,13 @@ Use to de-emphasize a piece of text that is less important to merchants than oth
 
 <!-- content-for: android -->
 
-![Subdued textstyle](components/TextStyle/android/subdued.png)
+![Subdued textstyle](/public_images/components/TextStyle/android/subdued@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Subdued text style](components/TextStyle/ios/subdued.png)
+![Subdued text style](/public_images/components/TextStyle/ios/subdued@2x.png)
 
 <!-- /content-for -->
 
@@ -74,13 +74,13 @@ Use to mark text representing user input, or to emphasize the totals row in a pr
 
 <!-- content-for: android -->
 
-![Strong text style](components/TextStyle/android/strong.png)
+![Strong text style](/public_images/components/TextStyle/android/strong@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Strong text style](components/TextStyle/ios/strong.png)
+![Strong text style](/public_images/components/TextStyle/ios/strong@2x.png)
 
 <!-- /content-for -->
 
@@ -94,13 +94,13 @@ Use in combination with a symbol showing an increasing value to indicate an upwa
 
 <!-- content-for: android -->
 
-![Positive text style](components/TextStyle/android/positive.png)
+![Positive text style](/public_images/components/TextStyle/android/positive@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Positive text style](components/TextStyle/ios/positive.png)
+![Positive text style](/public_images/components/TextStyle/ios/positive@2x.png)
 
 <!-- /content-for -->
 
@@ -114,13 +114,13 @@ Use in combination with a symbol showing a decreasing value to indicate a downwa
 
 <!-- content-for: android -->
 
-![Negative text style](components/TextStyle/android/negative.png)
+![Negative text style](/public_images/components/TextStyle/android/negative@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Negative text style](components/TextStyle/ios/negative.png)
+![Negative text style](/public_images/components/TextStyle/ios/negative@2x.png)
 
 <!-- /content-for -->
 
@@ -137,12 +137,12 @@ Use to display inline snippets of code or code-like text.
 
 <!-- content-for: android -->
 
-![Code text style](components/TextStyle/android/code.png)
+![Code text style](/public_images/components/TextStyle/android/code@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Code text style](components/TextStyle/ios/code.png)
+![Code text style](/public_images/components/TextStyle/ios/code@2x.png)
 
 <!-- /content-for -->

--- a/src/components/Thumbnail/README.md
+++ b/src/components/Thumbnail/README.md
@@ -68,13 +68,13 @@ Use as the default size.
 
 <!-- content-for: android -->
 
-![Default thumbnail](components/Thumbnail/android/default.png)
+![Default thumbnail](/public_images/components/Thumbnail/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default thumbnail](components/Thumbnail/ios/default.png)
+![Default thumbnail](/public_images/components/Thumbnail/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -106,13 +106,13 @@ Use when a thumbnail is a major focal point. Avoid this size in lists of like it
 
 <!-- content-for: android -->
 
-![Large thumbnail](components/Thumbnail/android/large.png)
+![Large thumbnail](/public_images/components/Thumbnail/android/large@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Large thumbnail](components/Thumbnail/ios/large.png)
+![Large thumbnail](/public_images/components/Thumbnail/ios/large@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Toast/README.md
+++ b/src/components/Toast/README.md
@@ -266,7 +266,7 @@ Use default toast for informative and neutral feedback.
 
 <!-- content-for: android -->
 
-![Default toast with neutral color](components/Toast/android/default.png)
+![Default toast with neutral color](/public_images/components/Toast/android/default@2x.png)
 
 <!-- /content-for -->
 
@@ -274,7 +274,7 @@ Use default toast for informative and neutral feedback.
 
 On iOS, icons are available for cases where you want to re-inforce the message.
 
-![Default toast with neutral color](components/Toast/ios/default.png)
+![Default toast with neutral color](/public_images/components/Toast/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -286,7 +286,7 @@ Use success toast to indicate that something was successful. For example, a prod
 
 <!-- content-for: android -->
 
-![Success toast](components/Toast/android/success.png)
+![Success toast](/public_images/components/Toast/android/success@2x.png)
 
 <!-- /content-for -->
 
@@ -294,7 +294,7 @@ Use success toast to indicate that something was successful. For example, a prod
 
 On iOS, icons are available for cases where you want to re-inforce the message.
 
-![Success toast](components/Toast/ios/success.png)
+![Success toast](/public_images/components/Toast/ios/success@2x.png)
 
 <!-- /content-for -->
 
@@ -340,7 +340,7 @@ class ToastExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Error toast](components/Toast/android/error.png)
+![Error toast](/public_images/components/Toast/android/error@2x.png)
 
 <!-- /content-for -->
 
@@ -348,7 +348,7 @@ class ToastExample extends React.Component {
 
 On iOS, icons are available for cases where you want to re-inforce the message.
 
-![Error toast](components/Toast/ios/error.png)
+![Error toast](/public_images/components/Toast/ios/error@2x.png)
 
 <!-- /content-for -->
 
@@ -361,13 +361,13 @@ Keep the action label short, preferably 1 verb action.
 
 <!-- content-for: android -->
 
-![Default toast with action to undo](components/Toast/android/default-action.png)
+![Default toast with action to undo](/public_images/components/Toast/android/default-action@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default toast with action to undo](components/Toast/ios/default-action.png)
+![Default toast with action to undo](/public_images/components/Toast/ios/default-action@2x.png)
 
 <!-- /content-for -->
 


### PR DESCRIPTION
Related to https://github.com/Shopify/polaris-styleguide/pull/2446

This is an interim solution, allowing us to simplify image path parsing code on polaris-styleguide until we figure out a path forward for #684.