### PR TITLE
[Exploration] Styled components

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@types/react-hot-loader": "^3.0.6",
     "@types/react-router-dom": "^4.2.7",
     "@types/rollup": "0.51.4",
+    "@types/styled-components": "^4.1.4",
     "archiver": "^2.1.0",
     "aws-sdk": "^2.58.0",
     "babel-cli": "^6.26.0",
@@ -188,6 +189,7 @@
     "lodash-decorators": "^4.3.5",
     "prop-types": "^15.6.1",
     "react-transition-group": "^2.4.0",
+    "styled-components": "^4.1.2",
     "tslib": "^1.9.3"
   }
 }

--- a/playground/Playground.tsx
+++ b/playground/Playground.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Page} from '@shopify/polaris';
+import {Page, Button} from '@shopify/polaris';
 
 interface State {}
 
@@ -10,7 +10,7 @@ export default class Playground extends React.Component<{}, State> {
         title="Playground"
         primaryAction={{content: 'View Examples', url: '/examples'}}
       >
-        {/* Add the code you want to test here */}
+        <Button>Click me!</Button>
       </Page>
     );
   }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -9,6 +9,7 @@ import Spinner from '../Spinner';
 import Indicator from '../Indicator';
 
 import * as styles from './Button.scss';
+import {Button as StyledButton} from './ButtonStyles';
 
 export type Size = 'slim' | 'medium' | 'large';
 
