### PR TITLE
Revert "Infer HoC props"

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -39,5 +39,3 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Upgraded `@shopify/polaris-tokens` to v2.1.1 ([#813](https://github.com/Shopify/polaris-react/pull/813))
 
 ### Code quality
-
-- Improve `withAppProvider`, `withSticky`, `withRef`, and `withContext` types to allow them to infer a components props ([#805](https://github.com/Shopify/polaris-react/pull/805))

--- a/src/components/AppProvider/utilities/withAppProvider/withAppProvider.tsx
+++ b/src/components/AppProvider/utilities/withAppProvider/withAppProvider.tsx
@@ -23,13 +23,13 @@ export interface WithAppProviderProps {
   };
 }
 
-export default function withAppProvider() {
-  return function addProvider<OriginalProps, C>(
+export default function withAppProvider<OwnProps>() {
+  return function addProvider<C>(
     WrappedComponent:
-      | React.ComponentClass<OriginalProps & WithAppProviderProps> & C
-      | React.SFC<OriginalProps & WithAppProviderProps> & C,
-  ): React.ComponentClass<OriginalProps> & C {
-    class WithProvider extends React.Component<OriginalProps, never> {
+      | React.ComponentClass<OwnProps & WithAppProviderProps> & C
+      | React.SFC<OwnProps & WithAppProviderProps> & C,
+  ): React.ComponentClass<OwnProps> & C {
+    class WithProvider extends React.Component<OwnProps, never> {
       static contextTypes = WrappedComponent.contextTypes
         ? merge(WrappedComponent.contextTypes, polarisAppProviderContextTypes)
         : polarisAppProviderContextTypes;
@@ -90,6 +90,6 @@ export default function withAppProvider() {
       WrappedComponent as React.ComponentClass<any>,
     );
 
-    return FinalComponent as React.ComponentClass<OriginalProps> & C;
+    return FinalComponent as React.ComponentClass<OwnProps> & C;
   };
 }

--- a/src/components/AppProvider/utilities/withSticky/withSticky.tsx
+++ b/src/components/AppProvider/utilities/withSticky/withSticky.tsx
@@ -10,7 +10,7 @@ export default function withSticky() {
     WrappedComponent:
       | React.ComponentClass<OwnProps & WithAppProviderProps> & C
       | React.SFC<OwnProps & WithAppProviderProps> & C,
-  ): React.ComponentClass<OwnProps> & C {
+  ): any & C {
     // eslint-disable-next-line shopify/react-initialize-state
     class WithStickyManager extends React.Component<
       {},
@@ -50,6 +50,6 @@ export default function withSticky() {
       WithStickyManager,
       WrappedComponent as React.ComponentClass<any>,
     );
-    return FinalComponent as React.ComponentClass<OwnProps> & C;
+    return FinalComponent as React.ComponentClass<any> & C;
   };
 }

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -101,4 +101,4 @@ export class Autocomplete extends React.PureComponent<CombinedProps, never> {
   }
 }
 
-export default withAppProvider()(Autocomplete);
+export default withAppProvider<Props>()(Autocomplete);

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -173,4 +173,4 @@ function customerPlaceholder(name?: string) {
     : AVATAR_IMAGES[0];
 }
 
-export default withAppProvider()(Avatar);
+export default withAppProvider<Props>()(Avatar);

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -109,4 +109,4 @@ function Badge({
   );
 }
 
-export default withAppProvider()(Badge);
+export default withAppProvider<Props>()(Badge);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -203,4 +203,4 @@ function isIconSource(x: any): x is IconSource {
   return typeof x === 'string' || (typeof x === 'object' && x.body);
 }
 
-export default withAppProvider()(Button);
+export default withAppProvider<Props>()(Button);

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -131,4 +131,4 @@ function Checkbox({
   );
 }
 
-export default withAppProvider()(Checkbox);
+export default withAppProvider<Props>()(Checkbox);

--- a/src/components/ChoiceList/ChoiceList.tsx
+++ b/src/components/ChoiceList/ChoiceList.tsx
@@ -145,4 +145,4 @@ function updateSelectedChoices(
   return selected.filter((selectedChoice) => selectedChoice !== value);
 }
 
-export default withAppProvider()(ChoiceList);
+export default withAppProvider<Props>()(ChoiceList);

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -192,4 +192,4 @@ function collapsibleHeight(
   return `${height || 0}px`;
 }
 
-export default withAppProvider()(Collapsible);
+export default withAppProvider<Props>()(Collapsible);

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -511,4 +511,4 @@ export class DataTable extends React.PureComponent<
   }
 }
 
-export default withAppProvider()(DataTable);
+export default withAppProvider<Props>()(DataTable);

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -126,4 +126,4 @@ function Cell({
   return cellMarkup;
 }
 
-export default withAppProvider()(Cell);
+export default withAppProvider<Props>()(Cell);

--- a/src/components/DataTable/components/Navigation/Navigation.tsx
+++ b/src/components/DataTable/components/Navigation/Navigation.tsx
@@ -66,4 +66,4 @@ function Navigation({
   );
 }
 
-export default withAppProvider()(Navigation);
+export default withAppProvider<Props>()(Navigation);

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -325,4 +325,4 @@ function deriveRange(selected?: Date | Range) {
   return selected instanceof Date ? {start: selected, end: selected} : selected;
 }
 
-export default withAppProvider()(DatePicker);
+export default withAppProvider<Props>()(DatePicker);

--- a/src/components/DatePicker/components/Day/Day.tsx
+++ b/src/components/DatePicker/components/Day/Day.tsx
@@ -94,4 +94,4 @@ export class Day extends React.PureComponent<CombinedProps, never> {
   }
 }
 
-export default withAppProvider()(Day);
+export default withAppProvider<Props>()(Day);

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -561,4 +561,4 @@ function handleDragStart(event: React.DragEvent<HTMLDivElement>) {
   event.stopPropagation();
 }
 
-export default withAppProvider()(DropZone);
+export default withAppProvider<Props>()(DropZone);

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -149,7 +149,7 @@ export class FileUpload extends React.Component<CombinedProps, State> {
 }
 
 export default compose<Props>(
-  withContext<DropZoneContext>(Consumer),
-  withAppProvider(),
-  withRef(),
+  withContext<Props, WithAppProviderProps, DropZoneContext>(Consumer),
+  withAppProvider<Props>(),
+  withRef<Props>(),
 )(FileUpload);

--- a/src/components/EmptySearchResult/EmptySearchResult.tsx
+++ b/src/components/EmptySearchResult/EmptySearchResult.tsx
@@ -52,4 +52,4 @@ export class EmptySearchResult extends React.PureComponent<
   }
 }
 
-export default withAppProvider()(EmptySearchResult);
+export default withAppProvider<Props>()(EmptySearchResult);

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -416,4 +416,4 @@ function isMobileView() {
   return navigationBarCollapsed().matches;
 }
 
-export default withAppProvider()(Frame);
+export default withAppProvider<Props>()(Frame);

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -131,4 +131,4 @@ class ContextualSaveBar extends React.PureComponent<CombinedProps, State> {
   }
 }
 
