### PR TITLE
Infer HoC props

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -32,3 +32,5 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Dependency upgrades
 
 ### Code quality
+
+- Improve `withAppProvider`, `withSticky`, `withRef`, and `withContext` types to allow them to infer a components props ([#805](https://github.com/Shopify/polaris-react/pull/805))

--- a/src/components/AppProvider/utilities/withAppProvider/withAppProvider.tsx
+++ b/src/components/AppProvider/utilities/withAppProvider/withAppProvider.tsx
@@ -23,13 +23,13 @@ export interface WithAppProviderProps {
   };
 }
 
-export default function withAppProvider<OwnProps>() {
-  return function addProvider<C>(
+export default function withAppProvider() {
+  return function addProvider<OriginalProps, C>(
     WrappedComponent:
-      | React.ComponentClass<OwnProps & WithAppProviderProps> & C
-      | React.SFC<OwnProps & WithAppProviderProps> & C,
-  ): React.ComponentClass<OwnProps> & C {
-    class WithProvider extends React.Component<OwnProps, never> {
+      | React.ComponentClass<OriginalProps & WithAppProviderProps> & C
+      | React.SFC<OriginalProps & WithAppProviderProps> & C,
+  ): React.ComponentClass<OriginalProps> & C {
+    class WithProvider extends React.Component<OriginalProps, never> {
       static contextTypes = WrappedComponent.contextTypes
         ? merge(WrappedComponent.contextTypes, polarisAppProviderContextTypes)
         : polarisAppProviderContextTypes;
@@ -90,6 +90,6 @@ export default function withAppProvider<OwnProps>() {
       WrappedComponent as React.ComponentClass<any>,
     );
 
-    return FinalComponent as React.ComponentClass<OwnProps> & C;
+    return FinalComponent as React.ComponentClass<OriginalProps> & C;
   };
 }

--- a/src/components/AppProvider/utilities/withSticky/withSticky.tsx
+++ b/src/components/AppProvider/utilities/withSticky/withSticky.tsx
@@ -10,7 +10,7 @@ export default function withSticky() {
     WrappedComponent:
       | React.ComponentClass<OwnProps & WithAppProviderProps> & C
       | React.SFC<OwnProps & WithAppProviderProps> & C,
-  ): any & C {
+  ): React.ComponentClass<OwnProps> & C {
     // eslint-disable-next-line shopify/react-initialize-state
     class WithStickyManager extends React.Component<
       {},
@@ -50,6 +50,6 @@ export default function withSticky() {
       WithStickyManager,
       WrappedComponent as React.ComponentClass<any>,
     );
-    return FinalComponent as React.ComponentClass<any> & C;
+    return FinalComponent as React.ComponentClass<OwnProps> & C;
   };
 }

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -101,4 +101,4 @@ export class Autocomplete extends React.PureComponent<CombinedProps, never> {
   }
 }
 
-export default withAppProvider<Props>()(Autocomplete);
+export default withAppProvider()(Autocomplete);

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -173,4 +173,4 @@ function customerPlaceholder(name?: string) {
     : AVATAR_IMAGES[0];
 }
 
-export default withAppProvider<Props>()(Avatar);
+export default withAppProvider()(Avatar);

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -109,4 +109,4 @@ function Badge({
   );
 }
 
-export default withAppProvider<Props>()(Badge);
+export default withAppProvider()(Badge);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -203,4 +203,4 @@ function isIconSource(x: any): x is IconSource {
   return typeof x === 'string' || (typeof x === 'object' && x.body);
 }
 
-export default withAppProvider<Props>()(Button);
+export default withAppProvider()(Button);

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -131,4 +131,4 @@ function Checkbox({
   );
 }
 
-export default withAppProvider<Props>()(Checkbox);
+export default withAppProvider()(Checkbox);

--- a/src/components/ChoiceList/ChoiceList.tsx
+++ b/src/components/ChoiceList/ChoiceList.tsx
@@ -145,4 +145,4 @@ function updateSelectedChoices(
   return selected.filter((selectedChoice) => selectedChoice !== value);
 }
 
-export default withAppProvider<Props>()(ChoiceList);
+export default withAppProvider()(ChoiceList);

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -192,4 +192,4 @@ function collapsibleHeight(
   return `${height || 0}px`;
 }
 
-export default withAppProvider<Props>()(Collapsible);
+export default withAppProvider()(Collapsible);

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -511,4 +511,4 @@ export class DataTable extends React.PureComponent<
   }
 }
 
-export default withAppProvider<Props>()(DataTable);
+export default withAppProvider()(DataTable);

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -126,4 +126,4 @@ function Cell({
   return cellMarkup;
 }
 
-export default withAppProvider<Props>()(Cell);
+export default withAppProvider()(Cell);

--- a/src/components/DataTable/components/Navigation/Navigation.tsx
+++ b/src/components/DataTable/components/Navigation/Navigation.tsx
@@ -66,4 +66,4 @@ function Navigation({
   );
 }
 
-export default withAppProvider<Props>()(Navigation);
+export default withAppProvider()(Navigation);

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -325,4 +325,4 @@ function deriveRange(selected?: Date | Range) {
   return selected instanceof Date ? {start: selected, end: selected} : selected;
 }
 
-export default withAppProvider<Props>()(DatePicker);
+export default withAppProvider()(DatePicker);

--- a/src/components/DatePicker/components/Day/Day.tsx
+++ b/src/components/DatePicker/components/Day/Day.tsx
@@ -94,4 +94,4 @@ export class Day extends React.PureComponent<CombinedProps, never> {
   }
 }
 
-export default withAppProvider<Props>()(Day);
+export default withAppProvider()(Day);

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -561,4 +561,4 @@ function handleDragStart(event: React.DragEvent<HTMLDivElement>) {
   event.stopPropagation();
 }
 
-export default withAppProvider<Props>()(DropZone);
+export default withAppProvider()(DropZone);

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -149,7 +149,7 @@ export class FileUpload extends React.Component<CombinedProps, State> {
 }
 
 export default compose<Props>(
-  withContext<Props, WithAppProviderProps, DropZoneContext>(Consumer),
-  withAppProvider<Props>(),
-  withRef<Props>(),
+  withContext<DropZoneContext>(Consumer),
+  withAppProvider(),
+  withRef(),
 )(FileUpload);

--- a/src/components/EmptySearchResult/EmptySearchResult.tsx
+++ b/src/components/EmptySearchResult/EmptySearchResult.tsx
@@ -52,4 +52,4 @@ export class EmptySearchResult extends React.PureComponent<
   }
 }
 
