### PR TITLE
[AppProvider]: Fix server side rendering for embedded apps

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Ensured server side rendering matches client side rendering for embedded app components (ex. `<Page>`)
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
+++ b/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
@@ -1,6 +1,5 @@
 import {noop} from '@shopify/javascript-utilities/other';
 import createApp, {getShopOrigin} from '@shopify/app-bridge';
-import {isServer} from '@shopify/react-utilities/target';
 import {AppProviderProps, Context} from '../../types';
 import {StickyManager} from '../withSticky';
 import ScrollLockManager from '../ScrollLockManager';
@@ -13,25 +12,6 @@ export interface CreateAppProviderContext extends AppProviderProps {
   subscribe?(callback: () => void): void;
   unsubscribe?(callback: () => void): void;
 }
-
-const serverAppBridge = {
-  dispatch<A>() {
-    return {} as A;
-  },
-  error() {
-    return noop;
-  },
-  featuresAvailable() {
-    return new Promise(noop);
-  },
-  getState() {
-    return new Promise(noop);
-  },
-  localOrigin: '',
-  subscribe() {
-    return noop;
-  },
-};
 
 export default function createAppProviderContext({
   i18n,
@@ -46,18 +26,13 @@ export default function createAppProviderContext({
 }: CreateAppProviderContext = {}): Context {
   const intl = new Intl(i18n);
   const link = new Link(linkComponent);
-
-  let appBridge;
-
-  if (apiKey) {
-    appBridge = isServer
-      ? serverAppBridge
-      : createApp({
-          apiKey,
-          shopOrigin: shopOrigin || getShopOrigin(),
-          forceRedirect,
-        });
-  }
+  const appBridge = apiKey
+    ? createApp({
+        apiKey,
+        shopOrigin: shopOrigin || getShopOrigin(),
+        forceRedirect,
+      })
+    : undefined;
 
   return {
     polaris: {

--- a/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
+++ b/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
@@ -14,6 +14,25 @@ export interface CreateAppProviderContext extends AppProviderProps {
   unsubscribe?(callback: () => void): void;
 }
 
+const serverAppBridge = {
+  dispatch<A>() {
+    return {} as A;
+  },
+  error() {
+    return noop;
+  },
+  featuresAvailable() {
+    return new Promise(noop);
+  },
+  getState() {
+    return new Promise(noop);
+  },
+  localOrigin: '',
+  subscribe() {
+    return noop;
+  },
+};
+
 export default function createAppProviderContext({
   i18n,
   linkComponent,
@@ -27,14 +46,18 @@ export default function createAppProviderContext({
 }: CreateAppProviderContext = {}): Context {
   const intl = new Intl(i18n);
   const link = new Link(linkComponent);
-  const appBridge =
-    apiKey && !isServer
-      ? createApp({
+
+  let appBridge;
+
+  if (apiKey) {
+    appBridge = isServer
+      ? serverAppBridge
+      : createApp({
           apiKey,
           shopOrigin: shopOrigin || getShopOrigin(),
           forceRedirect,
-        })
-      : undefined;
+        });
+  }
 
   return {
     polaris: {

--- a/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
+++ b/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
@@ -83,7 +83,7 @@ describe('createAppProviderContext()', () => {
     expect(context).toEqual(mockContext);
   });
 
-  it('does not instantiate app bridge if server side rendering', () => {
+  it('initializes a noop app bridge if server side rendering', () => {
     mockIsServer(true);
     const apiKey = '4p1k3y';
     const context = createAppProviderContext({apiKey});
@@ -95,7 +95,14 @@ describe('createAppProviderContext()', () => {
         scrollLockManager: new ScrollLockManager(),
         subscribe: noop,
         unsubscribe: noop,
-        appBridge: undefined,
+        appBridge: {
+          dispatch: expect.any(Function),
+          error: expect.any(Function),
+          featuresAvailable: expect.any(Function),
+          getState: expect.any(Function),
+          localOrigin: '',
+          subscribe: expect.any(Function),
+        },
       },
     };
 


### PR DESCRIPTION

### WHY are these changes introduced?

Resolves [#824](https://github.com/Shopify/polaris-react/issues/824)

This bug was the result of the `Page` component rendering different content on the server due to App Bridge not being available without `window`. 

### WHAT is this pull request doing?

Use a noop version of App Bridge on the server so that the child embedded components can correctly skip rendering UI that will be delegated to App Bridge. This ensures the rendered HTML on the server matches client side rendering
 
### How to 🎩
1. Create a test app using server side rendering following the instructions here: https://help.shopify.com/en/api/tutorials/build-a-shopify-app-with-node-and-react
2. Include the following content in your app
```
<AppProvider apiKey={apiKey}>
  <Page
    title="Title"
    primaryAction={{
      content: 'Save',
      disabled: true,
    }}
    secondaryAction={{
      content: 'Cancel',
      disabled: false,
    }}
    actionGroups={[
      {
        title: 'Promote',
        actions: [
          {content: 'Share on Facebook'},
          {content: 'Share on Instagram'},
        ],
      },
    ]}
  >
    <Layout>
      <Layout.AnnotatedSection
        title="Preview"
        description="This is how the information will be displayed on your shop under the &quot;Add to Cart&quot; button."
      >
        <Card title="Country with value range" sectioned>
          <Heading>Country with single value</Heading>
        </Card>
      </Layout.AnnotatedSection>
      <Layout.AnnotatedSection
        title="Display"
        description="Setup the text to be displayed on your page."
      >
        <Card sectioned>
          <TextField label="Display text for value range" onChange={() => {}} />
          <TextField
            label="Display text for single value"
            onChange={() => {}}
          />
        </Card>
      </Layout.AnnotatedSection>
    </Layout>
  </Page>
</AppProvider>
```
3. Run `yarn run build-consumer PROJECT_DIRECTORY`
4. Open your app and ensure the page layout looks correct with 2 annotated sections


### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

