### PR TITLE
[PositionedOverlay] Fix test env console error with NaN check

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added dismiss button for `CalloutCard` ([#353](https://github.com/Shopify/polaris-react/issues/353))
 - Removed an extra tab stop from `ResourceList.Item` and make it unactionable while loading ([#745](https://github.com/Shopify/polaris-react/pull/745))
 - Fixed `Checkbox` from losing focus when quickly toggled ([#717](https://github.com/Shopify/polaris-react/pull/717))
+- Fixed the console error in the `PositionedOverlay` test environment ([#758](https://github.com/Shopify/polaris-react/pull/758))
 
 ### Documentation
 

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -117,10 +117,10 @@ export default class PositionedOverlay extends React.PureComponent<
     const {render, fixed} = this.props;
 
     const style = {
-      top: top == null ? undefined : top,
-      left: left == null ? undefined : left,
-      width: width == null ? undefined : width,
-      zIndex: zIndex == null ? undefined : zIndex,
+      top: top == null || isNaN(top) ? undefined : top,
+      left: left == null || isNaN(left) ? undefined : left,
+      width: width == null || isNaN(width) ? undefined : width,
+      zIndex: zIndex == null || isNaN(zIndex) ? undefined : zIndex,
     };
 
     const className = classNames(
@@ -196,8 +196,7 @@ export default class PositionedOverlay extends React.PureComponent<
           ? {...currentOverlayRect, width: activatorRect.width}
           : currentOverlayRect;
 
-        // If `body` is 100% height, it still acts as though it were not constrained
-        // to that size. This adjusts for that.
+        // If `body` is 100% height, it still acts as though it were not constrained to that size. This adjusts for that.
         if (scrollableElement === document.body) {
           scrollableContainerRect.height = document.body.scrollHeight;
         }


### PR DESCRIPTION
### WHY are these changes introduced?

There's currently a `NaN` error thrown while running the positioned overlay component tests. It also shows up in CI traces of any views with tests for components that render Polaris overlay components, like `Popover`. This is because of the lack of browser measurements accessible in the `jsdom` environment when the positioned overlay component calculates its `left` style property based on the activator and scroll container.

### WHAT is this pull request doing?

Adds a check to the definition of the inline style properties to ensure the value set is not `NaN`.

### How to 🎩

- `git checkout overlay-console-error` 
- `yarn dev`
- `yarn test PositionedOverlay --no-watch`
    - the console error should be gone
    - all tests should still pass
- all _foundational_ overlay component examples should render as expected (`Popover`, `Modal`, `Tooltip`)
