### PR TITLE
[TextField] [Resizer] Stop replacing newline with line break tag 

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed unnecessary height on `TextField` due to unhandled carriage returns ([#901](https://github.com/Shopify/polaris-react/pull/901))
+
 ### Documentation
 
 - Added accessibility documentation for `Checkbox`, `RadioButton`, and `ChoiceList` ([#1145](https://github.com/Shopify/polaris-react/pull/1145))

--- a/src/components/TextField/components/Resizer/Resizer.tsx
+++ b/src/components/TextField/components/Resizer/Resizer.tsx
@@ -90,9 +90,10 @@ const ENTITIES_TO_REPLACE = {
   '&': '&amp;',
   '<': '&lt;',
   '>': '&gt;',
+  '\n': '<br>',
 };
 
-const REPLACE_REGEX = /[&<>]/g;
+const REPLACE_REGEX = /[\n&<>]/g;
 
 function replaceEntity(entity: keyof typeof ENTITIES_TO_REPLACE) {
   return ENTITIES_TO_REPLACE[entity] || entity;

--- a/src/components/TextField/components/Resizer/Resizer.tsx
+++ b/src/components/TextField/components/Resizer/Resizer.tsx
@@ -90,10 +90,9 @@ const ENTITIES_TO_REPLACE = {
   '&': '&amp;',
   '<': '&lt;',
   '>': '&gt;',
-  '\n': '<br>',
 };
 
-const REPLACE_REGEX = /[\n&<>]/g;
+const REPLACE_REGEX = /[&<>]/g;
 
 function replaceEntity(entity: keyof typeof ENTITIES_TO_REPLACE) {
   return ENTITIES_TO_REPLACE[entity] || entity;

--- a/src/components/TextField/components/Resizer/Resizer.tsx
+++ b/src/components/TextField/components/Resizer/Resizer.tsx
@@ -94,12 +94,13 @@ const ENTITIES_TO_REPLACE = {
   '\r': '',
 };
 
-const REPLACE_REGEX = /[\n\r&<>]/g;
+const REPLACE_REGEX = new RegExp(
+  `[${Object.keys(ENTITIES_TO_REPLACE).join()}]`,
+  'g',
+);
 
 function replaceEntity(entity: keyof typeof ENTITIES_TO_REPLACE) {
-  return ENTITIES_TO_REPLACE[entity] === undefined
-    ? entity
-    : ENTITIES_TO_REPLACE[entity];
+  return ENTITIES_TO_REPLACE[entity];
 }
 
 function getContentsForMinimumLines(minimumLines: number) {

--- a/src/components/TextField/components/Resizer/Resizer.tsx
+++ b/src/components/TextField/components/Resizer/Resizer.tsx
@@ -91,12 +91,15 @@ const ENTITIES_TO_REPLACE = {
   '<': '&lt;',
   '>': '&gt;',
   '\n': '<br>',
+  '\r': '',
 };
 
-const REPLACE_REGEX = /[\n&<>]/g;
+const REPLACE_REGEX = /[\n\r&<>]/g;
 
 function replaceEntity(entity: keyof typeof ENTITIES_TO_REPLACE) {
-  return ENTITIES_TO_REPLACE[entity] || entity;
+  return ENTITIES_TO_REPLACE[entity] === undefined
+    ? entity
+    : ENTITIES_TO_REPLACE[entity];
 }
 
 function getContentsForMinimumLines(minimumLines: number) {

--- a/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
+++ b/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
@@ -30,6 +30,17 @@ describe('<Resizer />', () => {
         '&lt;div&gt;&amp;<br>Contents&lt;/div&gt;<br></div>';
       expect(contentsNode.html()).toContain(expectedEncodedContents);
     });
+
+    it('ignores carriage returns when rendering content', () => {
+      const contents = `<div>&\n\r\r\rContents</div>`;
+      const resizer = mountWithAppProvider(
+        <Resizer {...mockProps} contents={contents} />,
+      );
+      const contentsNode = findByTestID(resizer, 'ContentsNode');
+      const expectedEncodedContents =
+        '&lt;div&gt;&amp;<br>Contents&lt;/div&gt;<br></div>';
+      expect(contentsNode.html()).toContain(expectedEncodedContents);
+    });
   });
 
   describe('minimumLines', () => {


### PR DESCRIPTION
The `TextField` component sizes itself incorrectly due to the way it handles some whitespace characters. 

For example, here’s some text that a user submitted in a Rails app. Notice how the text includes carriage returns (`\r`):
![image](https://user-images.githubusercontent.com/1395522/51455773-21cd4780-1d19-11e9-887d-59a77c64da79.png)


This is how the content gets rendered in a multiline `TextField`:
![image](https://user-images.githubusercontent.com/1395522/51455783-28f45580-1d19-11e9-9516-aa88d931b453.png)


If we take out all the carriage returns, the exact same piece of text renders like this:
![image](https://user-images.githubusercontent.com/1395522/51455790-301b6380-1d19-11e9-9b9c-5ac23129ec6c.png)


The extra height visible seems to stem from two factors: 
1. [This CSS property](https://github.com/Shopify/polaris-react/blob/master/src/components/TextField/TextField.scss#L207):
```
white-space: pre-wrap;
```
2. [This code](https://github.com/Shopify/polaris-react/blob/master/src/components/TextField/components/Resizer/Resizer.tsx#L93) in the `Resizer` component:
``` js
const ENTITIES_TO_REPLACE = {
  '&': '&amp;',
  '<': '&lt;',
  '>': '&gt;',
  '\n': '<br>',
};

const REPLACE_REGEX = /[\n&<>]/g;

function replaceEntity(entity: keyof typeof ENTITIES_TO_REPLACE) {
  return ENTITIES_TO_REPLACE[entity] || entity;
}
```
The expectation here is that each newline is converted to a `<br>` so the `DummyInput` div can correctly size itself, but somewhere in the process the remaining carriage returns are also being considered as line breaks, so the `DummyInput` div now contains one extra line for each carriage return character, resulting in the `TextField` component having additional space at the bottom unrelated to it's contents actually height.

Another solution that worked was replacing all the carriage returns with nothing, along the lines of:
```
  '\n': '<br>',
  '\r': '',
```

### WHAT is this pull request doing?


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        {/* Add the code you want to test here */}
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
