### PR TITLE
Fix cyclical imports redux (part2)

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,5 +17,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Development workflow
 
 - Added a slight delay to the Percy screenshot script to give time for components to render fully ([#704](https://github.com/Shopify/polaris-react/pull/704))
+- Refactors to remove cyclical type imports ([#759](https://github.com/Shopify/polaris-react/pull/759))
 
 ### Dependency upgrades

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -12,14 +12,20 @@ import {
   polarisAppProviderContextTypes,
 } from './types';
 
-export default class AppProvider extends React.Component<AppProviderProps> {
+// The script in the styleguide that generates the Props Explorer data expects
+// a component's props to be found in the Props interface. This silly workaround
+// ensures that the Props Explorer table is generated correctly, instead of
+// crashing if we write `AppProvider extends React.Component<AppProviderProps>`
+interface Props extends AppProviderProps {}
+
+export default class AppProvider extends React.Component<Props> {
   static childContextTypes = polarisAppProviderContextTypes;
   public polarisContext: Context;
   private stickyManager: StickyManager;
   private scrollLockManager: ScrollLockManager;
   private subscriptions: {(): void}[] = [];
 
-  constructor(props: AppProviderProps) {
+  constructor(props: Props) {
     super(props);
     this.stickyManager = new StickyManager();
     this.scrollLockManager = new ScrollLockManager();
@@ -46,7 +52,7 @@ export default class AppProvider extends React.Component<AppProviderProps> {
     apiKey,
     shopOrigin,
     forceRedirect,
-  }: AppProviderProps) {
+  }: Props) {
     if (
       i18n !== this.props.i18n ||
       linkComponent !== this.props.linkComponent ||

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -1,42 +1,25 @@
 import * as React from 'react';
 import {autobind} from '@shopify/javascript-utilities/decorators';
-import ThemeProvider, {Theme} from '../ThemeProvider';
-import {LinkLikeComponent} from '../UnstyledLink';
+import ThemeProvider from '../ThemeProvider';
 import {
   StickyManager,
   ScrollLockManager,
-  TranslationDictionary,
   createAppProviderContext,
 } from './utilities';
-import {Context, polarisAppProviderContextTypes} from './types';
+import {
+  AppProviderProps,
+  Context,
+  polarisAppProviderContextTypes,
+} from './types';
 
-export interface Props {
-  /** A locale object or array of locale objects that overrides default translations */
-  i18n?: TranslationDictionary | TranslationDictionary[];
-  /** A custom component to use for all links used by Polaris components */
-  linkComponent?: LinkLikeComponent;
-  /** The API key for your application from the Partner dashboard */
-  apiKey?: string;
-  /**
-   * The current shop’s origin, provided in the session from the Shopify API (to be provided without the https://)
-   * @default getShopOrigin()
-   * @see {@link https://help.shopify.com/en/api/embedded-apps/app-bridge#set-up-your-app|Shopify App Bridge docs}
-   **/
-  shopOrigin?: string;
-  /** Forces a redirect to the relative admin path when not rendered in an iframe */
-  forceRedirect?: boolean;
-  /** Custom logos and colors provided to select components */
-  theme?: Theme;
-}
-
-export default class AppProvider extends React.Component<Props> {
+export default class AppProvider extends React.Component<AppProviderProps> {
   static childContextTypes = polarisAppProviderContextTypes;
   public polarisContext: Context;
   private stickyManager: StickyManager;
   private scrollLockManager: ScrollLockManager;
   private subscriptions: {(): void}[] = [];
 
-  constructor(props: Props) {
+  constructor(props: AppProviderProps) {
     super(props);
     this.stickyManager = new StickyManager();
     this.scrollLockManager = new ScrollLockManager();
@@ -63,7 +46,7 @@ export default class AppProvider extends React.Component<Props> {
     apiKey,
     shopOrigin,
     forceRedirect,
-  }: Props) {
+  }: AppProviderProps) {
     if (
       i18n !== this.props.i18n ||
       linkComponent !== this.props.linkComponent ||

--- a/src/components/AppProvider/index.ts
+++ b/src/components/AppProvider/index.ts
@@ -14,5 +14,9 @@ export {
   ComplexReplacementDictionary,
   CreateAppProviderContext,
 } from './utilities';
-export {Context, polarisAppProviderContextTypes} from './types';
-export {default, Props as AppProviderProps} from './AppProvider';
+export {
+  AppProviderProps as Props,
+  Context,
+  polarisAppProviderContextTypes,
+} from './types';
+export {default} from './AppProvider';

--- a/src/components/AppProvider/types.ts
+++ b/src/components/AppProvider/types.ts
@@ -1,8 +1,34 @@
 import {ClientApplication} from '@shopify/app-bridge';
 import {ValidationMap} from 'react';
 import * as PropTypes from 'prop-types';
-import {THEME_CONTEXT_TYPES as polarisTheme} from '../ThemeProvider';
-import {Intl, Link, StickyManager, ScrollLockManager} from './utilities';
+import {LinkLikeComponent} from '../UnstyledLink';
+import {Theme, THEME_CONTEXT_TYPES as polarisTheme} from '../ThemeProvider';
+import {
+  Intl,
+  Link,
+  StickyManager,
+  ScrollLockManager,
+  TranslationDictionary,
+} from './utilities';
+
+export interface AppProviderProps {
+  /** A locale object or array of locale objects that overrides default translations */
+  i18n?: TranslationDictionary | TranslationDictionary[];
+  /** A custom component to use for all links used by Polaris components */
+  linkComponent?: LinkLikeComponent;
+  /** The API key for your application from the Partner dashboard */
+  apiKey?: string;
+  /**
+   * The current shop’s origin, provided in the session from the Shopify API (to be provided without the https://)
+   * @default getShopOrigin()
+   * @see {@link https://help.shopify.com/en/api/embedded-apps/app-bridge#set-up-your-app|Shopify App Bridge docs}
+   **/
+  shopOrigin?: string;
+  /** Forces a redirect to the relative admin path when not rendered in an iframe */
+  forceRedirect?: boolean;
+  /** Custom logos and colors provided to select components */
+  theme?: Theme;
+}
 
 export interface Context {
   polaris: {

--- a/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
+++ b/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
@@ -1,12 +1,11 @@
 import {noop} from '@shopify/javascript-utilities/other';
 import createApp, {getShopOrigin} from '@shopify/app-bridge';
 import {isServer} from '@shopify/react-utilities/target';
-import {Context} from '../../types';
+import {AppProviderProps, Context} from '../../types';
 import {StickyManager} from '../withSticky';
 import ScrollLockManager from '../ScrollLockManager';
 import Intl from '../Intl';
 import Link from '../Link';
-import {Props as AppProviderProps} from '../../AppProvider';
 
 export interface CreateAppProviderContext extends AppProviderProps {
   stickyManager?: StickyManager;

--- a/src/components/AppProvider/utilities/createPolarisContext/createPolarisContext.ts
+++ b/src/components/AppProvider/utilities/createPolarisContext/createPolarisContext.ts
@@ -3,7 +3,7 @@ import {
   createThemeContext,
   ThemeContext as CreateThemeContext,
 } from '../../../ThemeProvider';
-import {Props as AppProviderProps} from '../../AppProvider';
+import {AppProviderProps} from '../../types';
 import {StickyManager} from '../withSticky';
 import createAppProviderContext, {
   CreateAppProviderContext,

--- a/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -1,10 +1,16 @@
 import * as React from 'react';
 import isEqual from 'lodash/isEqual';
 import {
-  ContextualSaveBarProps as Props,
+  ContextualSaveBarProps,
   FrameContext,
   frameContextTypes,
 } from '../Frame';
+
+// The script in the styleguide that generates the Props Explorer data expects
+// a component's props to be found in the Props interface. This silly workaround
+// ensures that the Props Explorer table is generated correctly, instead of
+// crashing if we write `ContextualSaveBar extends React.Component<ContextualSaveBarProps>`
+interface Props extends ContextualSaveBarProps {}
 
 class ContextualSaveBar extends React.PureComponent<Props, never> {
   static contextTypes = frameContextTypes;

--- a/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -1,38 +1,10 @@
 import * as React from 'react';
 import isEqual from 'lodash/isEqual';
-import {FrameContext, frameContextTypes} from '../Frame';
-
-interface ContextualSaveBarAction {
-  /** A destination to link to */
-  url?: string;
-  /** Content the action displays */
-  content?: string;
-  /** Should a spinner be displayed */
-  loading?: boolean;
-  /** Should the action be disabled */
-  disabled?: boolean;
-  /** Callback when an action takes place */
-  onAction?(): void;
-}
-
-interface ContextualSaveBarDiscardActionProps {
-  /** Whether to show a modal confirming the discard action */
-  discardConfirmationModal?: boolean;
-}
-
-type ContextualSaveBarCombinedActionProps = ContextualSaveBarDiscardActionProps &
-  ContextualSaveBarAction;
-
-export interface Props {
-  /** Extend the contents section to be flush with the left edge  */
-  alignContentFlush?: boolean;
-  /** Accepts a string of content that will be rendered to the left of the actions */
-  message?: string;
-  /** Save or commit contextual save bar action with text defaulting to 'Save' */
-  saveAction?: ContextualSaveBarAction;
-  /** Discard or cancel contextual save bar action with text defaulting to 'Discard' */
-  discardAction?: ContextualSaveBarCombinedActionProps;
-}
+import {
+  ContextualSaveBarProps as Props,
+  FrameContext,
+  frameContextTypes,
+} from '../Frame';
 
 class ContextualSaveBar extends React.PureComponent<Props, never> {
   static contextTypes = frameContextTypes;

--- a/src/components/ContextualSaveBar/index.ts
+++ b/src/components/ContextualSaveBar/index.ts
@@ -1,4 +1,3 @@
 import ContextualSaveBar from './ContextualSaveBar';
 
-export {Props as ContextualSaveBarProps} from './ContextualSaveBar';
 export default ContextualSaveBar;

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -11,9 +11,12 @@ import Backdrop from '../Backdrop';
 import TrapFocus from '../TrapFocus';
 import {dataPolarisTopBar, layer, Duration} from '../shared';
 import {setRootProperty} from '../../utilities/setRootProperty';
-import {ContextualSaveBarProps} from '../ContextualSaveBar';
-import {ToastProps} from '../Toast';
-import {FrameContext, frameContextTypes} from './types';
+import {
+  ContextualSaveBarProps,
+  FrameContext,
+  frameContextTypes,
+  ToastProps,
+} from './types';
 import {ToastManager, Loading, ContextualSaveBar} from './components';
 
 import * as styles from './Frame.scss';

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -3,7 +3,7 @@ import {autobind} from '@shopify/javascript-utilities/decorators';
 
 import {getWidth} from '../../../../utilities/getWidth';
 
-import {ContextualSaveBarProps as Props} from '../../../ContextualSaveBar';
+import {ContextualSaveBarProps as Props} from '../../types';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 import Button from '../../../Button';
 import Image from '../../../Image';

--- a/src/components/Frame/components/Toast/Toast.tsx
+++ b/src/components/Frame/components/Toast/Toast.tsx
@@ -5,7 +5,7 @@ import {Key} from '../../../../types';
 
 import Icon from '../../../Icon';
 import KeypressListener from '../../../KeypressListener';
-import {ToastProps as Props} from '../../../Toast';
+import {ToastProps as Props} from '../../types';
 
 import * as styles from './Toast.scss';
 

--- a/src/components/Frame/components/Toast/tests/Toast.test.tsx
+++ b/src/components/Frame/components/Toast/tests/Toast.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {timer} from '@shopify/jest-dom-mocks';
 import {mountWithAppProvider} from 'test-utilities';
 import {noop} from 'utilities/other';
-import {ToastProps as Props} from '../../../../Toast';
+import {ToastProps as Props} from '../../../types';
 import Toast from '../Toast';
 import {Key} from '../../../../../types';
 

--- a/src/components/Frame/components/ToastManager/ToastManager.tsx
+++ b/src/components/Frame/components/ToastManager/ToastManager.tsx
@@ -4,7 +4,7 @@ import {autobind} from '@shopify/javascript-utilities/decorators';
 import {classNames} from '@shopify/react-utilities/styles';
 import EventListener from '../../../EventListener';
 import Portal from '../../../Portal';
-import {ToastProps} from '../../../Toast';
+import {ToastProps} from '../../types';
 import Toast from '../Toast';
 
 import * as styles from './ToastManager.scss';

--- a/src/components/Frame/index.ts
+++ b/src/components/Frame/index.ts
@@ -4,6 +4,11 @@ export {Props} from './Frame';
 
 export {DEFAULT_TOAST_DURATION} from './components';
 
-export {FrameContext, frameContextTypes} from './types';
+export {
+  ContextualSaveBarProps,
+  FrameContext,
+  frameContextTypes,
+  ToastProps,
+} from './types';
 
 export default Frame;

--- a/src/components/Frame/types.ts
+++ b/src/components/Frame/types.ts
@@ -1,6 +1,4 @@
 import * as PropTypes from 'prop-types';
-import {ToastProps} from '../Toast';
-import {ContextualSaveBarProps} from '../ContextualSaveBar';
 
 export interface FrameManager {
   showToast(toast: {id: string} & ToastProps): void;
@@ -19,4 +17,50 @@ export const frameContextTypes = {
   frame: PropTypes.object,
 };
 
+interface ContextualSaveBarAction {
+  /** A destination to link to */
+  url?: string;
+  /** Content the action displays */
+  content?: string;
+  /** Should a spinner be displayed */
+  loading?: boolean;
+  /** Should the action be disabled */
+  disabled?: boolean;
+  /** Callback when an action takes place */
+  onAction?(): void;
+}
+
+interface ContextualSaveBarDiscardActionProps {
+  /** Whether to show a modal confirming the discard action */
+  discardConfirmationModal?: boolean;
+}
+
+type ContextualSaveBarCombinedActionProps = ContextualSaveBarDiscardActionProps &
+  ContextualSaveBarAction;
+
+export interface ContextualSaveBarProps {
+  /** Extend the contents section to be flush with the left edge  */
+  alignContentFlush?: boolean;
+  /** Accepts a string of content that will be rendered to the left of the actions */
+  message?: string;
+  /** Save or commit contextual save bar action with text defaulting to 'Save' */
+  saveAction?: ContextualSaveBarAction;
+  /** Discard or cancel contextual save bar action with text defaulting to 'Discard' */
+  discardAction?: ContextualSaveBarCombinedActionProps;
+}
+
 // Toast
+
+export interface ToastProps {
+  /** The content that should appear in the toast message */
+  content: string;
+  /**
+   * The length of time in milliseconds the toast message should persist
+   * @default 5000
+   */
+  duration?: number;
+  /** Display an error toast. */
+  error?: boolean;
+  /** Callback when the dismiss icon is clicked */
+  onDismiss(): void;
+}

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -6,11 +6,17 @@ import {
   DEFAULT_TOAST_DURATION,
   FrameContext,
   frameContextTypes,
-  ToastProps as Props,
+  ToastProps,
 } from '../Frame';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 
 const createId = createUniqueIDFactory('Toast');
+
+// The script in the styleguide that generates the Props Explorer data expects
+// a component's props to be found in the Props interface. This silly workaround
+// ensures that the Props Explorer table is generated correctly, instead of
+// crashing if we write `ComposedProps = ToastProps & WithAppProviderProps`
+interface Props extends ToastProps {}
 
 export type ComposedProps = Props & WithAppProviderProps;
 

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -6,28 +6,15 @@ import {
   DEFAULT_TOAST_DURATION,
   FrameContext,
   frameContextTypes,
+  ToastProps as Props,
 } from '../Frame';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 
 const createId = createUniqueIDFactory('Toast');
 
-export interface ToastProps {
-  /** The content that should appear in the toast message */
-  content: string;
-  /**
-   * The length of time in milliseconds the toast message should persist
-   * @default 5000
-   */
-  duration?: number;
-  /** Display an error toast. */
-  error?: boolean;
-  /** Callback when the dismiss icon is clicked */
-  onDismiss(): void;
-}
+export type ComposedProps = Props & WithAppProviderProps;
 
-export type Props = ToastProps & WithAppProviderProps;
-
-export class Toast extends React.PureComponent<Props, never> {
+export class Toast extends React.PureComponent<ComposedProps, never> {
   static contextTypes = frameContextTypes;
   context: FrameContext;
 
@@ -47,7 +34,7 @@ export class Toast extends React.PureComponent<Props, never> {
     if (appBridge == null) {
       context.frame.showToast({
         id,
-        ...(props as ToastProps),
+        ...(props as Props),
       });
     } else {
       this.appBridgeToast = AppBridgeToast.create(appBridge, {
@@ -77,4 +64,4 @@ export class Toast extends React.PureComponent<Props, never> {
   }
 }
 
-export default withAppProvider<ToastProps>()(Toast);
+export default withAppProvider<Props>()(Toast);

--- a/src/components/Toast/index.ts
+++ b/src/components/Toast/index.ts
@@ -1,4 +1,3 @@
 import Toast from './Toast';
 
-export {ToastProps} from './Toast';
 export default Toast;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,7 +7,7 @@ export {default as ActionList, Props as ActionListProps} from './ActionList';
 
 export {
   default as AppProvider,
-  AppProviderProps,
+  Props as AppProviderProps,
   Context as AppProviderContext,
   polarisAppProviderContextTypes as polarisContextTypes,
   createAppProviderContext,
@@ -77,10 +77,7 @@ export {
 
 export {default as Connected, Props as ConnectedProps} from './Connected';
 
-export {
-  default as ContextualSaveBar,
-  ContextualSaveBarProps,
-} from './ContextualSaveBar';
+export {default as ContextualSaveBar} from './ContextualSaveBar';
 
 export {
   default as DataTable,
@@ -138,6 +135,8 @@ export {default as FormLayout, Props as FormLayoutProps} from './FormLayout';
 export {
   default as Frame,
   Props as FrameProps,
+  ContextualSaveBarProps,
+  ToastProps,
   DEFAULT_TOAST_DURATION,
 } from './Frame';
 
@@ -261,7 +260,7 @@ export {
   Context as ThemeProviderContext,
 } from './ThemeProvider';
 
-export {default as Toast, ToastProps} from './Toast';
+export {default as Toast} from './Toast';
 
 export {default as Tooltip, Props as TooltipProps} from './Tooltip';
 


### PR DESCRIPTION
Continuing the cyclical type import dance (almost there)

### WHY are these changes introduced?

#698 Did some refactoring to remove some cyclical type imports. It turns out those changes broke the Props Explorer in the styleguide, as the script in the styleguide that generates props data assumes that each component has an interface called `Props` in it and #698 moved some props declarations outside of the component to remove circularity - as the Props were shared by two components.

#727 reverted the problematic parts of that PR and made the styleguide work again, at the cost of bringing back those cyclical type imports.

This PR fixes the cyclical types in a way that does not break the props explorer.

### WHAT is this pull request doing?

This PR consists of two commits. The first reverts #727. The second applies a change that allows the props explorer to be generated correctly while retaining no circular imports. It does this by adding  a `Props` interface to AppProvider, Toast and ContextualSaveBar that extends from the actual Props interface we want to use.

Essentially changing the following code that causes problems with the props explorer:

```ts
import { ContextualSaveBarProps } from '../Frame';

class ContextualSaveBar extends React.PureComponent<ContextualSaveBarProps, never>  {}
```

to the following, which the props explorer works with:

```ts
import { ContextualSaveBarProps } from '../Frame';

interface Props extends ContextualSaveBarProps {}

class ContextualSaveBar extends React.PureComponent<Props, never>  {}
```

I tried doing this with a type alias `type Props = ContextualSaveBarProps;` but it didn't work so we have to create a new interface.


### How to 🎩

* Run tests
* Run `yarn run sk type-check` to prove typescript is happy
* Run `yarn build-consumer web` then run `yarn run sk type-check` in web to prove there are no missing exports (You may have to install polaris-icons in web as a workaround because build-consumer isn't smart enough to handle updating transitive dependencies)
* Run `yarn build-consumer polaris-styleguide` then run `yarn run dev` in polaris-styleguide and check the props explorer for the AppProvider, Toast and ContextualSaveBar components still render the same (You may have to install polaris-icons in web as a workaround because build-consumer isn't smart enough to handle updating transitive dependencies)

