### PR TITLE
[TextField] Expose title attribute

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -86,6 +86,8 @@ export interface BaseProps {
   minLength?: number;
   /** A regular expression to check the value against */
   pattern?: string;
+  /** Title text for the input */
+  title?: string;
   /** Indicate whether value should have spelling checked */
   spellCheck?: boolean;
   /** Indicates the id of a component owned by the input */
@@ -173,6 +175,7 @@ export default class TextField extends React.PureComponent<Props, State> {
       maxLength,
       spellCheck,
       pattern,
+      title,
       ariaOwns,
       ariaActiveDescendant,
       ariaAutocomplete,
@@ -270,6 +273,7 @@ export default class TextField extends React.PureComponent<Props, State> {
       maxLength,
       spellCheck,
       pattern,
+      title,
       type: inputType,
       'aria-describedby': describedBy.length
         ? describedBy.join(' ')

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -24,6 +24,7 @@ describe('<TextField />', () => {
         maxLength={2}
         spellCheck={false}
         pattern={pattern}
+        title="Title text"
       />,
     ).find('input');
 
@@ -39,6 +40,7 @@ describe('<TextField />', () => {
     expect(input.prop('maxLength')).toBe(2);
     expect(input.prop('spellCheck')).toBe(false);
     expect(input.prop('pattern')).toBe(pattern);
+    expect(input.prop('title')).toBe('Title text');
   });
 
   it('blocks props not listed as component props to pass on the input', () => {


### PR DESCRIPTION
This exposes the `title` HTML attribute as a prop on `<TextField />`.

### WHY are these changes introduced?

The motivation for this is to provide better feedback when using the `pattern` attribute. MDN provides the following "tip":

> Use the `title` attribute to specify text that most browsers will display as a tooltip to explain what the requirements are to match the pattern. You should also include other explanatory text nearby.

See [MDN's section on `pattern`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text#pattern) for details.

### WHAT is this pull request doing?

Exposes the `title` HTML attribute as a prop on `<TextField />`.

#### Code

<table>
<theader>
<tr>
<th>Without <code>title</code></th>
<th>With <code>title</code></th>
</tr>
</theader>

<tbody>
<tr>
<td>

```jsx
<TextField
  pattern="^text$"
  ...
/>
```

</td>
<td>

```jsx
<TextField
  pattern="^text$"
  title="Enter 'text'"
  ...
/>
```

</td>
</tr>
</tbody>
</table>

#### On hover

Without `title`|With `title`
-|-
![image](https://user-images.githubusercontent.com/8219340/51493511-8de49580-1d83-11e9-9f32-50842abf58ba.png)|![image](https://user-images.githubusercontent.com/8219340/51493513-9046ef80-1d83-11e9-9aef-45646c66fb53.png)

#### On submission of content not matching `pattern`

Without `title`|With `title`
-|-
|![image](https://user-images.githubusercontent.com/8219340/51493507-8a510e80-1d83-11e9-881d-9965e70cac81.png)|![image](https://user-images.githubusercontent.com/8219340/51493525-9ccb4800-1d83-11e9-91a6-9547ddbd284a.png)


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {TextField, Form} from '../src';

interface State {
  text: string;
}

export default class Playground extends React.Component<{}, State> {
  state = {text: ''};

  render() {
    return (
      <Form onSubmit={this.handleSubmit}>
        <TextField
          label="Label text"
          onChange={this.handleChange}
          pattern="^text$"
          title="Enter 'text'"
          value={this.state.text}
        />
      </Form>
    );
  }

  private handleChange = (text) => {
    this.setState({text});
  };

  private handleSubmit = () => {
    console.log(`Input: ${this.state.text}`);
  };
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->

----
cc. @alanhill