### PR TITLE
Don't use math on colors as it is deprecated

### DIFF
--- a/src/styles/foundation/colors.scss
+++ b/src/styles/foundation/colors.scss
@@ -76,11 +76,25 @@ Available options: #{available-names($color-palette-data)}
 
 @function color-multiply($foreground, $background: null) {
   @if $background == null {
-    // stylelint-disable-next-line color-no-hex
-    $background: #ffffff;
+    $background: rgb(255, 255, 255);
   }
 
-  @return $foreground * $background / 255;
+  $red: red($background) * red($foreground) / 255;
+  $green: green($background) * green($foreground) / 255;
+  $blue: blue($background) * blue($foreground) / 255;
+
+  $opacity: opacity($foreground);
+  $background-opacity: opacity($background);
+
+  // calculate opacity
+  $bm-red: $red * $opacity + red($background) * $background-opacity *
+    (1 - $opacity);
+  $bm-green: $green * $opacity + green($background) * $background-opacity *
+    (1 - $opacity);
+  $bm-blue: $blue * $opacity + blue($background) * $background-opacity *
+    (1 - $opacity);
+
+  @return rgb($bm-red, $bm-green, $bm-blue);
 }
 
 ///


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #779

### WHAT is this pull request doing?

Use an implementation of color-multiply based off
https://github.com/heygrady/scss-blend-modes/blob/master/stylesheets/_blend-modes.scss

### How to 🎩

This is slightly tricky as we never call this function in our code. The only place it is referenced is if you call `color()` with a 3rd argument - which we never do. The easiest way to prove this is to add an `@error 'HI!'` at the top of the `color-multiply()` function then run `yarn run build` and see that the build still completes successfully.

We can't straight-up delete this function as that would violate our deprecation guidelines.

However we should prove that this new implementation works the same way as the prior implementation:

- Open up https://www.sassmeister.com/
- Add the following code, which contains the old and new implementations and a few test calls. Ensure that the old and new output matches

```scss
@function color-multiply($foreground, $background: null) {
  @if $background == null {
    $background: rgb(255, 255, 255);
  }

  $red: red($background) * red($foreground) / 255;
  $green: green($background) * green($foreground) / 255;
  $blue: blue($background) * blue($foreground) / 255;

  $new-foreground: rgba($red, $green, $blue, opacity($foreground));
  $opacity: opacity($foreground);
  $background-opacity: opacity($background);

  // calculate opacity
  $bm-red: $red * $opacity + red($background) *
    $background-opacity * (1 - $opacity);
  $bm-green: $green * $opacity + green($background) *
    $background-opacity * (1 - $opacity);
  $bm-blue: $blue * $opacity + blue($background) *
    $background-opacity * (1 - $opacity);

  @return rgb($bm-red, $bm-green, $bm-blue);
}


@function old-color-multiply($foreground, $background: null) {
  @if $background == null {
    $background: #ffffff;
  }

  @return $foreground * $background / 255;
}


@mixin test($name, $c1, $c2) {
  #{$name}: (old-color-multiply($c1, $c2), color-multiply($c1, $c2));
}

:root {
  // Each line shall output two colors. If the implementations
  // are identical then the colors should both match
  @include test('1', #658443, null);
  @include test('2', #123456, #345212);
  @include test('3', #456332, #996986);
}
```