### PR TITLE
Bump eslint-plugin-shopify and stylelint-config-shopify versions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7143,10 +7143,10 @@ eslint-plugin-node@7.0.1:
     resolve "^1.8.1"
     semver "^5.5.0"
 
-eslint-plugin-prettier@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.0.tgz#f6b823e065f8c36529918cdb766d7a0e975ec30c"
-  integrity sha512-4g11opzhqq/8+AMmo5Vc2Gn7z9alZ4JqrbZ+D4i8KlSyxeQhZHlmIrY8U9Akf514MoEhogPa87Jgkq87aZ2Ohw==
+eslint-plugin-prettier@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz#19d521e3981f69dd6d14f64aec8c6a6ac6eb0b0d"
+  integrity sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -7167,11 +7167,12 @@ eslint-plugin-react@7.11.1:
     prop-types "^15.6.2"
 
 eslint-plugin-shopify@^26.1.1:
-  version "26.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-shopify/-/eslint-plugin-shopify-26.1.1.tgz#8e2b3af7de246145b45df6bec130922d2b642866"
-  integrity sha512-tuXjwTonJMcKheAApf2So/BlN0vvZnKSrFGOz0dO3txeLYzeKR7hkFj65SHspcDcTB3oGTByuqhQ35BqnRDusw==
+  version "26.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-shopify/-/eslint-plugin-shopify-26.1.2.tgz#8bad611ea3331cdb179af4312c192d06c0890611"
+  integrity sha512-/09asmD7toCeALjJhpX9+mV0d+vc58DmB1DbaZdjqughQtH1AxtbGamI5uhIkMhwjVL+T5kdeLXU5Kanxm2DTA==
   dependencies:
     babel-eslint "9.0.0"
+    common-tags "^1.8.0"
     eslint-config-prettier "3.0.1"
     eslint-import-resolver-typescript "^1.1.1"
     eslint-module-utils "2.1.1"
@@ -7187,7 +7188,7 @@ eslint-plugin-shopify@^26.1.1:
     eslint-plugin-lodash "2.6.1"
     eslint-plugin-mocha "5.2.0"
     eslint-plugin-node "7.0.1"
-    eslint-plugin-prettier "3.0.0"
+    eslint-plugin-prettier "3.0.1"
     eslint-plugin-promise "4.0.0"
     eslint-plugin-react "7.11.1"
     eslint-plugin-sort-class-members "1.3.1"
@@ -16661,14 +16662,14 @@ stylelint-config-prettier@^4.0.0:
   integrity sha512-cwh3QbBC2+3zBeMvuxFjT8XsbSdyoyELOY9BZqMuvphUKEQ+srkPWoN60FlvRwLB014TOke4Y12KvTtfKnaHhg==
 
 stylelint-config-shopify@^7.0.4:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/stylelint-config-shopify/-/stylelint-config-shopify-7.0.4.tgz#7d412a4c1cfe89f6dcf3c41f63b328c5608a6689"
-  integrity sha512-LUrUEmLEC2PjkXflILGZZbfqKakdzwvsHp/gMiPpe55gQsyVlfwmut55W/9xk0qseW9T/+5o2O+5LMnu5cZIVw==
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-shopify/-/stylelint-config-shopify-7.1.0.tgz#0435e1452dd17f94a8cacc60fc0dc95c9d225d28"
+  integrity sha512-ujO7wQRCN8/FbtA9X3+dL2rxuhgspi8LmFsbR713txKV66yTguk3xokdv8YEgy3EHrlgc+OZwNY1z7wmaL5V+Q==
   dependencies:
     merge "1.2.x"
     stylelint-config-prettier "^4.0.0"
     stylelint-order "1.0.0"
-    stylelint-prettier "1.0.3"
+    stylelint-prettier "1.0.6"
     stylelint-scss "3.3.0"
 
 stylelint-order@1.0.0:
@@ -16680,10 +16681,10 @@ stylelint-order@1.0.0:
     postcss "^7.0.2"
     postcss-sorting "^4.0.0"
 
-stylelint-prettier@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-1.0.3.tgz#d7b1e8c331045dc1fd9d792dd8a1a5afc5304018"
-  integrity sha512-yzlhOKg2AmzGmKfWN9LPONr7/8O15QkGLtofhDsbpiEHCXMS5fZbQ0lcjopOAm6iU7vzETRFbOSHrDNJCRepbA==
+stylelint-prettier@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-1.0.6.tgz#479b76336751cb617c5beb7545d05a791f945e1e"
+  integrity sha512-XKlTyJHJYiyXs9JXRMt2FQxMJoBSjz4I6+4+/R3o8/ePof19v9naC4d0zsMKUJ88by81+qHfqXBLfmAalu46cg==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 


### PR DESCRIPTION
### WHY are these changes introduced?

VSCode's stylelint extension checks on typing. Sometimes when you're typing you write unparsable  code  - because you've wrote `if {` but not the `}` yet.

When this happens you get a bunch of problem notifications raised because prior to this change eslint and stylelint crashed when given unparsable code:

<img width="606" alt="screen shot 2019-01-07 at 1 02 40 pm" src="https://user-images.githubusercontent.com/227292/50859912-78b24480-1349-11e9-8355-00cc412e8c89.png">

### WHAT is this pull request doing?

This bumps the versions of the eslint and stylelint prettier plugins to not crash when faced
with invalid code, so these errors-because-youve-not-finished-typing are denoted as temporary red squiggly lines instead of those problem popups.

### How to 🎩

* Have the stylelint VSCode plugin installed
* `yarn install`
* Restart VSCode
* Write some unparsable code in a tsx file. I suggest changing an `export` to `ex}port`. See that no problem notification appears
