### PR TITLE
Revert "Deprecates Navigation.UserMenu (#849)"

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -35,5 +35,3 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Code quality
 
 ### Deprecations
-
-- Deprecated `Navigation.UserMenu` in favor of `TopBar.UserMenu` ([#849](https://github.com/Shopify/polaris-react/pull/849))

--- a/src/components/Navigation/README.md
+++ b/src/components/Navigation/README.md
@@ -182,10 +182,6 @@ The user menu component displays the current user’s avatar and name, and actio
 | avatarInitials | AvatarProps['initials'] | The merchant’s initials, rendered in place of an avatar image when not provided                         |
 | avatarSource   | AvatarProps['source']   | An avatar image representing the merchant                                                               |
 
-### Deprecation rationale
-
-As of release 3.4.1 `Navigation.UserMenu` will be deprecated in favor of [`TopBar.UserMenu`](https://polaris.shopify.com/components/structure/top-bar#top-bar-menu). `TopBar.UserMenu` will stay visible on mobile with the updated `TopBar` layout.
-
 ---
 
 ## Examples

--- a/src/components/Navigation/components/UserMenu/UserMenu.tsx
+++ b/src/components/Navigation/components/UserMenu/UserMenu.tsx
@@ -32,19 +32,10 @@ interface State {
   userMenuExpanded?: boolean;
 }
 
-/** @deprecated Use <TopBar.UserMenu /> instead. */
 export default class UserMenu extends React.PureComponent<Props, State> {
   state: State = {
     userMenuExpanded: false,
   };
-
-  constructor(props: Props) {
-    super(props);
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: <Navigation.UserMenu /> is deprecated and will be removed in the next major version. Use <TopBar.UserMenu /> instead.',
-    );
-  }
 
   render() {
     const {


### PR DESCRIPTION
This reverts commit 6a029c68ad1a5a36d2c756d25733bc60da06a45e because `console.warn` [seems to be causing Jest to fail tests](https://buildkite.com/shopify/web-ci-builder/builds/39591#c85aef2f-bf35-455c-a103-60e0aee05d38).