### PR TITLE
Caption a11y docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -24,7 +24,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Documentation
 
 - Added `Stack.Item` properties and description to [style guide](https://polaris.shopify.com)’s ([#772](https://github.com/Shopify/polaris-react/pull/772))
-- Added accessibility recommendations for `Caption` ([#928](https://github.com/Shopify/polaris-react/pull/928/))
+- Added accessibility recommendations for the caption component ([#928](https://github.com/Shopify/polaris-react/pull/928/))
 
 ### Development workflow
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -24,7 +24,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Documentation
 
 - Added `Stack.Item` properties and description to [style guide](https://polaris.shopify.com)’s ([#772](https://github.com/Shopify/polaris-react/pull/772))
-- Added accessibility recommendations for `Caption` ([#...](...))
+- Added accessibility recommendations for `Caption` ([#928](https://github.com/Shopify/polaris-react/pull/928/))
 
 ### Development workflow
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -24,6 +24,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Documentation
 
 - Added `Stack.Item` properties and description to [style guide](https://polaris.shopify.com)’s ([#772](https://github.com/Shopify/polaris-react/pull/772))
+- Added accessibility recommendations for `Caption` ([#...](...))
 
 ### Development workflow
 

--- a/src/components/Caption/README.md
+++ b/src/components/Caption/README.md
@@ -89,3 +89,31 @@ Use to provide details in situations where content is compact and space is tight
 ![Default caption](/public_images/components/Caption/ios/default@2x.png)
 
 <!-- /content-for -->
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Follow best practices for [data visualizations](/design/data-visualizations) to ensure that the purpose of captions is clear to all merchants, including those with issues related to seeing or understanding data and complex information.
+
+<!-- /content-for -->


### PR DESCRIPTION
Short and sweet update for the caption component. Ideally should be published along with https://github.com/Shopify/polaris-styleguide/pull/2521 since that PR adds accessibility guidance for the data viz section.

### WHY are these changes introduced?

Adds accessibility guidance for web, iOS, and Android for captions. Changes appear at the bottom of the gray examples/props section.

### WHAT is this pull request doing?

- Adds an accessibility section to the `README.md`
- Adds an entry to `UNRELEASED.md`

### How to 🎩

1. Check out https://github.com/Shopify/polaris-styleguide/pull/2493 from `polaris-styleguide` to get the changes that support the accessibility section.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes: https://polaris.myshopify.io/components/titles-and-text/caption

### Screenshots

Web:

<img width="651" alt="Caption example for web" src="https://user-images.githubusercontent.com/1462085/51634699-c6ae7700-1f09-11e9-8f7b-b88434c8a4e9.png">

Android:

<img width="746" alt="Caption example for Android" src="https://user-images.githubusercontent.com/1462085/51634763-e9409000-1f09-11e9-9a38-6113fb04342b.png">

iOS:

<img width="757" alt="Caption example for iOS" src="https://user-images.githubusercontent.com/1462085/51634781-f8274280-1f09-11e9-91eb-dc3e6f4d9c79.png">
