### PR TITLE
Specify babel config in babel.config.js

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,6 +1,0 @@
-{
-  "presets": [
-    ["babel-preset-shopify/web", {"modules": false}],
-    ["babel-preset-shopify/react", {"hot": true}]
-  ]
-}

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -41,8 +41,6 @@ module.exports = (baseConfig, env, config) => {
         {
           loader: 'babel-loader',
           options: {
-            babelrc: false,
-            configFile: `${__dirname}/.babelrc`,
             // Don't use the production environment as it contains optimisations
             // that break compilation. The shopify/react preset enables the
             // babel-plugin-transform-react-constant-elements plugin which
@@ -63,8 +61,6 @@ module.exports = (baseConfig, env, config) => {
         {
           loader: 'babel-loader',
           options: {
-            babelrc: false,
-            configFile: `${__dirname}/.babelrc`,
             minified: isProduction,
             cacheDirectory: `${cacheDir}/typescript`,
           },

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,18 @@
+module.exports = function(api) {
+  // When building (using rollup) or running storybook (using babel-loader) we
+  // want to compile for the web otherwise compile for node usage (within jest)
+  const isWeb = api.caller((caller = {}) => {
+    return ['babel-loader', 'rollup-plugin-babel'].includes(caller.name);
+  });
+
+  const runtimePreset = isWeb
+    ? ['babel-preset-shopify/web', {modules: false}]
+    : ['babel-preset-shopify/node', {modules: 'commonjs'}];
+
+  // babel-preset-shopify/react only uses HMR if hot is true and the env is
+  // development or test
+  return {
+    presets: [runtimePreset, ['babel-preset-shopify/react', {hot: isWeb}]],
+    plugins: ['./config/babel/plugins/sass-namespace-to-default-import.js'],
+  };
+};

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -69,22 +69,6 @@ copy(['./src/**/*.{scss,svg,png,jpg,jpeg,json}', intermediateBuild], {up: 1})
       esnextIndex.replace(/import '.\/styles\/global\.scss';/g, ''),
     );
   })
-  .then(() => {
-    writeFileSync(
-      resolvePath(intermediateBuild, '.babelrc'),
-      `
-      {
-        "presets": [
-          ["babel-preset-shopify/web", {"modules": false}],
-          ["babel-preset-shopify/react"]
-        ],
-        "plugins": [
-          "../config/babel/plugins/sass-namespace-to-default-import.js"
-        ]
-      }
-    `,
-    );
-  })
   // Main CJS and ES modules bundles: supports all our supported browsers and
   // uses the full class names for any Sass imports
   .then(() => runRollup())

--- a/sewing-kit.config.ts
+++ b/sewing-kit.config.ts
@@ -24,16 +24,6 @@ export default function sewingKitConfig(
           ...config.transform,
         };
 
-        // Needed because we set js: 'react-native' in our tsconfig to leave the
-        // transformation up to consuming projects, but within Jest we want to
-        // transform the jsx content
-        // eslint-disable-next-line typescript/no-var-requires
-        const {compilerOptions} = require('./tsconfig.json');
-        config.globals['ts-jest'].tsConfig = {
-          ...compilerOptions,
-          jsx: 'react',
-        };
-
         // Code coverage
         config.collectCoverageFrom = [
           'src/**/*.{ts,tsx}',


### PR DESCRIPTION
### WHY are these changes introduced?

To stop repeating ourselves and a slight build process simplification

### WHAT is this pull request doing?

Unifies our babel config into babel.config.js

### How to 🎩

- On master, create a build output: `git checkout master && mkdir -p master-build/node_modules/@shopify && yarn run build-consumer polaris-react/master-build`
- On this branch create a build output: `git checkout simpler-babel-config && mkdir -p new-build/node_modules/@shopify && yarn run build-consumer polaris-react/new-build`
- Compare the outputs and ensure they are the same: `diff -r -u master-build new-build`
- Ensure tests pass
- Ensure storybook still works, including hot reloading of tsx and README files.