### PR TITLE
Only optimize our svgs when building

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,6 +26,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Development workflow
 
+- Improve Build speed ([#912](https://github.com/Shopify/polaris-react/pull/912) and [#920](https://github.com/Shopify/polaris-react/pull/920))
+
 ### Dependency upgrades
 
 - Updated App Bridge to version 1.0.3 ([#844](https://github.com/Shopify/polaris-react/pull/844))

--- a/scripts/optimize.js
+++ b/scripts/optimize.js
@@ -10,7 +10,7 @@ const {svgOptions} = require('@shopify/images/optimize');
 
 const svgo = new SVGO(svgOptions());
 
-glob(resolvePath(__dirname, '../**/*.svg'), (error, files) => {
+glob(resolvePath(__dirname, '../src/**/*.svg'), (error, files) => {
   if (error) {
     console.error(error);
     process.exit(1);


### PR DESCRIPTION
### WHY are these changes introduced?

Previously this tried to optimize all svgs, including those in the node_modules folder - all of which we never use and many of which are complex. Instead lets only target svgs we actually care about - those within our src folder.

This makes the optimize build step take about 250ms instead of 4300ms -
shaving about 4 seconds off our build time.

### WHAT is this pull request doing?

Only optimize svgs in the `src` folder

### How to 🎩

- On master, create a build output: `git checkout master && mkdir master-build/node_modules/@shopify && yarn run build-consumer polaris-react/master-build`
- On this branch create a build output: `git checkout only-optimize-our-svgs && mkdir new-build/node_modules/@shopify && yarn run build-consumer polaris-react/new-build`
- Compare the outputs and ensure they are the same: `diff -r -u master-build new-build`

