### PR TITLE
Add injectable cell props to DataTable

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Updated `DataTable` to support _injectable_ `Cell` props ([#915](https://github.com/Shopify/polaris-react/pull/915))
+
 ### Bug fixes
 
 - Removed a duplicate `activatorWrapper` in `Popover` when destructuring props ([#916](https://github.com/Shopify/polaris-react/pull/916))

--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -103,6 +103,17 @@ $breakpoint: 768px;
   vertical-align: top;
 }
 
+.Cell-link {
+  padding: 0;
+
+  > a {
+    display: block;
+    padding: spacing();
+    color: inherit;
+    text-decoration: none;
+  }
+}
+
 .Cell-numeric {
   text-align: right;
 }

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -243,6 +243,124 @@ class DataTableLinkExample extends React.Component {
 }
 ```
 
+### Data table with row links
+
+Use to link individual rows
+
+```jsx
+class DataTableRowLinkExample extends React.Component {
+  render() {
+    const rows = [
+      {
+        cells: ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+        url: '/product/124689',
+      },
+      {
+        cells: ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+        url: '/product/124533',
+      },
+      {
+        cells: [
+          'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+          '$445.00',
+          124518,
+          32,
+          '$14,240.00',
+        ],
+        url: '/product/124518',
+      },
+    ];
+
+    return (
+      <Page title="Sales by product">
+        <Card>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Quantity',
+              'Net sales',
+            ]}
+            rows={rows}
+            totals={['', '', '', 255, '$155,830.00']}
+          />
+        </Card>
+      </Page>
+    );
+  }
+}
+```
+
+### Data table with cell links
+
+Use to link individual cells
+
+```jsx
+class DataTableCellLinkExample extends React.Component {
+  render() {
+    const rows = [
+      [
+        {content: 'Emerald Silk Gown', url: '/product/124689'},
+        '$875.00',
+        124689,
+        140,
+        '$122,500.00',
+      ],
+      [
+        {content: 'Mauve Cashmere Scarf', url: '/product/124533'},
+        '$230.00',
+        124533,
+        83,
+        '$19,090.00',
+      ],
+      [
+        {
+          content: 'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+          url: '/product/124518',
+        },
+        '$445.00',
+        124518,
+        32,
+        '$14,240.00',
+      ],
+    ];
+
+    return (
+      <Page title="Sales by product">
+        <Card>
+          <DataTable
+            columnContentTypes={[
+              'text',
+              'numeric',
+              'numeric',
+              'numeric',
+              'numeric',
+            ]}
+            headings={[
+              'Product',
+              'Price',
+              'SKU Number',
+              'Quantity',
+              'Net sales',
+            ]}
+            rows={rows}
+            totals={['', '', '', 255, '$155,830.00']}
+          />
+        </Card>
+      </Page>
+    );
+  }
+}
+```
+
 ---
 
 ## Best practices

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -4,17 +4,22 @@ import {classNames} from '@shopify/react-utilities/styles';
 import {headerCell} from '../../../shared';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 import Icon, {IconSource} from '../../../Icon';
+import UnstyledLink from '../../../UnstyledLink';
 import {SortDirection} from '../../types';
 
 import * as styles from '../../DataTable.scss';
 
-export interface Props {
-  testID?: string;
+export interface InjectableProps {
   height?: number;
   content?: React.ReactNode;
   contentType?: string;
   fixed?: boolean;
   truncate?: boolean;
+  url?: string;
+}
+
+export interface Props extends InjectableProps {
+  testID?: string;
   header?: boolean;
   total?: boolean;
   footer?: boolean;
@@ -44,11 +49,13 @@ function Cell({
     intl: {translate},
   },
   onSort,
+  url,
 }: CombinedProps) {
   const numeric = contentType === 'numeric';
 
   const className = classNames(
     styles.Cell,
+    url && styles['Cell-link'],
     fixed && styles['Cell-fixed'],
     fixed && truncate && styles['Cell-truncated'],
     header && styles['Cell-header'],
@@ -97,6 +104,13 @@ function Cell({
   );
 
   const columnHeadingContent = sortable ? sortableHeadingContent : content;
+  const cellContent = url ? (
+    <UnstyledLink url={url} style={style}>
+      {content}
+    </UnstyledLink>
+  ) : (
+    content
+  );
 
   const headingMarkup = header ? (
     <th
@@ -109,8 +123,8 @@ function Cell({
       {columnHeadingContent}
     </th>
   ) : (
-    <th className={className} scope="row" style={style}>
-      {content}
+    <th className={className} scope="row" style={url ? undefined : style}>
+      {cellContent}
     </th>
   );
 
@@ -118,8 +132,8 @@ function Cell({
     header || fixed ? (
       headingMarkup
     ) : (
-      <td className={className} style={style}>
-        {content}
+      <td className={className} style={url ? undefined : style}>
+        {cellContent}
       </td>
     );
 

--- a/src/components/DataTable/components/Cell/index.ts
+++ b/src/components/DataTable/components/Cell/index.ts
@@ -1,4 +1,4 @@
 import Cell from './Cell';
 
-export {Props} from './Cell';
+export {InjectableProps, Props} from './Cell';
 export default Cell;

--- a/src/components/DataTable/components/index.ts
+++ b/src/components/DataTable/components/index.ts
@@ -1,3 +1,7 @@
-export {default as Cell, Props as CellProps} from './Cell';
+export {
+  default as Cell,
+  InjectableProps as InjectableCellProps,
+  Props as CellProps,
+} from './Cell';
 
 export {default as Navigation, Props as NavigationProps} from './Navigation';

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -62,6 +62,98 @@ describe('<DataTable />', () => {
     expect(dataTable.find('tbody tr')).toHaveLength(3);
   });
 
+  it('passes injectable row props to cells', () => {
+    const url = '#test';
+    const content = 'Cell1';
+    const props = {
+      columnContentTypes: ['text'] as Props['columnContentTypes'],
+      headings: ['Col1'],
+      rows: [{cells: [content], url}],
+    };
+
+    const dataTable = mountWithAppProvider(<DataTable {...props} />);
+
+    expect(
+      dataTable
+        .find(Cell)
+        .last()
+        .props(),
+    ).toMatchObject({
+      content,
+      url,
+    });
+  });
+
+  it('passes injectable cell props to cells', () => {
+    const url = '#test';
+    const content = 'Cell1';
+    const props = {
+      columnContentTypes: ['text'] as Props['columnContentTypes'],
+      headings: ['Col1'],
+      rows: [[{content, url}]],
+    };
+
+    const dataTable = mountWithAppProvider(<DataTable {...props} />);
+
+    expect(
+      dataTable
+        .find(Cell)
+        .last()
+        .props(),
+    ).toMatchObject({
+      content,
+      url,
+    });
+  });
+
+  it('overrides injectable row props with injectable cell props', () => {
+    const url = '#cell';
+    const content = 'Cell1';
+    const props = {
+      columnContentTypes: ['text'] as Props['columnContentTypes'],
+      headings: ['Col1'],
+      rows: [{cells: [{content, url}], url: '#row'}],
+    };
+
+    const dataTable = mountWithAppProvider(<DataTable {...props} />);
+
+    expect(
+      dataTable
+        .find(Cell)
+        .last()
+        .props(),
+    ).toMatchObject({
+      content,
+      url,
+    });
+  });
+
+  it('overrides DataTable props with injectable props', () => {
+    const content = 'Cell1';
+    const truncate = false;
+    const props = {
+      columnContentTypes: ['text'] as Props['columnContentTypes'],
+      headings: ['Col1'],
+      rows: [[{content, truncate}]],
+      truncate: true,
+    };
+
+    const dataTable = mountWithAppProvider(<DataTable {...props} />);
+
+    expect(dataTable.find(DataTable).props()).toMatchObject({
+      truncate: true,
+    });
+    expect(
+      dataTable
+        .find(Cell)
+        .last()
+        .props(),
+    ).toMatchObject({
+      content,
+      truncate,
+    });
+  });
+
   it('defaults to non-sorting column headings', () => {
     const {dataTable} = setup();
     const sortableHeadings = dataTable.find(Cell).filter({sortable: true});
@@ -112,6 +204,22 @@ describe('<DataTable />', () => {
           .first()
           .prop('contentType'),
       ).toEqual('text');
+    });
+
+    it('renders a link cell when a url prop is provided', () => {
+      const url = '#test';
+      const content = 'Cell1';
+      const props = {
+        columnContentTypes: ['text'] as Props['columnContentTypes'],
+        headings: ['Col1'],
+        rows: [[{content, url}]],
+      };
+
+      const dataTable = mountWithAppProvider(<DataTable {...props} />);
+
+      expect(dataTable.find('a').props()).toMatchObject({
+        href: url,
+      });
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

<!--
  Context about the problem that’s being addressed.
-->

The `DataTable` did not previously support full bound linkable cells.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

By first adding some more structure to the `rows` prop on the `DataTable` component, we can support custom prop injections per cell (also per row, which are projected down to the cell props). This enables a simple modification to the `Cell` props adding `url?: string` to enable new rendering capabilities. When the `url` prop is supplied the cell content is wrapped in an `UnstyledLink` and padding is shuffled off of the `<td>` and onto the link.

The injectable props enable a lot more customizations than just the new `url` rendering. There are a number of new capabilities opened up with this type of cell composition, some of these capabilities may be too wide reaching. Fortunately, it is very easy to move injectable props to _non-injectable_ props if we feel any prop should not allow overrides. The current set of injectable props was taken from the pre-existing props being passed to a typical cell (found in the `defaultRenderRow` function).

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {DataTable, Page} from '../src';

export default class Playground extends React.PureComponent {
  render() {
    return (
      <Page title="Playground">
        <DataTable
          columnContentTypes={['text', 'text']}
          headings={['Col 1', 'Col 2']}
          rows={[
            ['No Link', {content: 'Cell Link', url: '#cell'}],
            {
              cells: [
                {content: 'Cell Override', url: '#cell-override'},
                'Row Link',
              ],
              url: '#row',
            },
          ]}
        />
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