-export default withAppProvider()(ContextualSaveBar);
+export default withAppProvider<Props>()(ContextualSaveBar);

--- a/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/DiscardConfirmationModal.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/DiscardConfirmationModal.tsx
@@ -47,4 +47,4 @@ function DiscardConfirmationModal({
   );
 }
 
-export default withAppProvider()(DiscardConfirmationModal);
+export default withAppProvider<Props>()(DiscardConfirmationModal);

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -239,4 +239,4 @@ function isBundledIcon(key: string | BundledIcon): key is BundledIcon {
   return Object.keys(BUNDLED_ICONS).includes(key);
 }
 
-export default withAppProvider()(Icon);
+export default withAppProvider<Props>()(Icon);

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -37,4 +37,4 @@ export class Loading extends React.PureComponent<ComposedProps, never> {
   }
 }
 
-export default withAppProvider()(Loading);
+export default withAppProvider<Props>()(Loading);

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -384,4 +384,4 @@ function isIframeModal(
   );
 }
 
-export default withAppProvider()(Modal);
+export default withAppProvider<Props>()(Modal);

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -376,6 +376,6 @@ function matchStateForItem(
   return matchesUrl ? MatchState.MatchUrl : MatchState.NoMatch;
 }
 
-export const Item = withAppProvider()(BaseItem);
+export const Item = withAppProvider<Props>()(BaseItem);
 
 export default Item;

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -226,4 +226,4 @@ function testSectionsPropEquality(
   return optionsAreEqual && titlesAreEqual;
 }
 
