### PR TITLE
[RangeSlider] Clamp single thumb

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Ensure disabled `Button` components with a `url` prop output valid HTML ([#773](https://github.com/Shopify/polaris-react/pull/773))
 - Fixed `DropZone` which was unable to add a duplicate file back to back or add a file again once removed [#782](https://github.com/Shopify/polaris-react/pull/782). Thank you [@jzsplk](https://github.com/jzsplk) for the contribution [#425](https://github.com/Shopify/polaris-react/issues/425) and [@vladucu](https://github.com/vladucu) for the clear example.
+- Added clamp to `RangeSlider` so its initial value doesn't fall outside of min or max bounds ([#834](https://github.com/Shopify/polaris-react/pull/834))
 
 ### Documentation
 

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
+import clamp from '../../../../utilities/clamp';
 import Labelled, {helpTextID} from '../../../Labelled';
 
 import {invertNumber, CSS_VAR_PREFIX} from '../../utilities';
@@ -34,6 +35,7 @@ export default function SingleThumb(props: Props) {
     onBlur,
     onFocus,
   } = props;
+  const clampedValue = clamp(value, min, max);
   const describedBy: string[] = [];
 
   if (error) {
@@ -48,13 +50,13 @@ export default function SingleThumb(props: Props) {
     ? describedBy.join(' ')
     : undefined;
 
-  const sliderProgress = ((value - min) * 100) / (max - min);
+  const sliderProgress = ((clampedValue - min) * 100) / (max - min);
   const outputFactor = invertNumber((sliderProgress - 50) / 100);
 
   const cssVars = {
     [`${CSS_VAR_PREFIX}min`]: min,
     [`${CSS_VAR_PREFIX}max`]: max,
-    [`${CSS_VAR_PREFIX}current`]: value,
+    [`${CSS_VAR_PREFIX}current`]: clampedValue,
     [`${CSS_VAR_PREFIX}progress`]: `${sliderProgress}%`,
     [`${CSS_VAR_PREFIX}output-factor`]: `${outputFactor}`,
   };
@@ -63,7 +65,7 @@ export default function SingleThumb(props: Props) {
     output && (
       <output htmlFor={id} className={styles.Output}>
         <div className={styles.OutputBubble}>
-          <span className={styles.OutputText}>{value}</span>
+          <span className={styles.OutputText}>{clampedValue}</span>
         </div>
       </output>
     );
@@ -98,14 +100,14 @@ export default function SingleThumb(props: Props) {
             min={min}
             max={max}
             step={step}
-            value={value}
+            value={clampedValue}
             disabled={disabled}
             onChange={handleChange}
             onFocus={onFocus}
             onBlur={onBlur}
             aria-valuemin={min}
             aria-valuemax={max}
-            aria-valuenow={value}
+            aria-valuenow={clampedValue}
             aria-invalid={Boolean(error)}
             aria-describedby={ariaDescribedBy}
           />

--- a/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
@@ -173,7 +173,6 @@ describe('<SingleThumb />', () => {
 
   describe('suffix', () => {
     const text = 'suffix text';
-
     it('outputs the provided suffix element', () => {
       const element = mountWithAppProvider(
         <SingleThumb {...mockProps} suffix={<p>{text}</p>} />,
@@ -197,6 +196,59 @@ describe('<SingleThumb />', () => {
       const actual = element.find('[style]').prop('style');
 
       expect(expected).toEqual(actual);
+    });
+  });
+
+  describe('value', () => {
+    it('gets adjusted to be at least the min', () => {
+      const value = 9;
+      const min = 10;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} min={min} />,
+      );
+
+      expect(singleThumb.find('input').prop('value')).toBe(min);
+    });
+
+    it('gets adjusted to be no more than the max', () => {
+      const value = 101;
+      const max = 100;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} max={max} />,
+      );
+
+      expect(singleThumb.find('input').prop('value')).toBe(max);
+    });
+  });
+
+  describe('aria-valuenow', () => {
+    it('gets passed the value', () => {
+      const value = 15;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} />,
+      );
+
+      expect(singleThumb.find('input').prop('aria-valuenow')).toBe(value);
+    });
+
+    it('gets adjusted to be at least the min', () => {
+      const value = 9;
+      const min = 10;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} min={min} />,
+      );
+
+      expect(singleThumb.find('input').prop('aria-valuenow')).toBe(min);
+    });
+
+    it('gets adjusted to be no more than the max', () => {
+      const value = 101;
+      const max = 100;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} max={max} />,
+      );
+
+      expect(singleThumb.find('input').prop('aria-valuenow')).toBe(max);
     });
   });
 });

--- a/src/utilities/clamp.ts
+++ b/src/utilities/clamp.ts
@@ -1,0 +1,5 @@
+export default function clamp(number: number, min: number, max: number) {
+  if (number < min) return min;
+  if (number > max) return max;
+  return number;
+}

--- a/src/utilities/tests/clamp.test.ts
+++ b/src/utilities/tests/clamp.test.ts
@@ -1,0 +1,23 @@
+import clamp from '../clamp';
+
+describe('clamp', () => {
+  it('adjusts the given number to be at least the min', () => {
+    const min = 10;
+    const number = clamp(9, min, 50);
+    expect(number).toBe(min);
+  });
+
+  it('adjusts the given number to be no more than the max', () => {
+    const max = 100;
+    const number = clamp(101, 0, max);
+    expect(number).toBe(max);
+  });
+
+  it('does not change the given number if it is between the min and max', () => {
+    const value = 50;
+    const min = 0;
+    const max = 100;
+    const number = clamp(value, min, max);
+    expect(number).toBe(value);
+  });
+});


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #815

### WHAT is this pull request doing?
Creates a clamp function that adjusts a given number based on given min/max bounds.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, RangeSlider} from '@shopify/polaris';

interface State {
  singleValue: number;
}

export default class Playground extends React.Component<{}, State> {
  state = {
    singleValue: 50 as number,
  };

  handleSingleChange = (value: number) => {
    this.setState({singleValue: value});
  };

  render() {
    return (
      <Page title="Playground">
        <div style={{width: '200px'}}>
          <RangeSlider
            label="Native ranger slider"
            value={this.state.singleValue}
            onChange={this.handleSingleChange}
            output
            min={5}
            max={30}
            prefix="low"
            suffix="high"
          />
        </div>
      </Page>
    );
  }
}

```

</details>

