### PR TITLE
Use the latest version of yarn to upgrade Polaris on the style guide

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -28,6 +28,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Development workflow
 
 - Improved build speed by adjusting our rollup workflow ([#912](https://github.com/Shopify/polaris-react/pull/912)) and not optimizing svgs in the node_modules folder ([#920](https://github.com/Shopify/polaris-react/pull/920))
+- Fixed an issue where deployments would use an old version of Yarn, and open a pull request to polaris-styleguide with thousands of deleted integrity hashes in `yarn.lock` ([#856](https://github.com/Shopify/polaris-react/pull/856))
 
 ### Dependency upgrades
 

--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,7 @@ name: polaris-react
 up:
   - node:
       yarn: true
-      version: v10.13.0 # to be kept in sync with .nvmrc and .circleci/config.yml
+      version: v10.13.0 # to be kept in sync with .nvmrc, scripts/open-styleguide-pr.js, and .circleci/config.yml
   - git_hooks:
       pre-commit: pre-commit
 

--- a/dev.yml
+++ b/dev.yml
@@ -1,8 +1,8 @@
 name: polaris-react
 up:
   - node:
-      yarn: true
-      version: v10.13.0 # to be kept in sync with .nvmrc, scripts/open-styleguide-pr.js, and .circleci/config.yml
+      yarn: v1.13.0
+      version: v10.13.0 # to be kept in sync with .nvmrc and .circleci/config.yml
   - git_hooks:
       pre-commit: pre-commit
 

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "gray-matter": "^4.0.1",
     "in-publish": "^2.0.0",
     "isomorphic-fetch": "^2.2.1",
+    "js-yaml": "^3.12.1",
     "node-sass": "^4.10.0",
     "npm-run-all": "^4.0.2",
     "object-hash": "^1.3.0",

--- a/scripts/open-styleguide-pr.js
+++ b/scripts/open-styleguide-pr.js
@@ -65,7 +65,7 @@ execSync(
 );
 
 execSync(
-  `yarn upgrade @shopify/polaris@${releaseVersion.replace(
+  `npx yarn@latest upgrade @shopify/polaris@${releaseVersion.replace(
     'v',
     '',
   )} --no-progress --ignore-engines`,

--- a/scripts/open-styleguide-pr.js
+++ b/scripts/open-styleguide-pr.js
@@ -11,6 +11,7 @@ const polarisBotName = 'Shopify Polaris Bot';
 const polarisBotEmail = 'shopify-polaris-bot@users.noreply.github.com';
 const polarisBotToken = require('../secrets.json').github['shopify-polaris'];
 
+const YARN_VERSION = '10.13.0';
 const STYLEGUIDE = 'polaris-styleguide';
 const root = resolve(__dirname, '../');
 const sandbox = resolve(root, 'sandbox');
@@ -65,7 +66,7 @@ execSync(
 );
 
 execSync(
-  `npx yarn@latest upgrade @shopify/polaris@${releaseVersion.replace(
+  `npx yarn@${YARN_VERSION} upgrade @shopify/polaris@${releaseVersion.replace(
     'v',
     '',
   )} --no-progress --ignore-engines`,

--- a/scripts/open-styleguide-pr.js
+++ b/scripts/open-styleguide-pr.js
@@ -1,22 +1,27 @@
 /* eslint-disable no-console */
 
 const {execSync} = require('child_process');
+const {readFileSync} = require('fs');
 const {resolve} = require('path');
 const {mkdir} = require('shelljs');
+const yaml = require('js-yaml');
 const semver = require('semver');
 
-const {version: packageVersion} = require('../package.json');
+const {version: PACKAGE_VERSION} = require('../package.json');
+
+const YARN_VERSION = yaml
+  .safeLoad(readFileSync(resolve(__dirname, '..', 'dev.yml'), 'utf8'))
+  .up.find((obj) => Object.keys(obj).includes('node')).node.yarn;
 
 const polarisBotName = 'Shopify Polaris Bot';
 const polarisBotEmail = 'shopify-polaris-bot@users.noreply.github.com';
 const polarisBotToken = require('../secrets.json').github['shopify-polaris'];
 
-const YARN_VERSION = '10.13.0';
 const STYLEGUIDE = 'polaris-styleguide';
 const root = resolve(__dirname, '../');
 const sandbox = resolve(root, 'sandbox');
 const polarisStyleguide = resolve(sandbox, STYLEGUIDE);
-const releaseVersion = `v${packageVersion}`;
+const releaseVersion = `v${PACKAGE_VERSION}`;
 
 // Compute the base branch on polaris-styleguide (default: master)
 // Example: will open a PR against the v4 branch if the
@@ -36,8 +41,8 @@ function isMajorPrerelease(version) {
   );
 }
 
-const baseBranch = isMajorPrerelease(packageVersion)
-  ? `v${semver.major(packageVersion)}`
+const baseBranch = isMajorPrerelease(PACKAGE_VERSION)
+  ? `v${semver.major(PACKAGE_VERSION)}`
   : 'master';
 
 mkdir(sandbox);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9965,18 +9965,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.7.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
-  integrity sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==
+js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.12.1, js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
+  integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
### WHY are these changes introduced?

ShipIt comes with an old version of Yarn, that doesn't support integrity hashes. This means each polaris-styleguide PR coming from polaris-react deploys is deleting thousands of lines (hashes) from yarn.lock.

### WHAT is this pull request doing?

By leveraging a more recent version of Yarn, we know those hashes will be kept in.


---

To tophat, let's create a new Shipit stack, create a beta version, and see if the resulting PR has a yarn.lock that still contains integrity hashes.

See this PR https://github.com/Shopify/polaris-styleguide/pull/2501/files where the resulting yarn.lock still contains integrity hashes.