@@ -174,14 +175,13 @@ function Button({
       {content}
     </UnstyledLink>
   ) : (
-    <button
+    <StyledButton
       id={id}
       type={type}
       onClick={onClick}
       onFocus={onFocus}
       onBlur={onBlur}
       onMouseUp={handleMouseUpByBlurring}
-      className={className}
       disabled={isDisabled}
       aria-label={accessibilityLabel}
       aria-controls={ariaControls}
@@ -191,7 +191,7 @@ function Button({
     >
       {indicatorMarkup}
       {content}
-    </button>
+    </StyledButton>
   );
 }
 

--- a/src/components/Button/ButtonStyles.ts
+++ b/src/components/Button/ButtonStyles.ts
@@ -1,0 +1,69 @@
+import {
+  colorInk,
+  colorInkLighter,
+  colorWhite,
+  colorSkyLighter,
+  colorIndigo,
+  colorSkyLight,
+  colorSkyDark,
+} from '@shopify/polaris-tokens';
+import styled from 'styled-components';
+import {
+  recolorIcon,
+  controlHeight,
+  border,
+  borderRadius,
+  shadow,
+  duration,
+  easing,
+  spacing,
+} from '../../utilities/style-utilities';
+
+const minHeight = controlHeight;
+
+export const Button = styled.button`
+  ${recolorIcon(colorInkLighter)} position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: ${minHeight};
+  min-width: ${minHeight};
+  margin: 0;
+  padding: ${spacing()} ${spacing('loose')};
+  background: linear-gradient(to bottom, ${colorWhite}, ${colorSkyLighter});
+  border: ${border('dark')};
+  box-shadow: ${shadow('faint')};
+  border-radius: ${borderRadius()};
+  line-height: 1;
+  color: ${colorInk};
+  text-align: center;
+  cursor: pointer;
+  user-select: none;
+  text-decoration: none;
+  transition-property: background, border, box-shadow;
+  transition-duration: ${duration()};
+  transition-timing-function: ${easing()};
+
+  &:hover {
+    background: linear-gradient(
+      to bottom,
+      ${colorSkyLighter},
+      ${colorSkyLight}
+    );
+    border-color: ${colorSkyDark};
+  }
+
+  &:focus {
+    border-color: ${colorIndigo};
+    outline: 0;
+    box-shadow: 0 0 0 1px ${colorIndigo};
+  }
+
+  &:active {
+    background: linear-gradient(to bottom, ${colorSkyLight}, ${colorSkyLight});
+    border-color: ${colorSkyDark};
+    box-shadow: 0 0 0 0 transparent,
+      inset 0 1px 1px 0 rgba(${colorInkLighter}, 0.1),
+      inset 0 1px 4px 0 rgba(${colorInkLighter}, 0.2);
+  }
+`;

--- a/src/utilities/style-utilities.ts
+++ b/src/utilities/style-utilities.ts
@@ -1,0 +1,59 @@
+import {colorSkyDark} from '@shopify/polaris-tokens';
+
+function setHasVariants(dataSet: any) {
+  const [firstKey] = Object.keys(dataSet);
+  return typeof dataSet[firstKey] === 'object';
+}
+
+function createDataGetter(dataSet: any) {
+  if (setHasVariants(dataSet)) {
+    return (style = 'base', variant = 'base') => dataSet[style][variant];
+  }
+  return (style = 'base') => dataSet[style];
+}
+
+export function rem(px: number) {
+  return `${px / 16}rem`;
+}
+
+export const lineHeight = createDataGetter({
+  body: {
+    base: rem(20),
+  },
+});
+
+export const border = createDataGetter({
+  dark: `${rem(1)} solid ${colorSkyDark}`,
+});
+
+export const borderRadius = createDataGetter({
+  base: '3px',
+});
+
+export const shadow = createDataGetter({
+  faint: `0 1px 0 0 rgba(22, 29, 37, 0.05)`,
+});
+
+export const duration = createDataGetter({
+  base: '200ms',
+});
+
+export const easing = createDataGetter({
+  base: 'cubic-bezier(0.64, 0, 0.35, 1)',
+});
+
+const spacingUnit = 4;
+
+export const spacing = createDataGetter({
+  base: rem(spacingUnit * 4),
+  loose: rem(spacingUnit * 5),
+});
+
+export function recolorIcon(mainColor: string, secondaryColor?: string) {
+  return `
+    fill: ${mainColor};
+    ${secondaryColor && `color: ${secondaryColor};`}
+  `;
+}
+
+export const controlHeight = rem(36);

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,13 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/helper-annotate-as-pure@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
+  integrity sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
 "@babel/helper-function-name@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0.tgz#a68cc8d04420ccc663dd258f9cc41b8261efa2d4"
@@ -203,6 +210,23 @@
     esutils "^2.0.2"
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
+
+"@emotion/is-prop-valid@^0.6.8":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz#68ad02831da41213a2089d2cab4e8ac8b30cbd85"
+  integrity sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==
+  dependencies:
+    "@emotion/memoize" "^0.6.6"
+
+"@emotion/memoize@^0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
+  integrity sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==
+
+"@emotion/unitless@^0.7.0":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
+  integrity sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -646,6 +670,15 @@
   dependencies:
     "@types/acorn" "*"
     source-map "^0.6.1"
+
+"@types/styled-components@^4.1.4":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-4.1.4.tgz#c6915ccee4413da2e1e81b4df9d7ea5b97eb56aa"
+  integrity sha512-zEj6BptOBBxob0hnNdr/qiXZjlC8EUVl7GDN1z+kp58zLtDBjbrbo+1yjL2Gi64IjhFaF7Qz4MbsDdbBuUa83A==
+  dependencies:
+    "@types/node" "*"
+    "@types/react" "*"
+    csstype "^2.2.0"
 
 "@webassemblyjs/ast@1.7.11":
   version "1.7.11"
@@ -1783,6 +1816,15 @@ babel-plugin-react-test-id@^1.0.2:
   resolved "https://registry.yarnpkg.com/babel-plugin-react-test-id/-/babel-plugin-react-test-id-1.0.2.tgz#90fb7ab91e9623bea47ad1f7eddd9a38e2dfc51b"
   integrity sha1-kPt6uR6WI76ketH37d2aOOLfxRs=
 
+"babel-plugin-styled-components@>= 1":
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.9.4.tgz#5f2c34d31237c6ee1e86453cc5fa488b97136669"
+  integrity sha512-FIACAvgJsUasYA+CdhPMWUIXWCdUUirz7fL9FGQYNNuOls+bs9OUWWHYVM2W9gjVoS2TXdEMqcOVVyG3Hagd/g==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.10"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -1813,7 +1855,7 @@ babel-plugin-syntax-flow@^6.18.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
   integrity sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=
 
-babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
+babel-plugin-syntax-jsx@^6.18.0, babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
@@ -3991,6 +4033,11 @@ crypto@^1.0.1:
   resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
   integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -4049,6 +4096,15 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-to-react-native@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.2.tgz#c077d0f7bf3e6c915a539e7325821c9dd01f9965"
+  integrity sha512-w99Fzop1FO8XKm0VpbQp3y5mnTnaS+rtCvS+ylSEOK76YXO5zoHQx/QMB1N54Cp+Ya9jB9922EHrh14ld4xmmw==
+  dependencies:
+    css-color-keywords "^1.0.0"
+    fbjs "^0.8.5"
+    postcss-value-parser "^3.3.0"
 
 css-tree@1.0.0-alpha.28:
   version "1.0.0-alpha.28"
@@ -5972,6 +6028,19 @@ fbjs@^0.8.16:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
+
+fbjs@^0.8.5:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 fd-slicer@~1.0.1:
   version "1.0.1"
@@ -9712,6 +9781,11 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
 
+memoize-one@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
+  integrity sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA==
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -12301,6 +12375,11 @@ react-is@^16.5.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
   integrity sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==
 
+react-is@^16.6.0:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
+  integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
+
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -14141,6 +14220,22 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
 
+styled-components@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.1.2.tgz#f8a685e3b2bcd03c5beac7f2c02bb6ad237da9b3"
+  integrity sha512-NdvWatJ2WLqZxAvto+oH0k7GAC/TlAUJTrHoXJddjbCrU6U23EmVbb9LXJBF+d6q6hH+g9nQYOWYPUeX/Vlc2w==
+  dependencies:
+    "@emotion/is-prop-valid" "^0.6.8"
+    "@emotion/unitless" "^0.7.0"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^4.0.0"
+    prop-types "^15.5.4"
+    react-is "^16.6.0"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
 stylelint-config-prettier@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-4.0.0.tgz#8c712977be13bd25191ab8b986b5c07a3342a5dc"
@@ -14236,6 +14331,16 @@ stylelint@^9.7.1:
     sugarss "^2.0.0"
     svg-tags "^1.0.0"
     table "^5.0.0"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
+
+stylis@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
 sugarss@^2.0.0:
   version "2.0.0"
@@ -14777,6 +14882,11 @@ typescript@~3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
   integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+
+ua-parser-js@^0.7.18:
+  version "0.7.19"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
+  integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
## What is this?
While working on https://github.com/Shopify/polaris-react/pull/755 it became clear that making Polaris fully theme-able poses some challenges. One of the biggest ones being that we `lighten` and `darken` a lot of our colours in our SCSS which is complicated to do with values that are being passed into the `ThemeProvider` as those values are not known until runtime.

A potential workaround would be to generate the problematic CSS rules in JS and pass them into the component at runtime but if a lot of components are going to need that you might start to wonder if using SCSS is even still in our advantage.

Hence this exploration which recreates one of our components using JS styles, which would give us a lot more flexibility. The cons of course being that no other codebase at Shopify currently does this and that porting everything over would be a lot of work. We could also partially use JS styling to work around some of the issues we're having.

No matter what way we think this might be useful in I wanted to share the exploration for future reference and to hear your thoughts on if and how this might be useful in the future.

## Playing around with the changes
This exploration contains a playground with the JS styled button.

**⚠️This PR is an exploration, contains breaking changes and should not be merged in its current state.**

cc @dfmcphee @kaelig (I know you explored this at some point 🙂)