-export default withAppProvider()(OptionList);
+export default withAppProvider<Props>()(OptionList);

--- a/src/components/OptionList/tests/OptionList.test.tsx
+++ b/src/components/OptionList/tests/OptionList.test.tsx
@@ -61,7 +61,7 @@ describe('<OptionList />', () => {
 
   it('renders options and sections', () => {
     const {options, sections} = defaultProps;
-    const optionWrappers = shallowWithAppProvider(
+    const optionWrappers = shallowWithAppProvider<Props>(
       <OptionList {...defaultProps} />,
     ).find(Option);
 
@@ -71,7 +71,7 @@ describe('<OptionList />', () => {
   it('renders sections', () => {
     const {sections} = defaultProps;
     const options: OptionDescriptor[] = [];
-    const optionWrappers = shallowWithAppProvider(
+    const optionWrappers = shallowWithAppProvider<Props>(
       <OptionList {...defaultProps} options={options} />,
     ).find(Option);
 
@@ -81,7 +81,7 @@ describe('<OptionList />', () => {
   it('renders options', () => {
     const {options} = defaultProps;
     const sections: SectionDescriptor[] = [];
-    const optionWrappers = shallowWithAppProvider(
+    const optionWrappers = shallowWithAppProvider<Props>(
       <OptionList {...defaultProps} sections={sections} />,
     ).find(Option);
 
@@ -90,7 +90,9 @@ describe('<OptionList />', () => {
 
   it('re-renders with new options passed in', () => {
     const {sections} = defaultProps;
-    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
+    const optionList = shallowWithAppProvider<Props>(
+      <OptionList {...defaultProps} />,
+    );
 
     const newOptions: OptionDescriptor[] = [
       {
@@ -112,7 +114,9 @@ describe('<OptionList />', () => {
 
   it('re-renders with new sections passed in', () => {
     const {options} = defaultProps;
-    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
+    const optionList = shallowWithAppProvider<Props>(
+      <OptionList {...defaultProps} />,
+    );
 
     const newSections: SectionDescriptor[] = [
       {
@@ -137,7 +141,9 @@ describe('<OptionList />', () => {
   });
 
   it('re-renders with new options and new sections passed in', () => {
-    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
+    const optionList = shallowWithAppProvider<Props>(
+      <OptionList {...defaultProps} />,
+    );
 
     const newOptions: OptionDescriptor[] = [
       {
@@ -175,7 +181,9 @@ describe('<OptionList />', () => {
 
   it('re-renders with undefined options', () => {
     const {sections} = defaultProps;
-    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
+    const optionList = shallowWithAppProvider<Props>(
+      <OptionList {...defaultProps} />,
+    );
 
     optionList.setProps({options: undefined});
 
@@ -185,7 +193,9 @@ describe('<OptionList />', () => {
 
   it('re-renders with undefined sections', () => {
     const {options} = defaultProps;
-    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
+    const optionList = shallowWithAppProvider<Props>(
+      <OptionList {...defaultProps} />,
+    );
 
     optionList.setProps({sections: undefined});
 
@@ -194,7 +204,9 @@ describe('<OptionList />', () => {
   });
 
   it('re-renders with undefined options and new sections', () => {
-    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
+    const optionList = shallowWithAppProvider<Props>(
+      <OptionList {...defaultProps} />,
+    );
 
     const newSections: SectionDescriptor[] = [
       {
@@ -219,7 +231,9 @@ describe('<OptionList />', () => {
   });
 
   it('re-renders with new options and undefined sections', () => {
-    const optionList = shallowWithAppProvider(<OptionList {...defaultProps} />);
+    const optionList = shallowWithAppProvider<Props>(
+      <OptionList {...defaultProps} />,
+    );
 
     const newOptions: OptionDescriptor[] = [
       {
@@ -243,7 +257,7 @@ describe('<OptionList />', () => {
     const spy = jest.fn();
     const {options, sections} = defaultProps;
 
-    const buttonWrappers = mountWithAppProvider(
+    const buttonWrappers = mountWithAppProvider<Props>(
       <OptionList {...defaultProps} onChange={spy} />,
     ).find('button');
 
@@ -256,7 +270,7 @@ describe('<OptionList />', () => {
   describe('allowMultiple', () => {
     it('renders options and sections', () => {
       const {options, sections} = defaultProps;
-      const optionWrappers = shallowWithAppProvider(
+      const optionWrappers = shallowWithAppProvider<Props>(
         <OptionList {...defaultProps} allowMultiple />,
       ).find(Option);
 
@@ -266,7 +280,7 @@ describe('<OptionList />', () => {
     it('renders sections', () => {
       const {sections} = defaultProps;
       const options: OptionDescriptor[] = [];
-      const optionWrappers = shallowWithAppProvider(
+      const optionWrappers = shallowWithAppProvider<Props>(
         <OptionList {...defaultProps} options={options} allowMultiple />,
       ).find(Option);
 
@@ -276,7 +290,7 @@ describe('<OptionList />', () => {
     it('renders options', () => {
       const {options} = defaultProps;
       const sections: SectionDescriptor[] = [];
-      const optionWrappers = shallowWithAppProvider(
+      const optionWrappers = shallowWithAppProvider<Props>(
         <OptionList {...defaultProps} sections={sections} allowMultiple />,
       ).find(Option);
 
@@ -285,7 +299,7 @@ describe('<OptionList />', () => {
 
     it('re-renders with new options passed in', () => {
       const {sections} = defaultProps;
-      const optionList = shallowWithAppProvider(
+      const optionList = shallowWithAppProvider<Props>(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -309,7 +323,7 @@ describe('<OptionList />', () => {
 
     it('re-renders with new sections passed in', () => {
       const {options} = defaultProps;
-      const optionList = shallowWithAppProvider(
+      const optionList = shallowWithAppProvider<Props>(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -336,7 +350,7 @@ describe('<OptionList />', () => {
     });
 
     it('re-renders with new options and new sections passed in', () => {
-      const optionList = shallowWithAppProvider(
+      const optionList = shallowWithAppProvider<Props>(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -378,7 +392,7 @@ describe('<OptionList />', () => {
 
     it('re-renders with undefined options', () => {
       const {sections} = defaultProps;
-      const optionList = shallowWithAppProvider(
+      const optionList = shallowWithAppProvider<Props>(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -390,7 +404,7 @@ describe('<OptionList />', () => {
 
     it('re-renders with undefined sections', () => {
       const {options} = defaultProps;
-      const optionList = shallowWithAppProvider(
+      const optionList = shallowWithAppProvider<Props>(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -401,7 +415,7 @@ describe('<OptionList />', () => {
     });
 
     it('re-renders with undefined options and new sections', () => {
-      const optionList = shallowWithAppProvider(
+      const optionList = shallowWithAppProvider<Props>(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -428,7 +442,7 @@ describe('<OptionList />', () => {
     });
 
     it('re-renders with new options and undefined sections', () => {
-      const optionList = shallowWithAppProvider(
+      const optionList = shallowWithAppProvider<Props>(
         <OptionList {...defaultProps} allowMultiple />,
       );
 
@@ -455,7 +469,7 @@ describe('<OptionList />', () => {
         const spy = jest.fn();
         const {options, sections} = defaultProps;
 
-        const inputWrappers = mountWithAppProvider(
+        const inputWrappers = mountWithAppProvider<Props>(
           <OptionList {...defaultProps} onChange={spy} allowMultiple />,
         ).find('input');
 
@@ -470,7 +484,7 @@ describe('<OptionList />', () => {
         const {options, sections} = defaultProps;
         const selected = ['11', '8'];
 
-        const inputWrappers = mountWithAppProvider(
+        const inputWrappers = mountWithAppProvider<Props>(
           <OptionList
             {...defaultProps}
             onChange={spy}
@@ -493,7 +507,7 @@ describe('<OptionList />', () => {
         const {options, sections} = defaultProps;
         const selected = ['10', '8', '5'];
 
-        const inputWrappers = mountWithAppProvider(
+        const inputWrappers = mountWithAppProvider<Props>(
           <OptionList
             {...defaultProps}
             onChange={spy}

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -152,4 +152,4 @@ export class Page extends React.PureComponent<ComposedProps, never> {
   }
 }
 
-export default withAppProvider()(Page);
+export default withAppProvider<Props>()(Page);

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -291,4 +291,4 @@ function secondaryActionsFrom(
   ));
 }
 
-export default withAppProvider()(Header);
+export default withAppProvider<Props>()(Header);

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -192,4 +192,4 @@ function handleCallback(fn: () => void) {
   };
 }
 
-export default withAppProvider()(Pagination);
+export default withAppProvider<Props>()(Pagination);

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -68,4 +68,4 @@ function parseProgress(progress: number, warningMessage: string) {
   return progressWidth;
 }
 
-export default withAppProvider()(ProgressBar);
+export default withAppProvider<Props>()(ProgressBar);

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -202,4 +202,4 @@ export function invertNumber(number: number) {
   }
 }
 
-export default withAppProvider()(RangeSlider);
+export default withAppProvider<Props>()(RangeSlider);

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -721,4 +721,4 @@ function isSmallScreen() {
     : window.innerWidth <= SMALL_SCREEN_WIDTH;
 }
 
-export default withAppProvider()(ResourceList);
+export default withAppProvider<Props>()(ResourceList);

--- a/src/components/ResourceList/components/BulkActions/BulkActions.tsx
+++ b/src/components/ResourceList/components/BulkActions/BulkActions.tsx
@@ -481,4 +481,4 @@ function instanceOfBulkActionArray(
   return actions.length === validList.length;
 }
 
-export default withAppProvider()(BulkActions);
+export default withAppProvider<Props>()(BulkActions);

--- a/src/components/ResourceList/components/CheckableButton/CheckableButton.tsx
+++ b/src/components/ResourceList/components/CheckableButton/CheckableButton.tsx
@@ -51,4 +51,4 @@ function CheckableButton({
   );
 }
 
-export default withAppProvider()(CheckableButton);
+export default withAppProvider<Props>()(CheckableButton);

--- a/src/components/ResourceList/components/FilterControl/FilterControl.tsx
+++ b/src/components/ResourceList/components/FilterControl/FilterControl.tsx
@@ -297,6 +297,6 @@ function findOperatorLabel(filter: Filter, appliedFilter: AppliedFilter) {
 }
 
 export default compose<Props>(
-  withAppProvider(),
-  withContext<ResourceListContext>(Consumer),
+  withAppProvider<Props>(),
+  withContext<Props, WithAppProviderProps, ResourceListContext>(Consumer),
 )(FilterControl);

--- a/src/components/ResourceList/components/FilterControl/components/DateSelector/DateSelector.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/DateSelector/DateSelector.tsx
@@ -412,4 +412,4 @@ function formatDateValue(date: Date) {
   return date.toISOString().slice(0, 10);
 }
 
-export default withAppProvider()(DateSelector);
+export default withAppProvider<Props>()(DateSelector);

--- a/src/components/ResourceList/components/FilterControl/components/FilterCreator/FilterCreator.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterCreator/FilterCreator.tsx
@@ -211,4 +211,4 @@ export class FilterCreator extends React.PureComponent<CombinedProps, State> {
   }
 }
 
-export default withAppProvider()(FilterCreator);
+export default withAppProvider<Props>()(FilterCreator);

--- a/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/FilterValueSelector.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/FilterValueSelector.tsx
@@ -135,4 +135,4 @@ function buildOperatorOptions(operatorText?: string | Operator[]) {
   });
 }
 
-export default withAppProvider()(FilterValueSelector);
+export default withAppProvider<Props>()(FilterValueSelector);

--- a/src/components/ResourceList/components/Item/Item.tsx
+++ b/src/components/ResourceList/components/Item/Item.tsx
@@ -401,6 +401,6 @@ function stopPropagation(event: React.MouseEvent<any>) {
 }
 
 export default compose<Props>(
-  withContext<ResourceListContext>(Consumer),
-  withAppProvider(),
+  withContext<Props, WithAppProviderProps, ResourceListContext>(Consumer),
+  withAppProvider<Props>(),
 )(Item);

--- a/src/components/ResourcePicker/ResourcePicker.tsx
+++ b/src/components/ResourcePicker/ResourcePicker.tsx
@@ -157,4 +157,4 @@ export class ResourcePicker extends React.PureComponent<CombinedProps, never> {
   }
 }
 
-export default withAppProvider()(ResourcePicker);
+export default withAppProvider<Props>()(ResourcePicker);

--- a/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/src/components/SkeletonPage/SkeletonPage.tsx
@@ -113,4 +113,4 @@ function renderTitle(title: string) {
   return <div className={styles.Title}>{titleContent}</div>;
 }
 
-export default withAppProvider()(SkeletonPage);
+export default withAppProvider<Props>()(SkeletonPage);

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -69,4 +69,4 @@ function Spinner({
   );
 }
 
-export default withAppProvider()(Spinner);
+export default withAppProvider<Props>()(Spinner);

--- a/src/components/Tabs/components/Tab/Tab.tsx
+++ b/src/components/Tabs/components/Tab/Tab.tsx
@@ -152,4 +152,4 @@ function focusPanelID(panelID: string) {
   }
 }
 
-export default withAppProvider()(Tab);
+export default withAppProvider<Props>()(Tab);

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -44,4 +44,4 @@ function Tag({
   );
 }
 
-export default withAppProvider()(Tag);
+export default withAppProvider<Props>()(Tag);

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -70,4 +70,4 @@ export class Toast extends React.PureComponent<ComposedProps, never> {
   }
 }
 
-export default withAppProvider()(Toast);
+export default withAppProvider<Props>()(Toast);

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -139,4 +139,4 @@ export class TopBar extends React.PureComponent<ComposedProps, State> {
   }
 }
 
-export default withAppProvider()(TopBar);
+export default withAppProvider<Props>()(TopBar);

--- a/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/src/components/UnstyledLink/UnstyledLink.tsx
@@ -38,6 +38,6 @@ export class UnstyledLink extends React.PureComponent<CombinedProps, never> {
 }
 
 export default compose<Props>(
-  withAppProvider(),
-  withRef(),
+  withAppProvider<Props>(),
+  withRef<Props>(),
 )(UnstyledLink);

--- a/src/components/WithContext/WithContext.tsx
+++ b/src/components/WithContext/WithContext.tsx
@@ -2,13 +2,19 @@ import * as React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 import {WithContextTypes} from '../../types';
 
-export default function withContext<InjectedProps>(
-  Consumer: React.ComponentType,
-) {
-  return function addContext<OriginalProps>(
+export default function withContext<
+  OriginalProps,
+  ExternalProps,
+  InjectedProps
+>(Consumer: React.ComponentType) {
+  return function addContext(
     WrappedComponent:
-      | React.ComponentClass<OriginalProps & WithContextTypes<InjectedProps>>
-      | React.SFC<OriginalProps & WithContextTypes<InjectedProps>>,
+      | React.ComponentClass<
+          OriginalProps & ExternalProps & WithContextTypes<InjectedProps>
+        >
+      | React.SFC<
+          OriginalProps & ExternalProps & WithContextTypes<InjectedProps>
+        >,
   ): React.ComponentClass<OriginalProps> {
     // eslint-disable-next-line react/prefer-stateless-function
     class WithContext extends React.Component<

--- a/src/components/WithRef/WithRef.tsx
+++ b/src/components/WithRef/WithRef.tsx
@@ -9,8 +9,8 @@ export interface Ref<T = any> {
   ref: React.RefObject<T> | null;
 }
 
-export default function withRef() {
-  return function addForwardRef<OriginalProps, C>(
+export default function withRef<OriginalProps>() {
+  return function addForwardRef<C>(
     WrappedComponent: ReactComponent<OriginalProps & Ref> & C,
   ): React.ComponentClass<OriginalProps> {
     class WithRef extends React.Component<OriginalProps, never> {


### PR DESCRIPTION
Reverts Shopify/polaris-react#805 as it was a breaking change in consuming apps that used our HOCs