### PR TITLE
[Card] Adjust padding of Card.Section, footer and header

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed the `DataTable` sort direction not reversing on second sort of the initially sorted column ([#918](https://github.com/Shopify/polaris-react/pull/918)) (thanks [@tabrez96](https://github.com/tabrez96) for the [issue report](https://github.com/Shopify/polaris-react/issues/873))
 - Allow `null` being passed to `value` in `TextField` ([#964](https://github.com/Shopify/polaris-react/pull/964)) (thanks [@mbaumbach](https://github.com/mbaumbach) for the [original issue](https://github.com/Shopify/polaris-react/issues/959))
 - Changed the default value for `showHidden` prop on `ResourcePicker` for backward compatibility with legacy EASDK ([#981](https://github.com/Shopify/polaris-react/pull/981))
+- Adjusted top and bottom padding to the header, footer and sections in `Card` to add space between action buttons in the header and footer and the card sections. ([#962](https://github.com/Shopify/polaris-react/pull/962))
 
 ### Documentation
 

--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -17,10 +17,11 @@
 }
 
 .Header {
-  padding: spacing() spacing() 0;
+  padding: spacing() spacing() rem(12px) spacing();
 
   @include page-content-when-not-fully-condensed {
-    padding: spacing(loose) spacing(loose) 0;
+    padding-right: spacing(loose);
+    padding-left: spacing(loose);
   }
 }
 
@@ -28,7 +29,7 @@
   padding: spacing();
 
   @include page-content-when-not-fully-condensed {
-    padding: spacing(loose);
+    padding: spacing() spacing(loose);
   }
 
   + .Section {
@@ -42,6 +43,7 @@
 
 .Section-subdued {
   background-color: color('sky', 'lighter');
+  border-top: border-width() solid color('sky');
 }
 
 .SectionHeader {
@@ -61,9 +63,14 @@
 .Footer {
   display: flex;
   justify-content: flex-end;
-  padding: 0 spacing() spacing();
+  padding: rem(12px) spacing() spacing() spacing();
 
   @include page-content-when-not-fully-condensed {
-    padding: 0 spacing(loose) spacing(loose);
+    padding-right: spacing(loose);
+    padding-left: spacing(loose);
+  }
+
+  .Section-subdued + & {
+    border-top: border-width() solid color('sky');
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #954  <!-- link to issue if one exists -->

When a subdued section `Card` and a footer prop were combined there was no padding/margin between the `Button Group` and the edge of the subdued card. 
It was also discovered in the interim there was the same issue with the Header  button Group and a subdued section card as well so this will be resolved.

### WHAT is this pull request doing?

This request is adding a margin to the footer section.
Before: 
![image](https://screenshot.click/06-26-t9bd4-myl5m.jpg)

After: 
![image](https://screenshot.click/06-58-milt4-xnx8v.jpg)

Small screen:
![image](https://screenshot.click/06-57-ajlv0-wdtit.jpg)


With no header and regular section cards:
![image](https://screenshot.click/06-59-k3z1b-6o3at.jpg)

Small screen:
![image](https://screenshot.click/06-00-9jnca-dbcs8.jpg)
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Card, List, Popover, Button, ActionList} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <Card
          secondaryFooterAction={{content: 'Dismiss'}}
          primaryFooterAction={{content: 'Export Report'}}
        >
          <Card.Header
            actions={[
              {
                content: 'Preview',
              },
            ]}
            title="Staff accounts"
          >
            <Popover
              active
              activator={
                <Button disclosure plain>
                  Add account
                </Button>
              }
              onClose={() => {}}
            >
              <ActionList items={[{content: 'Member'}, {content: 'Admin'}]} />
            </Popover>
          </Card.Header>
          <Card.Section title="Deactivated reports" subdued>
            <List>
              <List.Item>Payouts</List.Item>
              <List.Item>Total Sales By Channel</List.Item>
            </List>
          </Card.Section>
        </Card>
      </Page>
    );
  }
}
```

</details>

<details>
<summary>without subdued section:</summary>

```jsx
import * as React from 'react';
import {Page, Card, List, Popover, Button, ActionList} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <Card
          secondaryFooterAction={{content: 'Dismiss'}}
          primaryFooterAction={{content: 'Export Report'}}
        >
          <Card.Header
            actions={[
              {
                content: 'Preview',
              },
            ]}
            title="Staff accounts"
          >
            <Popover
              active
              activator={
                <Button disclosure plain>
                  Add account
                </Button>
              }
              onClose={() => {}}
            >
              <ActionList items={[{content: 'Member'}, {content: 'Admin'}]} />
            </Popover>
          </Card.Header>
          <Card.Section title="Deactivated reports">
            <List>
              <List.Item>Payouts</List.Item>
              <List.Item>Total Sales By Channel</List.Item>
            </List>
          </Card.Section>
        </Card>
      </Page>
    );
  }
}
```

</details>
### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