-export default withAppProvider<Props>()(EmptySearchResult);
+export default withAppProvider()(EmptySearchResult);

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -416,4 +416,4 @@ function isMobileView() {
   return navigationBarCollapsed().matches;
 }
 
-export default withAppProvider<Props>()(Frame);
+export default withAppProvider()(Frame);

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -131,4 +131,4 @@ class ContextualSaveBar extends React.PureComponent<CombinedProps, State> {
   }
 }
 
-export default withAppProvider<Props>()(ContextualSaveBar);
+export default withAppProvider()(ContextualSaveBar);

--- a/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/DiscardConfirmationModal.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/DiscardConfirmationModal.tsx
@@ -47,4 +47,4 @@ function DiscardConfirmationModal({
   );
 }
 
-export default withAppProvider<Props>()(DiscardConfirmationModal);
+export default withAppProvider()(DiscardConfirmationModal);

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -239,4 +239,4 @@ function isBundledIcon(key: string | BundledIcon): key is BundledIcon {
   return Object.keys(BUNDLED_ICONS).includes(key);
 }
 
-export default withAppProvider<Props>()(Icon);
+export default withAppProvider()(Icon);

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -37,4 +37,4 @@ export class Loading extends React.PureComponent<ComposedProps, never> {
   }
 }
 
-export default withAppProvider<Props>()(Loading);
+export default withAppProvider()(Loading);

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -384,4 +384,4 @@ function isIframeModal(
   );
 }
 
-export default withAppProvider<Props>()(Modal);
+export default withAppProvider()(Modal);

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -376,6 +376,6 @@ function matchStateForItem(
   return matchesUrl ? MatchState.MatchUrl : MatchState.NoMatch;
 }
 
-export const Item = withAppProvider<Props>()(BaseItem);
+export const Item = withAppProvider()(BaseItem);
 
 export default Item;

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -226,4 +226,4 @@ function testSectionsPropEquality(
   return optionsAreEqual && titlesAreEqual;
 }
 
