### PR TITLE
[Icon] Use img tag instead of inlining svgs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Updates `TopBar.UserMenu` interaction states styling ([#1006](https://github.com/Shopify/polaris-react/pull/1006))
 - Added `download` prop to `Button` and `UnstyledLink` components that enables setting the download attribute ([#1027](https://github.com/Shopify/polaris-react/pull/1027))
 - Extract months and week names into translation files ([#1005](https://github.com/Shopify/polaris-react/pull/1005))
+- Added `untrusted` prop to `Icon` to render SVG strings in an img tag ([#926](https://github.com/Shopify/polaris-react/pull/926))
 
 ### Bug fixes
 

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -3,6 +3,16 @@ $stacking-order: (
   icon: 2,
 );
 
+@mixin color-icon($value, $hue: base) {
+  svg {
+    fill: color($value, $hue);
+  }
+
+  img {
+    filter: filter($value, $hue);
+  }
+}
+
 .Icon {
   display: block;
   height: rem(20px);
@@ -35,36 +45,36 @@ $stacking-order: (
 }
 
 .colorWhite {
-  fill: color('white');
+  @include color-icon('white');
   color: transparent;
 }
 
 .colorBlack {
-  fill: color('black');
+  @include color-icon('black');
 }
 
 .colorSkyLighter {
-  fill: color('sky', 'lighter');
+  @include color-icon('sky', 'lighter');
 }
 
 .colorSkyLight {
-  fill: color('sky', 'light');
+  @include color-icon('sky', 'light');
 }
 
 .colorSky {
-  fill: color('sky');
+  @include color-icon('sky');
 }
 
 .colorSkyDark {
-  fill: color('sky', 'dark');
+  @include color-icon('sky', 'dark');
 }
 
 .colorInkLightest {
-  fill: color('ink', 'lightest');
+  @include color-icon('ink', 'lightest');
 }
 
 .colorInkLighter {
-  fill: color('ink', 'lighter');
+  @include color-icon('ink', 'lighter');
 
   &::after {
     background-color: color('sky');
@@ -72,11 +82,11 @@ $stacking-order: (
 }
 
 .colorInkLight {
-  fill: color('ink', 'light');
+  @include color-icon('ink', 'light');
 }
 
 .colorInk {
-  fill: color('ink');
+  @include color-icon('ink');
 
   &::after {
     background-color: color('sky');
@@ -84,19 +94,19 @@ $stacking-order: (
 }
 
 .colorBlueLighter {
-  fill: color('blue', 'lighter');
+  @include color-icon('blue', 'lighter');
 }
 
 .colorBlueLight {
-  fill: color('blue', 'light');
+  @include color-icon('blue', 'light');
 }
 
 .colorBlue {
-  fill: color('blue');
+  @include color-icon('blue');
 }
 
 .colorBlueDark {
-  fill: color('blue', 'dark');
+  @include color-icon('blue', 'dark');
 
   &::after {
     background-color: color('blue', 'light');
@@ -104,39 +114,39 @@ $stacking-order: (
 }
 
 .colorBlueDarker {
-  fill: color('blue', 'darker');
+  @include color-icon('blue', 'darker');
 }
 
 .colorIndigoLighter {
-  fill: color('indigo', 'lighter');
+  @include color-icon('indigo', 'lighter');
 }
 
 .colorIndigoLight {
-  fill: color('indigo', 'light');
+  @include color-icon('indigo', 'light');
 }
 
 .colorIndigo {
-  fill: color('indigo');
+  @include color-icon('indigo');
 }
 
 .colorIndigoDark {
-  fill: color('indigo', 'dark');
+  @include color-icon('indigo', 'dark');
 }
 
 .colorIndigoDarker {
-  fill: color('indigo', 'darker');
+  @include color-icon('indigo', 'darker');
 }
 
 .colorTealLighter {
-  fill: color('teal', 'lighter');
+  @include color-icon('teal', 'lighter');
 }
 
 .colorTealLight {
-  fill: color('teal', 'light');
+  @include color-icon('teal', 'light');
 }
 
 .colorTeal {
-  fill: color('teal');
+  @include color-icon('teal');
 
   &::after {
     background-color: color('white');
@@ -144,7 +154,7 @@ $stacking-order: (
 }
 
 .colorTealDark {
-  fill: color('teal', 'dark');
+  @include color-icon('teal', 'dark');
 
   &::after {
     background-color: color('teal', 'light');
@@ -152,15 +162,15 @@ $stacking-order: (
 }
 
 .colorTealDarker {
-  fill: color('teal', 'darker');
+  @include color-icon('teal', 'darker');
 }
 
 .colorGreenLighter {
-  fill: color('green', 'lighter');
+  @include color-icon('green', 'lighter');
 }
 
 .colorGreen {
-  fill: color('green');
+  @include color-icon('green');
 
   &::after {
     background-color: color('green', 'lighter');
@@ -168,7 +178,7 @@ $stacking-order: (
 }
 
 .colorGreenDark {
-  fill: color('green', 'dark');
+  @include color-icon('green', 'dark');
 
   &::after {
     background-color: color('green', 'light');
@@ -176,15 +186,15 @@ $stacking-order: (
 }
 
 .colorYellowLighter {
-  fill: color('yellow', 'lighter');
+  @include color-icon('yellow', 'lighter');
 }
 
 .colorYellow {
-  fill: color('yellow');
+  @include color-icon('yellow');
 }
 
 .colorYellowDark {
-  fill: color('yellow', 'dark');
+  @include color-icon('yellow', 'dark');
 
   &::after {
     background-color: color('yellow', 'light');
@@ -192,23 +202,23 @@ $stacking-order: (
 }
 
 .colorOrange {
-  fill: color('orange');
+  @include color-icon('orange');
 }
 
 .colorOrangeDark {
-  fill: color('orange', 'dark');
+  @include color-icon('orange', 'dark');
 }
 
 .colorRedLighter {
-  fill: color('red', 'lighter');
+  @include color-icon('red', 'lighter');
 }
 
 .colorRed {
-  fill: color('red');
+  @include color-icon('red');
 }
 
 .colorRedDark {
-  fill: color('red', 'dark');
+  @include color-icon('red', 'dark');
 
   &::after {
     background-color: color('red', 'light');
@@ -216,10 +226,11 @@ $stacking-order: (
 }
 
 .colorPurple {
-  fill: color('purple');
+  @include color-icon('purple');
 }
 
-.Svg {
+.Svg,
+.Img {
   position: relative;
   z-index: z-index(icon, $stacking-order);
   display: block;

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -51,3 +51,14 @@ Use to visually communicate core parts of the product and available actions.
 ```jsx
 <Icon source="circlePlus" />
 ```
+
+### User provided icon
+
+Use to mark an icon as untrusted to render it in an img tag.
+
+```jsx
+<Icon
+  source="<svg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'><path d='M10.707 17.707l5-5a.999.999 0 1 0-1.414-1.414L11 14.586V3a1 1 0 1 0-2 0v11.586l-3.293-3.293a.999.999 0 1 0-1.414 1.414l5 5a.999.999 0 0 0 1.414 0' /></svg>"
+  untrusted
+/>
+```

--- a/src/components/Icon/tests/Icon.test.tsx
+++ b/src/components/Icon/tests/Icon.test.tsx
@@ -38,5 +38,20 @@ describe('<Icon />', () => {
       const element = shallowWithAppProvider(<Icon source={component} />);
       expect(element.find(Button)).toHaveLength(1);
     });
+
+    it('renders an img when source is given an untrusted SVG', () => {
+      const svg =
+        "<svg><path d='M17 9h-6V3a1 1 0 1 0-2 0v6H3a1 1 0 1 0 0 2h6v6a1 1 0 1 0 2 0v-6h6a1 1 0 1 0 0-2'  fill-rule='evenodd'/></svg>";
+      const element = shallowWithAppProvider(<Icon source={svg} untrusted />);
+      expect(element.find('img')).toHaveLength(1);
+    });
+
+    it('renders nothing when source is given an svg string but untrusted is not true', () => {
+      const svg =
+        "<svg><path d='M17 9h-6V3a1 1 0 1 0-2 0v6H3a1 1 0 1 0 0 2h6v6a1 1 0 1 0 2 0v-6h6a1 1 0 1 0 0-2'  fill-rule='evenodd'/></svg>";
+      const element = shallowWithAppProvider(<Icon source={svg} />);
+      expect(element.find('img')).toHaveLength(0);
+      expect(element.find('svg')).toHaveLength(0);
+    });
   });
 });

--- a/src/styles/foundation.scss
+++ b/src/styles/foundation.scss
@@ -1,5 +1,6 @@
 @import 'foundation/utilities';
 @import 'foundation/colors';
+@import 'foundation/filters';
 @import 'foundation/spacing';
 @import 'foundation/border-width';
 @import 'foundation/borders';

--- a/src/styles/foundation/filters.scss
+++ b/src/styles/foundation/filters.scss
@@ -1,0 +1,44 @@
+@import '../polaris-tokens/color-filters.color-map';
+
+///
+/// Color filter data
+///
+/// Shopify color filter palette, extended specifically for polaris-react.
+///
+/// @type map
+$color-filter-palette-data: $polaris-color-filters;
+
+/// Returns the filter list for a given color name and group.
+///
+/// @param {String} $hue - The color’s hue.
+/// @param {String} $value - The darkness/lightness of the color. Defaults to
+/// base.
+/// @return {List} The filter list.
+
+@function filter($hue, $value: base) {
+  $fetched-color: map-get(map-get($color-filter-palette-data, $hue), $value);
+
+  @if map-has-key($color-filter-palette-data, $fetched-color) {
+    $fetched-color: map-get(
+      map-get($color-filter-palette-data, $fetched-color),
+      $value
+    );
+  }
+
+  @if type-of($fetched-color) == list {
+    @return $fetched-color;
+  } @else {
+    // stylelint-disable string-no-newline
+    // prettier-ignore
+    $error: "
+Filter `#{$hue}, #{$value}` not found. Make sure arguments are strings.
+GOOD: filter('yellow')
+BAD: filter(yellow)
+
+Available options: #{available-names($color-filter-palette-data)}
+";
+    // stylelint-enable
+
+    @error $error;
+  }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-react/issues/885

Inlining svgs is potentially dangerous as scripts can be executed if they are in the svg.


### WHAT is this pull request doing?

If the user provides an svg, we will display it in an `img` tag instead. Since we can't use fill on img tag we need to use a filter from the polaris-tokens to get the correct colour that we want. 

This is adding a `untrusted` prop to Icon that a user will have to manually set in order to render a svg string. This is temporary as we wait for the work on SVGR to be completed.

| `white` | `black` |
|---|---|
| ![image](https://user-images.githubusercontent.com/9055413/52433977-517f9c00-2adc-11e9-9d18-8eff96207f84.png) | ![image](https://user-images.githubusercontent.com/9055413/52434043-6fe59780-2adc-11e9-8d8f-ac955282eba0.png) |

| `skyLighter` | `skyLight` | `sky` | `skyDark` |
|---|---|---|---|
| ![image](https://user-images.githubusercontent.com/9055413/52434100-94417400-2adc-11e9-9f0e-5d39fe3695d9.png) | ![image](https://user-images.githubusercontent.com/9055413/52434163-bb984100-2adc-11e9-8abb-97e9bc9e180b.png) | ![image](https://user-images.githubusercontent.com/9055413/52434180-c521a900-2adc-11e9-8f49-59cd2398c6f2.png) | ![image](https://user-images.githubusercontent.com/9055413/52434285-fc905580-2adc-11e9-9f63-866a2de9bb60.png) |

| `inkLightest` | `inkLighter` | `inkLight` | `ink` |
|---|---|---|---|
| ![image](https://user-images.githubusercontent.com/9055413/52437928-18e4c000-2ae6-11e9-88fe-c3bc45e35db5.png) | ![image](https://user-images.githubusercontent.com/9055413/52437945-21d59180-2ae6-11e9-867d-0379968717f5.png) | ![image](https://user-images.githubusercontent.com/9055413/52437965-2b5ef980-2ae6-11e9-91f1-8fa9fae4cecf.png) | ![image](https://user-images.githubusercontent.com/9055413/52437979-31ed7100-2ae6-11e9-87f5-8ea455ec1cd1.png) |

| `blueLighter` | `blueLight` | `blue` | `blueDark` | `blueDarker` |
|---|---|---|---|---|
| ![image](https://user-images.githubusercontent.com/9055413/52438233-d079d200-2ae6-11e9-888f-ec64520c7831.png) | ![image](https://user-images.githubusercontent.com/9055413/52438268-e25b7500-2ae6-11e9-9f51-50caa2a37aa2.png) | ![image](https://user-images.githubusercontent.com/9055413/52438279-eb4c4680-2ae6-11e9-9048-e408e12d7d3d.png) | ![image](https://user-images.githubusercontent.com/9055413/52438294-f1dabe00-2ae6-11e9-8674-1833c67e653f.png) | ![image](https://user-images.githubusercontent.com/9055413/52438311-fb642600-2ae6-11e9-9134-f18188d041cb.png) |

| `indigoLighter` | `indigoLight` | `indigo` | `indigoDark` | `indigoDarker` |
|---|---|---|---|---|
| ![image](https://user-images.githubusercontent.com/9055413/52438582-9eb53b00-2ae7-11e9-898f-e27f6d11fb15.png) | ![image](https://user-images.githubusercontent.com/9055413/52438591-a379ef00-2ae7-11e9-9861-16f362f6c0e9.png) | ![image](https://user-images.githubusercontent.com/9055413/52438594-a70d7600-2ae7-11e9-98a5-7dc11a301a56.png) | ![image](https://user-images.githubusercontent.com/9055413/52438603-aaa0fd00-2ae7-11e9-9ff3-484da2b164df.png) | ![image](https://user-images.githubusercontent.com/9055413/52438611-aecd1a80-2ae7-11e9-955d-e06d227776f6.png) |

| `tealLighter` | `tealLight` | `teal` | `tealDark` | `tealDarker` |
|---|---|---|---|---|
| ![image](https://user-images.githubusercontent.com/9055413/52438714-e936b780-2ae7-11e9-87ae-88b1aceae64d.png) | ![image](https://user-images.githubusercontent.com/9055413/52438727-ed62d500-2ae7-11e9-9ba9-8b58fe68d387.png) | ![image](https://user-images.githubusercontent.com/9055413/52438730-f05dc580-2ae7-11e9-886e-2d033e598b0b.png) | ![image](https://user-images.githubusercontent.com/9055413/52438736-f2c01f80-2ae7-11e9-92ae-2e78d33864e5.png) | ![image](https://user-images.githubusercontent.com/9055413/52438740-f5227980-2ae7-11e9-8e86-6e63769ca476.png) |

| `greenLighter` | `green` | `greenDark` |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/9055413/52438827-2ac76280-2ae8-11e9-8a81-df0414c185a0.png) | ![image](https://user-images.githubusercontent.com/9055413/52438831-2dc25300-2ae8-11e9-9d0e-d1cf2208cf85.png) | ![image](https://user-images.githubusercontent.com/9055413/52438835-30bd4380-2ae8-11e9-8ede-14d269cd1337.png) |

| `yellowLighter` | `yellow` | `yellowDark` |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/9055413/52438876-4d597b80-2ae8-11e9-8782-1c20c01820b2.png) | ![image](https://user-images.githubusercontent.com/9055413/52438883-50546c00-2ae8-11e9-9aa6-9ba94e5edccf.png) | ![image](https://user-images.githubusercontent.com/9055413/52438889-534f5c80-2ae8-11e9-9ff8-289efe309bbc.png) |

| `orange` | `orangeDark` |
|---|---|
| ![image](https://user-images.githubusercontent.com/9055413/52439075-ade8b880-2ae8-11e9-99cb-1fcfead814fc.png) | ![image](https://user-images.githubusercontent.com/9055413/52439080-b17c3f80-2ae8-11e9-812a-fbed48f5fab2.png) |

|`redLighter` | `red` | `redDark` |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/9055413/52439003-8eea2680-2ae8-11e9-818e-dbd5c8d6d3af.png) | ![image](https://user-images.githubusercontent.com/9055413/52439030-99a4bb80-2ae8-11e9-96ad-6e315b91748d.png) | ![image](https://user-images.githubusercontent.com/9055413/52439038-9d384280-2ae8-11e9-93c6-484bb92845ad.png) |

| `purple` |
|---|
| ![image](https://user-images.githubusercontent.com/9055413/52438959-7ed24700-2ae8-11e9-8499-af9e93e5334a.png) |



## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Icon} from '@shopify/polaris';

interface State {}

const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 438.549 438.549" style="enable-background:new 0 0 438.549 438.549;"
xml:space="preserve">
<g><path d="M409.132,114.573c-19.608-33.596-46.205-60.194-79.798-79.8C295.736,15.166,259.057,5.365,219.271,5.365
 c-39.781,0-76.472,9.804-110.063,29.408c-33.596,19.605-60.192,46.204-79.8,79.8C9.803,148.168,0,184.854,0,224.63
 c0,47.78,13.94,90.745,41.827,128.906c27.884,38.164,63.906,64.572,108.063,79.227c5.14,0.954,8.945,0.283,11.419-1.996
 c2.475-2.282,3.711-5.14,3.711-8.562c0-0.571-0.049-5.708-0.144-15.417c-0.098-9.709-0.144-18.179-0.144-25.406l-6.567,1.136
 c-4.187,0.767-9.469,1.092-15.846,1c-6.374-0.089-12.991-0.757-19.842-1.999c-6.854-1.231-13.229-4.086-19.13-8.559
 c-5.898-4.473-10.085-10.328-12.56-17.556l-2.855-6.57c-1.903-4.374-4.899-9.233-8.992-14.559
 c-4.093-5.331-8.232-8.945-12.419-10.848l-1.999-1.431c-1.332-0.951-2.568-2.098-3.711-3.429c-1.142-1.331-1.997-2.663-2.568-3.997
 c-0.572-1.335-0.098-2.43,1.427-3.289c1.525-0.859,4.281-1.276,8.28-1.276l5.708,0.853c3.807,0.763,8.516,3.042,14.133,6.851
 c5.614,3.806,10.229,8.754,13.846,14.842c4.38,7.806,9.657,13.754,15.846,17.847c6.184,4.093,12.419,6.136,18.699,6.136
 c6.28,0,11.704-0.476,16.274-1.423c4.565-0.952,8.848-2.383,12.847-4.285c1.713-12.758,6.377-22.559,13.988-29.41
 c-10.848-1.14-20.601-2.857-29.264-5.14c-8.658-2.286-17.605-5.996-26.835-11.14c-9.235-5.137-16.896-11.516-22.985-19.126
 c-6.09-7.614-11.088-17.61-14.987-29.979c-3.901-12.374-5.852-26.648-5.852-42.826c0-23.035,7.52-42.637,22.557-58.817
 c-7.044-17.318-6.379-36.732,1.997-58.24c5.52-1.715,13.706-0.428,24.554,3.853c10.85,4.283,18.794,7.952,23.84,10.994
 c5.046,3.041,9.089,5.618,12.135,7.708c17.705-4.947,35.976-7.421,54.818-7.421s37.117,2.474,54.823,7.421l10.849-6.849
 c7.419-4.57,16.18-8.758,26.262-12.565c10.088-3.805,17.802-4.853,23.134-3.138c8.562,21.509,9.325,40.922,2.279,58.24
 c15.036,16.18,22.559,35.787,22.559,58.817c0,16.178-1.958,30.497-5.853,42.966c-3.9,12.471-8.941,22.457-15.125,29.979
 c-6.191,7.521-13.901,13.85-23.131,18.986c-9.232,5.14-18.182,8.85-26.84,11.136c-8.662,2.286-18.415,4.004-29.263,5.146
 c9.894,8.562,14.842,22.077,14.842,40.539v60.237c0,3.422,1.19,6.279,3.572,8.562c2.379,2.279,6.136,2.95,11.276,1.995
 c44.163-14.653,80.185-41.062,108.068-79.226c27.88-38.161,41.825-81.126,41.825-128.906
 C438.536,184.851,428.728,148.168,409.132,114.573z"/>
</g></svg>`;

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        <Icon source={svg} untrusted color="indigo" />
        <br />
        <Icon source="home" color="indigo" />
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->

cc @ragalie 