### PR TITLE
Rename Option and Group types in Select to workaround typedoc oddness

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -25,6 +25,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed the console error in the `PositionedOverlay` test environment ([#758](https://github.com/Shopify/polaris-react/pull/758))
 - Fixed `ResourceList` not rendering a header after initial load (thanks to [@andrewpye](https://github.com/andrewpye) for the [original issue](https://github.com/Shopify/polaris-react/issues/735))
 - Fixed `TextField` not passing `step` to the input ([#829](https://github.com/Shopify/polaris-react/pull/829))
+- Renamed `Option` and `Group` types in `Select` to work around typedoc oddness ([#830](https://github.com/Shopify/polaris-react/pull/830))
 
 ### Documentation
 

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -8,7 +8,7 @@ import EventListener from '../EventListener';
 import Sticky from '../Sticky';
 import Spinner from '../Spinner';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
-import Select, {Option} from '../Select';
+import Select, {SelectOption} from '../Select';
 import EmptySearchResult from '../EmptySearchResult';
 import selectIcon from './icons/enable-selection.svg';
 
@@ -60,7 +60,7 @@ export interface Props {
   /** Current value of the sort control */
   sortValue?: string;
   /** Collection of sort options to choose from */
-  sortOptions?: Option[];
+  sortOptions?: SelectOption[];
   /** ReactNode to display instead of the sort control */
   alternateTool?: React.ReactNode;
   /** Callback when sort option is changed */

--- a/src/components/ResourceList/components/FilterControl/types.ts
+++ b/src/components/ResourceList/components/FilterControl/types.ts
@@ -1,4 +1,4 @@
-import {Option} from '../../../Select';
+import {SelectOption} from '../../../Select';
 import {Type} from '../../../TextField';
 
 export interface Operator {
@@ -28,7 +28,7 @@ export interface FilterBase<FilterKeys = {}> {
 
 export interface FilterSelect<FilterKeys = {}> extends FilterBase<FilterKeys> {
   type: FilterType.Select;
-  options: Option[];
+  options: SelectOption[];
 }
 
 export interface FilterTextField<FilterKeys = {}>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -28,18 +28,18 @@ interface StrictGroup {
   options: StrictOption[];
 }
 
-export type Option = string | StrictOption;
+export type SelectOption = string | StrictOption;
 
-export interface Group {
+export interface SelectGroup {
   title: string;
-  options: Option[];
+  options: SelectOption[];
 }
 
 export interface BaseProps {
   /** List of options or option groups to choose from */
-  options?: (Option | Group)[];
+  options?: (SelectOption | SelectGroup)[];
   /** @deprecated List of grouped options to choose from */
-  groups?: (Option | Group)[];
+  groups?: (SelectOption | SelectGroup)[];
   /** Label for the select */
   label: string;
   /** Adds an action to the label */
@@ -186,12 +186,12 @@ export default function Select({
   );
 }
 
-function isString(option: Option | Group): option is string {
+function isString(option: SelectOption | SelectGroup): option is string {
   return typeof option === 'string';
 }
 
-function isGroup(option: Option | Group): option is Group {
-  return (option as Group).options != null;
+function isGroup(option: SelectOption | SelectGroup): option is SelectGroup {
+  return (option as SelectGroup).options != null;
 }
 
 function normalizeStringOption(option: string): StrictOption {
@@ -206,7 +206,7 @@ function normalizeStringOption(option: string): StrictOption {
  * an Option object.
  */
 function normalizeOption(
-  option: Option | Group,
+  option: SelectOption | SelectGroup,
 ): HideableStrictOption | StrictGroup {
   if (isString(option)) {
     return normalizeStringOption(option);

--- a/src/components/Select/index.ts
+++ b/src/components/Select/index.ts
@@ -1,4 +1,4 @@
 import Select from './Select';
 
-export {Props, Option, Group} from './Select';
+export {Props, SelectOption, SelectGroup} from './Select';
 export default Select;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -222,8 +222,8 @@ export {default as ScrollLock} from './ScrollLock';
 export {
   default as Select,
   Props as SelectProps,
-  Option as SelectOption,
-  Group as SelectGroup,
+  SelectOption,
+  SelectGroup,
 } from './Select';
 
 export {


### PR DESCRIPTION
### WHY are these changes introduced?

Typedoc (which we use for generating prop tables on the styleguide) has
a bug in it where it doesn't correctly resolve types that are imported
from a different file (or we're using it wrong).
Instead of looking at imports it seems to look at a global bucket of
names. In this case there was a clash between Option (as living in Select)
and Option (as living in OptionList/components). 

This resulted it it thinking that the type for ResourceList -> sortOptions was `src/components/OptionList/components/Option/Option.tsx`'s default export instead of the type in `src/components/Select/Select.tsx`


### WHAT is this pull request doing?

Work around this by renaming Select's Option to "SelectOption".

This allows our type documentation generation in the styleguide to work
correctly.

Strictly speaking the change to SelectGroup isn't needed but i think
"SelectOption and SelectGroup" sounds nicer than "SelectOption and
Group".


### How to 🎩

- In polaris-styleguide checkout this PR: https://github.com/Shopify/polaris-styleguide/pull/2488
- In polaris-styleguide run `yarn run typedoc` and swear loudly because it fails.
- In polaris-react run `yarn build-consumer polaris-styleguide`
- In polaris-styleguide run `yarn run typedoc` again and see that it runs without errors. Cheer / run your temples /swear loudly again.
- In polaris-styleguide run `yarn dev` and see that the prop table on the ResourceList page correctly states that `sortOptions` has the typing `string | StrictOption[]` [just like in production](https://polaris.shopify.com/components/lists-and-tables/resource-list/sortOptions)
