### PR TITLE
[Card] Add full example to styleguide

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Added all props example to `Card` in the [style guide](https://polaris.shopify.com) ([#939](https://github.com/Shopify/polaris-react/pull/939))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -460,6 +460,89 @@ Use to render custom content such as icons, links, or buttons in a card section'
 </Card>
 ```
 
+### Card with all of its elements
+
+<!-- example-for: web -->
+
+Use as a broad example that includes most props available to card.
+
+```jsx
+<Card
+  secondaryFooterAction={{content: 'Dismiss'}}
+  primaryFooterAction={{content: 'Export Report'}}
+>
+  <Card.Header
+    actions={[
+      {
+        content: 'Total Sales',
+      },
+    ]}
+    title="Sales"
+  >
+    <Popover
+      active={false}
+      activator={
+        <Button disclosure plain>
+          View Sales
+        </Button>
+      }
+      onClose={() => {}}
+    >
+      <ActionList items={[{content: 'Gross Sales'}, {content: 'Net Sales'}]} />
+    </Popover>
+  </Card.Header>
+  <Card.Section>
+    <TextContainer>
+      You can use sales reports to see information about your customers' orders
+      based on criteria such as sales over time, by channel, or by staff.
+    </TextContainer>
+  </Card.Section>
+  <Card.Section title="Total Sales Breakdown">
+    <ResourceList
+      resourceName={{singular: 'sale', plural: 'sales'}}
+      items={[
+        {
+          sales: 'Orders',
+          amount: 'USD$0.00',
+          url: 'reports/orders',
+        },
+        {
+          sales: 'Returns',
+          amount: '-USD$250.00',
+          url: 'reports/returns',
+        },
+      ]}
+      renderItem={(item) => {
+        const {sales, amount, url} = item;
+        return (
+          <ResourceList.Item
+            url={url}
+            accessibilityLabel={`View Sales for ${sales}`}
+          >
+            <Stack>
+              <Stack.Item fill>{sales}</Stack.Item>
+              <Stack.Item>{amount}</Stack.Item>
+            </Stack>
+          </ResourceList.Item>
+        );
+      }}
+    />
+  </Card.Section>
+  <Card.Section title="Deactivated reports" subdued>
+    <List>
+      <List.Item>Payouts</List.Item>
+      <List.Item>Total Sales By Channel</List.Item>
+    </List>
+  </Card.Section>
+  <Card.Section title="Note">
+    <TextContainer>
+      The sales reports are available only if your store is on the Shopify plan
+      or higher.
+    </TextContainer>
+  </Card.Section>
+</Card>
+```
+
 ---
 
 ## Related components


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #890  <!-- link to issue if one exists -->


### WHAT is this pull request doing?

Adds an example to the `styleguide` that includes a combination of all the props available for `Card`.

![image](https://screenshot.click/11-21-ex0dw-0we9n.jpg)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {
  Card,
  Stack,
  ActionList,
  Popover,
  Button,
  TextContainer,
  ResourceList,
  List,
} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Card
        secondaryFooterAction={{content: 'Dismiss'}}
        primaryFooterAction={{content: 'Export Report'}}
      >
        <Card.Header
          actions={[
            {
              content: 'Total Sales',
            },
          ]}
          title="Sales"
        >
          <Popover
            active={false}
            activator={
              <Button disclosure plain>
                View Sales
              </Button>
            }
            onClose={() => {}}
          >
            <ActionList
              items={[{content: 'Gross Sales'}, {content: 'Net Sales'}]}
            />
          </Popover>
        </Card.Header>
        <Card.Section>
          <TextContainer>
            You can use sales reports to see information about your customers'
            orders based on criteria such as sales over time, by channel, or by
            staff.
          </TextContainer>
        </Card.Section>
        <Card.Section title="Total Sales Breakdown">
          <ResourceList
            resourceName={{singular: 'sale', plural: 'sales'}}
            items={[
              {
                sales: 'Orders',
                amount: 'USD$0.00',
                url: 'reports/orders',
              },
              {
                sales: 'Returns',
                amount: '-USD$250.00',
                url: 'reports/returns',
              },
            ]}
            renderItem={(item) => {
              const {sales, amount, url} = item;
              return (
                <ResourceList.Item
                  url={url}
                  accessibilityLabel={`View Sales for ${sales}`}
                >
                  <Stack>
                    <Stack.Item fill>{sales}</Stack.Item>
                    <Stack.Item>{amount}</Stack.Item>
                  </Stack>
                </ResourceList.Item>
              );
            }}
          />
        </Card.Section>
        <Card.Section title="Deactivated reports" subdued>
          <List>
            <List.Item>Payouts</List.Item>
            <List.Item>Total Sales By Channel</List.Item>
          </List>
        </Card.Section>
        <Card.Section title="Note">
          <TextContainer>
            The sales reports are available only if your store is on the Shopify
            plan or higher.
          </TextContainer>
        </Card.Section>
      </Card>
    );
  }
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
