### PR TITLE
[Resource Picker] change the default value of `showHidden` to `true`

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixed the `DataTable` sort direction not reversing on second sort of the initially sorted column ([#918](https://github.com/Shopify/polaris-react/pull/918)) (thanks [@tabrez96](https://github.com/tabrez96) for the [issue report](https://github.com/Shopify/polaris-react/issues/873))
 - Allow `null` being passed to `value` in `TextField` ([#964](https://github.com/Shopify/polaris-react/pull/964)) (thanks [@mbaumbach](https://github.com/mbaumbach) for the [original issue](https://github.com/Shopify/polaris-react/issues/959))
+- Changed the default value for `showHidden` prop on `ResourcePicker` for backward compatibility with legacy EASDK ([#981](https://github.com/Shopify/polaris-react/pull/981))
 
 ### Documentation
 

--- a/src/components/ResourcePicker/ResourcePicker.tsx
+++ b/src/components/ResourcePicker/ResourcePicker.tsx
@@ -20,7 +20,7 @@ export interface Props {
    */
   initialQuery?: string;
   /** Whether to show hidden products or not
-   * @default false
+   * @default true
    */
   showHidden?: boolean;
   /** Whether to allow selection of multiple items
@@ -54,7 +54,7 @@ export class ResourcePicker extends React.PureComponent<CombinedProps, never> {
       open,
       resourceType,
       initialQuery,
-      showHidden = false,
+      showHidden = true,
       allowMultiple = true,
       showVariants = true,
       onSelection,

--- a/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
+++ b/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
@@ -39,7 +39,7 @@ describe('<ResourcePicker />', () => {
           resourceType: AppBridgeResourcePicker.ResourceType.Product,
           options: {
             initialQuery: undefined,
-            showHidden: false,
+            showHidden: true,
             selectMultiple: true,
             showVariants: true,
           },


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/app-bridge/issues/717

`showHidden` default value was changed to `false` when App Bridge first launched, but the option didn't actually take effect due to a bug. Now that the bug is fixed by https://github.com/Shopify/web/pull/10116, it exposed behaviour inconsistency with EASDK.

More details on the issue here: https://github.com/Shopify/app-bridge/issues/721

### WHAT is this pull request doing?

Change the default value back to `true` in order to match the expected behaviour of EASDK, as well as other admin sections.