### PR TITLE
[TopBar] Remove `title` attribute from UserMenu

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added a `forceRender` prop to `Page` to not delegate to the app bridge TitleBar action ([#695](https://github.com/Shopify/polaris-react/pull/695))
 - Changed `Tabs` example to contain children so the `Panel` renders for accessibility ([#893](https://github.com/Shopify/polaris-react/pull/893))
 - Fixed timezone not being accounted for in `ResourceList` date filter control ([#710](https://github.com/Shopify/polaris-react/pull/710))
+- Removed unnecessary tooltip text in the `TopBar` component ([#859](https://github.com/Shopify/polaris-react/pull/859))
 
 ### Documentation
 

--- a/src/components/TopBar/components/UserMenu/components/UserMenu/UserMenu.tsx
+++ b/src/components/TopBar/components/UserMenu/components/UserMenu/UserMenu.tsx
@@ -46,9 +46,7 @@ function UserMenu({
         />
       </MessageIndicator>
       <span className={styles.Details}>
-        <p className={styles.Name} title="altText">
-          {name}
-        </p>
+        <p className={styles.Name}>{name}</p>
         <p className={styles.Detail}>{detail}</p>
       </span>
     </div>


### PR DESCRIPTION
Fixes #842 by removing a `title` attribute we don’t need.

- The `title` attribute is [ineffective for people using assistive technology](https://www.24a11y.com/2017/the-trials-and-tribulations-of-the-title-attribute/)
- It seems like the content here should already be available to screen readers
