### PR TITLE
[Button] keypress, keydown, and keyup events

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added `onKeyPress`, `onKeyDown`, and `onKeyUp` to `Button` ([#860](https://github.com/Shopify/polaris-react/pull/860))
+
 ### Design updates
 
 ### Bug fixes

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -59,11 +59,11 @@ export interface Props {
   /** Callback when focus leaves button */
   onBlur?(): void;
   /** Callback when a keypress event is registered on the button */
-  onKeyPress?(): void;
+  onKeyPress?(event: React.KeyboardEvent<HTMLButtonElement>): void;
   /** Callback when a keyup event is registered on the button */
-  onKeyUp?(): void;
+  onKeyUp?(event: React.KeyboardEvent<HTMLButtonElement>): void;
   /** Callback when a keydown event is registered on the button */
-  onKeyDown?(): void;
+  onKeyDown?(event: React.KeyboardEvent<HTMLButtonElement>): void;
 }
 
 export type CombinedProps = Props & WithAppProviderProps;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -58,6 +58,12 @@ export interface Props {
   onFocus?(): void;
   /** Callback when focus leaves button */
   onBlur?(): void;
+  /** Callback when a keypress event is registered on the button */
+  onKeyPress?(): void;
+  /** Callback when a keyup event is registered on the button */
+  onKeyUp?(): void;
+  /** Callback when a keydown event is registered on the button */
+  onKeyDown?(): void;
 }
 
 export type CombinedProps = Props & WithAppProviderProps;
@@ -76,6 +82,9 @@ function Button({
   onClick,
   onFocus,
   onBlur,
+  onKeyDown,
+  onKeyPress,
+  onKeyUp,
   external,
   icon,
   primary,
@@ -184,6 +193,9 @@ function Button({
       onClick={onClick}
       onFocus={onFocus}
       onBlur={onBlur}
+      onKeyDown={onKeyDown}
+      onKeyUp={onKeyUp}
+      onKeyPress={onKeyPress}
       onMouseUp={handleMouseUpByBlurring}
       className={className}
       disabled={isDisabled}

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -251,31 +251,40 @@ describe('<Button />', () => {
 
   describe('onKeyPress()', () => {
     it('is called when a keypress event is registered on the button', () => {
+      const fakeEventData = {key: 'foo'};
       const spy = jest.fn();
       shallowWithAppProvider(<Button onKeyPress={spy}>Test</Button>).simulate(
         'keypress',
+        fakeEventData,
       );
       expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(fakeEventData);
     });
   });
 
   describe('onKeyUp()', () => {
     it('is called when a keyup event is registered on the button', () => {
+      const fakeEventData = {key: 'foo'};
       const spy = jest.fn();
       shallowWithAppProvider(<Button onKeyUp={spy}>Test</Button>).simulate(
         'keyup',
+        fakeEventData,
       );
       expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(fakeEventData);
     });
   });
 
   describe('onKeyDown()', () => {
     it('is called when a keydown event is registered on the button', () => {
+      const fakeEventData = {key: 'foo'};
       const spy = jest.fn();
       shallowWithAppProvider(<Button onKeyDown={spy}>Test</Button>).simulate(
         'keydown',
+        fakeEventData,
       );
       expect(spy).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(fakeEventData);
     });
   });
 });

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -248,4 +248,34 @@ describe('<Button />', () => {
       expect(onBlurSpy).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('onKeyPress()', () => {
+    it('is called when a keypress event is registered on the button', () => {
+      const spy = jest.fn();
+      shallowWithAppProvider(<Button onKeyPress={spy}>Test</Button>).simulate(
+        'keypress',
+      );
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('onKeyUp()', () => {
+    it('is called when a keyup event is registered on the button', () => {
+      const spy = jest.fn();
+      shallowWithAppProvider(<Button onKeyUp={spy}>Test</Button>).simulate(
+        'keyup',
+      );
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('onKeyDown()', () => {
+    it('is called when a keydown event is registered on the button', () => {
+      const spy = jest.fn();
+      shallowWithAppProvider(<Button onKeyDown={spy}>Test</Button>).simulate(
+        'keydown',
+      );
+      expect(spy).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Porting over from https://github.com/Shopify/polaris-react-deprecated/pull/1820

### WHAT is this pull request doing?

Add events for the aforementioned.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Button} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <Button onKeyPress={log} onKeyDown={log} onKeyUp={log}>
          Test
        </Button>
      </Page>
    );
  }
}

function log(event: KeyboardEvent) {
  console.log(event.keyCode);
}
```

</details>

### 🎩 checklist

* [x] 🎩 
* [ ] ~~Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)~~
* [ ] ~~Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)~~
* [ ] ~~Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)~~

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
