### PR TITLE
Add "code quality" grouping to changelog docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,3 +22,5 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Refactors to remove cyclical type imports ([#759](https://github.com/Shopify/polaris-react/pull/759))
 
 ### Dependency upgrades
+
+### Code quality

--- a/documentation/Versioning and changelog.md
+++ b/documentation/Versioning and changelog.md
@@ -46,6 +46,7 @@ The possible groups in which to categorize changes are:
 - Documentation
 - Dependency upgrades
 - Development workflow (new yarn commands or changes to existing commands)
+- Code quality (non-trivial changes to code which effect the private API)
 
 ## Out of scope for `CHANGELOG.md`
 


### PR DESCRIPTION
There were a few PRs (#524, #691, and #698) that touched a non-trivial amount of code, were done for code quality reasons, but did not have a changelog entry. This proved problematic when understanding what level of risk, thus manual testing needed to be done before releasing.

While we can go through the history of commits, it is more efficient to tell a clear story of impact in the changelog, even if not all changes are consumer facing.