### PR TITLE
Data table and resource list a11y docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -23,7 +23,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Documentation
 
 - Added `Stack.Item` properties and description to [style guide](https://polaris.shopify.com)’s ([#772](https://github.com/Shopify/polaris-react/pull/772))
-- Added accessibility documentation to the `Resource list` and `Data table` components ([#...]())
+- Added accessibility documentation to the `Resource list` and `Data table` components ([#927](https://github.com/Shopify/polaris-react/pull/927))
 
 ### Development workflow
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -23,6 +23,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Documentation
 
 - Added `Stack.Item` properties and description to [style guide](https://polaris.shopify.com)’s ([#772](https://github.com/Shopify/polaris-react/pull/772))
+- Added accessibility documentation to the `Resource list` and `Data table` components ([#...]())
 
 ### Development workflow
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -23,7 +23,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Documentation
 
 - Added `Stack.Item` properties and description to [style guide](https://polaris.shopify.com)’s ([#772](https://github.com/Shopify/polaris-react/pull/772))
-- Added accessibility documentation to the `Resource list` and `Data table` components ([#927](https://github.com/Shopify/polaris-react/pull/927))
+- Added accessibility documentation to the resource list and data table components ([#927](https://github.com/Shopify/polaris-react/pull/927))
 
 ### Development workflow
 

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -347,6 +347,8 @@ Use tables for tabular data.
 
 Use tables for layout. For a table-like layout that doesn’t use table HTML elements, use the [resource list component](/components/lists-and-tables/resource-list).
 
+<!-- end -->
+
 ### Keyboard support
 
 Sorting controls for the data table component are implemented with native HTML buttons.

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -354,6 +354,6 @@ Use tables for layout. For a table-like layout that doesn’t use table HTML ele
 Sorting controls for the data table component are implemented with native HTML buttons.
 
 - Give buttons keyboard focus with the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
-- Activate buttons with the <kbd>enter</kbd>/<kbd>return</kbd> and <kbd>space</kbd> keys.
+- Activate buttons with the <kbd>enter</kbd>/<kbd>return</kbd> and <kbd>space</kbd> keys
 
 <!-- /content-for -->

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -353,7 +353,7 @@ Use tables for layout. For a table-like layout that doesn’t use table HTML ele
 
 Sorting controls for the data table component are implemented with native HTML buttons.
 
-- Give buttons keyboard focus with the `tab` key (or `shift` + `tab` when tabbing backwards).
+- Give buttons keyboard focus with the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards).
 - Activate buttons with the <kbd>enter</kbd>/<kbd>return</kbd> and <kbd>space</kbd> keys.
 
 <!-- /content-for -->

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -335,7 +335,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 Native HTML tables provide a large amount of structural information to screen reader users. Merchants who rely on screen readers can navigate tables and identify relationships between data cells (`<td>`) and headers (`<th>`) using keys specific to their screen reader.
 
-Sortable tables use the `aria-sort` attribute to convey which columns are sortable (and in what direction). They also use use `aria-label` on sorting buttons to convey what activating the button will do.
+Sortable tables use the `aria-sort` attribute to convey which columns are sortable (and in what direction). They also use `aria-label` on sorting buttons to convey what activating the button will do.
 
 <!-- usageblock -->
 

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -354,6 +354,6 @@ Use tables for layout. For a table-like layout that doesn’t use table HTML ele
 Sorting controls for the data table component are implemented with native HTML buttons.
 
 - Give buttons keyboard focus with the `tab` key (or `shift` + `tab` when tabbing backwards).
-- Activate buttons with the `enter`/`return` and `space` keys.
+- Activate buttons with the <kbd>enter</kbd>/<kbd>return</kbd> and <kbd>space</kbd> keys.
 
 <!-- /content-for -->

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -311,7 +311,7 @@ Keep decimals consistent. For example, don’t use 3 decimals in one row and 2 i
 
 ## Accessibility
 
-<!-- content-for: Android -->
+<!-- content-for: android -->
 
 See Material Design and development documentation about accessibility for Android:
 

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -353,7 +353,7 @@ Use tables for layout. For a table-like layout that doesn’t use table HTML ele
 
 Sorting controls for the data table component are implemented with native HTML buttons.
 
-- Give buttons keyboard focus with the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards).
+- Give buttons keyboard focus with the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
 - Activate buttons with the <kbd>enter</kbd>/<kbd>return</kbd> and <kbd>space</kbd> keys.
 
 <!-- /content-for -->

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -306,3 +306,52 @@ Keep decimals consistent. For example, don’t use 3 decimals in one row and 2 i
 ## Related components
 
 - To create an actionable list of related items that link to details pages, such as a list of customers, use the [resource list component](/components/lists-and-tables/resource-list).
+
+---
+
+## Accessibility
+
+<!-- content-for: Android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+### Structure
+
+Native HTML tables provide a large amount of structural information to screen reader users. Merchants who rely on screen readers can navigate tables and identify relationships between data cells (`<td>`) and headers (`<th>`) using keys specific to their screen reader.
+
+Sortable tables use the `aria-sort` attribute to convey which columns are sortable (and in what direction). They also use use `aria-label` on sorting buttons to convey what activating the button will do.
+
+<!-- usageblock -->
+
+#### Do
+
+Use tables for tabular data.
+
+#### Don’t
+
+Use tables for layout. For a table-like layout that doesn’t use table HTML elements, use the [resource list component](/components/lists-and-tables/resource-list).
+
+### Keyboard support
+
+Sorting controls for the data table component are implemented with native HTML buttons.
+
+- Give buttons keyboard focus with the `tab` key (or `shift` + `tab` when tabbing backwards).
+- Activate buttons with the `enter`/`return` and `space` keys.
+
+<!-- /content-for -->

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -3126,7 +3126,7 @@ export default App;
 
 <!-- content-for: web -->
 
-Use the resource list component to let merchants access and manage a list of items. To present content that’s primarily a table of data, use the [data table component](https://polaris.shopify.com/components/lists-and-tables/data-table) instead.
+Use the resource list component to let merchants access and manage a list of items. To present a list of items in a tabular format for merchants to analyze, use the [data table component](https://polaris.shopify.com/components/lists-and-tables/data-table) instead.
 
 ### Structure
 

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -3137,7 +3137,7 @@ To show the relationships between items in the list, the resource list component
 
 ### Bulk actions
 
-A resource list with bulk actions includes checkboxes that merchants can use to select all items or individual items. The component generates a unique `id` is for each checkbox `<input>`, and each `<input>` is given a visually hidden label that leverages the `accessibilityLabel` for the item.
+A resource list with bulk actions includes checkboxes that merchants can use to select all items or individual items. The component generates a unique `id` for each checkbox `<input>`, and each `<input>` is given a visually hidden label that leverages the `accessibilityLabel` for the item.
 
 If some but not all items are checked, then the bulk checkbox uses `aria-checked=”mixed”` to convey the partially selected state.
 

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -1148,47 +1148,6 @@ The content that represents applied filter tags should use short, clear, non-tec
 
 ---
 
-## Accessibility
-
-Use the resource list component to let merchants access and manage a list of items. To present content that’s primarily a table of data, use the [data table component](https://polaris.shopify.com/components/lists-and-tables/data-table) instead.
-
-### Structure
-
-To show the relationships between items in the list, the resource list component produces a list wrapper (`<ul>`) and list items (`<li>`). This structure allows merchants who use screen readers to:
-
-- Identify how many items are in the current resource list view
-- Know that all of the list items go together
-
-### Bulk actions
-
-A resource list with bulk actions includes checkboxes that merchants can use to select all items or individual items. The component generates a unique `id` is for each checkbox `<input>`, and each `<input>` is given a visually hidden label that leverages the `accessibilityLabel` for the item.
-
-If some but not all items are checked, then the bulk checkbox uses `aria-checked=”mixed”` to convey the partially selected state.
-
-### Sorting and filtering
-
-When merchants use sorting and filtering controls to update items in the list, the update is conveyed to screen readers with an `aria-live="polite"` attribute on the list.
-
-### Navigation
-
-Primarily, items in a resource list function as links to the full-page representations of the items. Each item should have a unique `name` prop. For each `ResourceList.Item`, the `accessibilityLabel` prop should be used to give the link a unique `aria-label`. The `aria-label` should convey the link’s purpose, using the `name` value. Merchants who use screen readers should be able to easily distinguish each link from the others. Using a unique `name` for each item is recommended.
-
-### Keyboard
-
-Keyboard users expect to give controls in the resource list keyboard focus with the `tab` key (or `shift` + `tab` when tabbing backwards).
-
-- Links can be activated with the `enter`/`return` key by default
-- Checkboxes can be checked and unchecked with the `space` key by default
-- Buttons added with other configurations can be activated with the `enter`/`return` key or the `space` by default
-
-If you add custom list items with additional controls or an alternate tool, then ensure that the controls:
-
-- Can be used with the keyboard
-- Receive keyboard focus in a logical order
-- Display a visible focus indicator
-
----
-
 <a name="study"></a>
 
 ## Case study
@@ -1407,7 +1366,7 @@ Resource lists don’t have column headings, so care must be taken to avoid ambi
     #### Don’t
 
     - 3
-    - $492.76
+    - \$492.76
 
     <!-- end -->
 
@@ -3160,3 +3119,48 @@ class App extends Component {
 
 export default App;
 ```
+
+---
+
+## Accessibility
+
+<!-- content-for: web -->
+
+Use the resource list component to let merchants access and manage a list of items. To present content that’s primarily a table of data, use the [data table component](https://polaris.shopify.com/components/lists-and-tables/data-table) instead.
+
+### Structure
+
+To show the relationships between items in the list, the resource list component produces a list wrapper (`<ul>`) and list items (`<li>`). This structure allows merchants who use screen readers to:
+
+- Identify how many items are in the current resource list view
+- Know that all of the list items go together
+
+### Bulk actions
+
+A resource list with bulk actions includes checkboxes that merchants can use to select all items or individual items. The component generates a unique `id` is for each checkbox `<input>`, and each `<input>` is given a visually hidden label that leverages the `accessibilityLabel` for the item.
+
+If some but not all items are checked, then the bulk checkbox uses `aria-checked=”mixed”` to convey the partially selected state.
+
+### Sorting and filtering
+
+When merchants use sorting and filtering controls to update items in the list, the update is conveyed to screen readers with an `aria-live="polite"` attribute on the list.
+
+### Navigation
+
+Primarily, items in a resource list function as links to the full-page representations of the items. Each item should have a unique `name` prop. For each `ResourceList.Item`, the `accessibilityLabel` prop should be used to give the link a unique `aria-label`. The `aria-label` should convey the link’s purpose, using the `name` value. Merchants who use screen readers should be able to easily distinguish each link from the others. Using a unique `name` for each item is recommended.
+
+### Keyboard
+
+Keyboard users expect to give controls in the resource list keyboard focus with the `tab` key (or `shift` + `tab` when tabbing backwards).
+
+- Links can be activated with the `enter`/`return` key by default
+- Checkboxes can be checked and unchecked with the `space` key by default
+- Buttons added with other configurations can be activated with the `enter`/`return` key or the `space` by default
+
+If you add custom list items with additional controls or an alternate tool, then ensure that the controls:
+
+- Can be used with the keyboard
+- Receive keyboard focus in a logical order
+- Display a visible focus indicator
+
+<!-- /content-for -->

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -3155,7 +3155,7 @@ Keyboard users expect to give controls in the resource list keyboard focus with 
 
 - Links can be activated with the <kbd>enter</kbd>/<kbd>return</kbd> key by default
 - Checkboxes can be checked and unchecked with the <kbd>space</kbd> key by default
-- Buttons added with other configurations can be activated with the `enter`/`return` key or the `space` by default
+- Buttons added with other configurations can be activated with the <kbd>enter</kbd>/<kbd>return</kbd> key or the <kbd>space</kbd> by default
 
 If you add custom list items with additional controls or an alternate tool, then ensure that the controls:
 

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -3154,7 +3154,7 @@ Primarily, items in a resource list function as links to the full-page represent
 Keyboard users expect to give controls in the resource list keyboard focus with the `tab` key (or `shift` + `tab` when tabbing backwards).
 
 - Links can be activated with the <kbd>enter</kbd>/<kbd>return</kbd> key by default
-- Checkboxes can be checked and unchecked with the `space` key by default
+- Checkboxes can be checked and unchecked with the <kbd>space</kbd> key by default
 - Buttons added with other configurations can be activated with the `enter`/`return` key or the `space` by default
 
 If you add custom list items with additional controls or an alternate tool, then ensure that the controls:

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -3151,7 +3151,7 @@ Primarily, items in a resource list function as links to the full-page represent
 
 ### Keyboard
 
-Keyboard users expect to give controls in the resource list keyboard focus with the `tab` key (or `shift` + `tab` when tabbing backwards).
+Keyboard users expect to give controls in the resource list keyboard focus with the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards).
 
 - Links can be activated with the <kbd>enter</kbd>/<kbd>return</kbd> key by default
 - Checkboxes can be checked and unchecked with the <kbd>space</kbd> key by default

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -3147,7 +3147,7 @@ When merchants use sorting and filtering controls to update items in the list, t
 
 ### Navigation
 
-Primarily, items in a resource list function as links to the full-page representations of the items. Each item should have a unique `name` prop. For each `ResourceList.Item`, the `accessibilityLabel` prop should be used to give the link a unique `aria-label`. The `aria-label` should convey the link’s purpose, using the `name` value. Merchants who use screen readers should be able to easily distinguish each link from the others. Using a unique `name` for each item is recommended.
+Primarily, items in a resource list function as links to the full-page representations of the items. Each item should have a unique `name` prop. For each `ResourceList.Item`, the `accessibilityLabel` prop should be used to give the link a unique `aria-label`. The `aria-label` should convey the link’s purpose, using the `name` value. Merchants who use screen readers should be able to easily distinguish each link from the others.
 
 ### Keyboard
 

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -3153,7 +3153,7 @@ Primarily, items in a resource list function as links to the full-page represent
 
 Keyboard users expect to give controls in the resource list keyboard focus with the `tab` key (or `shift` + `tab` when tabbing backwards).
 
-- Links can be activated with the `enter`/`return` key by default
+- Links can be activated with the <kbd>enter</kbd>/<kbd>return</kbd> key by default
 - Checkboxes can be checked and unchecked with the `space` key by default
 - Buttons added with other configurations can be activated with the `enter`/`return` key or the `space` by default
 

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -1148,6 +1148,47 @@ The content that represents applied filter tags should use short, clear, non-tec
 
 ---
 
+## Accessibility
+
+Use the resource list component to let merchants access and manage a list of items. To present content that’s primarily a table of data, use the [data table component](https://polaris.shopify.com/components/lists-and-tables/data-table) instead.
+
+### Structure
+
+To show the relationships between items in the list, the resource list component produces a list wrapper (`<ul>`) and list items (`<li>`). This structure allows merchants who use screen readers to:
+
+- Identify how many items are in the current resource list view
+- Know that all of the list items go together
+
+### Bulk actions
+
+A resource list with bulk actions includes checkboxes that merchants can use to select all items or individual items. The component generates a unique `id` is for each checkbox `<input>`, and each `<input>` is given a visually hidden label that leverages the `accessibilityLabel` for the item.
+
+If some but not all items are checked, then the bulk checkbox uses `aria-checked=”mixed”` to convey the partially selected state.
+
+### Sorting and filtering
+
+When merchants use sorting and filtering controls to update items in the list, the update is conveyed to screen readers with an `aria-live="polite"` attribute on the list.
+
+### Navigation
+
+Primarily, items in a resource list function as links to the full-page representations of the items. Each item should have a unique `name` prop. For each `ResourceList.Item`, the `accessibilityLabel` prop should be used to give the link a unique `aria-label`. The `aria-label` should convey the link’s purpose, using the `name` value. Merchants who use screen readers should be able to easily distinguish each link from the others. Using a unique `name` for each item is recommended.
+
+### Keyboard
+
+Keyboard users expect to give controls in the resource list keyboard focus with the `tab` key (or `shift` + `tab` when tabbing backwards).
+
+- Links can be activated with the `enter`/`return` key by default
+- Checkboxes can be checked and unchecked with the `space` key by default
+- Buttons added with other configurations can be activated with the `enter`/`return` key or the `space` by default
+
+If you add custom list items with additional controls or an alternate tool, then ensure that the controls:
+
+- Can be used with the keyboard
+- Receive keyboard focus in a logical order
+- Display a visible focus indicator
+
+---
+
 <a name="study"></a>
 
 ## Case study
@@ -3119,44 +3160,3 @@ class App extends Component {
 
 export default App;
 ```
-
----
-
-## Accessibility
-
-Use the resource list component to let merchants access and manage a list of items. To present content that’s primarily a table of data, use the [data table component](https://polaris.shopify.com/components/lists-and-tables/data-table) instead.
-
-### Structure
-
-To show the relationships between items in the list, the resource list component produces a list wrapper (`<ul>`) and list items (`<li>`). This structure allows merchants who use screen readers to:
-
-- Identify how many items are in the current resource list view
-- Know that all of the list items go together
-
-### Bulk actions
-
-A resource list with bulk actions includes checkboxes that merchants can use to select all items or individual items. The component generates a unique `id` is for each checkbox `<input>`, and each `<input>` is given a visually hidden label that leverages the `accessibilityLabel` for the item.
-
-If some but not all items are checked, then the bulk checkbox uses `aria-checked=”mixed”` to convey the partially selected state.
-
-### Sorting and filtering
-
-When merchants use sorting and filtering controls to update items in the list, the update is conveyed to screen readers with an `aria-live="polite"` attribute on the list.
-
-### Navigation
-
-Primarily, items in a resource list function as links to the full-page representations of the items. Each item should have a unique `name` prop. For each `ResourceList.Item`, the `accessibilityLabel` prop should be used to give the link a unique `aria-label`. The `aria-label` should convey the link’s purpose, using the `name` value. Merchants who use screen readers should be able to easily distinguish each link from the others. Using a unique `name` for each item is recommended.
-
-### Keyboard
-
-Keyboard users expect to give controls in the resource list keyboard focus with the `tab` key (or `shift` + `tab` when tabbing backwards).
-
-- Links can be activated with the `enter`/`return` key by default
-- Checkboxes can be checked and unchecked with the `space` key by default
-- Buttons added with other configurations can be activated with the `enter`/`return` key or the `space` by default
-
-If you add custom list items with additional controls or an alternate tool, then ensure that the controls:
-
-- Can be used with the keyboard
-- Receive keyboard focus in a logical order
-- Display a visible focus indicator

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -3139,7 +3139,7 @@ To show the relationships between items in the list, the resource list component
 
 A resource list with bulk actions includes checkboxes that merchants can use to select all items or individual items. The component generates a unique `id` for each checkbox `<input>`, and each `<input>` is given a visually hidden label that leverages the `accessibilityLabel` for the item.
 
-If some but not all items are checked, then the bulk checkbox uses `aria-checked=”mixed”` to convey the partially selected state.
+If some but not all items are checked, then the bulk checkbox uses `aria-checked="mixed"` to convey the partially selected state.
 
 ### Sorting and filtering
 

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -3155,7 +3155,7 @@ Keyboard users expect to give controls in the resource list keyboard focus with 
 
 - Links can be activated with the <kbd>enter</kbd>/<kbd>return</kbd> key by default
 - Checkboxes can be checked and unchecked with the <kbd>space</kbd> key by default
-- Buttons added with other configurations can be activated with the <kbd>enter</kbd>/<kbd>return</kbd> key or the <kbd>space</kbd> by default
+- Buttons added with other configurations can be activated with the <kbd>enter</kbd>/<kbd>return</kbd> key or the <kbd>space</kbd> key by default
 
 If you add custom list items with additional controls or an alternate tool, then ensure that the controls:
 

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -3119,3 +3119,44 @@ class App extends Component {
 
 export default App;
 ```
+
+---
+
+## Accessibility
+
+Use the resource list component to let merchants access and manage a list of items. To present content that’s primarily a table of data, use the [data table component](https://polaris.shopify.com/components/lists-and-tables/data-table) instead.
+
+### Structure
+
+To show the relationships between items in the list, the resource list component produces a list wrapper (`<ul>`) and list items (`<li>`). This structure allows merchants who use screen readers to:
+
+- Identify how many items are in the current resource list view
+- Know that all of the list items go together
+
+### Bulk actions
+
+A resource list with bulk actions includes checkboxes that merchants can use to select all items or individual items. The component generates a unique `id` is for each checkbox `<input>`, and each `<input>` is given a visually hidden label that leverages the `accessibilityLabel` for the item.
+
+If some but not all items are checked, then the bulk checkbox uses `aria-checked=”mixed”` to convey the partially selected state.
+
+### Sorting and filtering
+
+When merchants use sorting and filtering controls to update items in the list, the update is conveyed to screen readers with an `aria-live="polite"` attribute on the list.
+
+### Navigation
+
+Primarily, items in a resource list function as links to the full-page representations of the items. Each item should have a unique `name` prop. For each `ResourceList.Item`, the `accessibilityLabel` prop should be used to give the link a unique `aria-label`. The `aria-label` should convey the link’s purpose, using the `name` value. Merchants who use screen readers should be able to easily distinguish each link from the others. Using a unique `name` for each item is recommended.
+
+### Keyboard
+
+Keyboard users expect to give controls in the resource list keyboard focus with the `tab` key (or `shift` + `tab` when tabbing backwards).
+
+- Links can be activated with the `enter`/`return` key by default
+- Checkboxes can be checked and unchecked with the `space` key by default
+- Buttons added with other configurations can be activated with the `enter`/`return` key or the `space` by default
+
+If you add custom list items with additional controls or an alternate tool, then ensure that the controls:
+
+- Can be used with the keyboard
+- Receive keyboard focus in a logical order
+- Display a visible focus indicator


### PR DESCRIPTION
This PR adds component-level accessibility documentation to the data table and resource list components (which link to each other), to display in the `polaris-react` repo and on the style guide. Changes should appear at the bottom of the gray Examples and Props section.

### WHY are these changes introduced?

Adds documentation on accessibility features built into the components.

### WHAT is this pull request doing?

- Edits the `README.md` files for the data table and resource list components to add a new section.
- Adds an entry to `UNRELEASED.md`.

### How to 🎩

1. Check out https://github.com/Shopify/polaris-styleguide/pull/2493 from `polaris-styleguide` to get the changes that support the accessibility section.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes:
 - https://polaris.myshopify.io/components/lists-and-tables/resource-list
 - https://polaris.myshopify.io/components/lists-and-tables/data-table

### Screenshot example

<img width="911" alt="Data table accessibility content" src="https://user-images.githubusercontent.com/1462085/51633003-80571900-1f05-11e9-8a52-05198193c1d3.png">