### PR TITLE
[Collapsible] Set `overflow: visible` once the Collapsible is fully open

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Set `Collapsible` to use `overflow: visible;` once fully open ([#951](https://github.com/Shopify/polaris-react/pull/951))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Collapsible/Collapsible.scss
+++ b/src/components/Collapsible/Collapsible.scss
@@ -16,3 +16,7 @@
 .open {
   opacity: 1;
 }
+
+.fullyOpen {
+  overflow: visible;
+}

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -61,6 +61,7 @@ export class Collapsible extends React.Component<CombinedProps, State> {
     const {open} = this.props;
     const {animationState} = this.state;
     const {parentCollapsibleExpanding} = this.context;
+
     return {
       parentCollapsibleExpanding:
         parentCollapsibleExpanding || (open && animationState !== 'idle'),
@@ -78,13 +79,14 @@ export class Collapsible extends React.Component<CombinedProps, State> {
 
   componentDidUpdate({open: wasOpen}: Props) {
     const {animationState} = this.state;
-
     const {parentCollapsibleExpanding} = this.context;
+
     if (parentCollapsibleExpanding && animationState !== 'idle') {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
         animationState: 'idle',
       });
+
       return;
     }
 
@@ -118,6 +120,7 @@ export class Collapsible extends React.Component<CombinedProps, State> {
     if (this.node == null) {
       return;
     }
+
     addEventListener(this.node, 'transitionend', this.handleTransitionEnd);
   }
 
@@ -125,6 +128,7 @@ export class Collapsible extends React.Component<CombinedProps, State> {
     if (this.node == null) {
       return;
     }
+
     removeEventListener(this.node, 'transitionend', this.handleTransitionEnd);
   }
 
@@ -138,6 +142,7 @@ export class Collapsible extends React.Component<CombinedProps, State> {
       styles.Collapsible,
       open && styles.open,
       animating && styles.animating,
+      !animating && open && styles.fullyOpen,
     );
 
     const displayHeight = collapsibleHeight(open, animationState, height);


### PR DESCRIPTION
I have an instance where I need to nudge a component "outside" of the `<Collapsible />` area - so that when a `Collapsible` is open, our design has an element that "overflows" out of the container.

This is currently not possible because `Collapsible` **always** sets `overflow: hidden`, which is necessary for when the `Collapsible` is closed and transitioning open/closed. But once fully open, its safe to set `overflow: visible`.

### Before
<img width="485" alt="before" src="https://user-images.githubusercontent.com/643944/52140163-0c60f300-2620-11e9-876c-c9552afc4622.png">

### After
<img width="481" alt="after" src="https://user-images.githubusercontent.com/643944/52140172-1125a700-2620-11e9-8234-1f1760ea7c95.png">

This PR achieves this in the _easiest_ way possible by adding a `.fullyOpen` under the following condition: `animationState === 'idle' && props.open`

Perhaps we want to solve the problem a different way... One idea would be to replace the `idle` state with both a `fullyClosed` and `fullyOpened` state. This approach would require more code to change, as well as tests to be written/updated - but there could be value in pursuing it. I'll defer to the Polaris team on what they think.

For now, I propose this simple solution 😄 

### Playground
```js
import {relative} from 'path';
import * as React from 'react';
import {Button, Card, Collapsible, Page, Stack, TextContainer} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <CollapsibleExample />
      </Page>
    );
  }
}

class CollapsibleExample extends React.Component {
  state = {
    open: true,
  };

  handleToggleClick = () => {
    this.setState((state) => {
      const open = !state.open;

      return {
        open,
      };
    });
  };

  render() {
    const {open} = this.state;

    const inlineStyleContainerOutside: React.CSSProperties = {
      position: 'relative',
      height: '200px',
    };
    const inlineStyleContainerInside: React.CSSProperties = {
      position: 'relative',
      background: 'cyan',
    };
    const inlineStyleTooltip: React.CSSProperties = {
      position: 'absolute',
      top: '-40px',
      left: '-40px',
      width: '200px',
      background: 'black',
      padding: '10px',
      fontSize: '22px',
      color: 'white',
    };

    return (
      <div style={inlineStyleContainerOutside}>
        <Card sectioned>
          <Stack vertical>
            <Button onClick={this.handleToggleClick} ariaExpanded={open}>
              Toggle
            </Button>

            <div style={inlineStyleContainerInside}>
              <Collapsible id="basic-collapsible" open={open}>
                <div style={inlineStyleTooltip}>
                  <p>This is a custom tooltip for demonstation purposes!</p>
                </div>

                <TextContainer>
                  There are many variations of passages of Lorem Ipsum
                  available, but the majority have suffered alteration in some
                  form, by injected humour, or randomised words which don't look
                  even slightly believable. If you are going to use a passage of
                  Lorem Ipsum, you need to be sure there isn't anything
                  embarrassing hidden in the middle of text. All the Lorem Ipsum
                  generators on the Internet tend to repeat predefined chunks as
                  necessary, making this the first true generator on the
                  Internet. It uses a dictionary of over 200 Latin words,
                  combined with a handful of model sentence structures, to
                  generate Lorem Ipsum which looks reasonable. The generated
                  Lorem Ipsum is therefore always free from repetition, injected
                  humour, or non-characteristic words etc.
                </TextContainer>
              </Collapsible>
            </div>
          </Stack>
        </Card>
      </div>
    );
  }
}
```