### PR TITLE
[AppProvider]: Fix server side rendering for embedded apps

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,7 +19,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed unnecessary height on `TextField` due to unhandled carriage returns ([#901](https://github.com/Shopify/polaris-react/pull/901))
-- Ensured server side rendering matches client side rendering for embedded app components (ex. `<Page>`)
+- Ensured server side rendering matches client side rendering for [embedded app components](https://github.com/Shopify/polaris-react/blob/master/documentation/Embedded%20apps.md#components-which-wrap-shopify-app-bridge) ([#976](https://github.com/Shopify/polaris-react/pull/976))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed unnecessary height on `TextField` due to unhandled carriage returns ([#901](https://github.com/Shopify/polaris-react/pull/901))
+- Ensured server side rendering matches client side rendering for embedded app components (ex. `<Page>`)
 
 ### Documentation
 

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.1.6",
-    "@shopify/app-bridge": "^1.0.8-0",
+    "@shopify/app-bridge": "^1.1.2",
     "@shopify/images": "^1.1.0",
     "@shopify/javascript-utilities": "^2.2.1",
     "@shopify/polaris-icons": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.1.6",
-    "@shopify/app-bridge": "^1.0.3",
+    "@shopify/app-bridge": "^1.0.8-0",
     "@shopify/images": "^1.1.0",
     "@shopify/javascript-utilities": "^2.2.1",
     "@shopify/polaris-icons": "^3.0.0",

--- a/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
+++ b/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
@@ -19,6 +19,25 @@ export interface CreateAppProviderContext extends AppProviderProps {
   unsubscribe?(callback: () => void): void;
 }
 
+const serverAppBridge = {
+  dispatch<A>() {
+    return {} as A;
+  },
+  error() {
+    return noop;
+  },
+  featuresAvailable() {
+    return new Promise(noop);
+  },
+  getState() {
+    return new Promise(noop);
+  },
+  localOrigin: '',
+  subscribe() {
+    return noop;
+  },
+};
+
 export default function createAppProviderContext({
   i18n,
   linkComponent,
@@ -32,14 +51,18 @@ export default function createAppProviderContext({
 }: CreateAppProviderContext = {}): Context {
   const intl = new Intl(i18n);
   const link = new Link(linkComponent);
-  const appBridge =
-    apiKey && !isServer
-      ? createApp({
+
+  let appBridge;
+
+  if (apiKey) {
+    appBridge = isServer
+      ? serverAppBridge
+      : createApp({
           apiKey,
           shopOrigin: shopOrigin || getShopOrigin(),
           forceRedirect,
-        })
-      : undefined;
+        });
+  }
 
   if (appBridge && appBridge.hooks) {
     appBridge.hooks.set(LifecycleHook.DispatchAction, setClientInterfaceHook);

--- a/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
+++ b/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
@@ -4,7 +4,6 @@ import createApp, {
   LifecycleHook,
   DispatchActionHook,
 } from '@shopify/app-bridge';
-import {isServer} from '@shopify/react-utilities/target';
 import {AppProviderProps, Context} from '../../types';
 import {StickyManager} from '../withSticky';
 import ScrollLockManager from '../ScrollLockManager';
@@ -19,25 +18,6 @@ export interface CreateAppProviderContext extends AppProviderProps {
   unsubscribe?(callback: () => void): void;
 }
 
-const serverAppBridge = {
-  dispatch<A>() {
-    return {} as A;
-  },
-  error() {
-    return noop;
-  },
-  featuresAvailable() {
-    return new Promise(noop);
-  },
-  getState() {
-    return new Promise(noop);
-  },
-  localOrigin: '',
-  subscribe() {
-    return noop;
-  },
-};
-
 export default function createAppProviderContext({
   i18n,
   linkComponent,
@@ -51,18 +31,13 @@ export default function createAppProviderContext({
 }: CreateAppProviderContext = {}): Context {
   const intl = new Intl(i18n);
   const link = new Link(linkComponent);
-
-  let appBridge;
-
-  if (apiKey) {
-    appBridge = isServer
-      ? serverAppBridge
-      : createApp({
-          apiKey,
-          shopOrigin: shopOrigin || getShopOrigin(),
-          forceRedirect,
-        });
-  }
+  const appBridge = apiKey
+    ? createApp({
+        apiKey,
+        shopOrigin: shopOrigin || getShopOrigin(),
+        forceRedirect,
+      })
+    : undefined;
 
   if (appBridge && appBridge.hooks) {
     appBridge.hooks.set(LifecycleHook.DispatchAction, setClientInterfaceHook);

--- a/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
+++ b/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {serverAppBridge, LifecycleHook} from '@shopify/app-bridge';
+import * as appBridge from '@shopify/app-bridge';
 import * as redirect from '@shopify/app-bridge/client/redirect';
 import {noop} from '@shopify/javascript-utilities/other';
 import * as targets from '@shopify/react-utilities/target';
@@ -10,7 +10,6 @@ import Intl from '../../Intl';
 import Link from '../../Link';
 import {StickyManager} from '../../withSticky';
 import ScrollLockManager from '../../ScrollLockManager';
-import * as appBridge from '@shopify/app-bridge';
 
 const actualIsServer = targets.isServer;
 
@@ -21,7 +20,6 @@ function mockIsServer(value: boolean) {
 let createAppSpy = jest.spyOn(appBridge, 'default');
 
 describe('createAppProviderContext()', () => {
-
   beforeEach(() => {
     jest.clearAllMocks();
     createAppSpy = jest.spyOn(appBridge, 'default');
@@ -96,7 +94,7 @@ describe('createAppProviderContext()', () => {
     const apiKey = '4p1k3y';
     const context = createAppProviderContext({apiKey});
 
-    expect(context.polaris.appBridge).toEqual(serverAppBridge);
+    expect(context.polaris.appBridge).toEqual(appBridge.serverAppBridge);
   });
 
   it('adds an app bridge hook to set clientInterface data', () => {
@@ -109,7 +107,7 @@ describe('createAppProviderContext()', () => {
     createAppProviderContext({apiKey});
 
     expect(set).toHaveBeenCalledWith(
-      LifecycleHook.DispatchAction,
+      appBridge.LifecycleHook.DispatchAction,
       setClientInterfaceHook,
     );
   });

--- a/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
+++ b/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
@@ -93,8 +93,15 @@ describe('createAppProviderContext()', () => {
 
     const apiKey = '4p1k3y';
     const context = createAppProviderContext({apiKey});
-
-    expect(context.polaris.appBridge).toEqual(appBridge.serverAppBridge);
+    const serverAppBridge = {
+      dispatch: expect.any(Function),
+      localOrigin: '',
+      featuresAvailable: expect.any(Function),
+      getState: expect.any(Function),
+      subscribe: expect.any(Function),
+      error: expect.any(Function),
+    };
+    expect(context.polaris.appBridge).toEqual(serverAppBridge);
   });
 
   it('adds an app bridge hook to set clientInterface data', () => {

--- a/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
+++ b/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
@@ -85,7 +85,7 @@ describe('createAppProviderContext()', () => {
     expect(context).toEqual(mockContext);
   });
 
-  it('does not instantiate app bridge if server side rendering', () => {
+  it('initializes a noop app bridge if server side rendering', () => {
     mockIsServer(true);
     const apiKey = '4p1k3y';
     const context = createAppProviderContext({apiKey});
@@ -97,7 +97,14 @@ describe('createAppProviderContext()', () => {
         scrollLockManager: new ScrollLockManager(),
         subscribe: noop,
         unsubscribe: noop,
-        appBridge: undefined,
+        appBridge: {
+          dispatch: expect.any(Function),
+          error: expect.any(Function),
+          featuresAvailable: expect.any(Function),
+          getState: expect.any(Function),
+          localOrigin: '',
+          subscribe: expect.any(Function),
+        },
       },
     };
 

--- a/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
+++ b/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as appBridge from '@shopify/app-bridge';
-import * as redirect from '@shopify/app-bridge/client/redirect';
 import {noop} from '@shopify/javascript-utilities/other';
 import * as targets from '@shopify/react-utilities/target';
 import createAppProviderContext, {
@@ -18,20 +17,15 @@ function mockIsServer(value: boolean) {
 }
 
 describe('createAppProviderContext()', () => {
-  let createAppSpy: jest.SpyInstance<any>;
-
-  beforeEach(() => {
-    createAppSpy = jest
-      .spyOn(appBridge, 'default');
-  });
+  const createAppSpy: jest.SpyInstance<any> = jest.spyOn(appBridge, 'default');
 
   afterEach(() => {
     mockIsServer(actualIsServer);
-    createAppSpy.mockRestore();
+    createAppSpy.mockReset();
   });
 
   it('returns the right context without properties', () => {
-    createAppSpy.mockImplementation((args) => args);
+    createAppSpy.mockImplementationOnce((args) => args);
     const context = createAppProviderContext();
     const mockContext = {
       polaris: {
@@ -49,7 +43,7 @@ describe('createAppProviderContext()', () => {
   });
 
   it('returns the right context with properties', () => {
-    createAppSpy.mockImplementation((args) => ({
+    createAppSpy.mockImplementationOnce((args) => ({
       ...args,
       dispatch: () => {},
       localOrigin: '',
@@ -106,7 +100,7 @@ describe('createAppProviderContext()', () => {
 
   it('adds an app bridge hook to set clientInterface data', () => {
     const set = jest.fn();
-    createAppSpy.mockImplementation((args) => {
+    createAppSpy.mockImplementationOnce((args) => {
       return {...args, hooks: {set}};
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,10 +1077,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@shopify/app-bridge@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@shopify/app-bridge/-/app-bridge-1.0.3.tgz#a898b0450e4f917bbfcd65e5671718ad53bdaed9"
-  integrity sha512-YlHDBICC9UzLhF04T4zD+zHAhMEut0XRops9ZZeIlSLNeRTeQfwZPMP9UjHx+akZR+f2CeeBS8/nEthv7hmjvQ==
+"@shopify/app-bridge@^1.0.8-0":
+  version "1.0.8-0"
+  resolved "https://registry.yarnpkg.com/@shopify/app-bridge/-/app-bridge-1.0.8-0.tgz#b45ffe7e7ff5bd2dccac1bfd1cfad95932c71998"
+  integrity sha512-97v6MKCOJFy57/Lt7sxT8aw2ef3Cf8Y29KfOUJqKTI3XrSOAnVA+x9dFNL4lCW56hBxaIAiAcKGg58jeUCSmAQ==
 
 "@shopify/browserslist-config@^0.0.2-beta.2":
   version "0.0.2-beta.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,10 +1077,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@shopify/app-bridge@^1.0.8-0":
-  version "1.0.8-0"
-  resolved "https://registry.yarnpkg.com/@shopify/app-bridge/-/app-bridge-1.0.8-0.tgz#b45ffe7e7ff5bd2dccac1bfd1cfad95932c71998"
-  integrity sha512-97v6MKCOJFy57/Lt7sxT8aw2ef3Cf8Y29KfOUJqKTI3XrSOAnVA+x9dFNL4lCW56hBxaIAiAcKGg58jeUCSmAQ==
+"@shopify/app-bridge@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@shopify/app-bridge/-/app-bridge-1.1.2.tgz#d5d614d799e527f956b962ea8082a4f1cbd39597"
+  integrity sha512-DzjQV52DS8i0VZB0b2Mcf+btBV/lC+47TZbtg6tcTXcgn+TXWh5ynm8niahAwMpMZR8/HlFQdZ1utxbN6kZQzA==
 
 "@shopify/browserslist-config@^0.0.2-beta.2":
   version "0.0.2-beta.2"


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris-react/issues/824 https://github.com/Shopify/app-bridge/issues/722

**Polaris** `Page` component renders content differently on the server vs client side because **App Bridge** is set to `undefined` when `window` is not available.

### WHAT is this pull request doing?

Always call `createApp` and allow **App Bridge** to return a noop version of App Bridge when `window` is unavailable.

### How to 🎩

#### Install and test sample app
1. Check out `shopify` and run test branch `app-bridge/test/ss-app`: `dev up; dev server`
    *This will make the sample server side app available to your local shop*
1. Check out and run Hanna's **Test Polaris App Bridge Embedded App**: https://github.com/hannachen/nextjs-app-test
1. Once the app is installed to your shop, it will initially render the correct UI (server side), but mangled once **App Bridge** client kicks in:
    <img width="1201" alt="screen shot 2019-02-05 at 2 19 27 pm" src="https://user-images.githubusercontent.com/2709526/52298505-1866f080-2951-11e9-88a3-e187950ba58a.png">

#### Build App Bridge for sample app
1. Check out `app-bridge` from this PR: https://github.com/Shopify/app-bridge/pull/724
1. Build `app-bridge` by running `dev nuke; dev up; dev build`
1. Pack and apply to `nextjs-app-test` by running the following from `app-bridge` project root: 
    ```sh
   dev build-consumer ../hannachen/nextjs-app-test app-bridge
    ```
    *Please change the relative path to `nextjs-app-test` according to your setup*

#### Build Polaris for sample app
1. Build `polaris-react` at the project root by running:
    ```sh
    dev build-consumer ../hannachen/nextjs-app-test
    ```
    *This will build and copy `polaris` into the test app*

#### Test Changes
1. Restart the sample app and  view the test app again
    This time there should be no difference between client and server side render:
    <img width="1203" alt="screen shot 2019-02-05 at 3 48 10 pm" src="https://user-images.githubusercontent.com/2709526/52303261-89aca080-295d-11e9-84aa-7facb5f9cc64.png">

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [N/A] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [N/A] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
