### PR TITLE
[RangeSlider] Remove accessiblityInputs

### DIFF
--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -10,11 +10,11 @@ $range-thumbs-border: rem(1px) solid color('sky', 'dark');
 $range-thumbs-border-error: rem(2px) solid color('red');
 $range-thumbs-shadow-hover: (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint));
 $range-thumbs-border-active: rem(2px) solid color('indigo');
-$range-accessibility-input-margin: rem(8px);
 
 .Wrapper {
   position: relative;
   width: 100%;
+  display: flex;
 }
 
 .TrackWrapper {
@@ -57,18 +57,6 @@ $range-accessibility-input-margin: rem(8px);
       // stylelint-enable selector-max-class
     }
   }
-}
-
-.AccessibilityInputsWrapper {
-  width: 100%;
-  display: flex;
-  flex-wrap: nowrap;
-  justify-content: space-between;
-  margin-top: $range-accessibility-input-margin;
-}
-
-.AccessibilityInputLower {
-  min-width: rem(80px);
 }
 
 .Track {
@@ -153,6 +141,16 @@ $range-accessibility-input-margin: rem(8px);
 
 $range-output-size: rem(32px);
 $range-output-tip-size: rem(8px);
+
+.Prefix {
+  flex: 0 0 auto;
+  margin-right: spacing(tight);
+}
+
+.Suffix {
+  flex: 0 0 auto;
+  margin-left: spacing(tight);
+}
 
 .Output {
   position: absolute;

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -5,7 +5,6 @@ import {
   removeEventListener,
 } from '@shopify/javascript-utilities/events';
 import {classNames} from '@shopify/react-utilities/styles';
-import TextField from '../../../TextField';
 import {CSS_VAR_PREFIX} from '../../utilities';
 import {Props as RangeSliderProps} from '../../types';
 import Labelled from '../../../Labelled';
@@ -102,13 +101,11 @@ export default class DualThumb extends React.Component<Props, State> {
       id,
       min,
       max,
-      step,
       prefix,
       suffix,
       disabled,
       output,
       error,
-      accessibilityInputs,
       onFocus,
       onBlur,
       label,
@@ -147,61 +144,6 @@ export default class DualThumb extends React.Component<Props, State> {
       styles.ThumbUpper,
       disabled && styles.disabled,
     );
-
-    const classNameAccessibilityInputLower = classNames(
-      styles.AccessibilityInputs,
-      styles.AccessibilityInputLower,
-    );
-    const classNameAccessibilityInputUpper = classNames(
-      styles.AccessibilityInputs,
-      styles.AccessibilityInputUpper,
-    );
-
-    const lowerMaxValue = isNaN(valueUpper - step)
-      ? undefined
-      : valueUpper - step;
-
-    const accessibilityPrefixMarkup = accessibilityInputs ? (
-      <div className={classNameAccessibilityInputLower}>
-        <TextField
-          label="Lower value"
-          labelHidden
-          type="number"
-          step={step}
-          prefix={prefix}
-          suffix={suffix}
-          disabled={disabled}
-          value={String(valueLower)}
-          onChange={this.handleTextFieldChangeLower}
-          onBlur={this.handleTextFieldBlurLower}
-          max={lowerMaxValue}
-          min={min}
-        />
-      </div>
-    ) : null;
-
-    const upperMinValue = isNaN(valueLower + step)
-      ? undefined
-      : valueLower + step;
-
-    const accessibilitySuffixMarkup = accessibilityInputs ? (
-      <div className={classNameAccessibilityInputUpper}>
-        <TextField
-          label="Upper value"
-          labelHidden
-          type="number"
-          step={step}
-          prefix={prefix}
-          suffix={suffix}
-          disabled={disabled}
-          value={String(valueUpper)}
-          onChange={this.handleTextFieldChangeUpper}
-          onBlur={this.handleTextFieldBlurUpper}
-          max={max}
-          min={upperMinValue}
-        />
-      </div>
-    ) : null;
 
     const trackWidth = this.state.trackWidth;
     const adjustedTrackWidth = trackWidth - THUMB_SIZE;
@@ -250,6 +192,14 @@ export default class DualThumb extends React.Component<Props, State> {
       [`${CSS_VAR_PREFIX}progress-upper`]: `${progressUpper}px`,
     };
 
+    const prefixMarkup = prefix && (
+      <div className={styles.Prefix}>{prefix}</div>
+    );
+
+    const suffixMarkup = suffix && (
+      <div className={styles.Suffix}>{suffix}</div>
+    );
+
     return (
       <Labelled
         id={id}
@@ -260,6 +210,7 @@ export default class DualThumb extends React.Component<Props, State> {
         helpText={helpText}
       >
         <div className={styles.Wrapper} id={id}>
+          {prefixMarkup}
           <div className={classNameTrackWrapper}>
             <div
               className={styles.Track}
@@ -306,10 +257,7 @@ export default class DualThumb extends React.Component<Props, State> {
             />
             {outputMarkupUpper}
           </div>
-          <div className={styles.AccessibilityInputsWrapper}>
-            {accessibilityPrefixMarkup}
-            {accessibilitySuffixMarkup}
-          </div>
+          {suffixMarkup}
         </div>
       </Labelled>
     );
@@ -427,60 +375,6 @@ export default class DualThumb extends React.Component<Props, State> {
     const {valueLower, valueUpper} = this.state;
 
     return onChange([valueLower, valueUpper], id);
-  }
-
-  @autobind
-  private handleTextFieldChangeLower(value: string) {
-    this.setState({valueLower: Number(value)});
-  }
-
-  @autobind
-  private handleTextFieldChangeUpper(value: string) {
-    this.setState({valueUpper: Number(value)});
-  }
-
-  @autobind
-  private handleTextFieldBlurLower() {
-    const {valueLower, valueUpper} = this.state;
-    const {step, min} = this.props;
-    const steppedValue = roundToNearestStepValue(valueLower, step);
-
-    const valueWithinBoundsLower = keepValueWithinBoundsLower(
-      steppedValue,
-      valueUpper,
-      min,
-      step,
-    );
-    this.setState(
-      {
-        valueLower: valueWithinBoundsLower,
-      },
-      () => {
-        this.handleChange();
-      },
-    );
-  }
-
-  @autobind
-  private handleTextFieldBlurUpper() {
-    const {step, max} = this.props;
-    const {valueUpper, valueLower} = this.state;
-    const steppedValue = roundToNearestStepValue(valueUpper, step);
-
-    const valueWithinBoundsUpper = keepValueWithinBoundsUpper(
-      steppedValue,
-      valueLower,
-      max,
-      step,
-    );
-    this.setState(
-      {
-        valueUpper: valueWithinBoundsUpper,
-      },
-      () => {
-        this.handleChange();
-      },
-    );
   }
 
   @autobind

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import {noop} from '@shopify/javascript-utilities/other';
-import {mountWithAppProvider, findByTestID, trigger} from 'test-utilities';
+import {mountWithAppProvider, findByTestID} from 'test-utilities';
 import DualThumb from '../DualThumb';
-import TextField from '../../../../TextField';
 
 describe('<DualThumb />', () => {
   const mockProps = {
@@ -112,160 +111,6 @@ describe('<DualThumb />', () => {
     });
   });
 
-  describe('accessibilityInputs', () => {
-    it('renders two TextFields when true', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs />,
-      );
-
-      expect(dualThumb.find(TextField)).toHaveLength(2);
-    });
-
-    it('renders the lower TextField as a number', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs />,
-      );
-
-      const textFieldLower = dualThumb.find(TextField).first();
-      expect(textFieldLower.prop('type')).toBe('number');
-    });
-
-    it('renders the upper TextField as a number', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs />,
-      );
-
-      const textFieldUpper = dualThumb.find(TextField).last();
-      expect(textFieldUpper.prop('type')).toBe('number');
-    });
-
-    it('renders the lower TextField with a visually hidden label', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs />,
-      );
-
-      const textFieldLower = dualThumb.find(TextField).first();
-      expect(textFieldLower.prop('label')).toBe('Lower value');
-      expect(textFieldLower.prop('labelHidden')).toBe(true);
-    });
-
-    it('renders the upper TextField with a visually hidden label', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs />,
-      );
-
-      const textFieldUpper = dualThumb.find(TextField).last();
-      expect(textFieldUpper.prop('label')).toBe('Upper value');
-      expect(textFieldUpper.prop('labelHidden')).toBe(true);
-    });
-
-    it('renders the lower TextField with the lower value as a string', () => {
-      const value = [5, 10] as [number, number];
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs value={value} />,
-      );
-
-      const textFieldLower = dualThumb.find(TextField).first();
-      expect(textFieldLower.prop('value')).toBe('5');
-    });
-
-    it('renders the upper TextField with the upper value as a string', () => {
-      const value = [5, 10] as [number, number];
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs value={value} />,
-      );
-
-      const textFieldUpper = dualThumb.find(TextField).last();
-      expect(textFieldUpper.prop('value')).toBe('10');
-    });
-
-    describe('prefix', () => {
-      it('passes the prefix to the lower TextField', () => {
-        const prefix = '$';
-        const dualThumb = mountWithAppProvider(
-          <DualThumb {...mockProps} accessibilityInputs prefix={prefix} />,
-        );
-
-        const textFieldLower = dualThumb.find(TextField).first();
-        expect(textFieldLower.prop('prefix')).toBe(prefix);
-      });
-
-      it('passes the prefix to the upper TextField', () => {
-        const prefix = '$';
-        const dualThumb = mountWithAppProvider(
-          <DualThumb {...mockProps} accessibilityInputs prefix={prefix} />,
-        );
-
-        const textFieldUpper = dualThumb.find(TextField).last();
-        expect(textFieldUpper.prop('prefix')).toBe(prefix);
-      });
-    });
-
-    describe('suffix', () => {
-      it('passes the suffix to the lower TextField', () => {
-        const suffix = '£';
-        const dualThumb = mountWithAppProvider(
-          <DualThumb {...mockProps} accessibilityInputs suffix={suffix} />,
-        );
-
-        const textFieldLower = dualThumb.find(TextField).first();
-        expect(textFieldLower.prop('suffix')).toBe(suffix);
-      });
-
-      it('passes the suffix to the upper TextField', () => {
-        const suffix = '£';
-        const dualThumb = mountWithAppProvider(
-          <DualThumb {...mockProps} accessibilityInputs suffix={suffix} />,
-        );
-
-        const textFieldUpper = dualThumb.find(TextField).last();
-        expect(textFieldUpper.prop('suffix')).toBe(suffix);
-      });
-    });
-
-    describe('onChange()', () => {
-      it('returns value and id when called by the lower TextField', () => {
-        const onChangeSpy = jest.fn();
-        const value = [10, 20] as [number, number];
-
-        const dualThumb = mountWithAppProvider(
-          <DualThumb
-            {...mockProps}
-            accessibilityInputs
-            onChange={onChangeSpy}
-            value={value}
-          />,
-        );
-
-        const id = 'RangeSlider';
-        const textFieldLower = dualThumb.find(TextField).first();
-        trigger(textFieldLower, 'onChange', {value, id}, () => {
-          expect(onChangeSpy).toHaveBeenCalledWith({value, id});
-        });
-      });
-
-      it('returns value and id when called by the upper TextField', () => {
-        const onChangeSpy = jest.fn();
-        const value = [10, 20] as [number, number];
-
-        const dualThumb = mountWithAppProvider(
-          <DualThumb
-            {...mockProps}
-            accessibilityInputs
-            onChange={onChangeSpy}
-            value={value}
-          />,
-        );
-
-        const id = 'RangeSlider';
-        const textFieldUpper = dualThumb.find(TextField).last();
-        trigger(textFieldUpper, 'onChange', {value, id}, () => {
-          expect(onChangeSpy).toHaveBeenCalledWith({value, id});
-        });
-      });
-    });
-  });
-
   describe('step', () => {
     it('adjusts the lower value', () => {
       const step = 5;
@@ -287,26 +132,6 @@ describe('<DualThumb />', () => {
 
       const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
       expect(thumbUpper.prop('aria-valuenow')).toBe(10);
-    });
-
-    it('passes step to the lower TextField', () => {
-      const step = 5;
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs step={step} />,
-      );
-
-      const textFieldLower = dualThumb.find(TextField).first();
-      expect(textFieldLower.prop('step')).toBe(step);
-    });
-
-    it('passes step to the upper TextField', () => {
-      const step = 5;
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs step={step} />,
-      );
-
-      const textFieldUpper = dualThumb.find(TextField).last();
-      expect(textFieldUpper.prop('step')).toBe(step);
     });
   });
 
@@ -341,24 +166,6 @@ describe('<DualThumb />', () => {
 
       const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
       expect(thumbUpper.prop('aria-disabled')).toBe(true);
-    });
-
-    it('gets passed to the lower TextField', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs disabled />,
-      );
-
-      const textFieldLower = dualThumb.find(TextField).first();
-      expect(textFieldLower.prop('disabled')).toBe(true);
-    });
-
-    it('gets passed to the upper TextField', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs disabled />,
-      );
-
-      const textFieldUpper = dualThumb.find(TextField).last();
-      expect(textFieldUpper.prop('disabled')).toBe(true);
     });
   });
 

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -33,8 +33,6 @@ export interface Props {
   prefix?: React.ReactNode;
   /** Element to display after the input */
   suffix?: React.ReactNode;
-  /** Displays text fields as the prefix and suffix for the dual thumb slider only */
-  accessibilityInputs?: boolean;
   /** Callback when the range input is changed */
   onChange(value: RangeSliderValue, id: string): void;
   /** Callback when range input is focused */


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris-react/issues/839

### WHAT is this pull request doing?

Removes `accessibilityInputs`. A better example in the style guide and clear documentation will be in a separate PR.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Fire up Storybook!

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
