### PR TITLE
adds deprecation notice for Navigation's userMenu prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -39,4 +39,4 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Deprecations
 
 - Deprecated `Navigation.UserMenu` in favor of `TopBar.UserMenu` ([#849](https://github.com/Shopify/polaris-react/pull/849))
-- Deprecated `Navigation`'s `userMenu` prop ([#930](https://github.com/Shopify/polaris-react/pull/930))
+- Deprecated `Navigation`’s `userMenu` prop ([#930](https://github.com/Shopify/polaris-react/pull/930))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -39,3 +39,4 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Deprecations
 
 - Deprecated `Navigation.UserMenu` in favor of `TopBar.UserMenu` ([#849](https://github.com/Shopify/polaris-react/pull/849))
+- Deprecated `Navigation`'s `userMenu` prop ([#930](https://github.com/Shopify/polaris-react/pull/930))

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -11,6 +11,7 @@ export interface Props {
   location: string;
   sections?: SectionType[];
   children?: React.ReactNode;
+  /** @deprecated Pass a user menu into <TopBar /> instead. */
   userMenu?: React.ReactNode;
   onDismiss?(): void;
 }
@@ -20,6 +21,17 @@ export default class Navigation extends React.Component<Props, never> {
   static UserMenu = UserMenu;
   static Section = Section;
   static childContextTypes = contextTypes;
+
+  constructor(props: Props) {
+    super(props);
+
+    if (props.userMenu) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Deprecation: the `userMenu` prop is deprecated and will be removed in the next major version. Pass a user menu into <TopBar /> instead.',
+      );
+    }
+  }
 
   getChildContext() {
     return {


### PR DESCRIPTION
### WHY are these changes introduced?
Follow up on https://github.com/Shopify/polaris-react/pull/887. Deprecates the `userMenu` prop on `Navigation` as with the deprecation of `Navigation.UserMenu` it won't be needed anymore.

### WHAT is this pull request doing?
Adds the appropriate deprecation messages to the component.

### How to 🎩
1. Mount a `<Navigation />` component in the playground.
2. Make sure no deprecation messages show up in the console.
3. Add a `userMenu` to the `<Navigation />`.
4. Make sure the `userMenu` deprecation notice shows up in the console.

<details>
<summary>Playground code</summary>

```tsx
import * as React from 'react';
import {Page, Navigation} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <Navigation location="" userMenu={<div />} />
      </Page>
    );
  }
}
```
</details>
