### PR TITLE
Adds example to deprecation guidelines

### DIFF
--- a/documentation/Deprecation guidelines.md
+++ b/documentation/Deprecation guidelines.md
@@ -11,4 +11,5 @@
 - Call out deprecations in our changelog
 
 ## Examples
+
 - [Deprecation of `Navigation.UserMenu`](https://github.com/Shopify/polaris-react/pull/849).

--- a/documentation/Deprecation guidelines.md
+++ b/documentation/Deprecation guidelines.md
@@ -1,6 +1,6 @@
 # Deprecation guidelines
 
-- Ship backwards compatible changes which include supporting both the old and new API
+- Ship backwards compatible changes which include supporting both the old and new API (make sure the full upgrade path is available)
 - Support backwards compatibility for at least half of a major release cycle, but never more that 2 major release cycles
   - For example, before or part of 3.5, okay to remove in 4.0. After 3.5, remove in 5.0
   - Large changes consider a full major release cycle. For example, a large change in 3.1 would be removed in 5.0. But a large change in 2.9 would never wait until 5.0 to remove

--- a/documentation/Deprecation guidelines.md
+++ b/documentation/Deprecation guidelines.md
@@ -9,3 +9,6 @@
   - Add the console warning in the constructor for classes and in the render method for functional components
 - For significant deprecations, add a section to the component documentation with rationale. State the upgrade path and include a link to a new component if applicable
 - Call out deprecations in our changelog
+
+## Examples
+- [Deprecation of `Navigation.UserMenu`](https://github.com/Shopify/polaris-react/pull/849).


### PR DESCRIPTION
### WHY are these changes introduced?
We give a lot of instructions on how to deprecate a feature and it might be useful to provide some examples.

### WHAT is this pull request doing?
It adds [the deprecation of `Navigation.UserMenu`](https://github.com/Shopify/polaris-react/pull/849) as an example.