### PR TITLE
[Stack.Item] Add Stack.Item properties to style guide documentation

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Added `Stack.Item` properties and description to [style guide](https://polaris.shopify.com)’s ([#772](https://github.com/Shopify/polaris-react/pull/772))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/Stack/README.md
+++ b/src/components/Stack/README.md
@@ -118,6 +118,8 @@ Use to have the stack’s items fill the horizontal space in the container and b
 </Stack>
 ```
 
+<a name="single-item-fills-remaining-space"></a>
+
 ### Stack where a single item fills the remaining space
 
 Use for aligning buttons or secondary content to the right edge of another element, allowing it to wrap below on small screens.
@@ -135,6 +137,19 @@ Use for aligning buttons or secondary content to the right edge of another eleme
   </Stack.Item>
 </Stack>
 ```
+
+---
+
+## Stack item
+
+The stack component will treat multiple elements wrapped in a stack item component as one item. By default, each individual element is treated as one stack item. Use the fill prop on a single stack item component to make it fill the rest of the available horizontal space. See the [Stack where a single item fills the remaining space](#single-item-fills-remaining-space) example.
+
+### Stack item properties
+
+| Prop     | Type    | Description                                                    | Default |
+| -------- | ------- | -------------------------------------------------------------- | ------- |
+| fill     | boolean | Fill the available horizontal space in the stack with the item | false   |
+| children | any     | Elements to display inside stack item                          |         |
 
 ---
 

--- a/src/components/Stack/components/Item/Item.tsx
+++ b/src/components/Stack/components/Item/Item.tsx
@@ -3,8 +3,13 @@ import {classNames} from '@shopify/react-utilities/styles';
 import * as styles from '../../Stack.scss';
 
 export interface Props {
+  /** Elements to display inside item */
   children?: React.ReactNode;
+  /** Fill the remaining horizontal space in the stack with the item  */
   fill?: boolean;
+  /**
+   * @default false
+   */
 }
 
 export default function Item({children, fill}: Props) {


### PR DESCRIPTION

### WHY are these changes introduced?

Resolves #536  <!-- link to issue if one exists -->

Stack Item properties needed to be listed in the documentation. 


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
