### PR TITLE
Update to use app-bridge@1.0.3

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,7 +7,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Update build toolchain to use Babel v7, PostCSS v7 and Rollup v1. Update our build targets match our [supported browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers), leading to a reduction in bundle size ([#837](https://github.com/Shopify/polaris-react/pull/837))
-- Updated `Toast` to use App Bridge `Toast` action and remove deprecated `isDismissible` property
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Update build toolchain to use Babel v7, PostCSS v7 and Rollup v1. Update our build targets match our [supported browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers), leading to a reduction in bundle size ([#837](https://github.com/Shopify/polaris-react/pull/837))
+- Updated `Toast` to use App Bridge `Toast` action and remove deprecated `isDismissible` property
 
 ### Bug fixes
 
@@ -18,6 +19,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed our usage of babel-node for build scripts - use plain node instead ([#836](https://github.com/Shopify/polaris-react/pull/836))
 
 ### Dependency upgrades
+
+- Updated App Bridge to version 1.0.3 ([#844](https://github.com/Shopify/polaris-react/pull/844))
 
 ### Code quality
 

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.1.6",
-    "@shopify/app-bridge": "^0.7.3",
+    "@shopify/app-bridge": "^1.0.3",
     "@shopify/images": "^1.1.0",
     "@shopify/javascript-utilities": "^2.2.1",
     "@shopify/polaris-icons": "1.0.0-beta.5",

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
-import {Flash as AppBridgeToast} from '@shopify/app-bridge/actions';
+import {Toast as AppBridgeToast} from '@shopify/app-bridge/actions';
 
 import {
   DEFAULT_TOAST_DURATION,
@@ -25,7 +25,7 @@ export class Toast extends React.PureComponent<ComposedProps, never> {
   context: FrameContext;
 
   private id = createId();
-  private appBridgeToast: AppBridgeToast.Flash | undefined;
+  private appBridgeToast: AppBridgeToast.Toast | undefined;
 
   componentDidMount() {
     const {context, id, props} = this;
@@ -47,7 +47,6 @@ export class Toast extends React.PureComponent<ComposedProps, never> {
         message: content,
         duration,
         isError: error,
-        isDismissible: true,
       });
 
       this.appBridgeToast.subscribe(AppBridgeToast.Action.CLEAR, onDismiss);

--- a/src/components/Toast/tests/Toast.test.tsx
+++ b/src/components/Toast/tests/Toast.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import {Flash as AppBridgeToast} from '@shopify/app-bridge/actions';
+import {Toast as AppBridgeToast} from '@shopify/app-bridge/actions';
 import {mountWithAppProvider, createPolarisProps} from 'test-utilities';
 import {noop} from '../../../utilities/other';
 import Toast from '../Toast';
@@ -42,7 +42,7 @@ describe('<Toast />', () => {
     };
     AppBridgeToast.create = jest.fn().mockReturnValue(appBridgeToastMock);
 
-    it('shows app bridge flash notice content on mount and unmounts safely', () => {
+    it('shows app bridge toast notice content on mount and unmounts safely', () => {
       const content = 'Message sent';
       const {toast, polaris} = mountWithAppBridge(
         <Toast content={content} duration={1000} onDismiss={noop} />,
@@ -51,7 +51,6 @@ describe('<Toast />', () => {
 
       expect(AppBridgeToast.create).toHaveBeenCalledWith(polaris.appBridge, {
         duration: 1000,
-        isDismissible: true,
         isError: undefined,
         message: 'Message sent',
       });
@@ -62,7 +61,7 @@ describe('<Toast />', () => {
       expect(appBridgeToastMock.dispatch).toHaveBeenCalledTimes(1);
     });
 
-    it('shows app bridge flash error content on mount', () => {
+    it('shows app bridge toast error content on mount', () => {
       const content = 'Message sent';
       const {polaris} = mountWithAppBridge(
         <Toast content={content} duration={1000} onDismiss={noop} error />,
@@ -70,7 +69,6 @@ describe('<Toast />', () => {
 
       expect(AppBridgeToast.create).toHaveBeenCalledWith(polaris.appBridge, {
         duration: 1000,
-        isDismissible: true,
         isError: true,
         message: 'Message sent',
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,10 +1077,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@shopify/app-bridge@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@shopify/app-bridge/-/app-bridge-0.7.3.tgz#abadfa2ef6293f630764bc5ddca31750caf00f1c"
-  integrity sha512-xDkYvVvN8Gxy3JZduoT4Ohrl6fAuW+wEfhfL+qPzysu0LuJZ7CKgVCdEazPmtcI+V4GQPQLYLzcbCn3mWFU8dg==
+"@shopify/app-bridge@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@shopify/app-bridge/-/app-bridge-1.0.3.tgz#a898b0450e4f917bbfcd65e5671718ad53bdaed9"
+  integrity sha512-YlHDBICC9UzLhF04T4zD+zHAhMEut0XRops9ZZeIlSLNeRTeQfwZPMP9UjHx+akZR+f2CeeBS8/nEthv7hmjvQ==
 
 "@shopify/browserslist-config@^0.0.2-beta.2":
   version "0.0.2-beta.2"


### PR DESCRIPTION
### WHY are these changes introduced?
Resolves https://github.com/Shopify/polaris-react/issues/820

### WHAT is this pull request doing?
- Update to use app-bridge@1.0.3
- [Toast] Use new Toast action from app-bridge instead of legacy Flash
- [Toast] Remove deprecated `isDismissible` prop

### How to 🎩

1. Clone this app https://github.com/vividviolet/test-shopify-app and run `dev up`. Make sure you stop running the App Bridge Playground as the test app will replace the Playground.
2. In the Polaris directory run `yarn build-consumer DIRNAME` with `DIRNAME` replaced with the directory containing the test app
3. In the Polaris directory run `yarn build-consumer web`
4. Build and run Web
5. Install the test app at http://app-bridge.myshopify.io/auth/shopify?shop=shop1.myshopify.io
6. Open https://shop1.myshopify.io/admin/apps/app-bridge
7. Test all buttons and ensure the `Page`, `Toast`, `ResourcePicker`, `Loading` and `Modal` components are working

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
