### PR TITLE
[Range Slider] Add example with accessibility inputs for dual thumb

### DIFF
--- a/src/components/RangeSlider/README.md
+++ b/src/components/RangeSlider/README.md
@@ -29,7 +29,7 @@ Range sliders should:
 - When a label is visible, it should clearly communicate the purpose of the range input and its values (min, max, step, value)
 - Be labeled as “Optional” when you need to request input that’s not required
 - Validate input as soon as merchants have finished interacting with a field (but not before)
-- Always be used with `accessibilityInputs` when range slider has dual thumbs, to provide accessible alternatives to sliding the thumbs
+- Always be used with two text field components when range slider has dual thumbs, to provide accessible alternatives to both the lower and upper thumbs
 
 ---
 
@@ -231,21 +231,109 @@ class RangeSliderExample extends React.Component {
 Use a dual thumb range slider when merchants need to select a range of values.
 
 ```jsx
+const initialValue = [900, 1000];
+
 class RangeSliderExample extends React.Component {
-  handleChange = (value) => {
-    console.log({value});
+  state = {
+    intermediateTextFieldValue: initialValue,
+    value: initialValue,
+  };
+
+  handleRangeSliderChange = (value) => {
+    this.setState({value, intermediateTextFieldValue: value});
+  };
+
+  handleLowerTextFieldChange = (value) => {
+    const upperValue = this.state.value[1];
+    this.setState({intermediateTextFieldValue: [parseInt(value), upperValue]});
+  };
+
+  handleUpperTextFieldChange = (value) => {
+    const lowerValue = this.state.value[0];
+    this.setState({intermediateTextFieldValue: [lowerValue, parseInt(value)]});
+  };
+
+  handleLowerTextFieldBlur = () => {
+    const upperValue = this.state.value[1];
+    const value = this.state.intermediateTextFieldValue[0];
+
+    this.setState({value: [parseInt(value), upperValue]});
+  };
+
+  handleUpperTextFieldBlur = () => {
+    const lowerValue = this.state.value[0];
+    const value = this.state.intermediateTextFieldValue[1];
+
+    this.setState({value: [lowerValue, parseInt(value)]});
+  };
+
+  handleEnterKeyPress = (event) => {
+    const newValue = this.state.intermediateTextFieldValue;
+    const oldValue = this.state.value;
+
+    if (event.keyCode === Key.Enter && newValue !== oldValue) {
+      this.setState({value: newValue});
+    }
   };
 
   render() {
+    const {value, intermediateTextFieldValue} = this.state;
+    const prefix = '$';
+    const min = 0;
+    const max = 2000;
+    const step = 10;
+    const disabled = false;
+
+    const lowerTextFieldValue =
+      intermediateTextFieldValue[0] === value[0]
+        ? value[0]
+        : intermediateTextFieldValue[0];
+    const upperTextFieldValue =
+      intermediateTextFieldValue[1] === value[1]
+        ? value[1]
+        : intermediateTextFieldValue[1];
+
     return (
       <Card sectioned>
-        <RangeSlider
-          label=""
-          value={[35, 60]}
-          onChange={this.handleChange}
-          accessibilityInputs
-          step={5}
-        />
+        <div style={{marginTop: '20px'}} onKeyDown={this.handleEnterKeyPress}>
+          <RangeSlider
+            label="Money spent is between"
+            value={value}
+            prefix={prefix}
+            output
+            min={min}
+            max={max}
+            step={step}
+            disabled={disabled}
+            onChange={this.handleRangeSliderChange}
+          />
+          <Stack distribution="equalSpacing" spacing="extraLoose">
+            <TextField
+              label="Min money spent"
+              type="number"
+              value={`${lowerTextFieldValue}`}
+              prefix={prefix}
+              min={min}
+              max={max}
+              step={step}
+              disabled={disabled}
+              onChange={this.handleLowerTextFieldChange}
+              onBlur={this.handleLowerTextFieldBlur}
+            />
+            <TextField
+              label="Max money spent"
+              type="number"
+              value={`${upperTextFieldValue}`}
+              prefix={prefix}
+              min={min}
+              max={max}
+              step={step}
+              disabled={disabled}
+              onChange={this.handleUpperTextFieldChange}
+              onBlur={this.handleUpperTextFieldBlur}
+            />
+          </Stack>
+        </div>
       </Card>
     );
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris-react/issues/854

The example uses a stack component, which does not fully meet the requirements of the design, but it's not possible to do in the example without CSS media queries.

I'm questioning if these really should be handled by the component. A debounce or timeout might solve the issue we were having?

![screen shot 2019-01-10 at 1 12 18 pm](https://user-images.githubusercontent.com/6239480/50997575-c6f64d80-14d9-11e9-8313-746fe15eda6d.jpg)

![image](https://user-images.githubusercontent.com/6239480/50997904-b72b3900-14da-11e9-8941-d92ed5f0c14c.png)

## Error state
<details>
The need to handle errors seems like an edge case, so we left it out.

![image](https://user-images.githubusercontent.com/6239480/50997981-e9d53180-14da-11e9-80d1-4041be37be64.png)

![image](https://user-images.githubusercontent.com/6239480/50997986-ef327c00-14da-11e9-81c3-b0ffd6695bac.png)

**Devon Persing**
Hmm. If someone isn’t interacting directly with the slider it might weird. (Since it’s not going to work with all AT.)

What are the scenarios where an error would get triggered?

**Solona Armstrong**
I had a similar question, Devon, in terms of scenarios. I don't really know. The `type="number"` prevents characters from being typed and the `min` `max` prevent the number from exceeding its bounds. If no value is entered, the thumb value can fill it in, so I can't imagine what an error would be.

I just figured we should consider error state. 🤷‍♀️ (edited)

**Devon Persing**
Yeah, it’s a good question, but I’m having the same thoughts you were. :smile:

**Devon Persing**
If a person leaves the slider alone altogether, they would just get all results.

**Solona Armstrong**
exactly

**Solona Armstrong**
The slider can't have no values, so _something_ will be set. I can't think of how something would be entered incorrectly (without being adjusted by the component), so maybe we don't handle errors? I figured there might be an edge case I hadn't thought of that would come back as a question later, but perhaps I'm overcomplicating. (edited)


**Devon Persing**
Yeah, I think we’re okay to ship with no error states. I’m sure we’ll find a scenario in the wild, but for now…

</details>