### PR TITLE
Remove a deep-link to an example as the styleguide doesn't support them

### DIFF
--- a/src/components/Stack/README.md
+++ b/src/components/Stack/README.md
@@ -118,8 +118,6 @@ Use to have the stack’s items fill the horizontal space in the container and b
 </Stack>
 ```
 
-<a name="single-item-fills-remaining-space"></a>
-
 ### Stack where a single item fills the remaining space
 
 Use for aligning buttons or secondary content to the right edge of another element, allowing it to wrap below on small screens.
@@ -142,7 +140,7 @@ Use for aligning buttons or secondary content to the right edge of another eleme
 
 ## Stack item
 
-The stack component will treat multiple elements wrapped in a stack item component as one item. By default, each individual element is treated as one stack item. Use the fill prop on a single stack item component to make it fill the rest of the available horizontal space. See the [Stack where a single item fills the remaining space](#single-item-fills-remaining-space) example.
+The stack component will treat multiple elements wrapped in a stack item component as one item. By default, each individual element is treated as one stack item. Use the fill prop on a single stack item component to make it fill the rest of the available horizontal space. See the “Stack where a single item fills the remaining space” example.
 
 ### Stack item properties
 


### PR DESCRIPTION
### WHY are these changes introduced?

Per title. This should fix the pa11y test failing in polaris-styleguide when trying out the 3.6.0 rcs.

### WHAT is this pull request doing?

Removes a hyperlink.
