### PR TITLE
[Toast] Add `action` prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Updated `Navigation` badge prop to accept a react node ([#1142](https://github.com/Shopify/polaris-react/pull/1142))
 - Changed max width on `Search` to 694px so that it is perfectly centered in the top bar ([#1107](https://github.com/Shopify/polaris-react/issues/1107))
+- Added `action` prop to `Toast` ([#919](https://github.com/Shopify/polaris-react/pull/919))
 
 ### Bug fixes
 

--- a/src/components/Frame/components/Toast/Toast.scss
+++ b/src/components/Frame/components/Toast/Toast.scss
@@ -4,7 +4,7 @@ $Backdrop-opacity: 0.88;
 .Toast {
   @include text-style-display-small;
   display: inline-flex;
-  max-width: rem(400px);
+  max-width: rem(500px);
   padding: spacing(tight) spacing();
   border-radius: border-radius();
   background: rgba(color('black'), $Backdrop-opacity);
@@ -15,6 +15,11 @@ $Backdrop-opacity: 0.88;
   @include breakpoint-after($breakpoint) {
     padding: spacing();
   }
+}
+
+.Action {
+  margin-left: spacing(extra-loose);
+  margin-right: spacing();
 }
 
 .error {

--- a/src/components/Frame/components/Toast/Toast.tsx
+++ b/src/components/Frame/components/Toast/Toast.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {classNames} from '@shopify/react-utilities';
 
 import {Key} from '../../../../types';
+import Button from '../../../Button';
 
 import Icon from '../../../Icon';
 import KeypressListener from '../../../KeypressListener';
@@ -10,6 +11,7 @@ import {ToastProps as Props} from '../../types';
 import styles from './Toast.scss';
 
 export const DEFAULT_TOAST_DURATION = 5000;
+export const DEFAULT_TOAST_DURATION_WITH_ACTION = 10000;
 
 export default class Toast extends React.Component<Props, never> {
   private timer?: number;
@@ -27,13 +29,26 @@ export default class Toast extends React.Component<Props, never> {
   }
 
   render() {
-    const {content, onDismiss, error} = this.props;
+    const {content, onDismiss, error, action} = this.props;
 
     const dismissMarkup = (
-      <button type="button" className={styles.CloseButton} onClick={onDismiss}>
+      <button
+        type="button"
+        className={styles.CloseButton}
+        onClick={onDismiss}
+        testID="closeButton"
+      >
         <Icon source="cancel" />
       </button>
     );
+
+    const actionMarkup = action ? (
+      <div className={styles.Action}>
+        <Button plain monochrome onClick={action.onAction}>
+          {action.content}
+        </Button>
+      </div>
+    ) : null;
 
     const className = classNames(styles.Toast, error && styles.error);
 
@@ -41,6 +56,7 @@ export default class Toast extends React.Component<Props, never> {
       <div className={className}>
         <KeypressListener keyCode={Key.Escape} handler={onDismiss} />
         {content}
+        {actionMarkup}
         {dismissMarkup}
       </div>
     );
@@ -53,11 +69,26 @@ export default class Toast extends React.Component<Props, never> {
   }
 
   private triggerDismissalTimeout() {
-    const {onDismiss, duration = DEFAULT_TOAST_DURATION} = this.props;
+    const {onDismiss, duration, action} = this.props;
+
+    let timeoutDuration = duration || DEFAULT_TOAST_DURATION;
+
+    if (action && !duration) {
+      timeoutDuration = DEFAULT_TOAST_DURATION_WITH_ACTION;
+    } else if (
+      action &&
+      duration &&
+      duration < DEFAULT_TOAST_DURATION_WITH_ACTION
+    ) {
+      // eslint-disable-next-line-no-console
+      console.log(
+        'Toast with action should persist for at least 10,000 milliseconds to give the merchant enough time to act on it.',
+      );
+    }
 
     this.clearDismissalTimeout();
-    if (onDismiss != null && duration != null) {
-      this.timer = window.setTimeout(onDismiss, duration);
+    if (onDismiss != null) {
+      this.timer = window.setTimeout(onDismiss, timeoutDuration);
     }
   }
 }

--- a/src/components/Frame/components/Toast/Toast.tsx
+++ b/src/components/Frame/components/Toast/Toast.tsx
@@ -80,7 +80,7 @@ export default class Toast extends React.Component<Props, never> {
       duration &&
       duration < DEFAULT_TOAST_DURATION_WITH_ACTION
     ) {
-      // eslint-disable-next-line-no-console
+      // eslint-disable-next-line no-console
       console.log(
         'Toast with action should persist for at least 10,000 milliseconds to give the merchant enough time to act on it.',
       );

--- a/src/components/Frame/components/Toast/index.ts
+++ b/src/components/Frame/components/Toast/index.ts
@@ -1,1 +1,5 @@
-export {default, DEFAULT_TOAST_DURATION} from './Toast';
+export {
+  default,
+  DEFAULT_TOAST_DURATION,
+  DEFAULT_TOAST_DURATION_WITH_ACTION,
+} from './Toast';

--- a/src/components/Frame/components/index.ts
+++ b/src/components/Frame/components/index.ts
@@ -1,4 +1,8 @@
-export {default as Toast, DEFAULT_TOAST_DURATION} from './Toast';
+export {
+  default as Toast,
+  DEFAULT_TOAST_DURATION,
+  DEFAULT_TOAST_DURATION_WITH_ACTION,
+} from './Toast';
 export {
   default as ToastManager,
   Props as ToastManagerProps,

--- a/src/components/Frame/index.ts
+++ b/src/components/Frame/index.ts
@@ -2,7 +2,10 @@ import Frame from './Frame';
 
 export {Props} from './Frame';
 
-export {DEFAULT_TOAST_DURATION} from './components';
+export {
+  DEFAULT_TOAST_DURATION,
+  DEFAULT_TOAST_DURATION_WITH_ACTION,
+} from './components';
 
 export {
   ContextualSaveBarProps,

--- a/src/components/Frame/types.ts
+++ b/src/components/Frame/types.ts
@@ -1,4 +1,5 @@
 import * as PropTypes from 'prop-types';
+import {Action} from '../../types';
 
 export interface FrameManager {
   showToast(toast: {id: string} & ToastProps): void;
@@ -63,4 +64,6 @@ export interface ToastProps {
   error?: boolean;
   /** Callback when the dismiss icon is clicked */
   onDismiss(): void;
+  /** Adds an action next to the message (stand-alone app use only) */
+  action?: Action;
 }

--- a/src/components/Toast/README.md
+++ b/src/components/Toast/README.md
@@ -68,10 +68,18 @@ class EmbeddedAppToastExample extends React.Component {
 
 Toast should:
 
-- Be used for short messages to confirm an action. Maximum of 2 lines of text.
-- Not be used for actionable links or messages.
-- Not be used for error messages.
-- Be displayed once at the time. If you need multiple toasts, queue them.
+- Be used for short messages to confirm an action
+- Not go over 3 words
+- Rarely be used for error messages
+
+When to use:
+
+- For success messages
+- Only for non-critical errors that are relevant in the moment and can be explained in 3 words. For example, if there’s an internet connection issue, the toast would say, Internet disconnected.
+
+When not to use:
+
+- Avoid using toast for error messages. Always try to use a banner to prominently inform merchants about persistent errors.
 
 ---
 
@@ -79,7 +87,7 @@ Toast should:
 
 ### Message
 
-Messages should be:
+Toast messages should be:
 
 - Short and affirmative
 - Written in the pattern of: noun + verb
@@ -91,10 +99,14 @@ Messages should be:
 - Product updated
 - Collection added
 - Customer updated
-- No internet connection
+- Internet disconnected
+- Connection timed out
 
 #### Don’t
 
+- No internet connection
+- Can’t charge negative tax rates
+- Your online store has a maximum of 20 themes. Delete unused themes to add more.
 - Your product has been successfully updated
 - We were unable to save the customer
 - Your Order was Archived Today
@@ -102,12 +114,18 @@ Messages should be:
 
 <!-- end -->
 
-### Action
+### Toast with action
+
+Only include an action in toast if the same action is available elsewhere on the page. For example:
+
+- If merchants need to reload a section, offer the call to action [Reload] in the toast. If they miss the toast message, they can also refresh the entire page.
+- If merchants delete an image, offer the option to [Undo] the deletion. If they miss it in the toast message, they can still retrieve it from somewhere else.
 
 Action should:
 
-- Keep the action label short. Preferably 1 verb
-- Not have actions for dismissing toast
+- Keep the action label short, preferably 1 verb.
+- Not have actions, like [Cancel], for dismissing toast. The [X] to dismiss is already included in the component.
+- Be used with a duration of at least 10,000 milliseconds for accessibility.
 
 <!-- usagelist -->
 
@@ -258,6 +276,50 @@ class ToastExample extends React.Component {
 }
 ```
 
+### Toast with action
+
+<!-- example-for: web -->
+
+Use when a merchant has the ability to act on the message. For example, to undo a change or retry an action.
+
+```jsx
+class ToastExample extends React.Component {
+  state = {
+    showToast: false,
+  };
+
+  render() {
+    const {showToast} = this.state;
+    const toastMarkup = showToast ? (
+      <Toast
+        content="Image deleted"
+        action={{
+          content: 'Undo',
+          onAction: () => {},
+        }}
+        duration={10000}
+        onDismiss={this.toggleToast}
+      />
+    ) : null;
+
+    return (
+      <div style={{height: '250px'}}>
+        <Frame>
+          <Page title="Toast example">
+            <Button onClick={this.toggleToast}>Show Toast</Button>
+            {toastMarkup}
+          </Page>
+        </Frame>
+      </div>
+    );
+  }
+
+  toggleToast = () => {
+    this.setState(({showToast}) => ({showToast: !showToast}));
+  };
+}
+```
+
 ### Default toast
 
 <!-- example-for: android, ios -->
@@ -302,7 +364,7 @@ On iOS, icons are available for cases where you want to re-inforce the message.
 
 <!-- example-for: android, ios, web -->
 
-Use error toast to indicate that an operation has failed. For example, your phone is offline and need to reconnect to the internet. For all other error message types, follow the [error message guidelines](/patterns/error-messages).
+Although error toast is still available and used in the system, we discourage its use. Reserve it for errors not caused by merchants, like a connection issue. Error toast should convey what went wrong in plain language and should not go over 3 words. For all other error message types, follow the [error message guidelines](/patterns/error-messages).
 
 <!-- content-for: web -->
 
@@ -356,8 +418,7 @@ On iOS, icons are available for cases where you want to re-inforce the message.
 
 <!-- example-for: android, ios -->
 
-Use action when you have the ability to act on the message. For example, undo changes, or edit message.
-Keep the action label short, preferably 1 verb action.
+Use action when merchants have the ability to act on the message. For example, to undo a change or retry an action. Keep the action label short, preferably 1 verb action.
 
 <!-- content-for: android -->
 
@@ -377,3 +438,25 @@ Keep the action label short, preferably 1 verb action.
 
 - To present a small amount of content or a menu of actions in a non-blocking overlay, [use the popover component](/components/popover)
 - To communicate a change or condition that needs the merchant’s attention within the context of a page, [use the banner component](/components/feedback-indicators/banner)
+
+---
+
+## Accessibility
+
+ <!-- content-for: web -->
+
+The content of the toast component is implemented as an ARIA live region using `aria-live="polite"`. When the toast appears, screen readers should announce the toast text after any other more pressing announcements.
+
+Avoid using toast for critical information that merchants need to act on immediately. Toast might be difficult for merchants with low vision or low dexterity to access because it:
+
+- Disappears automatically
+- Can’t be easily accessed with the keyboard
+- Might appear outside the proximity of the merchant’s current focus
+
+### Toast with action
+
+Make sure that merchants can also accomplish the action in the toast another way, since the toast action may be difficult to access for some merchants. If the toast action is not available somewhere else on the page, for example a retry action that reloads a section, it should have a fallback action, for example a browser refresh.
+
+Toast with action should persist for at least 10,000 milliseconds to give the merchant enough time to act on it.
+
+ <!-- /content-for -->

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -138,6 +138,7 @@ export {
   ContextualSaveBarProps,
   ToastProps,
   DEFAULT_TOAST_DURATION,
+  DEFAULT_TOAST_DURATION_WITH_ACTION,
 } from './Frame';
 
 export {default as Heading, Props as HeadingProps} from './Heading';

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -220,10 +220,6 @@
     "TextField": {
       "characterCount": "{count} characters",
       "characterCountWithMaxLength": "{count} of {limit} characters used"
-    },
-
-    "Toast": {
-      "durationWarning": "Toast with action should persist for at least 10,000 milliseconds to give the merchant enough time to act on it."
     }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -220,6 +220,10 @@
     "TextField": {
       "characterCount": "{count} characters",
       "characterCountWithMaxLength": "{count} of {limit} characters used"
+    },
+
+    "Toast": {
+      "durationWarning": "Toast with action should persist for at least 10,000 milliseconds to give the merchant enough time to act on it."
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #553

As highlight on this comment https://github.com/Shopify/polaris-react/issues/553#issuecomment-436714929, there are some use cases for the action inside `Toast` in `online-store-web` project. 

### WHAT is this pull request doing?

Adds the action prop to `Toast`, shows a `<Button />` when `action` is defined. Follows designs from #553. Adds clarification in the docs about how to use it. As far as app-bridge, for now, there will be no action.

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Frame, Toast, Button, Pagination, Key} from '../src';

interface State {
  showToast: boolean;
}

export default class Playground extends React.Component<{}, State> {
  state = {
    showToast: false,
  };

  toggleToast = () => {
    this.setState(({showToast}) => ({showToast: !showToast}));
  };

  render() {
    const {showToast} = this.state;
    const toastMarkup = showToast ? (
      <Toast
        content="Image deleted"
        // duration={10000}
        onDismiss={this.toggleToast}
        action={{content: 'Retry'}}
      />
    ) : null;
    return (
      <Page title="Playground">
        <Frame>
          <Button onClick={this.toggleToast}>Show Toast</Button>
          {toastMarkup}
        </Frame>
      </Page>
    );
  }
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
