### PR TITLE
[TextField] Fix focus error state

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed `TextField` not showing the correct color while it has focus and an error ([#806](https://github.com/Shopify/polaris-react/pull/806))
 - Fixed `ResourceList` not rendering `BulkActions` on initial load when items were selected ([#746](https://github.com/Shopify/polaris-react/pull/746))
 - Fixed the new variant of the `Badge` component so that it is simpler and easier to read ([#751](https://github.com/Shopify/polaris-react/pull/751))
 - Reverted a change that set the `autocomplete` property on `TextField` to `nope` when it was `false` ([#761](https://github.com/Shopify/polaris-react/pull/761))

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -60,8 +60,8 @@ $stacking-order: (
   // We need this to override the box-shadow in the focus state.
   // stylelint-disable-next-line selector-max-class, selector-max-specificity, selector-max-combinators
   > .Input:focus ~ .Backdrop {
-    border-color: color('indigo');
-    box-shadow: inset shadow(transparent), 0 0 0 1px color('indigo');
+    border-color: color('red', 'dark');
+    box-shadow: inset shadow(transparent), 0 0 0 1px color('red', 'dark');
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #802

### Screen shot

![screen shot 2018-12-21 at 4 44 01 pm](https://user-images.githubusercontent.com/24610840/50364813-ade42780-053f-11e9-9c60-d0a78b27568f.png)


### WHAT is this pull request doing?

Indigo -> color(red, dark)

### How to 🎩



<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Button, Tooltip, Link, TextField} from '@shopify/polaris';

interface State {}

export default class TextFieldExample extends React.Component {
  state = {
    value: 'Jaded Pixel',
  };

  handleChange = (value) => {
    this.setState({value});
  };

  render() {
    return (
      <TextField
        label="Store name"
        value={this.state.value}
        onChange={this.handleChange}
        error="sdsad"
      />
    );
  }
}
```

</details>