-export default withAppProvider<Props>()(OptionList);
+export default withAppProvider()(OptionList);

--- a/src/components/OptionList/tests/OptionList.test.tsx
+++ b/src/components/OptionList/tests/OptionList.test.tsx
@@ -61,7 +61,7 @@ describe('<OptionList />', () => {
 
   it('renders options and sections', () => {
     const {options, sections} = defaultProps;
-    const optionWrappers = shallowWithAppProvider<Props>(
+    const optionWrappers = shallowWithAppProvider(
       <OptionList {...defaultProps} />,
     ).find(Option);
 
@@ -71,7 +71,7 @@ describe('<OptionList />', () => {
   it('renders sections', () => {
     const {sections} = defaultProps;
     const options: OptionDescriptor[] = [];
-    const optionWrappers = shallowWithAppProvider<Props>(
+    const optionWrappers = shallowWithAppProvider(
       <OptionList {...defaultProps} options={options} />,
     ).find(Option);
 
@@ -81,7 +81,7 @@ describe('<OptionList />', () => {
   it('renders options', () => {
     const {options} = defaultProps;
     const sections: SectionDescriptor[] = [];
-    const optionWrappers = shallowWithAppProvider<Props>(
+    const optionWrappers = shallowWithAppProvider(
       <OptionList {...defaultProps} sections={sections} />,
     ).find(Option);
 
@@ -90,9 +90,7 @@ describe('<OptionList />', () => {
 
   it('re-renders with new options passed in', () => {
     const {sections} = defaultProps;
-    const optionList = shallowWithAppProvider<Props>(
-      <OptionList {...defaultProps} />,
-    );
+    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
 
     const newOptions: OptionDescriptor[] = [
       {
@@ -114,9 +112,7 @@ describe('<OptionList />', () => {
 
   it('re-renders with new sections passed in', () => {
     const {options} = defaultProps;
-    const optionList = shallowWithAppProvider<Props>(
-      <OptionList {...defaultProps} />,
-    );
+    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
 
     const newSections: SectionDescriptor[] = [
       {
@@ -141,9 +137,7 @@ describe('<OptionList />', () => {
   });
 
   it('re-renders with new options and new sections passed in', () => {
-    const optionList = shallowWithAppProvider<Props>(
-      <OptionList {...defaultProps} />,
-    );
+    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
 
     const newOptions: OptionDescriptor[] = [
       {
@@ -181,9 +175,7 @@ describe('<OptionList />', () => {
 
   it('re-renders with undefined options', () => {
     const {sections} = defaultProps;
-    const optionList = shallowWithAppProvider<Props>(
-      <OptionList {...defaultProps} />,
-    );
+    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
 
     optionList.setProps({options: undefined});
 
@@ -193,9 +185,7 @@ describe('<OptionList />', () => {
 
   it('re-renders with undefined sections', () => {
     const {options} = defaultProps;
-    const optionList = shallowWithAppProvider<Props>(
-      <OptionList {...defaultProps} />,
-    );
+    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
 
     optionList.setProps({sections: undefined});
 
@@ -204,9 +194,7 @@ describe('<OptionList />', () => {
   });
 
   it('re-renders with undefined options and new sections', () => {
-    const optionList = shallowWithAppProvider<Props>(
-      <OptionList {...defaultProps} />,
-    );
+    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
 
     const newSections: SectionDescriptor[] = [
       {
@@ -231,9 +219,7 @@ describe('<OptionList />', () => {
   });
 
   it('re-renders with new options and undefined sections', () => {
-    const optionList = shallowWithAppProvider<Props>(
-      <OptionList {...defaultProps} />,
-    );
+    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
 
     const newOptions: OptionDescriptor[] = [
       {
@@ -257,7 +243,7 @@ describe('<OptionList />', () => {
     const spy = jest.fn();
     const {options, sections} = defaultProps;
 
-    const buttonWrappers = mountWithAppProvider<Props>(
+    const buttonWrappers = mountWithAppProvider(
       <OptionList {...defaultProps} onChange={spy} />,
     ).find('button');
 
@@ -270,7 +256,7 @@ describe('<OptionList />', () => {
   describe('allowMultiple', () => {
     it('renders options and sections', () => {
       const {options, sections} = defaultProps;
-      const optionWrappers = shallowWithAppProvider<Props>(
+      const optionWrappers = shallowWithAppProvider(
         <OptionList {...defaultProps} allowMultiple />,
       ).find(Option);
 
@@ -280,7 +266,7 @@ describe('<OptionList />', () => {
     it('renders sections', () => {
       const {sections} = defaultProps;
       const options: OptionDescriptor[] = [];
-      const optionWrappers = shallowWithAppProvider<Props>(
+      const optionWrappers = shallowWithAppProvider(
         <OptionList {...defaultProps} options={options} allowMultiple />,
       ).find(Option);
 
@@ -290,7 +276,7 @@ describe('<OptionList />', () => {
     it('renders options', () => {
       const {options} = defaultProps;
       const sections: SectionDescriptor[] = [];
-      const optionWrappers = shallowWithAppProvider<Props>(
+      const optionWrappers = shallowWithAppProvider(
         <OptionList {...defaultProps} sections={sections} allowMultiple />,
       ).find(Option);
 
@@ -299,7 +285,7 @@ describe('<OptionList />', () => {
 
     it('re-renders with new options passed in', () => {
       const {sections} = defaultProps;
-      const optionList = shallowWithAppProvider<Props>(
+      const optionList = shallowWithAppProvider(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -323,7 +309,7 @@ describe('<OptionList />', () => {
 
     it('re-renders with new sections passed in', () => {
       const {options} = defaultProps;
-      const optionList = shallowWithAppProvider<Props>(
+      const optionList = shallowWithAppProvider(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -350,7 +336,7 @@ describe('<OptionList />', () => {
     });
 
     it('re-renders with new options and new sections passed in', () => {
-      const optionList = shallowWithAppProvider<Props>(
+      const optionList = shallowWithAppProvider(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -392,7 +378,7 @@ describe('<OptionList />', () => {
 
     it('re-renders with undefined options', () => {
       const {sections} = defaultProps;
-      const optionList = shallowWithAppProvider<Props>(
+      const optionList = shallowWithAppProvider(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -404,7 +390,7 @@ describe('<OptionList />', () => {
 
     it('re-renders with undefined sections', () => {
       const {options} = defaultProps;
-      const optionList = shallowWithAppProvider<Props>(
+      const optionList = shallowWithAppProvider(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -415,7 +401,7 @@ describe('<OptionList />', () => {
     });
 
     it('re-renders with undefined options and new sections', () => {
-      const optionList = shallowWithAppProvider<Props>(
+      const optionList = shallowWithAppProvider(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -442,7 +428,7 @@ describe('<OptionList />', () => {
     });
 
     it('re-renders with new options and undefined sections', () => {
-      const optionList = shallowWithAppProvider<Props>(
+      const optionList = shallowWithAppProvider(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -469,7 +455,7 @@ describe('<OptionList />', () => {
         const spy = jest.fn();
         const {options, sections} = defaultProps;
 
-        const inputWrappers = mountWithAppProvider<Props>(
+        const inputWrappers = mountWithAppProvider(
           <OptionList {...defaultProps} onChange={spy} allowMultiple />,
         ).find('input');
 
@@ -484,7 +470,7 @@ describe('<OptionList />', () => {
         const {options, sections} = defaultProps;
         const selected = ['11', '8'];
 
-        const inputWrappers = mountWithAppProvider<Props>(
+        const inputWrappers = mountWithAppProvider(
           <OptionList
             {...defaultProps}
             onChange={spy}
@@ -507,7 +493,7 @@ describe('<OptionList />', () => {
         const {options, sections} = defaultProps;
         const selected = ['10', '8', '5'];
 
-        const inputWrappers = mountWithAppProvider<Props>(
+        const inputWrappers = mountWithAppProvider(
           <OptionList
             {...defaultProps}
             onChange={spy}

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -152,4 +152,4 @@ export class Page extends React.PureComponent<ComposedProps, never> {
   }
 }
 
-export default withAppProvider<Props>()(Page);
+export default withAppProvider()(Page);

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -291,4 +291,4 @@ function secondaryActionsFrom(
   ));
 }
 
-export default withAppProvider<Props>()(Header);
+export default withAppProvider()(Header);

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -192,4 +192,4 @@ function handleCallback(fn: () => void) {
   };
 }
 
-export default withAppProvider<Props>()(Pagination);
+export default withAppProvider()(Pagination);

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -68,4 +68,4 @@ function parseProgress(progress: number, warningMessage: string) {
   return progressWidth;
 }
 
-export default withAppProvider<Props>()(ProgressBar);
+export default withAppProvider()(ProgressBar);

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -202,4 +202,4 @@ export function invertNumber(number: number) {
   }
 }
 
-export default withAppProvider<Props>()(RangeSlider);
+export default withAppProvider()(RangeSlider);

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -705,4 +705,4 @@ function isSmallScreen() {
     : window.innerWidth <= SMALL_SCREEN_WIDTH;
 }
 
-export default withAppProvider<Props>()(ResourceList);
+export default withAppProvider()(ResourceList);

--- a/src/components/ResourceList/components/BulkActions/BulkActions.tsx
+++ b/src/components/ResourceList/components/BulkActions/BulkActions.tsx
@@ -481,4 +481,4 @@ function instanceOfBulkActionArray(
   return actions.length === validList.length;
 }
 
-export default withAppProvider<Props>()(BulkActions);
+export default withAppProvider()(BulkActions);

--- a/src/components/ResourceList/components/CheckableButton/CheckableButton.tsx
+++ b/src/components/ResourceList/components/CheckableButton/CheckableButton.tsx
@@ -51,4 +51,4 @@ function CheckableButton({
   );
 }
 
-export default withAppProvider<Props>()(CheckableButton);
+export default withAppProvider()(CheckableButton);

--- a/src/components/ResourceList/components/FilterControl/FilterControl.tsx
+++ b/src/components/ResourceList/components/FilterControl/FilterControl.tsx
@@ -297,6 +297,6 @@ function findOperatorLabel(filter: Filter, appliedFilter: AppliedFilter) {
 }
 
 export default compose<Props>(
-  withAppProvider<Props>(),
-  withContext<Props, WithAppProviderProps, ResourceListContext>(Consumer),
+  withAppProvider(),
+  withContext<ResourceListContext>(Consumer),
 )(FilterControl);

--- a/src/components/ResourceList/components/FilterControl/components/DateSelector/DateSelector.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/DateSelector/DateSelector.tsx
@@ -412,4 +412,4 @@ function formatDateValue(date: Date) {
   return date.toISOString().slice(0, 10);
 }
 
-export default withAppProvider<Props>()(DateSelector);
+export default withAppProvider()(DateSelector);

--- a/src/components/ResourceList/components/FilterControl/components/FilterCreator/FilterCreator.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterCreator/FilterCreator.tsx
@@ -211,4 +211,4 @@ export class FilterCreator extends React.PureComponent<CombinedProps, State> {
   }
 }
 
-export default withAppProvider<Props>()(FilterCreator);
+export default withAppProvider()(FilterCreator);

--- a/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/FilterValueSelector.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/FilterValueSelector.tsx
@@ -135,4 +135,4 @@ function buildOperatorOptions(operatorText?: string | Operator[]) {
   });
 }
 
-export default withAppProvider<Props>()(FilterValueSelector);
+export default withAppProvider()(FilterValueSelector);

--- a/src/components/ResourceList/components/Item/Item.tsx
+++ b/src/components/ResourceList/components/Item/Item.tsx
@@ -401,6 +401,6 @@ function stopPropagation(event: React.MouseEvent<any>) {
 }
 
 export default compose<Props>(
-  withContext<Props, WithAppProviderProps, ResourceListContext>(Consumer),
-  withAppProvider<Props>(),
+  withContext<ResourceListContext>(Consumer),
+  withAppProvider(),
 )(Item);

--- a/src/components/ResourcePicker/ResourcePicker.tsx
+++ b/src/components/ResourcePicker/ResourcePicker.tsx
@@ -157,4 +157,4 @@ export class ResourcePicker extends React.PureComponent<CombinedProps, never> {
   }
 }
 
-export default withAppProvider<Props>()(ResourcePicker);
+export default withAppProvider()(ResourcePicker);

--- a/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/src/components/SkeletonPage/SkeletonPage.tsx
@@ -113,4 +113,4 @@ function renderTitle(title: string) {
   return <div className={styles.Title}>{titleContent}</div>;
 }
 
-export default withAppProvider<Props>()(SkeletonPage);
+export default withAppProvider()(SkeletonPage);

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -69,4 +69,4 @@ function Spinner({
   );
 }
 
-export default withAppProvider<Props>()(Spinner);
+export default withAppProvider()(Spinner);

--- a/src/components/Tabs/components/Tab/Tab.tsx
+++ b/src/components/Tabs/components/Tab/Tab.tsx
@@ -152,4 +152,4 @@ function focusPanelID(panelID: string) {
   }
 }
 
-export default withAppProvider<Props>()(Tab);
+export default withAppProvider()(Tab);

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -44,4 +44,4 @@ function Tag({
   );
 }
 
-export default withAppProvider<Props>()(Tag);
+export default withAppProvider()(Tag);

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -70,4 +70,4 @@ export class Toast extends React.PureComponent<ComposedProps, never> {
   }
 }
 
-export default withAppProvider<Props>()(Toast);
+export default withAppProvider()(Toast);

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -139,4 +139,4 @@ export class TopBar extends React.PureComponent<ComposedProps, State> {
   }
 }
 
-export default withAppProvider<Props>()(TopBar);
+export default withAppProvider()(TopBar);

--- a/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/src/components/UnstyledLink/UnstyledLink.tsx
@@ -38,6 +38,6 @@ export class UnstyledLink extends React.PureComponent<CombinedProps, never> {
 }
 
 export default compose<Props>(
-  withAppProvider<Props>(),
-  withRef<Props>(),
+  withAppProvider(),
+  withRef(),
 )(UnstyledLink);

--- a/src/components/WithContext/WithContext.tsx
+++ b/src/components/WithContext/WithContext.tsx
@@ -2,19 +2,13 @@ import * as React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 import {WithContextTypes} from '../../types';
 
-export default function withContext<
-  OriginalProps,
-  ExternalProps,
-  InjectedProps
->(Consumer: React.ComponentType) {
-  return function addContext(
+export default function withContext<InjectedProps>(
+  Consumer: React.ComponentType,
+) {
+  return function addContext<OriginalProps>(
     WrappedComponent:
-      | React.ComponentClass<
-          OriginalProps & ExternalProps & WithContextTypes<InjectedProps>
-        >
-      | React.SFC<
-          OriginalProps & ExternalProps & WithContextTypes<InjectedProps>
-        >,
+      | React.ComponentClass<OriginalProps & WithContextTypes<InjectedProps>>
+      | React.SFC<OriginalProps & WithContextTypes<InjectedProps>>,
   ): React.ComponentClass<OriginalProps> {
     // eslint-disable-next-line react/prefer-stateless-function
     class WithContext extends React.Component<

--- a/src/components/WithRef/WithRef.tsx
+++ b/src/components/WithRef/WithRef.tsx
@@ -9,8 +9,8 @@ export interface Ref<T = any> {
   ref: React.RefObject<T> | null;
 }
 
-export default function withRef<OriginalProps>() {
-  return function addForwardRef<C>(
+export default function withRef() {
+  return function addForwardRef<OriginalProps, C>(
     WrappedComponent: ReactComponent<OriginalProps & Ref> & C,
   ): React.ComponentClass<OriginalProps> {
     class WithRef extends React.Component<OriginalProps, never> {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Improved HoC usage
* withSticky
* withAppProvider 
* withContext
* withRef

### WHAT is this pull request doing?

#### Letting typescript infer props rather than passing them as generics

##### Old
```tsx
export default withAppProvider<Props>()(Component)
```

##### New
```tsx
export default withAppProvider()(Component)
```

#### When we compose HoC we'll still have to pass props but only to compose

##### Old

```tsx
export default compose<Props>(
  withContext<Props, DropZoneContext>(Consumer),
  withAppProvider<Props>(),
  withRef<Props>(),
)(FileUpload);
```

##### New

```tsx
export default compose<Props>(
  withContext<DropZoneContext>(Consumer),
  withAppProvider(),
  withRef(),
)(FileUpload);
```

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

This is a pretty big change so we'll want to test the components making use of different HoC.
Here's small list of some components you'll want to test making use of some HoC's

#### withSticky

* Scrollable

#### withAppProvider 

* Button
* DatePicker
* OptionList
* most components 😄 

#### withContext

* DropZone.FileUpload
* ResourceList.FilterControl
* ResourceList.Item

#### withRef

* DropZone.FileUpload
* UnstyledLink
