### PR TITLE
fixes typescript/react.d.ts not found error in Consumer.d.ts

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,7 +22,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Changed `Tabs` example to contain children so the `Panel` renders for accessibility ([#893](https://github.com/Shopify/polaris-react/pull/893))
 - Fixed timezone not being accounted for in `ResourceList` date filter control ([#710](https://github.com/Shopify/polaris-react/pull/710))
 - Removed unnecessary tooltip text in the `TopBar` component ([#859](https://github.com/Shopify/polaris-react/pull/859))
-- Fixed `typescript/react.d.ts' not found` error caused by `UserMenu/context/Consumer.d.ts` ([#938](https://github.com/Shopify/polaris-react/pull/938))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Changed `Tabs` example to contain children so the `Panel` renders for accessibility ([#893](https://github.com/Shopify/polaris-react/pull/893))
 - Fixed timezone not being accounted for in `ResourceList` date filter control ([#710](https://github.com/Shopify/polaris-react/pull/710))
 - Removed unnecessary tooltip text in the `TopBar` component ([#859](https://github.com/Shopify/polaris-react/pull/859))
+- Fixed `typescript/react.d.ts' not found` error caused by `UserMenu/context/Consumer.d.ts` ([#938](https://github.com/Shopify/polaris-react/pull/938))
 
 ### Documentation
 

--- a/src/components/TopBar/components/UserMenu/context/Consumer.ts
+++ b/src/components/TopBar/components/UserMenu/context/Consumer.ts
@@ -1,3 +1,5 @@
+// Variable prefixed with underscore to prevent unused variable error.
+// More info here: https://github.com/Shopify/polaris-react/pull/938
 import * as _React from 'react';
 import UserMenuContext from './context';
 

--- a/src/components/TopBar/components/UserMenu/context/Consumer.ts
+++ b/src/components/TopBar/components/UserMenu/context/Consumer.ts
@@ -1,3 +1,4 @@
+import * as _React from 'react';
 import UserMenuContext from './context';
 
 export default UserMenuContext.Consumer;


### PR DESCRIPTION
### WHY are these changes introduced?
https://github.com/Shopify/polaris-react/pull/852 introduced a [`react.d.ts` not found error](https://circleci.com/gh/Shopify/polaris-styleguide/23123) in Web and the Polaris Styleguide caused by [`UserMenu/context/Consumer.ts`](https://github.com/Shopify/polaris-react/pull/852/files#diff-4fbf566e7626b1d2b295b411e744b33e).

### WHAT is this pull request doing?
It imports `React` into the file which changes the build output from:

```ts
/// <reference path="../../../../../../../config/typescript/react.d.ts" />
/// <reference types="react" />
declare const _default: import("react").ComponentType<import("react").ConsumerProps<import("./context").UserMenuContextTypes>>;
export default _default;
```

to

```ts
import * as _React from 'react';
declare const _default: _React.ComponentType<_React.ConsumerProps<import("./context").UserMenuContextTypes>>;
export default _default;
```

Even-though `React` is needed to get valid build output `tsc` doesn't agree that it is actually being used in the file as the variable isn't directly being referenced and the file doesn't contain any `jsx`. Because of this it throws a `'React' is declared but its value is never read.` error on build which is why I had to prefix the variable with an underscore.

### How to 🎩
1. Switch to this branch and run `yarn build-consumer web`.
2. In Web run `yarn run type-check` and make sure [this error](https://circleci.com/gh/Shopify/polaris-styleguide/23123) doesn't show up anymore.
