### PR TITLE
[TextField] Remove on/off restriction for autocomplete

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -451,7 +451,7 @@ class TextField extends React.PureComponent<CombinedProps, State> {
 function normalizeAutoComplete(autoComplete?: string | boolean) {
   if (autoComplete == null) {
     return autoComplete;
-  } else if (typeof variable === "boolean"){
+} else if (typeof autoComplete === "boolean"){
     return autoComplete ? 'on' : 'off';
   }
   return autoComplete;

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -451,7 +451,7 @@ class TextField extends React.PureComponent<CombinedProps, State> {
 function normalizeAutoComplete(autoComplete?: string | boolean) {
   if (autoComplete == null) {
     return autoComplete;
-} else if (typeof autoComplete === "boolean"){
+  } else if (typeof autoComplete === 'boolean') {
     return autoComplete ? 'on' : 'off';
   }
   return autoComplete;

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -452,7 +452,7 @@ function normalizeAutoComplete(autoComplete?: boolean) {
   if (autoComplete == null) {
     return autoComplete;
   }
-  return autoComplete ? 'on' : 'off';
+  return autoComplete;
 }
 
 export default withAppProvider<Props>()(TextField);

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -76,7 +76,7 @@ export interface BaseProps {
   /** Limit increment value for numeric and date-time inputs */
   step?: number;
   /** Enable automatic completion by the browser */
-  autoComplete?: boolean;
+  autoComplete?: string | boolean;
   /** Mimics the behavior of the native HTML attribute, limiting how high the spinner can increment the value */
   max?: number;
   /** Maximum character length for an input */
@@ -448,9 +448,11 @@ class TextField extends React.PureComponent<CombinedProps, State> {
   }
 }
 
-function normalizeAutoComplete(autoComplete?: boolean) {
+function normalizeAutoComplete(autoComplete?: string | boolean) {
   if (autoComplete == null) {
     return autoComplete;
+  } else if (typeof variable === "boolean"){
+    return autoComplete ? 'on' : 'off';
   }
   return autoComplete;
 }

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -158,11 +158,18 @@ describe('<TextField />', () => {
       expect(textField.find('input').prop('autoComplete')).toBe('off');
     });
 
-    it('sets autoComplete to "on" when false', () => {
+    it('sets autoComplete to "on" when empty', () => {
       const textField = shallowWithAppProvider(
         <TextField label="TextField" autoComplete onChange={noop} />,
       );
       expect(textField.find('input').prop('autoComplete')).toBe('on');
+    });
+
+    it('sets autoComplete to "new-password" when new-password', () => {
+      const textField = shallowWithAppProvider(
+        <TextField label="TextField" autoComplete="new-password" onChange={noop} />,
+      );
+      expect(textField.find('input').prop('autoComplete')).toBe('new-password');
     });
   });
 


### PR DESCRIPTION
## The issue 
Browsers are constantly changing the way they handle autocomplete. Chrome is ignoring `off`, `nope`, etc. and is aiming to autocomplete all inputs. Restricting developers to `on` and `off` seems unnecessary and prevents fully supporting the browsers native functionality - here I'm referring to [W3C](https://www.w3.org/TR/html52/sec-forms.html#sec-autofill)

## The solution
Enabling custom `autoComplete` values.
```
<TextField autoComplete="new-password" ... />
```

This PR has no breaking changes. Passing a boolean will fallback to `on`/`off` 