### PR TITLE
[Docs] Update docs about App Bridge usage

### DIFF
--- a/src/components/AppProvider/README.md
+++ b/src/components/AppProvider/README.md
@@ -350,11 +350,12 @@ class ProviderThemeExample extends React.Component {
 
 ## Initializing the Shopify App Bridge
 
-When using Polaris, you don’t need to go through the initialization of the Shopify App Bridge as described [in the docs](https://help.shopify.com/en/api/embedded-apps/app-bridge#set-up-your-app). Instead, configure the connection to the Shopify admin through the app provider component, which must wrap all components in an embedded app. This component initializes the Shopify App Bridge using the `apiKey` you provide. **The `apiKey` attribute is required** and can be found in the [Shopify Partner Dashboard](https://partners.shopify.com).
+When using Polaris, you don’t need to go through the initialization of the Shopify App Bridge as described [in the docs](https://help.shopify.com/en/api/embedded-apps/app-bridge#set-up-your-app). Instead, configure the connection to the Shopify admin through the app provider component, which must wrap all components in an embedded app. This component initializes the Shopify App Bridge using the `apiKey` and `shopOrigin` you provide. **The `apiKey` attribute is required** and can be found in the [Shopify Partner Dashboard](https://partners.shopify.com).
+**The `shopOrigin` attribute is optional**, however it is best practice to get and store `shopOrigin` by yourself which can be found in [Embedded apps docs](https://help.shopify.com/en/api/embedded-apps/shop-origin).
 
 ```jsx
 ReactDOM.render(
-  <AppProvider apiKey="YOUR_API_KEY">
+  <AppProvider apiKey="YOUR_API_KEY" shopOrigin="SHOP_ORIGIN">
     <ResourcePicker
       resourceType="Product"
       open={this.state.open}


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/app-bridge/issues/567

`shopOrigin` is optional when using `AppProvider`. However, developer should maintain it by themselves. This PR updates the docs to guide developer how to do it. For more information, visit here https://help.shopify.com/en/api/embedded-apps/app-bridge/initialization and https://help.shopify.com/en/api/embedded-apps/shop-origin

### WHAT is this pull request doing?

Update docs 

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
