### PR TITLE
[Range slider] Remove tip

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,11 +13,14 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Updates `TopBar.UserMenu` interaction states styling ([#1006](https://github.com/Shopify/polaris-react/pull/1006))
 - Added `download` prop to `Button` and `UnstyledLink` components that enables setting the download attribute ([#1027](https://github.com/Shopify/polaris-react/pull/1027))
 - Extract months and week names into translation files ([#1005](https://github.com/Shopify/polaris-react/pull/1005))
+- Added support for dual values to `RangeSlider` component ([#784](https://github.com/Shopify/polaris-react/pull/784))
+- Widened click target area of track for `RangeSlider` ([#987](https://github.com/Shopify/polaris-react/pull/987))
 
 ### Bug fixes
 
 - Changed the offset from 5px to 4px in `Tooltip` between activator and message to be consistent with `Popover` ([#1019](https://github.com/Shopify/polaris-react/pull/1019))
 - Fixed `Card` header not showing when `title` empty or not set ([#1031](https://github.com/Shopify/polaris-react/pull/1032))
+- Added clamp to `RangeSlider` so its initial value doesn't fall outside of min or max bounds ([#784](https://github.com/Shopify/polaris-react/pull/784))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Extract months and week names into translation files ([#1005](https://github.com/Shopify/polaris-react/pull/1005))
 - Added support for dual values to `RangeSlider` component ([#784](https://github.com/Shopify/polaris-react/pull/784))
 - Widened click target area of track for `RangeSlider` ([#987](https://github.com/Shopify/polaris-react/pull/987))
+- Removed tip from `RangeSlider` `output` ([#988](https://github.com/Shopify/polaris-react/pull/988))
 
 ### Bug fixes
 

--- a/src/components/RangeSlider/README.md
+++ b/src/components/RangeSlider/README.md
@@ -29,7 +29,7 @@ Range sliders should:
 - When a label is visible, it should clearly communicate the purpose of the range input and its values (min, max, step, value)
 - Be labeled as “Optional” when you need to request input that’s not required
 - Validate input as soon as merchants have finished interacting with a field (but not before)
-- Always be used with `accessibilityInputs` when range slider has dual thumbs, to provide accessible alternatives to sliding the thumbs
+- Always be used with two text field components when range slider has dual thumbs, to provide accessible alternatives to both the lower and upper thumbs
 
 ---
 
@@ -231,21 +231,109 @@ class RangeSliderExample extends React.Component {
 Use a dual thumb range slider when merchants need to select a range of values.
 
 ```jsx
+const initialValue = [900, 1000];
+
 class RangeSliderExample extends React.Component {
-  handleChange = (value) => {
-    console.log({value});
+  state = {
+    intermediateTextFieldValue: initialValue,
+    value: initialValue,
+  };
+
+  handleRangeSliderChange = (value) => {
+    this.setState({value, intermediateTextFieldValue: value});
+  };
+
+  handleLowerTextFieldChange = (value) => {
+    const upperValue = this.state.value[1];
+    this.setState({intermediateTextFieldValue: [parseInt(value), upperValue]});
+  };
+
+  handleUpperTextFieldChange = (value) => {
+    const lowerValue = this.state.value[0];
+    this.setState({intermediateTextFieldValue: [lowerValue, parseInt(value)]});
+  };
+
+  handleLowerTextFieldBlur = () => {
+    const upperValue = this.state.value[1];
+    const value = this.state.intermediateTextFieldValue[0];
+
+    this.setState({value: [parseInt(value), upperValue]});
+  };
+
+  handleUpperTextFieldBlur = () => {
+    const lowerValue = this.state.value[0];
+    const value = this.state.intermediateTextFieldValue[1];
+
+    this.setState({value: [lowerValue, parseInt(value)]});
+  };
+
+  handleEnterKeyPress = (event) => {
+    const newValue = this.state.intermediateTextFieldValue;
+    const oldValue = this.state.value;
+
+    if (event.keyCode === Key.Enter && newValue !== oldValue) {
+      this.setState({value: newValue});
+    }
   };
 
   render() {
+    const {value, intermediateTextFieldValue} = this.state;
+    const prefix = '$';
+    const min = 0;
+    const max = 2000;
+    const step = 10;
+    const disabled = false;
+
+    const lowerTextFieldValue =
+      intermediateTextFieldValue[0] === value[0]
+        ? value[0]
+        : intermediateTextFieldValue[0];
+    const upperTextFieldValue =
+      intermediateTextFieldValue[1] === value[1]
+        ? value[1]
+        : intermediateTextFieldValue[1];
+
     return (
       <Card sectioned>
-        <RangeSlider
-          label=""
-          value={[35, 60]}
-          onChange={this.handleChange}
-          accessibilityInputs
-          step={5}
-        />
+        <div style={{marginTop: '20px'}} onKeyDown={this.handleEnterKeyPress}>
+          <RangeSlider
+            label="Money spent is between"
+            value={value}
+            prefix={prefix}
+            output
+            min={min}
+            max={max}
+            step={step}
+            disabled={disabled}
+            onChange={this.handleRangeSliderChange}
+          />
+          <Stack distribution="equalSpacing" spacing="extraLoose">
+            <TextField
+              label="Min money spent"
+              type="number"
+              value={`${lowerTextFieldValue}`}
+              prefix={prefix}
+              min={min}
+              max={max}
+              step={step}
+              disabled={disabled}
+              onChange={this.handleLowerTextFieldChange}
+              onBlur={this.handleLowerTextFieldBlur}
+            />
+            <TextField
+              label="Max money spent"
+              type="number"
+              value={`${upperTextFieldValue}`}
+              prefix={prefix}
+              min={min}
+              max={max}
+              step={step}
+              disabled={disabled}
+              onChange={this.handleUpperTextFieldChange}
+              onBlur={this.handleUpperTextFieldBlur}
+            />
+          </Stack>
+        </div>
       </Card>
     );
   }

--- a/src/components/RangeSlider/README.md
+++ b/src/components/RangeSlider/README.md
@@ -29,6 +29,7 @@ Range sliders should:
 - When a label is visible, it should clearly communicate the purpose of the range input and its values (min, max, step, value)
 - Be labeled as “Optional” when you need to request input that’s not required
 - Validate input as soon as merchants have finished interacting with a field (but not before)
+- Always be used with `accessibilityInputs` when range slider has dual thumbs, to provide accessible alternatives to sliding the thumbs
 
 ---
 
@@ -218,6 +219,32 @@ class RangeSliderExample extends React.Component {
           onChange={this.handleChange}
           prefix={<p>Hue</p>}
           suffix={<p style={suffixStyles}>{this.state.value}</p>}
+        />
+      </Card>
+    );
+  }
+}
+```
+
+### Dual thumb range slider
+
+Use a dual thumb range slider when merchants need to select a range of values.
+
+```jsx
+class RangeSliderExample extends React.Component {
+  handleChange = (value) => {
+    console.log({value});
+  };
+
+  render() {
+    return (
+      <Card sectioned>
+        <RangeSlider
+          label=""
+          value={[35, 60]}
+          onChange={this.handleChange}
+          accessibilityInputs
+          step={5}
         />
       </Card>
     );

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import {Props, RangeSliderValue} from './types';
+import {DEFAULT_RANGE_SLIDER_PROPS} from './utilities';
 
 import {SingleThumb, DualThumb} from './components';
 
@@ -12,9 +13,9 @@ const getUniqueID = createUniqueIDFactory('RangeSlider');
 export function RangeSlider(props: CombinedProps) {
   const {
     id = getUniqueID(),
-    min = 0,
-    max = 100,
-    step = 1,
+    min = DEFAULT_RANGE_SLIDER_PROPS.min,
+    max = DEFAULT_RANGE_SLIDER_PROPS.max,
+    step = DEFAULT_RANGE_SLIDER_PROPS.step,
     value,
     ...rest
   } = props;

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
-import {Props, RangeSliderValue} from './types';
+import {Props, RangeSliderValue, DualValue} from './types';
 import {RangeSliderDefault} from './utilities';
 
 import {SingleThumb, DualThumb} from './components';
@@ -35,7 +35,7 @@ export function RangeSlider(props: CombinedProps) {
   );
 }
 
-function isDualThumb(value: RangeSliderValue): value is [number, number] {
+function isDualThumb(value: RangeSliderValue): value is DualValue {
   return Array.isArray(value);
 }
 

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import {Props, RangeSliderValue} from './types';
-import {DEFAULT_RANGE_SLIDER_PROPS} from './utilities';
+import {RangeSliderDefault} from './utilities';
 
 import {SingleThumb, DualThumb} from './components';
 
@@ -13,9 +13,9 @@ const getUniqueID = createUniqueIDFactory('RangeSlider');
 export function RangeSlider(props: CombinedProps) {
   const {
     id = getUniqueID(),
-    min = DEFAULT_RANGE_SLIDER_PROPS.min,
-    max = DEFAULT_RANGE_SLIDER_PROPS.max,
-    step = DEFAULT_RANGE_SLIDER_PROPS.step,
+    min = RangeSliderDefault.Min,
+    max = RangeSliderDefault.Max,
+    step = RangeSliderDefault.Step,
     value,
     ...rest
   } = props;

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -1,205 +1,41 @@
 import * as React from 'react';
-import {autobind} from '@shopify/javascript-utilities/decorators';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
-import {classNames} from '@shopify/react-utilities/styles';
-
-import {Error} from '../../types';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
-import Labelled, {Action, helpTextID} from '../Labelled';
+import {Props, RangeSliderValue} from './types';
 
-import styles from './RangeSlider.scss';
+import {SingleThumb, DualThumb} from './components';
 
-export interface State {
-  id: string;
-}
-
-export interface BaseProps {
-  /** Label for the range input */
-  label: string;
-  /** Adds an action to the label */
-  labelAction?: Action;
-  /** Visually hide the label */
-  labelHidden?: boolean;
-  /** ID for range input */
-  id?: string;
-  /** Initial value for range input */
-  value: number;
-  /** Minimum possible value for range input */
-  min?: number;
-  /** Maximum possible value for range input */
-  max?: number;
-  /** Increment value for range input changes */
-  step?: number;
-  /** Provide a tooltip while sliding, indicating the current value */
-  output?: boolean;
-  /** Additional text to aid in use */
-  helpText?: React.ReactNode;
-  /** Display an error message */
-  error?: Error;
-  /** Disable input */
-  disabled?: boolean;
-  /** Element to display before the input */
-  prefix?: React.ReactNode;
-  /** Element to display after the input */
-  suffix?: React.ReactNode;
-  /** Callback when the range input is changed */
-  onChange(value: number, id: string): void;
-  /** Callback when range input is focused */
-  onFocus?(): void;
-  /** Callback when focus is removed */
-  onBlur?(): void;
-}
-
-export interface Props extends BaseProps {}
-export type CombinedProps = Props & WithAppProviderProps;
+type CombinedProps = Props & WithAppProviderProps;
 
 const getUniqueID = createUniqueIDFactory('RangeSlider');
-const cssVarPrefix = '--Polaris-RangeSlider-';
 
-export class RangeSlider extends React.PureComponent<CombinedProps, State> {
-  static getDerivedStateFromProps(nextProps: CombinedProps, prevState: State) {
-    return nextProps.id != null && nextProps.id !== prevState.id
-      ? {
-          id: nextProps.id || prevState.id,
-        }
-      : null;
-  }
+export function RangeSlider(props: CombinedProps) {
+  const {
+    id = getUniqueID(),
+    min = 0,
+    max = 100,
+    step = 1,
+    value,
+    ...rest
+  } = props;
 
-  constructor(props: CombinedProps) {
-    super(props);
+  const sharedProps = {
+    id,
+    min,
+    max,
+    step,
+    ...rest,
+  };
 
-    this.state = {
-      id: props.id || getUniqueID(),
-    };
-  }
-
-  render() {
-    const {id} = this.state;
-    const {min = 0, max = 100} = this.props;
-    const {
-      label,
-      labelAction,
-      labelHidden,
-      step,
-      value,
-      output,
-      helpText,
-      error,
-      disabled,
-      prefix,
-      suffix,
-      onFocus,
-      onBlur,
-    } = this.props;
-
-    const describedBy: string[] = [];
-
-    if (error) {
-      describedBy.push(`${id}Error`);
-    }
-
-    if (helpText) {
-      describedBy.push(helpTextID(id));
-    }
-
-    const ariaDescribedBy = describedBy.length
-      ? describedBy.join(' ')
-      : undefined;
-
-    const sliderProgress = ((value - min) * 100) / (max - min);
-
-    const cssVars = {
-      [`${cssVarPrefix}min`]: min,
-      [`${cssVarPrefix}max`]: max,
-      [`${cssVarPrefix}current`]: value,
-      [`${cssVarPrefix}progress`]: `${sliderProgress}%`,
-      [`${cssVarPrefix}output-factor`]: invertNumber(
-        (sliderProgress - 50) / 100,
-      ),
-    };
-
-    const outputMarkup = !disabled &&
-      output && (
-        <output htmlFor={id} className={styles.Output}>
-          <div className={styles.OutputBubble}>
-            <span className={styles.OutputText}>{value}</span>
-          </div>
-        </output>
-      );
-
-    const prefixMarkup = prefix && (
-      <div className={styles.Prefix}>{prefix}</div>
-    );
-
-    const suffixMarkup = suffix && (
-      <div className={styles.Suffix}>{suffix}</div>
-    );
-
-    const className = classNames(
-      styles.RangeSlider,
-      error && styles.error,
-      disabled && styles.disabled,
-    );
-
-    return (
-      <Labelled
-        id={id}
-        label={label}
-        error={error}
-        action={labelAction}
-        labelHidden={labelHidden}
-        helpText={helpText}
-      >
-        <div className={className} style={cssVars}>
-          {prefixMarkup}
-          <div className={styles.InputWrapper}>
-            <input
-              type="range"
-              className={styles.Input}
-              id={id}
-              name={id}
-              min={min}
-              max={max}
-              step={step}
-              value={value}
-              disabled={disabled}
-              onChange={this.handleChange}
-              onFocus={onFocus}
-              onBlur={onBlur}
-              aria-valuemin={min}
-              aria-valuemax={max}
-              aria-valuenow={value}
-              aria-invalid={Boolean(error)}
-              aria-describedby={ariaDescribedBy}
-            />
-            {outputMarkup}
-          </div>
-          {suffixMarkup}
-        </div>
-      </Labelled>
-    );
-  }
-
-  @autobind
-  private handleChange(event: React.ChangeEvent<HTMLInputElement>) {
-    const {onChange} = this.props;
-
-    if (onChange == null) {
-      return;
-    }
-
-    onChange(parseFloat(event.currentTarget.value), this.state.id);
-  }
+  return isDualThumb(value) ? (
+    <DualThumb value={value} {...sharedProps} />
+  ) : (
+    <SingleThumb value={value} {...sharedProps} />
+  );
 }
 
-export function invertNumber(number: number) {
-  if (Math.sign(number) === 1) {
-    return -Math.abs(number);
-  } else if (Math.sign(number) === -1) {
-    return Math.abs(number);
-  } else {
-    return 0;
-  }
+function isDualThumb(value: RangeSliderValue): value is [number, number] {
+  return Array.isArray(value);
 }
 
 export default withAppProvider<Props>()(RangeSlider);

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -10,11 +10,11 @@ $range-thumbs-border: rem(1px) solid color('sky', 'dark');
 $range-thumbs-border-error: rem(2px) solid color('red');
 $range-thumbs-shadow-hover: (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint));
 $range-thumbs-border-active: rem(2px) solid color('indigo');
-$range-accessibility-input-margin: rem(8px);
 
 .Wrapper {
   position: relative;
   width: 100%;
+  display: flex;
 }
 
 .TrackWrapper {
@@ -57,18 +57,6 @@ $range-accessibility-input-margin: rem(8px);
       // stylelint-enable selector-max-class
     }
   }
-}
-
-.AccessibilityInputsWrapper {
-  width: 100%;
-  display: flex;
-  flex-wrap: nowrap;
-  justify-content: space-between;
-  margin-top: $range-accessibility-input-margin;
-}
-
-.AccessibilityInputLower {
-  min-width: rem(80px);
 }
 
 .Track {
@@ -153,6 +141,16 @@ $range-accessibility-input-margin: rem(8px);
 
 $range-output-size: rem(32px);
 $range-output-tip-size: rem(8px);
+
+.Prefix {
+  flex: 0 0 auto;
+  margin-right: spacing(tight);
+}
+
+.Suffix {
+  flex: 0 0 auto;
+  margin-left: spacing(tight);
+}
 
 .Output {
   position: absolute;

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -64,11 +64,6 @@ $range-thumbs-border-active: rem(2px) solid color('indigo');
   width: 100%;
   height: $range-track-height;
   border-radius: $range-thumb-size;
-  cursor: pointer;
-
-  .disabled & {
-    cursor: default;
-  }
 
   --unselected-range: #{color('sky', 'dark')};
   --selected-range: #{color('indigo')};

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -1,0 +1,217 @@
+$stacking-order: (
+  output: 10,
+  input: 20,
+);
+
+$range-track-height: rem(4px);
+$range-thumb-size: rem(24px);
+$range-thumb-border-size: rem(2px);
+$range-thumbs-border: rem(1px) solid color('sky', 'dark');
+$range-thumbs-border-error: rem(2px) solid color('red');
+$range-thumbs-shadow-hover: (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint));
+$range-thumbs-border-active: rem(2px) solid color('indigo');
+$range-accessibility-input-margin: rem(8px);
+
+.Wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.TrackWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: $range-thumb-size;
+
+  &.disabled {
+    opacity: 0.8;
+    cursor: not-allowed;
+  }
+
+  &.error {
+    &:active,
+    &:focus {
+      // stylelint-disable selector-max-specificity
+      // stylelint-disable selector-max-class
+      .Track {
+        --unselected-range: #{color('sky', 'dark')};
+        --selected-range: #{color('indigo')};
+        --gradient-colors: var(--unselected-range, transparent) 0%,
+          var(--unselected-range, transparent)
+            var(--Polaris-RangeSlider-progress-lower),
+          var(--selected-range, transparent)
+            var(--Polaris-RangeSlider-progress-lower),
+          var(--selected-range, transparent)
+            var(--Polaris-RangeSlider-progress-upper),
+          var(--unselected-range, transparent)
+            var(--Polaris-RangeSlider-progress-upper),
+          var(--unselected-range, transparent) 100%;
+        background-image: linear-gradient(to right, var(--gradient-colors));
+      }
+
+      .Thumbs {
+        border: $range-thumbs-border-active;
+      }
+      // stylelint-enable selector-max-specificity
+      // stylelint-enable selector-max-class
+    }
+  }
+}
+
+.AccessibilityInputsWrapper {
+  width: 100%;
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  margin-top: $range-accessibility-input-margin;
+}
+
+.AccessibilityInputLower {
+  min-width: rem(80px);
+}
+
+.Track {
+  position: absolute;
+  width: 100%;
+  height: $range-track-height;
+  border-radius: $range-thumb-size;
+  cursor: pointer;
+
+  .disabled & {
+    cursor: default;
+  }
+
+  --unselected-range: #{color('sky', 'dark')};
+  --selected-range: #{color('indigo')};
+
+  .error & {
+    --selected-range: #{color('red')};
+    --gradient-colors: var(--unselected-range, transparent) 0%,
+      var(--unselected-range, transparent)
+        var(--Polaris-RangeSlider-progress-lower),
+      var(--selected-range, transparent)
+        var(--Polaris-RangeSlider-progress-lower),
+      var(--selected-range, transparent)
+        var(--Polaris-RangeSlider-progress-upper),
+      var(--unselected-range, transparent)
+        var(--Polaris-RangeSlider-progress-upper),
+      var(--unselected-range, transparent) 100%;
+    background-image: linear-gradient(to right, var(--gradient-colors));
+  }
+
+  --gradient-colors: var(--unselected-range, transparent) 0%,
+    var(--unselected-range, transparent)
+      var(--Polaris-RangeSlider-progress-lower),
+    var(--selected-range, transparent) var(--Polaris-RangeSlider-progress-lower),
+    var(--selected-range, transparent) var(--Polaris-RangeSlider-progress-upper),
+    var(--unselected-range, transparent)
+      var(--Polaris-RangeSlider-progress-upper),
+    var(--unselected-range, transparent) 100%;
+  background-image: linear-gradient(to right, var(--gradient-colors));
+}
+
+.Thumbs {
+  position: absolute;
+  z-index: z-index('input', $stacking-order);
+  width: $range-thumb-size;
+  height: $range-thumb-size;
+  border: $range-thumbs-border;
+  border-radius: 50%;
+  background: linear-gradient(color('sky', 'lighter'), color('sky', 'light'));
+
+  // stylelint-disable-next-line value-no-vendor-prefix
+  cursor: -webkit-grab;
+
+  &:hover,
+  &:active,
+  &:focus {
+    border: $range-thumbs-border-active;
+  }
+
+  &.disabled {
+    cursor: not-allowed;
+    border: $range-thumbs-border;
+  }
+
+  .error & {
+    border: $range-thumbs-border-error;
+  }
+
+  // stylelint-disable selector-max-specificity
+  &:hover + .Output &,
+  &:active + .Output &,
+  &:focus + .Output & {
+    transform: translateY(-$range-thumb-size);
+
+    @include page-content-when-not-partially-condensed {
+      transform: translateY(-($range-thumb-size / 2));
+    }
+  }
+  // stylelint-enable selector-max-specificity
+}
+
+$range-output-size: rem(32px);
+$range-output-tip-size: rem(8px);
+
+.Output {
+  position: absolute;
+  z-index: z-index('output', $stacking-order);
+  bottom: $range-output-size - $range-output-tip-size + $range-thumb-size;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition-property: opacity, visibility;
+  transition-duration: duration();
+  transition-timing-function: easing();
+
+  .ThumbLower:hover + &,
+  .ThumbLower:active + &,
+  .ThumbLower:focus + & {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .ThumbUpper:hover + &,
+  .ThumbUpper:active + &,
+  .ThumbUpper:focus + & {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+
+.OutputBubble {
+  position: relative;
+  display: flex;
+  padding: 0 spacing(tight);
+  min-width: $range-output-size;
+  height: $range-output-size;
+  background-color: color('ink');
+  border-radius: border-radius();
+  transition-property: transform;
+  transition-duration: duration();
+  transition-timing-function: easing();
+
+  &::before {
+    content: '';
+    position: absolute;
+    bottom: -($range-output-tip-size - rem(1px));
+    left: 50%;
+    margin-left: -$range-output-tip-size;
+    display: block;
+    width: 0;
+    height: 0;
+    border-left: $range-output-tip-size solid transparent;
+    border-right: $range-output-tip-size solid transparent;
+    border-top: $range-output-tip-size solid color('ink');
+  }
+}
+
+.OutputText {
+  @include text-style-subheading;
+  display: block;
+  flex: 1 1 auto;
+  margin: auto;
+  text-align: center;
+  color: color('white');
+}

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -4,7 +4,7 @@ $stacking-order: (
 );
 
 $range-track-height: rem(4px);
-$range-thumb-size: rem(24px);
+$range-thumb-size: rem(26px);
 $range-thumb-border-size: rem(2px);
 $range-thumbs-border: rem(1px) solid color('sky', 'dark');
 $range-thumbs-border-error: rem(2px) solid color('red');

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -68,6 +68,16 @@ $range-thumbs-border-active: rem(2px) solid color('indigo');
   --unselected-range: #{color('sky', 'dark')};
   --selected-range: #{color('indigo')};
 
+  --gradient-colors: var(--unselected-range, transparent) 0%,
+    var(--unselected-range, transparent)
+      var(--Polaris-RangeSlider-progress-lower),
+    var(--selected-range, transparent) var(--Polaris-RangeSlider-progress-lower),
+    var(--selected-range, transparent) var(--Polaris-RangeSlider-progress-upper),
+    var(--unselected-range, transparent)
+      var(--Polaris-RangeSlider-progress-upper),
+    var(--unselected-range, transparent) 100%;
+  background-image: linear-gradient(to right, var(--gradient-colors));
+
   .error & {
     --selected-range: #{color('red')};
     --gradient-colors: var(--unselected-range, transparent) 0%,
@@ -82,16 +92,6 @@ $range-thumbs-border-active: rem(2px) solid color('indigo');
       var(--unselected-range, transparent) 100%;
     background-image: linear-gradient(to right, var(--gradient-colors));
   }
-
-  --gradient-colors: var(--unselected-range, transparent) 0%,
-    var(--unselected-range, transparent)
-      var(--Polaris-RangeSlider-progress-lower),
-    var(--selected-range, transparent) var(--Polaris-RangeSlider-progress-lower),
-    var(--selected-range, transparent) var(--Polaris-RangeSlider-progress-upper),
-    var(--unselected-range, transparent)
-      var(--Polaris-RangeSlider-progress-upper),
-    var(--unselected-range, transparent) 100%;
-  background-image: linear-gradient(to right, var(--gradient-colors));
 }
 
 .Thumbs {

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -3,8 +3,9 @@ $stacking-order: (
   input: 20,
 );
 
+$range-wrapper: rem(28px);
 $range-track-height: rem(4px);
-$range-thumb-size: rem(26px);
+$range-thumb-size: rem(24px);
 $range-thumb-border-size: rem(2px);
 $range-thumbs-border: rem(1px) solid color('sky', 'dark');
 $range-thumbs-border-error: rem(2px) solid color('red');
@@ -15,6 +16,7 @@ $range-thumbs-border-active: rem(2px) solid color('indigo');
   position: relative;
   width: 100%;
   display: flex;
+  align-items: center;
 }
 
 .TrackWrapper {
@@ -22,7 +24,8 @@ $range-thumbs-border-active: rem(2px) solid color('indigo');
   display: flex;
   align-items: center;
   width: 100%;
-  min-height: $range-thumb-size;
+  min-height: $range-wrapper;
+  cursor: pointer;
 
   &.disabled {
     opacity: 0.8;

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -67,7 +67,6 @@ $range-thumbs-border-active: rem(2px) solid color('indigo');
 
   --unselected-range: #{color('sky', 'dark')};
   --selected-range: #{color('indigo')};
-
   --gradient-colors: var(--unselected-range, transparent) 0%,
     var(--unselected-range, transparent)
       var(--Polaris-RangeSlider-progress-lower),

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -96,6 +96,9 @@ $range-thumbs-border-active: rem(2px) solid color('indigo');
   }
 }
 
+$range-output-size: rem(32px);
+$range-output-offset: rem(4px);
+
 .Thumbs {
   position: absolute;
   z-index: z-index('input', $stacking-order);
@@ -122,22 +125,7 @@ $range-thumbs-border-active: rem(2px) solid color('indigo');
   .error & {
     border: $range-thumbs-border-error;
   }
-
-  // stylelint-disable selector-max-specificity
-  &:hover + .Output &,
-  &:active + .Output &,
-  &:focus + .Output & {
-    transform: translateY(-$range-thumb-size);
-
-    @include page-content-when-not-partially-condensed {
-      transform: translateY(-($range-thumb-size / 2));
-    }
-  }
-  // stylelint-enable selector-max-specificity
 }
-
-$range-output-size: rem(32px);
-$range-output-tip-size: rem(8px);
 
 .Prefix {
   flex: 0 0 auto;
@@ -152,7 +140,7 @@ $range-output-tip-size: rem(8px);
 .Output {
   position: absolute;
   z-index: z-index('output', $stacking-order);
-  bottom: $range-output-size - $range-output-tip-size + $range-thumb-size;
+  bottom: $range-thumb-size;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
@@ -187,19 +175,37 @@ $range-output-tip-size: rem(8px);
   transition-duration: duration();
   transition-timing-function: easing();
 
-  &::before {
-    content: '';
-    position: absolute;
-    bottom: -($range-output-tip-size - rem(1px));
-    left: 50%;
-    margin-left: -$range-output-tip-size;
-    display: block;
-    width: 0;
-    height: 0;
-    border-left: $range-output-tip-size solid transparent;
-    border-right: $range-output-tip-size solid transparent;
-    border-top: $range-output-tip-size solid color('ink');
+  // stylelint-disable selector-max-class
+  // stylelint-disable selector-max-combinators
+  // stylelint-disable selector-max-specificity
+  .ThumbLower:hover + .Output &,
+  .ThumbLower:active + .Output &,
+  .ThumbLower:focus + .Output & {
+    transform: translateY(-$range-output-offset);
   }
+
+  .ThumbUpper:hover + .Output &,
+  .ThumbUpper:active + .Output &,
+  .ThumbUpper:focus + .Output & {
+    transform: translateY(-$range-output-offset);
+  }
+  // stylelint-enable selector-max-class
+  // stylelint-enable selector-max-combinators
+  // stylelint-enable selector-max-specificity
+}
+
+$range-output-translate-x-lower: calc(
+  -50% + var(--Polaris-RangeSlider-output-factor-lower, 0) * #{$range-thumb-size}
+);
+$range-output-translate-x-upper: calc(
+  -50% + var(--Polaris-RangeSlider-output-factor-upper, 0) * #{$range-thumb-size}
+);
+
+.OutputLower {
+  transform: translateX($range-output-translate-x-lower);
+}
+.OutputUpper {
+  transform: translateX($range-output-translate-x-upper);
 }
 
 .OutputText {

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -5,7 +5,6 @@ import {
   removeEventListener,
 } from '@shopify/javascript-utilities/events';
 import {classNames} from '@shopify/react-utilities/styles';
-import TextField from '../../../TextField';
 import {CSS_VAR_PREFIX} from '../../utilities';
 import {Props as RangeSliderProps} from '../../types';
 import Labelled from '../../../Labelled';
@@ -102,13 +101,11 @@ export default class DualThumb extends React.Component<Props, State> {
       id,
       min,
       max,
-      step,
       prefix,
       suffix,
       disabled,
       output,
       error,
-      accessibilityInputs,
       onFocus,
       onBlur,
       label,
@@ -147,61 +144,6 @@ export default class DualThumb extends React.Component<Props, State> {
       styles.ThumbUpper,
       disabled && styles.disabled,
     );
-
-    const classNameAccessibilityInputLower = classNames(
-      styles.AccessibilityInputs,
-      styles.AccessibilityInputLower,
-    );
-    const classNameAccessibilityInputUpper = classNames(
-      styles.AccessibilityInputs,
-      styles.AccessibilityInputUpper,
-    );
-
-    const lowerMaxValue = isNaN(valueUpper - step)
-      ? undefined
-      : valueUpper - step;
-
-    const accessibilityPrefixMarkup = accessibilityInputs ? (
-      <div className={classNameAccessibilityInputLower}>
-        <TextField
-          label="Lower value"
-          labelHidden
-          type="number"
-          step={step}
-          prefix={prefix}
-          suffix={suffix}
-          disabled={disabled}
-          value={String(valueLower)}
-          onChange={this.handleTextFieldChangeLower}
-          onBlur={this.handleTextFieldBlurLower}
-          max={lowerMaxValue}
-          min={min}
-        />
-      </div>
-    ) : null;
-
-    const upperMinValue = isNaN(valueLower + step)
-      ? undefined
-      : valueLower + step;
-
-    const accessibilitySuffixMarkup = accessibilityInputs ? (
-      <div className={classNameAccessibilityInputUpper}>
-        <TextField
-          label="Upper value"
-          labelHidden
-          type="number"
-          step={step}
-          prefix={prefix}
-          suffix={suffix}
-          disabled={disabled}
-          value={String(valueUpper)}
-          onChange={this.handleTextFieldChangeUpper}
-          onBlur={this.handleTextFieldBlurUpper}
-          max={max}
-          min={upperMinValue}
-        />
-      </div>
-    ) : null;
 
     const trackWidth = this.state.trackWidth;
     const adjustedTrackWidth = trackWidth - THUMB_SIZE;
@@ -250,6 +192,14 @@ export default class DualThumb extends React.Component<Props, State> {
       [`${CSS_VAR_PREFIX}progress-upper`]: `${progressUpper}px`,
     };
 
+    const prefixMarkup = prefix && (
+      <div className={styles.Prefix}>{prefix}</div>
+    );
+
+    const suffixMarkup = suffix && (
+      <div className={styles.Suffix}>{suffix}</div>
+    );
+
     return (
       <Labelled
         id={id}
@@ -260,6 +210,7 @@ export default class DualThumb extends React.Component<Props, State> {
         helpText={helpText}
       >
         <div className={styles.Wrapper} id={id}>
+          {prefixMarkup}
           <div className={classNameTrackWrapper}>
             <div
               className={styles.Track}
@@ -306,10 +257,7 @@ export default class DualThumb extends React.Component<Props, State> {
             />
             {outputMarkupUpper}
           </div>
-          <div className={styles.AccessibilityInputsWrapper}>
-            {accessibilityPrefixMarkup}
-            {accessibilitySuffixMarkup}
-          </div>
+          {suffixMarkup}
         </div>
       </Labelled>
     );
@@ -427,60 +375,6 @@ export default class DualThumb extends React.Component<Props, State> {
     const {valueLower, valueUpper} = this.state;
 
     return onChange([valueLower, valueUpper], id);
-  }
-
-  @autobind
-  private handleTextFieldChangeLower(value: string) {
-    this.setState({valueLower: Number(value)});
-  }
-
-  @autobind
-  private handleTextFieldChangeUpper(value: string) {
-    this.setState({valueUpper: Number(value)});
-  }
-
-  @autobind
-  private handleTextFieldBlurLower() {
-    const {valueLower, valueUpper} = this.state;
-    const {step, min} = this.props;
-    const steppedValue = roundToNearestStepValue(valueLower, step);
-
-    const valueWithinBoundsLower = keepValueWithinBoundsLower(
-      steppedValue,
-      valueUpper,
-      min,
-      step,
-    );
-    this.setState(
-      {
-        valueLower: valueWithinBoundsLower,
-      },
-      () => {
-        this.handleChange();
-      },
-    );
-  }
-
-  @autobind
-  private handleTextFieldBlurUpper() {
-    const {step, max} = this.props;
-    const {valueUpper, valueLower} = this.state;
-    const steppedValue = roundToNearestStepValue(valueUpper, step);
-
-    const valueWithinBoundsUpper = keepValueWithinBoundsUpper(
-      steppedValue,
-      valueLower,
-      max,
-      step,
-    );
-    this.setState(
-      {
-        valueUpper: valueWithinBoundsUpper,
-      },
-      () => {
-        this.handleChange();
-      },
-    );
   }
 
   @autobind

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -59,8 +59,7 @@ export default class DualThumb extends React.Component<Props, State> {
 
     return {
       prevValue: value,
-      valueLower: sanitizedValue[0],
-      valueUpper: sanitizedValue[1],
+      value: sanitizedValue,
     };
   }
 

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -206,7 +206,6 @@ export default class DualThumb extends React.Component<Props, State> {
               />
               <button
                 id={idLower}
-                testID="thumbLower"
                 className={classNameThumbLower}
                 ref={this.thumbLower}
                 style={{
@@ -227,7 +226,6 @@ export default class DualThumb extends React.Component<Props, State> {
               {outputMarkupLower}
               <button
                 id={idUpper}
-                testID="thumbUpper"
                 className={classNameThumbUpper}
                 ref={this.thumbUpper}
                 style={{
@@ -361,7 +359,7 @@ export default class DualThumb extends React.Component<Props, State> {
   @autobind
   private incrementValueUpper() {
     this.setValue(
-      [this.state.value[1] + this.props.step, this.state.value[0]],
+      [this.state.value[0], this.state.value[1] + this.props.step],
       Control.Lower,
     );
   }

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -1,0 +1,594 @@
+import * as React from 'react';
+import {autobind} from '@shopify/javascript-utilities/decorators';
+import {
+  addEventListener,
+  removeEventListener,
+} from '@shopify/javascript-utilities/events';
+import {classNames} from '@shopify/react-utilities/styles';
+import TextField from '../../../TextField';
+import {CSS_VAR_PREFIX} from '../../utilities';
+import {Props as RangeSliderProps} from '../../types';
+import Labelled from '../../../Labelled';
+
+import {Key} from '../../../../types';
+
+import * as styles from './DualThumb.scss';
+
+export interface State {
+  valueLower: number;
+  valueUpper: number;
+  trackWidth: number;
+}
+
+export interface Props extends RangeSliderProps {
+  value: [number, number];
+  id: string;
+  min: number;
+  max: number;
+  step: number;
+}
+
+const THUMB_SIZE = 24;
+const OUTPUT_TIP_SIZE = 8;
+
+export default class DualThumb extends React.Component<Props, State> {
+  state: State = {
+    valueLower: this.props.value[0],
+    valueUpper: this.props.value[1],
+    trackWidth: 0,
+  };
+
+  private track = React.createRef<HTMLDivElement>();
+  private thumbLower = React.createRef<HTMLButtonElement>();
+  private thumbUpper = React.createRef<HTMLButtonElement>();
+
+  componentDidMount() {
+    const {valueLower, valueUpper} = this.state;
+    const {step, min, max} = this.props;
+    const valueWithinBoundsLower = keepValueWithinBoundsLower(
+      roundToNearestStepValue(valueLower, step),
+      valueUpper,
+      min,
+      step,
+    );
+
+    const valueWithinBoundsUpper = keepValueWithinBoundsUpper(
+      roundToNearestStepValue(valueUpper, step),
+      valueLower,
+      max,
+      step,
+    );
+
+    this.setState({
+      valueLower: valueWithinBoundsLower,
+      valueUpper: valueWithinBoundsUpper,
+    });
+
+    if (this.track.current) {
+      this.setState({
+        trackWidth: this.track.current.getBoundingClientRect().width,
+      });
+    }
+
+    if (this.thumbLower.current && !this.props.disabled) {
+      addEventListener(
+        this.thumbLower.current,
+        'mousedown',
+        this.handleMouseDownThumbLower,
+      );
+      addEventListener(
+        this.thumbLower.current,
+        'keyup',
+        this.handleKeypressLower,
+      );
+    }
+
+    if (this.thumbUpper.current && !this.props.disabled) {
+      addEventListener(
+        this.thumbUpper.current,
+        'mousedown',
+        this.handleMouseDownThumbUpper,
+      );
+      addEventListener(
+        this.thumbUpper.current,
+        'keyup',
+        this.handleKeypressUpper,
+      );
+    }
+  }
+
+  render() {
+    const {
+      id,
+      min,
+      max,
+      step,
+      prefix,
+      suffix,
+      disabled,
+      output,
+      error,
+      accessibilityInputs,
+      onFocus,
+      onBlur,
+      label,
+      labelAction,
+      labelHidden,
+      helpText,
+    } = this.props;
+    const {valueLower, valueUpper} = this.state;
+
+    const idLower = `${id}Lower`;
+    const idUpper = `${id}Upper`;
+
+    const describedBy: string[] = [];
+
+    if (error) {
+      describedBy.push(`${id}Error`);
+    }
+
+    const ariaDescribedBy = describedBy.length
+      ? describedBy.join(' ')
+      : undefined;
+
+    const classNameTrackWrapper = classNames(
+      styles.TrackWrapper,
+      error && styles.error,
+      disabled && styles.disabled,
+    );
+
+    const classNameThumbLower = classNames(
+      styles.Thumbs,
+      styles.ThumbLower,
+      disabled && styles.disabled,
+    );
+    const classNameThumbUpper = classNames(
+      styles.Thumbs,
+      styles.ThumbUpper,
+      disabled && styles.disabled,
+    );
+
+    const classNameAccessibilityInputLower = classNames(
+      styles.AccessibilityInputs,
+      styles.AccessibilityInputLower,
+    );
+    const classNameAccessibilityInputUpper = classNames(
+      styles.AccessibilityInputs,
+      styles.AccessibilityInputUpper,
+    );
+
+    const lowerMaxValue = isNaN(valueUpper - step)
+      ? undefined
+      : valueUpper - step;
+
+    const accessibilityPrefixMarkup = accessibilityInputs ? (
+      <div className={classNameAccessibilityInputLower}>
+        <TextField
+          label="Lower value"
+          labelHidden
+          type="number"
+          step={step}
+          prefix={prefix}
+          suffix={suffix}
+          disabled={disabled}
+          value={String(valueLower)}
+          onChange={this.handleTextFieldChangeLower}
+          onBlur={this.handleTextFieldBlurLower}
+          max={lowerMaxValue}
+          min={min}
+        />
+      </div>
+    ) : null;
+
+    const upperMinValue = isNaN(valueLower + step)
+      ? undefined
+      : valueLower + step;
+
+    const accessibilitySuffixMarkup = accessibilityInputs ? (
+      <div className={classNameAccessibilityInputUpper}>
+        <TextField
+          label="Upper value"
+          labelHidden
+          type="number"
+          step={step}
+          prefix={prefix}
+          suffix={suffix}
+          disabled={disabled}
+          value={String(valueUpper)}
+          onChange={this.handleTextFieldChangeUpper}
+          onBlur={this.handleTextFieldBlurUpper}
+          max={max}
+          min={upperMinValue}
+        />
+      </div>
+    ) : null;
+
+    const trackWidth = this.state.trackWidth;
+    const adjustedTrackWidth = trackWidth - THUMB_SIZE;
+    const range = max - min;
+
+    const leftPositionThumbLower = (valueLower / range) * adjustedTrackWidth;
+    const leftPositionThumbUpper = (valueUpper / range) * adjustedTrackWidth;
+
+    const classNameOutputLower = classNames(styles.Output, styles.OutputLower);
+    const outputMarkupLower =
+      !disabled && output ? (
+        <output
+          htmlFor={idLower}
+          className={classNameOutputLower}
+          style={{
+            left: `calc(${leftPositionThumbLower}px - ${OUTPUT_TIP_SIZE}px)`,
+          }}
+        >
+          <div className={styles.OutputBubble}>
+            <span className={styles.OutputText}>{valueLower}</span>
+          </div>
+        </output>
+      ) : null;
+
+    const classNameOutputUpper = classNames(styles.Output, styles.OutputUpper);
+    const outputMarkupUpper =
+      !disabled && output ? (
+        <output
+          htmlFor={idUpper}
+          className={classNameOutputUpper}
+          style={{
+            left: `calc(${leftPositionThumbUpper}px - ${OUTPUT_TIP_SIZE}px)`,
+          }}
+        >
+          <div className={styles.OutputBubble}>
+            <span className={styles.OutputText}>{valueUpper}</span>
+          </div>
+        </output>
+      ) : null;
+
+    const progressLower = leftPositionThumbLower + THUMB_SIZE / 2;
+    const progressUpper = leftPositionThumbUpper + THUMB_SIZE / 2;
+
+    const cssVars = {
+      [`${CSS_VAR_PREFIX}progress-lower`]: `${progressLower}px`,
+      [`${CSS_VAR_PREFIX}progress-upper`]: `${progressUpper}px`,
+    };
+
+    return (
+      <Labelled
+        id={id}
+        label={label}
+        error={error}
+        action={labelAction}
+        labelHidden={labelHidden}
+        helpText={helpText}
+      >
+        <div className={styles.Wrapper} id={id}>
+          <div className={classNameTrackWrapper}>
+            <div
+              className={styles.Track}
+              style={cssVars}
+              ref={this.track}
+              testID="track"
+            />
+            <button
+              id={idLower}
+              testID="thumbLower"
+              className={classNameThumbLower}
+              ref={this.thumbLower}
+              style={{
+                left: `${leftPositionThumbLower}px`,
+              }}
+              role="slider"
+              aria-disabled={disabled}
+              aria-valuemin={min}
+              aria-valuemax={max}
+              aria-valuenow={valueLower}
+              aria-invalid={Boolean(error)}
+              aria-describedby={ariaDescribedBy}
+              onFocus={onFocus}
+              onBlur={onBlur}
+            />
+            {outputMarkupLower}
+            <button
+              id={idUpper}
+              testID="thumbUpper"
+              className={classNameThumbUpper}
+              ref={this.thumbUpper}
+              style={{
+                left: `${leftPositionThumbUpper}px`,
+              }}
+              role="slider"
+              aria-disabled={disabled}
+              aria-valuemin={min}
+              aria-valuemax={max}
+              aria-valuenow={valueUpper}
+              aria-invalid={Boolean(error)}
+              aria-describedby={ariaDescribedBy}
+              onFocus={onFocus}
+              onBlur={onBlur}
+            />
+            {outputMarkupUpper}
+          </div>
+          <div className={styles.AccessibilityInputsWrapper}>
+            {accessibilityPrefixMarkup}
+            {accessibilitySuffixMarkup}
+          </div>
+        </div>
+      </Labelled>
+    );
+  }
+
+  @autobind
+  private handleMouseDownThumbLower() {
+    if (this.thumbLower.current) {
+      addEventListener(document, 'mousemove', this.handleMouseMoveThumbLower);
+      addEventListener(
+        document,
+        'mouseup',
+        () => {
+          removeEventListener(
+            document,
+            'mousemove',
+            this.handleMouseMoveThumbLower,
+          );
+        },
+        {once: true},
+      );
+    }
+  }
+
+  @autobind
+  private handleMouseMoveThumbLower(event: MouseEvent) {
+    if (this.track.current) {
+      const {valueUpper} = this.state;
+      const {min, max, step} = this.props;
+      const clientRect = this.track.current.getBoundingClientRect();
+
+      const relativeX = event.clientX - clientRect.left;
+
+      const percentageOfTrack = relativeX / (clientRect.width - THUMB_SIZE);
+      const percentageOfRange = percentageOfTrack * (max - min);
+
+      const steppedPercentageOfRange = roundToNearestStepValue(
+        percentageOfRange,
+        step,
+      );
+
+      const valueWithinBoundsLower = keepValueWithinBoundsLower(
+        steppedPercentageOfRange,
+        valueUpper,
+        min,
+        step,
+      );
+      this.setState(
+        {
+          valueLower: valueWithinBoundsLower,
+        },
+        () => {
+          this.handleChange();
+        },
+      );
+    }
+  }
+
+  @autobind
+  private handleMouseDownThumbUpper() {
+    if (this.thumbUpper.current) {
+      addEventListener(document, 'mousemove', this.handleMouseMoveThumbUpper);
+      addEventListener(
+        document,
+        'mouseup',
+        () => {
+          removeEventListener(
+            document,
+            'mousemove',
+            this.handleMouseMoveThumbUpper,
+          );
+        },
+        {once: true},
+      );
+    }
+  }
+
+  @autobind
+  private handleMouseMoveThumbUpper(event: MouseEvent) {
+    if (this.track.current) {
+      const {valueLower} = this.state;
+      const {min, max, step} = this.props;
+      const clientRect = this.track.current.getBoundingClientRect();
+
+      const relativeX = event.clientX - clientRect.left;
+
+      const percentageOfTrack = relativeX / (clientRect.width - THUMB_SIZE);
+      const percentageOfRange = percentageOfTrack * (max - min);
+
+      const steppedPercentageOfRange = roundToNearestStepValue(
+        percentageOfRange,
+        step,
+      );
+
+      const valueWithinBoundsUpper = keepValueWithinBoundsUpper(
+        steppedPercentageOfRange,
+        valueLower,
+        max,
+        step,
+      );
+      this.setState(
+        {
+          valueUpper: valueWithinBoundsUpper,
+        },
+        () => {
+          this.handleChange();
+        },
+      );
+    }
+  }
+
+  @autobind
+  private handleChange() {
+    const {onChange, id} = this.props;
+    const {valueLower, valueUpper} = this.state;
+
+    return onChange([valueLower, valueUpper], id);
+  }
+
+  @autobind
+  private handleTextFieldChangeLower(value: string) {
+    this.setState({valueLower: Number(value)});
+  }
+
+  @autobind
+  private handleTextFieldChangeUpper(value: string) {
+    this.setState({valueUpper: Number(value)});
+  }
+
+  @autobind
+  private handleTextFieldBlurLower() {
+    const {valueLower, valueUpper} = this.state;
+    const {step, min} = this.props;
+    const steppedValue = roundToNearestStepValue(valueLower, step);
+
+    const valueWithinBoundsLower = keepValueWithinBoundsLower(
+      steppedValue,
+      valueUpper,
+      min,
+      step,
+    );
+    this.setState(
+      {
+        valueLower: valueWithinBoundsLower,
+      },
+      () => {
+        this.handleChange();
+      },
+    );
+  }
+
+  @autobind
+  private handleTextFieldBlurUpper() {
+    const {step, max} = this.props;
+    const {valueUpper, valueLower} = this.state;
+    const steppedValue = roundToNearestStepValue(valueUpper, step);
+
+    const valueWithinBoundsUpper = keepValueWithinBoundsUpper(
+      steppedValue,
+      valueLower,
+      max,
+      step,
+    );
+    this.setState(
+      {
+        valueUpper: valueWithinBoundsUpper,
+      },
+      () => {
+        this.handleChange();
+      },
+    );
+  }
+
+  @autobind
+  private handleKeypressLower(event: KeyboardEvent) {
+    const {valueLower, valueUpper} = this.state;
+    const {step, min} = this.props;
+    event.preventDefault();
+    event.stopPropagation();
+
+    let newValue = valueLower;
+
+    if (event.keyCode === Key.DownArrow || event.keyCode === Key.LeftArrow) {
+      newValue = valueLower - step;
+    } else if (
+      event.keyCode === Key.UpArrow ||
+      event.keyCode === Key.RightArrow
+    ) {
+      newValue = valueLower + step;
+    }
+
+    const valueWithinBoundsLower = keepValueWithinBoundsLower(
+      newValue,
+      valueUpper,
+      min,
+      step,
+    );
+
+    this.setState(
+      {
+        valueLower: valueWithinBoundsLower,
+      },
+      () => {
+        this.handleChange();
+      },
+    );
+  }
+
+  @autobind
+  private handleKeypressUpper(event: KeyboardEvent) {
+    const {valueLower, valueUpper} = this.state;
+    const {max, step} = this.props;
+    event.preventDefault();
+    event.stopPropagation();
+
+    let newValue = valueUpper;
+
+    if (event.keyCode === Key.DownArrow || event.keyCode === Key.LeftArrow) {
+      newValue = valueUpper - step;
+    } else if (
+      event.keyCode === Key.UpArrow ||
+      event.keyCode === Key.RightArrow
+    ) {
+      newValue = valueUpper + step;
+    }
+
+    const valueWithinBoundsUpper = keepValueWithinBoundsUpper(
+      newValue,
+      valueLower,
+      max,
+      step,
+    );
+
+    this.setState(
+      {
+        valueUpper: valueWithinBoundsUpper,
+      },
+      () => {
+        this.handleChange();
+      },
+    );
+
+    event.preventDefault();
+    event.stopPropagation();
+  }
+}
+
+function keepValueWithinBoundsLower(
+  steppedValue: number,
+  valueUpper: number,
+  min: number,
+  step: number,
+) {
+  if (steppedValue <= min) {
+    return min;
+  } else if (steppedValue >= valueUpper) {
+    return valueUpper - step;
+  } else {
+    return steppedValue;
+  }
+}
+
+function keepValueWithinBoundsUpper(
+  steppedValue: number,
+  valueLower: number,
+  max: number,
+  step: number,
+) {
+  if (steppedValue >= max) {
+    return max;
+  } else if (steppedValue <= valueLower) {
+    return valueLower + step;
+  } else {
+    return steppedValue;
+  }
+}
+
+function roundToNearestStepValue(value: number, step: number) {
+  const intermediateValue = value / step;
+  const roundedValue = Math.round(intermediateValue);
+  return roundedValue * step;
+}

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -51,7 +51,7 @@ export default class DualThumb extends React.Component<Props, State> {
       return null;
     }
 
-    const sanitizedValue: DualValue = sanitizeValue(value, min, max, step);
+    const sanitizedValue = sanitizeValue(value, min, max, step);
 
     if (!isEqual(value, sanitizedValue)) {
       onChange(sanitizedValue, id);

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -13,7 +13,7 @@ import Labelled from '../../../Labelled';
 import EventListener from '../../../EventListener';
 import {Key} from '../../../../types';
 
-import * as styles from './DualThumb.scss';
+import styles from './DualThumb.scss';
 
 export interface State {
   value: DualValue;

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -7,7 +7,7 @@ import {
   removeEventListener,
 } from '@shopify/javascript-utilities/events';
 import {classNames} from '@shopify/react-utilities/styles';
-import {CSS_VAR_PREFIX} from '../../utilities';
+import {invertNumber, CSS_VAR_PREFIX} from '../../utilities';
 import {Props as RangeSliderProps, DualValue} from '../../types';
 import Labelled from '../../../Labelled';
 import EventListener from '../../../EventListener';
@@ -40,7 +40,6 @@ enum Control {
 }
 
 const THUMB_SIZE = 24;
-const OUTPUT_TIP_SIZE = 8;
 
 export default class DualThumb extends React.Component<Props, State> {
   static getDerivedStateFromProps(props: Props, state: State) {
@@ -136,6 +135,8 @@ export default class DualThumb extends React.Component<Props, State> {
 
     const leftPositionThumbLower = (value[0] / range) * trackWidth;
     const leftPositionThumbUpper = (value[1] / range) * trackWidth;
+    const leftPositionOutputLower = leftPositionThumbLower + THUMB_SIZE / 2;
+    const leftPositionOutputUpper = leftPositionThumbUpper + THUMB_SIZE / 2;
 
     const outputLowerClassName = classNames(styles.Output, styles.OutputLower);
     const outputMarkupLower =
@@ -144,7 +145,7 @@ export default class DualThumb extends React.Component<Props, State> {
           htmlFor={idLower}
           className={outputLowerClassName}
           style={{
-            left: `calc(${leftPositionThumbLower}px - ${OUTPUT_TIP_SIZE}px)`,
+            left: `calc(${leftPositionOutputLower}px)`,
           }}
         >
           <div className={styles.OutputBubble}>
@@ -160,7 +161,7 @@ export default class DualThumb extends React.Component<Props, State> {
           htmlFor={idUpper}
           className={outputUpperClassName}
           style={{
-            left: `calc(${leftPositionThumbUpper}px - ${OUTPUT_TIP_SIZE}px)`,
+            left: `calc(${leftPositionOutputUpper}px)`,
           }}
         >
           <div className={styles.OutputBubble}>
@@ -172,9 +173,16 @@ export default class DualThumb extends React.Component<Props, State> {
     const progressLower = leftPositionThumbLower + THUMB_SIZE / 2;
     const progressUpper = leftPositionThumbUpper + THUMB_SIZE / 2;
 
+    const sliderProgressLower = ((value[0] - min) * 100) / (max - min);
+    const sliderProgressUpper = ((value[1] - min) * 100) / (max - min);
+    const outputFactorLower = invertNumber((sliderProgressLower - 50) / 100);
+    const outputFactorUpper = invertNumber((sliderProgressUpper - 50) / 100);
+
     const cssVars = {
       [`${CSS_VAR_PREFIX}progress-lower`]: `${progressLower}px`,
       [`${CSS_VAR_PREFIX}progress-upper`]: `${progressUpper}px`,
+      [`${CSS_VAR_PREFIX}output-factor-lower`]: `${outputFactorLower}`,
+      [`${CSS_VAR_PREFIX}output-factor-upper`]: `${outputFactorUpper}`,
     };
 
     const prefixMarkup = prefix && (

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -114,18 +114,18 @@ export default class DualThumb extends React.Component<Props, State> {
       ? describedBy.join(' ')
       : undefined;
 
-    const classNameTrackWrapper = classNames(
+    const trackWrapperClassName = classNames(
       styles.TrackWrapper,
       error && styles.error,
       disabled && styles.disabled,
     );
 
-    const classNameThumbLower = classNames(
+    const thumbLowerClassName = classNames(
       styles.Thumbs,
       styles.ThumbLower,
       disabled && styles.disabled,
     );
-    const classNameThumbUpper = classNames(
+    const thumbUpperClassName = classNames(
       styles.Thumbs,
       styles.ThumbUpper,
       disabled && styles.disabled,
@@ -137,12 +137,12 @@ export default class DualThumb extends React.Component<Props, State> {
     const leftPositionThumbLower = (value[0] / range) * trackWidth;
     const leftPositionThumbUpper = (value[1] / range) * trackWidth;
 
-    const classNameOutputLower = classNames(styles.Output, styles.OutputLower);
+    const outputLowerClassName = classNames(styles.Output, styles.OutputLower);
     const outputMarkupLower =
       !disabled && output ? (
         <output
           htmlFor={idLower}
-          className={classNameOutputLower}
+          className={outputLowerClassName}
           style={{
             left: `calc(${leftPositionThumbLower}px - ${OUTPUT_TIP_SIZE}px)`,
           }}
@@ -153,12 +153,12 @@ export default class DualThumb extends React.Component<Props, State> {
         </output>
       ) : null;
 
-    const classNameOutputUpper = classNames(styles.Output, styles.OutputUpper);
+    const outputUpperClassName = classNames(styles.Output, styles.OutputUpper);
     const outputMarkupUpper =
       !disabled && output ? (
         <output
           htmlFor={idUpper}
-          className={classNameOutputUpper}
+          className={outputUpperClassName}
           style={{
             left: `calc(${leftPositionThumbUpper}px - ${OUTPUT_TIP_SIZE}px)`,
           }}
@@ -197,7 +197,7 @@ export default class DualThumb extends React.Component<Props, State> {
         >
           <div className={styles.Wrapper} id={id}>
             {prefixMarkup}
-            <div className={classNameTrackWrapper}>
+            <div className={trackWrapperClassName}>
               <div
                 className={styles.Track}
                 style={cssVars}
@@ -206,7 +206,7 @@ export default class DualThumb extends React.Component<Props, State> {
               />
               <button
                 id={idLower}
-                className={classNameThumbLower}
+                className={thumbLowerClassName}
                 ref={this.thumbLower}
                 style={{
                   left: `${leftPositionThumbLower}px`,
@@ -226,7 +226,7 @@ export default class DualThumb extends React.Component<Props, State> {
               {outputMarkupLower}
               <button
                 id={idUpper}
-                className={classNameThumbUpper}
+                className={thumbUpperClassName}
                 ref={this.thumbUpper}
                 style={{
                   left: `${leftPositionThumbUpper}px`,

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -197,7 +197,11 @@ export default class DualThumb extends React.Component<Props, State> {
         >
           <div className={styles.Wrapper} id={id}>
             {prefixMarkup}
-            <div className={trackWrapperClassName}>
+            <div
+              className={trackWrapperClassName}
+              onMouseDown={this.handleMouseDownTrack}
+              testID="trackWrapper"
+            >
               <div
                 className={styles.Track}
                 style={cssVars}
@@ -272,6 +276,7 @@ export default class DualThumb extends React.Component<Props, State> {
   ) {
     if (event.button !== 0) return;
     registerMouseMoveHandler(this.handleMouseMoveThumbLower);
+    event.stopPropagation();
   }
 
   @autobind
@@ -289,6 +294,7 @@ export default class DualThumb extends React.Component<Props, State> {
   ) {
     if (event.button !== 0) return;
     registerMouseMoveHandler(this.handleMouseMoveThumbUpper);
+    event.stopPropagation();
   }
 
   @autobind
@@ -396,6 +402,23 @@ export default class DualThumb extends React.Component<Props, State> {
         },
         this.dispatchValue,
       );
+    }
+  }
+
+  @autobind
+  private handleMouseDownTrack(event: React.MouseEvent) {
+    if (event.button !== 0) return;
+    const clickXPosition = this.actualXPosition(event.clientX);
+    const {value} = this.state;
+    const distanceFromLowerThumb = Math.abs(value[0] - clickXPosition);
+    const distanceFromUpperThumb = Math.abs(value[1] - clickXPosition);
+
+    if (distanceFromLowerThumb <= distanceFromUpperThumb) {
+      this.setValue([clickXPosition, value[1]], Control.Upper);
+      registerMouseMoveHandler(this.handleMouseMoveThumbLower);
+    } else {
+      this.setValue([value[0], clickXPosition], Control.Lower);
+      registerMouseMoveHandler(this.handleMouseMoveThumbUpper);
     }
   }
 

--- a/src/components/RangeSlider/components/DualThumb/index.ts
+++ b/src/components/RangeSlider/components/DualThumb/index.ts
@@ -1,0 +1,4 @@
+import DualThumb from './DualThumb';
+
+export {Props} from './DualThumb';
+export default DualThumb;

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import {noop} from '@shopify/javascript-utilities/other';
-import {mountWithAppProvider, findByTestID, trigger} from 'test-utilities';
+import {mountWithAppProvider, findByTestID} from 'test-utilities';
 import DualThumb from '../DualThumb';
-import TextField from '../../../../TextField';
 
 describe('<DualThumb />', () => {
   const mockProps = {
@@ -112,160 +111,6 @@ describe('<DualThumb />', () => {
     });
   });
 
-  describe('accessibilityInputs', () => {
-    it('renders two TextFields when true', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs />,
-      );
-
-      expect(dualThumb.find(TextField)).toHaveLength(2);
-    });
-
-    it('renders the lower TextField as a number', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs />,
-      );
-
-      const textFieldLower = dualThumb.find(TextField).first();
-      expect(textFieldLower.prop('type')).toBe('number');
-    });
-
-    it('renders the upper TextField as a number', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs />,
-      );
-
-      const textFieldUpper = dualThumb.find(TextField).last();
-      expect(textFieldUpper.prop('type')).toBe('number');
-    });
-
-    it('renders the lower TextField with a visually hidden label', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs />,
-      );
-
-      const textFieldLower = dualThumb.find(TextField).first();
-      expect(textFieldLower.prop('label')).toBe('Lower value');
-      expect(textFieldLower.prop('labelHidden')).toBe(true);
-    });
-
-    it('renders the upper TextField with a visually hidden label', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs />,
-      );
-
-      const textFieldUpper = dualThumb.find(TextField).last();
-      expect(textFieldUpper.prop('label')).toBe('Upper value');
-      expect(textFieldUpper.prop('labelHidden')).toBe(true);
-    });
-
-    it('renders the lower TextField with the lower value as a string', () => {
-      const value = [5, 10] as [number, number];
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs value={value} />,
-      );
-
-      const textFieldLower = dualThumb.find(TextField).first();
-      expect(textFieldLower.prop('value')).toBe('5');
-    });
-
-    it('renders the upper TextField with the upper value as a string', () => {
-      const value = [5, 10] as [number, number];
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs value={value} />,
-      );
-
-      const textFieldUpper = dualThumb.find(TextField).last();
-      expect(textFieldUpper.prop('value')).toBe('10');
-    });
-
-    describe('prefix', () => {
-      it('passes the prefix to the lower TextField', () => {
-        const prefix = '$';
-        const dualThumb = mountWithAppProvider(
-          <DualThumb {...mockProps} accessibilityInputs prefix={prefix} />,
-        );
-
-        const textFieldLower = dualThumb.find(TextField).first();
-        expect(textFieldLower.prop('prefix')).toBe(prefix);
-      });
-
-      it('passes the prefix to the upper TextField', () => {
-        const prefix = '$';
-        const dualThumb = mountWithAppProvider(
-          <DualThumb {...mockProps} accessibilityInputs prefix={prefix} />,
-        );
-
-        const textFieldUpper = dualThumb.find(TextField).last();
-        expect(textFieldUpper.prop('prefix')).toBe(prefix);
-      });
-    });
-
-    describe('suffix', () => {
-      it('passes the suffix to the lower TextField', () => {
-        const suffix = '£';
-        const dualThumb = mountWithAppProvider(
-          <DualThumb {...mockProps} accessibilityInputs suffix={suffix} />,
-        );
-
-        const textFieldLower = dualThumb.find(TextField).first();
-        expect(textFieldLower.prop('suffix')).toBe(suffix);
-      });
-
-      it('passes the suffix to the upper TextField', () => {
-        const suffix = '£';
-        const dualThumb = mountWithAppProvider(
-          <DualThumb {...mockProps} accessibilityInputs suffix={suffix} />,
-        );
-
-        const textFieldUpper = dualThumb.find(TextField).last();
-        expect(textFieldUpper.prop('suffix')).toBe(suffix);
-      });
-    });
-
-    describe('onChange()', () => {
-      it('returns value and id when called by the lower TextField', () => {
-        const onChangeSpy = jest.fn();
-        const value = [10, 20] as [number, number];
-
-        const dualThumb = mountWithAppProvider(
-          <DualThumb
-            {...mockProps}
-            accessibilityInputs
-            onChange={onChangeSpy}
-            value={value}
-          />,
-        );
-
-        const id = 'RangeSlider';
-        const textFieldLower = dualThumb.find(TextField).first();
-        trigger(textFieldLower, 'onChange', {value, id}, () => {
-          expect(onChangeSpy).toHaveBeenCalledWith({value, id});
-        });
-      });
-
-      it('returns value and id when called by the upper TextField', () => {
-        const onChangeSpy = jest.fn();
-        const value = [10, 20] as [number, number];
-
-        const dualThumb = mountWithAppProvider(
-          <DualThumb
-            {...mockProps}
-            accessibilityInputs
-            onChange={onChangeSpy}
-            value={value}
-          />,
-        );
-
-        const id = 'RangeSlider';
-        const textFieldUpper = dualThumb.find(TextField).last();
-        trigger(textFieldUpper, 'onChange', {value, id}, () => {
-          expect(onChangeSpy).toHaveBeenCalledWith({value, id});
-        });
-      });
-    });
-  });
-
   describe('step', () => {
     it('adjusts the lower value', () => {
       const step = 5;
@@ -287,26 +132,6 @@ describe('<DualThumb />', () => {
 
       const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
       expect(thumbUpper.prop('aria-valuenow')).toBe(10);
-    });
-
-    it('passes step to the lower TextField', () => {
-      const step = 5;
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs step={step} />,
-      );
-
-      const textFieldLower = dualThumb.find(TextField).first();
-      expect(textFieldLower.prop('step')).toBe(step);
-    });
-
-    it('passes step to the upper TextField', () => {
-      const step = 5;
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs step={step} />,
-      );
-
-      const textFieldUpper = dualThumb.find(TextField).last();
-      expect(textFieldUpper.prop('step')).toBe(step);
     });
   });
 
@@ -341,24 +166,6 @@ describe('<DualThumb />', () => {
 
       const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
       expect(thumbUpper.prop('aria-disabled')).toBe(true);
-    });
-
-    it('gets passed to the lower TextField', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs disabled />,
-      );
-
-      const textFieldLower = dualThumb.find(TextField).first();
-      expect(textFieldLower.prop('disabled')).toBe(true);
-    });
-
-    it('gets passed to the upper TextField', () => {
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} accessibilityInputs disabled />,
-      );
-
-      const textFieldUpper = dualThumb.find(TextField).last();
-      expect(textFieldUpper.prop('disabled')).toBe(true);
     });
   });
 

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -314,7 +314,7 @@ describe('<DualThumb />', () => {
       expect(onChangeSpy).toHaveBeenCalledWith([11, 40], mockProps.id);
     });
 
-    it('does not increment the lower value on upper value key press', () => {
+    it('increments the upper value on right arrow press', () => {
       const onChangeSpy = jest.fn();
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
@@ -324,7 +324,7 @@ describe('<DualThumb />', () => {
       expect(onChangeSpy).toHaveBeenCalledWith([10, 41], mockProps.id);
     });
 
-    it('does not decrement the lower value on upper value key press', () => {
+    it('decrement the upper value on left arrow press', () => {
       const onChangeSpy = jest.fn();
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
@@ -424,7 +424,7 @@ describe('<DualThumb />', () => {
       expect(onChangeSpy).toHaveBeenCalledWith([9, 40], mockProps.id);
     });
 
-    it('does not increment the upper value on lower value key press', () => {
+    it('increment the lower value on up arrow press', () => {
       const onChangeSpy = jest.fn();
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
@@ -434,7 +434,7 @@ describe('<DualThumb />', () => {
       expect(onChangeSpy).toHaveBeenCalledWith([11, 40], mockProps.id);
     });
 
-    it('does not decrement the upper value on lower value key press', () => {
+    it('decrement the lower value on down arrow press', () => {
       const onChangeSpy = jest.fn();
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -1,0 +1,524 @@
+import * as React from 'react';
+import {noop} from '@shopify/javascript-utilities/other';
+import {mountWithAppProvider, findByTestID, trigger} from 'test-utilities';
+import DualThumb from '../DualThumb';
+import TextField from '../../../../TextField';
+
+describe('<DualThumb />', () => {
+  const mockProps = {
+    id: 'RangeSlider',
+    cssVarPrefix: '--Polaris-RangeSlider-',
+    value: [5, 20] as [number, number],
+    min: 0,
+    max: 50,
+    step: 1,
+    output: false,
+    disabled: false,
+    onChange: noop,
+    label: 'Dual thumb range slider',
+  };
+
+  describe('id', () => {
+    it('is used to set the id on the wrapper div', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} id="RangeSlider" />,
+      );
+
+      expect(dualThumb.find('div#RangeSlider')).toHaveLength(1);
+    });
+
+    it('is used to set idLower on the lower thumb', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} id="RangeSlider" />,
+      );
+
+      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      expect(thumbLower.prop('id')).toBe('RangeSliderLower');
+    });
+
+    it('is used to set idUpper on the upper thumb', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} id="RangeSlider" />,
+      );
+
+      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      expect(thumbUpper.prop('id')).toBe('RangeSliderUpper');
+    });
+  });
+
+  describe('min', () => {
+    it('is used to set the aria-valuemin on the lower thumb', () => {
+      const min = 0;
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} min={min} />,
+      );
+
+      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      expect(thumbLower.prop('aria-valuemin')).toBe(min);
+    });
+
+    it('is used to set the aria-valuemin on the upper thumb', () => {
+      const min = 0;
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} min={min} />,
+      );
+
+      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      expect(thumbUpper.prop('aria-valuemin')).toBe(min);
+    });
+
+    it('sets a lower boundary for aria-valuenow on the lower thumb', () => {
+      const min = 5;
+      const value = [0, 20] as [number, number];
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} min={min} value={value} />,
+      );
+
+      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      expect(thumbLower.prop('aria-valuenow')).toBe(min);
+    });
+  });
+
+  describe('max', () => {
+    it('is used to set the aria-valuemax on the lower thumb', () => {
+      const max = 0;
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} max={max} />,
+      );
+
+      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      expect(thumbLower.prop('aria-valuemin')).toBe(max);
+    });
+
+    it('is used to set the aria-valuemax on the upper thumb', () => {
+      const max = 0;
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} max={max} />,
+      );
+
+      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      expect(thumbUpper.prop('aria-valuemax')).toBe(max);
+    });
+
+    it('sets an upper boundary for aria-valuenow on the upper thumb', () => {
+      const max = 5;
+      const value = [0, 6] as [number, number];
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} max={max} value={value} />,
+      );
+
+      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      expect(thumbUpper.prop('aria-valuenow')).toBe(max);
+    });
+  });
+
+  describe('accessibilityInputs', () => {
+    it('renders two TextFields when true', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} accessibilityInputs />,
+      );
+
+      expect(dualThumb.find(TextField)).toHaveLength(2);
+    });
+
+    it('renders the lower TextField as a number', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} accessibilityInputs />,
+      );
+
+      const textFieldLower = dualThumb.find(TextField).first();
+      expect(textFieldLower.prop('type')).toBe('number');
+    });
+
+    it('renders the upper TextField as a number', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} accessibilityInputs />,
+      );
+
+      const textFieldUpper = dualThumb.find(TextField).last();
+      expect(textFieldUpper.prop('type')).toBe('number');
+    });
+
+    it('renders the lower TextField with a visually hidden label', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} accessibilityInputs />,
+      );
+
+      const textFieldLower = dualThumb.find(TextField).first();
+      expect(textFieldLower.prop('label')).toBe('Lower value');
+      expect(textFieldLower.prop('labelHidden')).toBe(true);
+    });
+
+    it('renders the upper TextField with a visually hidden label', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} accessibilityInputs />,
+      );
+
+      const textFieldUpper = dualThumb.find(TextField).last();
+      expect(textFieldUpper.prop('label')).toBe('Upper value');
+      expect(textFieldUpper.prop('labelHidden')).toBe(true);
+    });
+
+    it('renders the lower TextField with the lower value as a string', () => {
+      const value = [5, 10] as [number, number];
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} accessibilityInputs value={value} />,
+      );
+
+      const textFieldLower = dualThumb.find(TextField).first();
+      expect(textFieldLower.prop('value')).toBe('5');
+    });
+
+    it('renders the upper TextField with the upper value as a string', () => {
+      const value = [5, 10] as [number, number];
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} accessibilityInputs value={value} />,
+      );
+
+      const textFieldUpper = dualThumb.find(TextField).last();
+      expect(textFieldUpper.prop('value')).toBe('10');
+    });
+
+    describe('prefix', () => {
+      it('passes the prefix to the lower TextField', () => {
+        const prefix = '$';
+        const dualThumb = mountWithAppProvider(
+          <DualThumb {...mockProps} accessibilityInputs prefix={prefix} />,
+        );
+
+        const textFieldLower = dualThumb.find(TextField).first();
+        expect(textFieldLower.prop('prefix')).toBe(prefix);
+      });
+
+      it('passes the prefix to the upper TextField', () => {
+        const prefix = '$';
+        const dualThumb = mountWithAppProvider(
+          <DualThumb {...mockProps} accessibilityInputs prefix={prefix} />,
+        );
+
+        const textFieldUpper = dualThumb.find(TextField).last();
+        expect(textFieldUpper.prop('prefix')).toBe(prefix);
+      });
+    });
+
+    describe('suffix', () => {
+      it('passes the suffix to the lower TextField', () => {
+        const suffix = '£';
+        const dualThumb = mountWithAppProvider(
+          <DualThumb {...mockProps} accessibilityInputs suffix={suffix} />,
+        );
+
+        const textFieldLower = dualThumb.find(TextField).first();
+        expect(textFieldLower.prop('suffix')).toBe(suffix);
+      });
+
+      it('passes the suffix to the upper TextField', () => {
+        const suffix = '£';
+        const dualThumb = mountWithAppProvider(
+          <DualThumb {...mockProps} accessibilityInputs suffix={suffix} />,
+        );
+
+        const textFieldUpper = dualThumb.find(TextField).last();
+        expect(textFieldUpper.prop('suffix')).toBe(suffix);
+      });
+    });
+
+    describe('onChange()', () => {
+      it('returns value and id when called by the lower TextField', () => {
+        const onChangeSpy = jest.fn();
+        const value = [10, 20] as [number, number];
+
+        const dualThumb = mountWithAppProvider(
+          <DualThumb
+            {...mockProps}
+            accessibilityInputs
+            onChange={onChangeSpy}
+            value={value}
+          />,
+        );
+
+        const id = 'RangeSlider';
+        const textFieldLower = dualThumb.find(TextField).first();
+        trigger(textFieldLower, 'onChange', {value, id}, () => {
+          expect(onChangeSpy).toHaveBeenCalledWith({value, id});
+        });
+      });
+
+      it('returns value and id when called by the upper TextField', () => {
+        const onChangeSpy = jest.fn();
+        const value = [10, 20] as [number, number];
+
+        const dualThumb = mountWithAppProvider(
+          <DualThumb
+            {...mockProps}
+            accessibilityInputs
+            onChange={onChangeSpy}
+            value={value}
+          />,
+        );
+
+        const id = 'RangeSlider';
+        const textFieldUpper = dualThumb.find(TextField).last();
+        trigger(textFieldUpper, 'onChange', {value, id}, () => {
+          expect(onChangeSpy).toHaveBeenCalledWith({value, id});
+        });
+      });
+    });
+  });
+
+  describe('step', () => {
+    it('adjusts the lower value', () => {
+      const step = 5;
+      const value = [3, 10] as [number, number];
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} step={step} value={value} />,
+      );
+
+      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      expect(thumbLower.prop('aria-valuenow')).toBe(step);
+    });
+
+    it('adjusts the upper value', () => {
+      const step = 5;
+      const value = [0, 9] as [number, number];
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} step={step} value={value} />,
+      );
+
+      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      expect(thumbUpper.prop('aria-valuenow')).toBe(10);
+    });
+
+    it('passes step to the lower TextField', () => {
+      const step = 5;
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} accessibilityInputs step={step} />,
+      );
+
+      const textFieldLower = dualThumb.find(TextField).first();
+      expect(textFieldLower.prop('step')).toBe(step);
+    });
+
+    it('passes step to the upper TextField', () => {
+      const step = 5;
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} accessibilityInputs step={step} />,
+      );
+
+      const textFieldUpper = dualThumb.find(TextField).last();
+      expect(textFieldUpper.prop('step')).toBe(step);
+    });
+  });
+
+  describe('disabled', () => {
+    it('sets aria-disabled to false by default on the lower thumb', () => {
+      const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
+
+      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      expect(thumbLower.prop('aria-disabled')).toBe(false);
+    });
+
+    it('sets aria-disabled to false by default on the upper thumb', () => {
+      const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
+
+      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      expect(thumbUpper.prop('aria-disabled')).toBe(false);
+    });
+
+    it('sets aria-disabled to true on the lower thumb', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} disabled />,
+      );
+
+      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      expect(thumbLower.prop('aria-disabled')).toBe(true);
+    });
+
+    it('sets aria-disabled to true on the upper thumb', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} disabled />,
+      );
+
+      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      expect(thumbUpper.prop('aria-disabled')).toBe(true);
+    });
+
+    it('gets passed to the lower TextField', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} accessibilityInputs disabled />,
+      );
+
+      const textFieldLower = dualThumb.find(TextField).first();
+      expect(textFieldLower.prop('disabled')).toBe(true);
+    });
+
+    it('gets passed to the upper TextField', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} accessibilityInputs disabled />,
+      );
+
+      const textFieldUpper = dualThumb.find(TextField).last();
+      expect(textFieldUpper.prop('disabled')).toBe(true);
+    });
+  });
+
+  describe('error', () => {
+    it('sets aria-invalid to true on the lower thumb', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} error="Error" />,
+      );
+
+      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      expect(thumbLower.prop('aria-invalid')).toBe(true);
+    });
+
+    it('sets aria-invalid to true on the upper thumb', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} error="Error" />,
+      );
+
+      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      expect(thumbUpper.prop('aria-invalid')).toBe(true);
+    });
+
+    describe('aria-describedby', () => {
+      it('gets set correctly on the lower thumb', () => {
+        const dualThumb = mountWithAppProvider(
+          <DualThumb {...mockProps} error="Error" />,
+        );
+
+        const thumbLower = findByTestID(dualThumb, 'thumbLower');
+        expect(thumbLower.prop('aria-describedby')).toBe('RangeSliderError');
+      });
+
+      it('gets set correctly on the upper thumb', () => {
+        const dualThumb = mountWithAppProvider(
+          <DualThumb {...mockProps} error="Error" />,
+        );
+
+        const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+        expect(thumbUpper.prop('aria-describedby')).toBe('RangeSliderError');
+      });
+    });
+  });
+
+  describe('output', () => {
+    it('does not render the lower output by default', () => {
+      const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
+
+      const outputLower = dualThumb.find('output').first();
+      expect(outputLower).toHaveLength(0);
+    });
+
+    it('does not render the upper output by default', () => {
+      const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
+
+      const outputUpper = dualThumb.find('output').last();
+      expect(outputUpper).toHaveLength(0);
+    });
+
+    it('renders the lower output', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} output />,
+      );
+
+      const outputLower = dualThumb.find('output').first();
+      expect(outputLower).toHaveLength(1);
+    });
+
+    it('renders the upper output', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} output />,
+      );
+
+      const outputUpper = dualThumb.find('output').last();
+      expect(outputUpper).toHaveLength(1);
+    });
+
+    it('renders the correct value for the lower output', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} output />,
+      );
+
+      const outputLower = dualThumb.find('output').first();
+      expect(outputLower.find('span').text()).toContain('5');
+    });
+
+    it('renders the correct value for the upper output', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} output />,
+      );
+
+      const outputUpper = dualThumb.find('output').last();
+      expect(outputUpper.find('span').text()).toContain('20');
+    });
+  });
+
+  describe('onFocus()', () => {
+    it('gets called when the lower thumb gets focus', () => {
+      const onFocusSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} onFocus={onFocusSpy} />,
+      );
+
+      const lowerThumb = findByTestID(dualThumb, 'thumbLower');
+      lowerThumb.simulate('focus');
+      expect(onFocusSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('gets called when the upper thumb gets focus', () => {
+      const onFocusSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} onFocus={onFocusSpy} />,
+      );
+
+      const upperThumb = findByTestID(dualThumb, 'thumbUpper');
+      upperThumb.simulate('focus');
+      expect(onFocusSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onBlur()', () => {
+    it('gets called when the lower thumb loses focus', () => {
+      const onBlurSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} onBlur={onBlurSpy} />,
+      );
+
+      const lowerThumb = findByTestID(dualThumb, 'thumbLower');
+      lowerThumb.simulate('blur');
+      expect(onBlurSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('gets called when the upper thumb loses focus', () => {
+      const onBlurSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} onBlur={onBlurSpy} />,
+      );
+
+      const upperThumb = findByTestID(dualThumb, 'thumbUpper');
+      upperThumb.simulate('blur');
+      expect(onBlurSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('CSS custom properties', () => {
+    it('sets the correct css custom properties on the track', () => {
+      const min = 10;
+      const max = 50;
+      const value = [20, 50] as [number, number];
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={value} min={min} max={max} />,
+      );
+
+      const expected = {
+        '--Polaris-RangeSlider-progress-lower': '0px',
+        '--Polaris-RangeSlider-progress-upper': '-18px',
+      };
+      const track = findByTestID(dualThumb, 'track');
+      const actual = track.find('[style]').prop('style');
+
+      expect(expected).toEqual(actual);
+    });
+  });
+});

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider, findByTestID} from 'test-utilities';
-import DualThumb from '../DualThumb';
+import DualThumb, {Props as DualThumbProps} from '../DualThumb';
 
 describe('<DualThumb />', () => {
-  const mockProps = {
+  const mockProps: DualThumbProps = {
     id: 'RangeSlider',
-    cssVarPrefix: '--Polaris-RangeSlider-',
-    value: [5, 20] as [number, number],
+    value: [0, 1],
     min: 0,
     max: 50,
     step: 1,
@@ -19,29 +18,29 @@ describe('<DualThumb />', () => {
 
   describe('id', () => {
     it('is used to set the id on the wrapper div', () => {
+      const id = 'MytestID';
       const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} id="RangeSlider" />,
+        <DualThumb {...mockProps} id={id} />,
       );
-
-      expect(dualThumb.find('div#RangeSlider')).toHaveLength(1);
+      expect(dualThumb.find(`div#${id}`)).toHaveLength(1);
     });
 
     it('is used to set idLower on the lower thumb', () => {
+      const id = 'MyNewID';
       const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} id="RangeSlider" />,
+        <DualThumb {...mockProps} id={id} />,
       );
-
       const thumbLower = findByTestID(dualThumb, 'thumbLower');
-      expect(thumbLower.prop('id')).toBe('RangeSliderLower');
+      expect(thumbLower.prop('id')).toBe(`${id}Lower`);
     });
 
     it('is used to set idUpper on the upper thumb', () => {
+      const id = 'MyNewID';
       const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} id="RangeSlider" />,
+        <DualThumb {...mockProps} id={id} />,
       );
-
       const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
-      expect(thumbUpper.prop('id')).toBe('RangeSliderUpper');
+      expect(thumbUpper.prop('id')).toBe(`${id}Upper`);
     });
   });
 
@@ -51,7 +50,6 @@ describe('<DualThumb />', () => {
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} min={min} />,
       );
-
       const thumbLower = findByTestID(dualThumb, 'thumbLower');
       expect(thumbLower.prop('aria-valuemin')).toBe(min);
     });
@@ -61,77 +59,28 @@ describe('<DualThumb />', () => {
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} min={min} />,
       );
-
       const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
       expect(thumbUpper.prop('aria-valuemin')).toBe(min);
-    });
-
-    it('sets a lower boundary for aria-valuenow on the lower thumb', () => {
-      const min = 5;
-      const value = [0, 20] as [number, number];
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} min={min} value={value} />,
-      );
-
-      const thumbLower = findByTestID(dualThumb, 'thumbLower');
-      expect(thumbLower.prop('aria-valuenow')).toBe(min);
     });
   });
 
   describe('max', () => {
     it('is used to set the aria-valuemax on the lower thumb', () => {
-      const max = 0;
+      const max = 100;
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} max={max} />,
       );
-
       const thumbLower = findByTestID(dualThumb, 'thumbLower');
-      expect(thumbLower.prop('aria-valuemin')).toBe(max);
+      expect(thumbLower.prop('aria-valuemax')).toBe(max);
     });
 
     it('is used to set the aria-valuemax on the upper thumb', () => {
-      const max = 0;
+      const max = 100;
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} max={max} />,
       );
-
       const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
       expect(thumbUpper.prop('aria-valuemax')).toBe(max);
-    });
-
-    it('sets an upper boundary for aria-valuenow on the upper thumb', () => {
-      const max = 5;
-      const value = [0, 6] as [number, number];
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} max={max} value={value} />,
-      );
-
-      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
-      expect(thumbUpper.prop('aria-valuenow')).toBe(max);
-    });
-  });
-
-  describe('step', () => {
-    it('adjusts the lower value', () => {
-      const step = 5;
-      const value = [3, 10] as [number, number];
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} step={step} value={value} />,
-      );
-
-      const thumbLower = findByTestID(dualThumb, 'thumbLower');
-      expect(thumbLower.prop('aria-valuenow')).toBe(step);
-    });
-
-    it('adjusts the upper value', () => {
-      const step = 5;
-      const value = [0, 9] as [number, number];
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} step={step} value={value} />,
-      );
-
-      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
-      expect(thumbUpper.prop('aria-valuenow')).toBe(10);
     });
   });
 
@@ -248,7 +197,7 @@ describe('<DualThumb />', () => {
       );
 
       const outputLower = dualThumb.find('output').first();
-      expect(outputLower.find('span').text()).toContain('5');
+      expect(outputLower.find('span').text()).toContain('0');
     });
 
     it('renders the correct value for the upper output', () => {
@@ -257,7 +206,7 @@ describe('<DualThumb />', () => {
       );
 
       const outputUpper = dualThumb.find('output').last();
-      expect(outputUpper.find('span').text()).toContain('20');
+      expect(outputUpper.find('span').text()).toContain('1');
     });
   });
 
@@ -309,23 +258,141 @@ describe('<DualThumb />', () => {
     });
   });
 
-  describe('CSS custom properties', () => {
-    it('sets the correct css custom properties on the track', () => {
-      const min = 10;
-      const max = 50;
-      const value = [20, 50] as [number, number];
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} value={value} min={min} max={max} />,
+  describe('onChange()', () => {
+    it('is called when the value prop needs sanitization', () => {
+      const onChangeSpy = jest.fn();
+      const id = 'onChangeID';
+
+      mountWithAppProvider(
+        <DualThumb
+          {...mockProps}
+          value={[15, 10]}
+          onChange={onChangeSpy}
+          id={id}
+        />,
       );
 
+      expect(onChangeSpy).toHaveBeenCalledWith([9, 10], id);
+    });
+
+    it('is not called when the value prop needs no sanitization', () => {
+      const onChangeSpy = jest.fn();
+
+      mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 15]} onChange={onChangeSpy} />,
+      );
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('CSS custom properties', () => {
+    it('sets the correct css custom properties on the track', () => {
+      const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
+
       const expected = {
-        '--Polaris-RangeSlider-progress-lower': '0px',
-        '--Polaris-RangeSlider-progress-upper': '-18px',
+        '--Polaris-RangeSlider-progress-lower': '12px',
+        '--Polaris-RangeSlider-progress-upper': '11.52px',
       };
       const track = findByTestID(dualThumb, 'track');
       const actual = track.find('[style]').prop('style');
 
       expect(expected).toEqual(actual);
+    });
+  });
+
+  describe('value prop sanitization', () => {
+    it('sanitizes the lower value with respect to the step prop', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[4, 40]} step={5} />,
+      );
+      expect([
+        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
+        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+      ]).toEqual([5, 40]);
+    });
+
+    it('sanitizes the upper value with respect to the step prop', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[5, 41]} step={5} />,
+      );
+      expect([
+        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
+        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+      ]).toEqual([5, 40]);
+    });
+
+    it('sanitizes the lower value with respect to the max prop', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[110, 150]} max={100} />,
+      );
+      expect([
+        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
+        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+      ]).toEqual([99, 100]);
+    });
+
+    it('sanitizes the upper value with respect to the max prop', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[110, 150]} max={100} />,
+      );
+      expect([
+        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
+        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+      ]).toEqual([99, 100]);
+    });
+
+    it('sanitizes the lower value with respect to the min prop', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} min={20} />,
+      );
+      expect([
+        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
+        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+      ]).toEqual([20, 40]);
+    });
+
+    it('sanitizes the upper value with respect to the min prop', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 15]} min={20} />,
+      );
+      expect([
+        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
+        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+      ]).toEqual([20, 21]);
+    });
+
+    it('sets the lower value to a step below the upper value if the lower value equals the upper value', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 10]} />,
+      );
+
+      expect([
+        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
+        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+      ]).toEqual([9, 10]);
+    });
+
+    it('sets the lower value to a step below the upper value if the lower value is higher than the upper value', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[15, 10]} />,
+      );
+
+      expect([
+        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
+        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+      ]).toEqual([9, 10]);
+    });
+
+    it('sets the upper value to one step above the min and the lower value to the min when they are out of bounds and inversed', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[1500, -10]} />,
+      );
+
+      expect([
+        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
+        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+      ]).toEqual([0, 1]);
     });
   });
 });

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import {noop} from '@shopify/javascript-utilities/other';
+import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider, findByTestID} from 'test-utilities';
+import {Key} from 'types';
 import DualThumb, {Props as DualThumbProps} from '../DualThumb';
 
 describe('<DualThumb />', () => {
@@ -30,7 +32,7 @@ describe('<DualThumb />', () => {
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} id={id} />,
       );
-      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      const thumbLower = findThumbLower(dualThumb);
       expect(thumbLower.prop('id')).toBe(`${id}Lower`);
     });
 
@@ -39,7 +41,7 @@ describe('<DualThumb />', () => {
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} id={id} />,
       );
-      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      const thumbUpper = findThumbUpper(dualThumb);
       expect(thumbUpper.prop('id')).toBe(`${id}Upper`);
     });
   });
@@ -50,7 +52,7 @@ describe('<DualThumb />', () => {
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} min={min} />,
       );
-      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      const thumbLower = findThumbLower(dualThumb);
       expect(thumbLower.prop('aria-valuemin')).toBe(min);
     });
 
@@ -59,7 +61,7 @@ describe('<DualThumb />', () => {
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} min={min} />,
       );
-      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      const thumbUpper = findThumbUpper(dualThumb);
       expect(thumbUpper.prop('aria-valuemin')).toBe(min);
     });
   });
@@ -70,7 +72,7 @@ describe('<DualThumb />', () => {
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} max={max} />,
       );
-      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      const thumbLower = findThumbLower(dualThumb);
       expect(thumbLower.prop('aria-valuemax')).toBe(max);
     });
 
@@ -79,7 +81,7 @@ describe('<DualThumb />', () => {
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} max={max} />,
       );
-      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      const thumbUpper = findThumbUpper(dualThumb);
       expect(thumbUpper.prop('aria-valuemax')).toBe(max);
     });
   });
@@ -88,14 +90,14 @@ describe('<DualThumb />', () => {
     it('sets aria-disabled to false by default on the lower thumb', () => {
       const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
 
-      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      const thumbLower = findThumbLower(dualThumb);
       expect(thumbLower.prop('aria-disabled')).toBe(false);
     });
 
     it('sets aria-disabled to false by default on the upper thumb', () => {
       const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
 
-      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      const thumbUpper = findThumbUpper(dualThumb);
       expect(thumbUpper.prop('aria-disabled')).toBe(false);
     });
 
@@ -104,7 +106,7 @@ describe('<DualThumb />', () => {
         <DualThumb {...mockProps} disabled />,
       );
 
-      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      const thumbLower = findThumbLower(dualThumb);
       expect(thumbLower.prop('aria-disabled')).toBe(true);
     });
 
@@ -113,7 +115,7 @@ describe('<DualThumb />', () => {
         <DualThumb {...mockProps} disabled />,
       );
 
-      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      const thumbUpper = findThumbUpper(dualThumb);
       expect(thumbUpper.prop('aria-disabled')).toBe(true);
     });
   });
@@ -124,7 +126,7 @@ describe('<DualThumb />', () => {
         <DualThumb {...mockProps} error="Error" />,
       );
 
-      const thumbLower = findByTestID(dualThumb, 'thumbLower');
+      const thumbLower = findThumbLower(dualThumb);
       expect(thumbLower.prop('aria-invalid')).toBe(true);
     });
 
@@ -133,7 +135,7 @@ describe('<DualThumb />', () => {
         <DualThumb {...mockProps} error="Error" />,
       );
 
-      const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+      const thumbUpper = findThumbUpper(dualThumb);
       expect(thumbUpper.prop('aria-invalid')).toBe(true);
     });
 
@@ -143,7 +145,7 @@ describe('<DualThumb />', () => {
           <DualThumb {...mockProps} error="Error" />,
         );
 
-        const thumbLower = findByTestID(dualThumb, 'thumbLower');
+        const thumbLower = findThumbLower(dualThumb);
         expect(thumbLower.prop('aria-describedby')).toBe('RangeSliderError');
       });
 
@@ -152,7 +154,7 @@ describe('<DualThumb />', () => {
           <DualThumb {...mockProps} error="Error" />,
         );
 
-        const thumbUpper = findByTestID(dualThumb, 'thumbUpper');
+        const thumbUpper = findThumbUpper(dualThumb);
         expect(thumbUpper.prop('aria-describedby')).toBe('RangeSliderError');
       });
     });
@@ -217,7 +219,7 @@ describe('<DualThumb />', () => {
         <DualThumb {...mockProps} onFocus={onFocusSpy} />,
       );
 
-      const lowerThumb = findByTestID(dualThumb, 'thumbLower');
+      const lowerThumb = findThumbLower(dualThumb);
       lowerThumb.simulate('focus');
       expect(onFocusSpy).toHaveBeenCalledTimes(1);
     });
@@ -228,7 +230,7 @@ describe('<DualThumb />', () => {
         <DualThumb {...mockProps} onFocus={onFocusSpy} />,
       );
 
-      const upperThumb = findByTestID(dualThumb, 'thumbUpper');
+      const upperThumb = findThumbUpper(dualThumb);
       upperThumb.simulate('focus');
       expect(onFocusSpy).toHaveBeenCalledTimes(1);
     });
@@ -241,7 +243,7 @@ describe('<DualThumb />', () => {
         <DualThumb {...mockProps} onBlur={onBlurSpy} />,
       );
 
-      const lowerThumb = findByTestID(dualThumb, 'thumbLower');
+      const lowerThumb = findThumbLower(dualThumb);
       lowerThumb.simulate('blur');
       expect(onBlurSpy).toHaveBeenCalledTimes(1);
     });
@@ -252,7 +254,7 @@ describe('<DualThumb />', () => {
         <DualThumb {...mockProps} onBlur={onBlurSpy} />,
       );
 
-      const upperThumb = findByTestID(dualThumb, 'thumbUpper');
+      const upperThumb = findThumbUpper(dualThumb);
       upperThumb.simulate('blur');
       expect(onBlurSpy).toHaveBeenCalledTimes(1);
     });
@@ -301,14 +303,164 @@ describe('<DualThumb />', () => {
     });
   });
 
+  describe('keyboard control', () => {
+    it('increments the lower value on right arrow press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.RightArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([11, 40], mockProps.id);
+    });
+
+    it('does not increment the lower value on upper value key press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbUpper(dualThumb), Key.RightArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([10, 41], mockProps.id);
+    });
+
+    it('does not decrement the lower value on upper value key press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbUpper(dualThumb), Key.LeftArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([10, 39], mockProps.id);
+    });
+
+    it('increments the lower value on up arrow press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.UpArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([11, 40], mockProps.id);
+    });
+
+    it('does not increment the lower value when it is a step below the upper value', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[39, 40]} onChange={onChangeSpy} />,
+      );
+      const lowerThumb = findThumbLower(dualThumb);
+      simulateKeyDown(lowerThumb, Key.RightArrow);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect([
+        lowerThumb.prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
+      ]).toEqual([39, 40]);
+    });
+
+    it('does not decrement the lower value when it is equal to the min', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[0, 40]} onChange={onChangeSpy} />,
+      );
+      const lowerThumb = findThumbLower(dualThumb);
+      simulateKeyDown(lowerThumb, Key.LeftArrow);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect([
+        lowerThumb.prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
+      ]).toEqual([0, 40]);
+    });
+
+    it('does not increment the upper value when it is equal to the max', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[0, 50]} onChange={onChangeSpy} />,
+      );
+      const upperThumb = findThumbUpper(dualThumb);
+      simulateKeyDown(upperThumb, Key.RightArrow);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect([
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        upperThumb.prop('aria-valuenow'),
+      ]).toEqual([0, 50]);
+    });
+
+    it('does not decrement the upper value when it is a step above the lower value', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[49, 50]} onChange={onChangeSpy} />,
+      );
+      const upperThumb = findThumbUpper(dualThumb);
+      simulateKeyDown(upperThumb, Key.LeftArrow);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect([
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        upperThumb.prop('aria-valuenow'),
+      ]).toEqual([49, 50]);
+    });
+
+    it('decrements the lower value on left arrow press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.LeftArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([9, 40], mockProps.id);
+    });
+
+    it('decrements the lower value on down arrow press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.DownArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([9, 40], mockProps.id);
+    });
+
+    it('does not increment the upper value on lower value key press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.UpArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([11, 40], mockProps.id);
+    });
+
+    it('does not decrement the upper value on lower value key press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.DownArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([9, 40], mockProps.id);
+    });
+
+    function simulateKeyDown(component: ReactWrapper, keyCode: Key) {
+      component.simulate('keyDown', {
+        keyCode,
+        preventDefault: noop,
+        stopPropagation: noop,
+      });
+    }
+  });
+
   describe('value prop sanitization', () => {
     it('sanitizes the lower value with respect to the step prop', () => {
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} value={[4, 40]} step={5} />,
       );
       expect([
-        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
-        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
       ]).toEqual([5, 40]);
     });
 
@@ -317,8 +469,8 @@ describe('<DualThumb />', () => {
         <DualThumb {...mockProps} value={[5, 41]} step={5} />,
       );
       expect([
-        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
-        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
       ]).toEqual([5, 40]);
     });
 
@@ -327,8 +479,8 @@ describe('<DualThumb />', () => {
         <DualThumb {...mockProps} value={[110, 150]} max={100} />,
       );
       expect([
-        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
-        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
       ]).toEqual([99, 100]);
     });
 
@@ -337,8 +489,8 @@ describe('<DualThumb />', () => {
         <DualThumb {...mockProps} value={[110, 150]} max={100} />,
       );
       expect([
-        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
-        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
       ]).toEqual([99, 100]);
     });
 
@@ -347,8 +499,8 @@ describe('<DualThumb />', () => {
         <DualThumb {...mockProps} value={[10, 40]} min={20} />,
       );
       expect([
-        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
-        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
       ]).toEqual([20, 40]);
     });
 
@@ -357,8 +509,8 @@ describe('<DualThumb />', () => {
         <DualThumb {...mockProps} value={[10, 15]} min={20} />,
       );
       expect([
-        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
-        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
       ]).toEqual([20, 21]);
     });
 
@@ -368,8 +520,8 @@ describe('<DualThumb />', () => {
       );
 
       expect([
-        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
-        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
       ]).toEqual([9, 10]);
     });
 
@@ -379,8 +531,8 @@ describe('<DualThumb />', () => {
       );
 
       expect([
-        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
-        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
       ]).toEqual([9, 10]);
     });
 
@@ -390,9 +542,17 @@ describe('<DualThumb />', () => {
       );
 
       expect([
-        findByTestID(dualThumb, 'thumbLower').prop('aria-valuenow'),
-        findByTestID(dualThumb, 'thumbUpper').prop('aria-valuenow'),
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
       ]).toEqual([0, 1]);
     });
   });
 });
+
+function findThumbLower(containerComponent: ReactWrapper): ReactWrapper {
+  return containerComponent.find('button').first();
+}
+
+function findThumbUpper(containerComponent: ReactWrapper): ReactWrapper {
+  return containerComponent.find('button').last();
+}

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -520,6 +520,65 @@ describe('<DualThumb />', () => {
       expect(onChangeSpy).not.toHaveBeenCalled();
     });
 
+    it('moves the lower thumb when the track is clicked closer to it than the upper thumb', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[5, 40]} onChange={onChangeSpy} />,
+      );
+
+      clickTrack(dualThumb, 0.2);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([10, 40], mockProps.id);
+    });
+
+    it('moves the upper thumb when the track is clicked closer to it than the lower thumb', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[5, 40]} onChange={onChangeSpy} />,
+      );
+
+      clickTrack(dualThumb, 0.6);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([5, 30], mockProps.id);
+    });
+
+    it('moves the lower thumb when the track is clicked closer to it than the upper thumb and the mouse moves', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[5, 40]} onChange={onChangeSpy} />,
+      );
+
+      clickTrack(dualThumb, 0.2);
+      moveLowerThumb(dualThumb, 0.3);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([15, 40], mockProps.id);
+    });
+
+    it('moves the upper thumb when the track is clicked closer to it than the lower thumb and the mouse moves', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[5, 40]} onChange={onChangeSpy} />,
+      );
+
+      clickTrack(dualThumb, 0.6);
+      moveUpperThumb(dualThumb, 0.9);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([5, 45], mockProps.id);
+    });
+
+    function clickTrack(
+      component: ReactWrapper,
+      percentageOfTrackX: number,
+      button = 0,
+    ) {
+      const trackWidth = 100;
+      const clientX = trackWidth * percentageOfTrackX;
+
+      component.setState({trackLeft: 0, trackWidth}, () => {
+        findTrack(component).simulate('mouseDown', {button, clientX});
+      });
+    }
+
     function moveLowerThumb(
       component: ReactWrapper,
       percentageOfTrackX: number,
@@ -649,4 +708,8 @@ function findThumbLower(containerComponent: ReactWrapper): ReactWrapper {
 
 function findThumbUpper(containerComponent: ReactWrapper): ReactWrapper {
   return containerComponent.find('button').last();
+}
+
+function findTrack(containerComponent: ReactWrapper): ReactWrapper {
+  return findByTestID(containerComponent, 'trackWrapper');
 }

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -293,6 +293,8 @@ describe('<DualThumb />', () => {
       const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
 
       const expected = {
+        '--Polaris-RangeSlider-output-factor-lower': '0.5',
+        '--Polaris-RangeSlider-output-factor-upper': '0.48',
         '--Polaris-RangeSlider-progress-lower': '12px',
         '--Polaris-RangeSlider-progress-upper': '11.52px',
       };

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -10,7 +10,7 @@ $range-thumb-shadow-hover: (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint));
 $range-thumb-shadow-error: 0 0 0 rem(1px) color('red');
 $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
 
-.RangeSlider {
+.SingleThumb {
   display: flex;
   align-items: center;
 

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -14,10 +14,6 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
   display: flex;
   align-items: center;
 
-  &:not(:first-child) {
-    margin-top: spacing(tight);
-  }
-
   &.disabled {
     opacity: 0.8;
   }
@@ -29,6 +25,12 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
   align-items: center;
   flex: 1 1 auto;
   height: $range-thumb-size;
+
+  input {
+    padding: rem(12px) 0;
+    background-color: transparent;
+    cursor: pointer;
+  }
 }
 
 .Prefix {

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -158,7 +158,7 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
 ///
 /// Output value indicator
 $range-output-size: rem(32px);
-$range-output-tip-size: rem(8px);
+$range-output-offset: rem(4px);
 $range-output-translate-x: calc(
   -50% + var(--Polaris-RangeSlider-output-factor, 0) * #{$range-thumb-size}
 );
@@ -166,7 +166,7 @@ $range-output-translate-x: calc(
 .Output {
   position: absolute;
   z-index: z-index('output', $stacking-order);
-  bottom: $range-output-size - $range-output-tip-size;
+  bottom: $range-thumb-size;
   left: var(--Polaris-RangeSlider-progress, 50%);
   transform: translateX($range-output-translate-x);
   opacity: 0;
@@ -196,30 +196,16 @@ $range-output-translate-x: calc(
   transition-duration: duration();
   transition-timing-function: easing();
 
-  &::before {
-    content: '';
-    position: absolute;
-    bottom: -($range-output-tip-size - rem(1px));
-    left: 50%;
-    margin-left: -$range-output-tip-size;
-    display: block;
-    width: 0;
-    height: 0;
-    border-left: $range-output-tip-size solid transparent;
-    border-right: $range-output-tip-size solid transparent;
-    border-top: $range-output-tip-size solid color('ink');
-  }
-
+  // stylelint-disable selector-max-class
+  // stylelint-disable selector-max-combinators
   // stylelint-disable selector-max-specificity
   .Input:hover + .Output &,
   .Input:active + .Output &,
   .Input:focus + .Output & {
-    transform: translateY(-$range-thumb-size);
-
-    @include page-content-when-not-partially-condensed {
-      transform: translateY(-($range-thumb-size / 2));
-    }
+    transform: translateY(-$range-output-offset);
   }
+  // stylelint-enable selector-max-class
+  // stylelint-enable selector-max-combinators
   // stylelint-enable selector-max-specificity
 }
 

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
+import clamp from '../../../../utilities/clamp';
 import Labelled, {helpTextID} from '../../../Labelled';
 
 import {invertNumber, CSS_VAR_PREFIX} from '../../utilities';
@@ -34,6 +35,7 @@ export default function SingleThumb(props: Props) {
     onBlur,
     onFocus,
   } = props;
+  const clampedValue = clamp(value, min, max);
   const describedBy: string[] = [];
 
   if (error) {
@@ -48,13 +50,13 @@ export default function SingleThumb(props: Props) {
     ? describedBy.join(' ')
     : undefined;
 
-  const sliderProgress = ((value - min) * 100) / (max - min);
+  const sliderProgress = ((clampedValue - min) * 100) / (max - min);
   const outputFactor = invertNumber((sliderProgress - 50) / 100);
 
   const cssVars = {
     [`${CSS_VAR_PREFIX}min`]: min,
     [`${CSS_VAR_PREFIX}max`]: max,
-    [`${CSS_VAR_PREFIX}current`]: value,
+    [`${CSS_VAR_PREFIX}current`]: clampedValue,
     [`${CSS_VAR_PREFIX}progress`]: `${sliderProgress}%`,
     [`${CSS_VAR_PREFIX}output-factor`]: `${outputFactor}`,
   };
@@ -63,7 +65,7 @@ export default function SingleThumb(props: Props) {
     output && (
       <output htmlFor={id} className={styles.Output}>
         <div className={styles.OutputBubble}>
-          <span className={styles.OutputText}>{value}</span>
+          <span className={styles.OutputText}>{clampedValue}</span>
         </div>
       </output>
     );
@@ -98,14 +100,14 @@ export default function SingleThumb(props: Props) {
             min={min}
             max={max}
             step={step}
-            value={value}
+            value={clampedValue}
             disabled={disabled}
             onChange={handleChange}
             onFocus={onFocus}
             onBlur={onBlur}
             aria-valuemin={min}
             aria-valuemax={max}
-            aria-valuenow={value}
+            aria-valuenow={clampedValue}
             aria-invalid={Boolean(error)}
             aria-describedby={ariaDescribedBy}
           />

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import {classNames} from '@shopify/react-utilities/styles';
+import Labelled, {helpTextID} from '../../../Labelled';
+
+import {invertNumber, CSS_VAR_PREFIX} from '../../utilities';
+import {Props as RangeSliderProps} from '../../types';
+
+import * as styles from './SingleThumb.scss';
+
+export interface Props extends RangeSliderProps {
+  value: number;
+  id: string;
+  min: number;
+  max: number;
+  step: number;
+}
+
+export default function SingleThumb(props: Props) {
+  const {
+    id,
+    error,
+    helpText,
+    value,
+    min,
+    max,
+    disabled,
+    output,
+    prefix,
+    suffix,
+    label,
+    labelAction,
+    labelHidden,
+    step,
+    onBlur,
+    onFocus,
+  } = props;
+  const describedBy: string[] = [];
+
+  if (error) {
+    describedBy.push(`${id}Error`);
+  }
+
+  if (helpText) {
+    describedBy.push(helpTextID(id));
+  }
+
+  const ariaDescribedBy = describedBy.length
+    ? describedBy.join(' ')
+    : undefined;
+
+  const sliderProgress = ((value - min) * 100) / (max - min);
+  const outputFactor = invertNumber((sliderProgress - 50) / 100);
+
+  const cssVars = {
+    [`${CSS_VAR_PREFIX}min`]: min,
+    [`${CSS_VAR_PREFIX}max`]: max,
+    [`${CSS_VAR_PREFIX}current`]: value,
+    [`${CSS_VAR_PREFIX}progress`]: `${sliderProgress}%`,
+    [`${CSS_VAR_PREFIX}output-factor`]: `${outputFactor}`,
+  };
+
+  const outputMarkup = !disabled &&
+    output && (
+      <output htmlFor={id} className={styles.Output}>
+        <div className={styles.OutputBubble}>
+          <span className={styles.OutputText}>{value}</span>
+        </div>
+      </output>
+    );
+
+  const prefixMarkup = prefix && <div className={styles.Prefix}>{prefix}</div>;
+
+  const suffixMarkup = suffix && <div className={styles.Suffix}>{suffix}</div>;
+
+  const className = classNames(
+    styles.SingleThumb,
+    error && styles.error,
+    disabled && styles.disabled,
+  );
+
+  return (
+    <Labelled
+      id={id}
+      label={label}
+      error={error}
+      action={labelAction}
+      labelHidden={labelHidden}
+      helpText={helpText}
+    >
+      <div className={className} style={cssVars}>
+        {prefixMarkup}
+        <div className={styles.InputWrapper}>
+          <input
+            type="range"
+            className={styles.Input}
+            id={id}
+            name={id}
+            min={min}
+            max={max}
+            step={step}
+            value={value}
+            disabled={disabled}
+            onChange={handleChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            aria-valuemin={min}
+            aria-valuemax={max}
+            aria-valuenow={value}
+            aria-invalid={Boolean(error)}
+            aria-describedby={ariaDescribedBy}
+          />
+          {outputMarkup}
+        </div>
+        {suffixMarkup}
+      </div>
+    </Labelled>
+  );
+
+  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const {onChange} = props;
+
+    if (onChange == null) {
+      return;
+    }
+
+    onChange(parseFloat(event.currentTarget.value), id);
+  }
+}

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
@@ -6,7 +6,7 @@ import Labelled, {helpTextID} from '../../../Labelled';
 import {invertNumber, CSS_VAR_PREFIX} from '../../utilities';
 import {Props as RangeSliderProps} from '../../types';
 
-import * as styles from './SingleThumb.scss';
+import styles from './SingleThumb.scss';
 
 export interface Props extends RangeSliderProps {
   value: number;

--- a/src/components/RangeSlider/components/SingleThumb/index.ts
+++ b/src/components/RangeSlider/components/SingleThumb/index.ts
@@ -1,0 +1,4 @@
+import SingleThumb from './SingleThumb';
+
+export {Props} from './SingleThumb';
+export default SingleThumb;

--- a/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
@@ -1,0 +1,202 @@
+import * as React from 'react';
+import {noop} from '@shopify/javascript-utilities/other';
+import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
+import {SingleThumb} from '../..';
+
+const mockProps = {
+  id: 'MyRangeSlider',
+  label: 'RangeSlider',
+  min: 10,
+  max: 20,
+  step: 0.5,
+  onChange: noop,
+  value: 15,
+};
+
+describe('<SingleThumb />', () => {
+  it('allows specific props to pass through properties on the input', () => {
+    const input = shallowWithAppProvider(
+      <SingleThumb disabled {...mockProps} />,
+    ).find('input');
+
+    expect(input.prop('value')).toBe(15);
+    expect(input.prop('min')).toBe(10);
+    expect(input.prop('max')).toBe(20);
+    expect(input.prop('step')).toBe(0.5);
+    expect(input.prop('disabled')).toBe(true);
+  });
+
+  describe('onChange()', () => {
+    it('is called when the input changes', () => {
+      const onChangeSpy = jest.fn();
+      const {onChange, ...rest} = mockProps;
+      const element = mountWithAppProvider(
+        <SingleThumb onChange={onChangeSpy} {...rest} />,
+      );
+
+      const singleThumb = element.find(SingleThumb);
+      singleThumb.find('input').simulate('change');
+      expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called with a new value', () => {
+      const onChangeSpy = jest.fn();
+      const {onChange, ...rest} = mockProps;
+      const element = mountWithAppProvider(
+        <SingleThumb onChange={onChangeSpy} {...rest} />,
+      );
+
+      const singleThumb = element.find(SingleThumb);
+      (element.find('input') as any).instance().value = 40;
+      singleThumb.find('input').simulate('change');
+      expect(onChangeSpy).toHaveBeenCalledWith(40, 'MyRangeSlider');
+    });
+  });
+
+  describe('onFocus()', () => {
+    it('is called when the input is focused', () => {
+      const onFocusSpy = jest.fn();
+      shallowWithAppProvider(
+        <SingleThumb {...mockProps} onFocus={onFocusSpy} />,
+      )
+        .find('input')
+        .simulate('focus');
+      expect(onFocusSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onBlur()', () => {
+    it('is called when the input is blurred', () => {
+      const onBlurSpy = jest.fn();
+      const element = shallowWithAppProvider(
+        <SingleThumb {...mockProps} onBlur={onBlurSpy} />,
+      );
+
+      element.find('input').simulate('focus');
+      element.find('input').simulate('blur');
+
+      expect(onBlurSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('id', () => {
+    it('sets the id on the input', () => {
+      const id = shallowWithAppProvider(<SingleThumb {...mockProps} />)
+        .find('input')
+        .prop('id');
+
+      expect(id).toBe('MyRangeSlider');
+    });
+  });
+
+  describe('output', () => {
+    it('connects the input to the output', () => {
+      const element = mountWithAppProvider(
+        <SingleThumb {...mockProps} output />,
+      );
+      const inputId = element.find('input').prop('id');
+
+      expect(typeof inputId).toBe('string');
+      expect(element.find('output').prop('htmlFor')).toBe(inputId);
+    });
+
+    it('contains the correct value text', () => {
+      const element = mountWithAppProvider(
+        <SingleThumb {...mockProps} output />,
+      );
+      const outputText = element.find('output').find('span');
+
+      expect(outputText.text()).toBe('15');
+    });
+  });
+
+  describe('helpText', () => {
+    it('connects the input to the help text', () => {
+      const element = mountWithAppProvider(
+        <SingleThumb {...mockProps} helpText="Some help" />,
+      );
+      const helpTextID = element.find('input').prop<string>('aria-describedby');
+
+      expect(typeof helpTextID).toBe('string');
+      expect(element.find(`#${helpTextID}`).text()).toBe('Some help');
+    });
+  });
+
+  describe('error', () => {
+    it('marks the input as invalid', () => {
+      const element = shallowWithAppProvider(
+        <SingleThumb error={<span>Invalid</span>} {...mockProps} />,
+      );
+      expect(element.find('input').prop<string>('aria-invalid')).toBe(true);
+
+      element.setProps({error: 'Some error'});
+      expect(element.find('input').prop<string>('aria-invalid')).toBe(true);
+    });
+
+    it('connects the input to the error', () => {
+      const element = mountWithAppProvider(
+        <SingleThumb {...mockProps} error="Some error" />,
+      );
+      const errorID = element.find('input').prop<string>('aria-describedby');
+
+      expect(typeof errorID).toBe('string');
+      expect(element.find(`#${errorID}`).text()).toBe('Some error');
+    });
+
+    it('connects the input to both an error and help text', () => {
+      const element = mountWithAppProvider(
+        <SingleThumb {...mockProps} helpText="Some help" error="Some error" />,
+      );
+      const descriptions = element
+        .find('input')
+        .prop<string>('aria-describedby')
+        .split(' ');
+
+      expect(descriptions).toHaveLength(2);
+      expect(element.find(`#${descriptions[1]}`).text()).toBe('Some help');
+      expect(element.find(`#${descriptions[0]}`).text()).toBe('Some error');
+    });
+
+    describe('prefix', () => {
+      const text = 'prefix text';
+
+      it('outputs the provided prefix element', () => {
+        const element = mountWithAppProvider(
+          <SingleThumb {...mockProps} prefix={<p>{text}</p>} />,
+        );
+        const prefixElement = element.find('p');
+
+        expect(prefixElement.text()).toBe(text);
+      });
+    });
+  });
+
+  describe('suffix', () => {
+    const text = 'suffix text';
+
+    it('outputs the provided suffix element', () => {
+      const element = mountWithAppProvider(
+        <SingleThumb {...mockProps} suffix={<p>{text}</p>} />,
+      );
+      const suffixElement = element.find('p');
+
+      expect(suffixElement.text()).toBe(text);
+    });
+  });
+
+  describe('CSS custom properties', () => {
+    it('sets the correct css custom properties', () => {
+      const element = mountWithAppProvider(<SingleThumb {...mockProps} />);
+      const expected = {
+        '--Polaris-RangeSlider-min': 10,
+        '--Polaris-RangeSlider-max': 20,
+        '--Polaris-RangeSlider-current': 15,
+        '--Polaris-RangeSlider-progress': '50%',
+        '--Polaris-RangeSlider-output-factor': '0',
+      };
+      const actual = element.find('[style]').prop('style');
+
+      expect(expected).toEqual(actual);
+    });
+  });
+});

--- a/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
@@ -173,7 +173,6 @@ describe('<SingleThumb />', () => {
 
   describe('suffix', () => {
     const text = 'suffix text';
-
     it('outputs the provided suffix element', () => {
       const element = mountWithAppProvider(
         <SingleThumb {...mockProps} suffix={<p>{text}</p>} />,
@@ -197,6 +196,59 @@ describe('<SingleThumb />', () => {
       const actual = element.find('[style]').prop('style');
 
       expect(expected).toEqual(actual);
+    });
+  });
+
+  describe('value', () => {
+    it('gets adjusted to be at least the min', () => {
+      const value = 9;
+      const min = 10;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} min={min} />,
+      );
+
+      expect(singleThumb.find('input').prop('value')).toBe(min);
+    });
+
+    it('gets adjusted to be no more than the max', () => {
+      const value = 101;
+      const max = 100;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} max={max} />,
+      );
+
+      expect(singleThumb.find('input').prop('value')).toBe(max);
+    });
+  });
+
+  describe('aria-valuenow', () => {
+    it('gets passed the value', () => {
+      const value = 15;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} />,
+      );
+
+      expect(singleThumb.find('input').prop('aria-valuenow')).toBe(value);
+    });
+
+    it('gets adjusted to be at least the min', () => {
+      const value = 9;
+      const min = 10;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} min={min} />,
+      );
+
+      expect(singleThumb.find('input').prop('aria-valuenow')).toBe(min);
+    });
+
+    it('gets adjusted to be no more than the max', () => {
+      const value = 101;
+      const max = 100;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} max={max} />,
+      );
+
+      expect(singleThumb.find('input').prop('aria-valuenow')).toBe(max);
     });
   });
 });

--- a/src/components/RangeSlider/components/index.ts
+++ b/src/components/RangeSlider/components/index.ts
@@ -1,0 +1,2 @@
+export {default as DualThumb} from './DualThumb';
+export {default as SingleThumb} from './SingleThumb';

--- a/src/components/RangeSlider/index.ts
+++ b/src/components/RangeSlider/index.ts
@@ -1,4 +1,4 @@
 import RangeSlider from './RangeSlider';
 
-export {Props, invertNumber} from './RangeSlider';
+export {Props, RangeSliderValue} from './types';
 export default RangeSlider;

--- a/src/components/RangeSlider/tests/RangeSlider.test.tsx
+++ b/src/components/RangeSlider/tests/RangeSlider.test.tsx
@@ -25,12 +25,12 @@ describe('<RangeSlider />', () => {
         <RangeSlider value={[0, 25]} {...mockRangeSliderProps} />,
       );
 
-      const elementProps = element.find(DualThumb).props();
+      const {min, max, step} = element.find(DualThumb).props();
 
       expect({
-        min: elementProps.min,
-        max: elementProps.max,
-        step: elementProps.step,
+        min,
+        max,
+        step,
       }).toEqual({
         min: DEFAULT_RANGE_SLIDER_PROPS.min,
         max: DEFAULT_RANGE_SLIDER_PROPS.max,
@@ -54,13 +54,13 @@ describe('<RangeSlider />', () => {
         />,
       );
 
-      const elementProps = element.find(DualThumb).props();
+      const {min, max, id, step} = element.find(DualThumb).props();
 
       expect({
-        min: elementProps.min,
-        max: elementProps.max,
-        step: elementProps.step,
-        id: elementProps.id,
+        min,
+        max,
+        step,
+        id,
       }).toEqual(overrideProps);
     });
 
@@ -86,12 +86,12 @@ describe('<RangeSlider />', () => {
         <RangeSlider value={25} {...mockRangeSliderProps} />,
       );
 
-      const elementProps = element.find(SingleThumb).props();
+      const {min, max, step} = element.find(SingleThumb).props();
 
       expect({
-        min: elementProps.min,
-        max: elementProps.max,
-        step: elementProps.step,
+        min,
+        max,
+        step,
       }).toEqual({
         min: DEFAULT_RANGE_SLIDER_PROPS.min,
         max: DEFAULT_RANGE_SLIDER_PROPS.max,
@@ -119,13 +119,13 @@ describe('<RangeSlider />', () => {
         <RangeSlider value={25} {...mockRangeSliderProps} {...overrideProps} />,
       );
 
-      const elementProps = element.find(SingleThumb).props();
+      const {min, max, id, step} = element.find(SingleThumb).props();
 
       expect({
-        min: elementProps.min,
-        max: elementProps.max,
-        step: elementProps.step,
-        id: elementProps.id,
+        min,
+        max,
+        step,
+        id,
       }).toEqual(overrideProps);
     });
   });

--- a/src/components/RangeSlider/tests/RangeSlider.test.tsx
+++ b/src/components/RangeSlider/tests/RangeSlider.test.tsx
@@ -3,29 +3,130 @@ import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import RangeSlider from '../RangeSlider';
 import {DualThumb, SingleThumb} from '../components';
+import {DEFAULT_RANGE_SLIDER_PROPS} from '../utilities';
 
-const mockProps = {
-  id: 'MyRangeSlider',
+const mockRangeSliderProps = {
   label: 'RangeSlider',
-  min: 10,
-  max: 20,
-  step: 0.5,
   onChange: noop,
 };
 
 describe('<RangeSlider />', () => {
-  it('renders a dual thumb if value is a tuple', () => {
-    const element = mountWithAppProvider(
-      <RangeSlider value={[0, 25]} {...mockProps} />,
-    );
+  describe('<DualThumb />', () => {
+    it('renders a dual thumb if value is a tuple', () => {
+      const element = mountWithAppProvider(
+        <RangeSlider value={[0, 25]} {...mockRangeSliderProps} />,
+      );
 
-    expect(element.find(DualThumb)).toHaveLength(1);
+      expect(element.find(DualThumb)).toHaveLength(1);
+    });
+
+    it('passes default props to dual thumb', () => {
+      const element = mountWithAppProvider(
+        <RangeSlider value={[0, 25]} {...mockRangeSliderProps} />,
+      );
+
+      const elementProps = element.find(DualThumb).props();
+
+      expect({
+        min: elementProps.min,
+        max: elementProps.max,
+        step: elementProps.step,
+      }).toEqual({
+        min: DEFAULT_RANGE_SLIDER_PROPS.min,
+        max: DEFAULT_RANGE_SLIDER_PROPS.max,
+        step: DEFAULT_RANGE_SLIDER_PROPS.step,
+      });
+    });
+
+    it('passes overrides to default props to dual thumb', () => {
+      const overrideProps = {
+        id: 'MyRangeSlider',
+        min: 99,
+        max: 999,
+        step: 9,
+      };
+
+      const element = mountWithAppProvider(
+        <RangeSlider
+          value={[0, 25]}
+          {...mockRangeSliderProps}
+          {...overrideProps}
+        />,
+      );
+
+      const elementProps = element.find(DualThumb).props();
+
+      expect({
+        min: elementProps.min,
+        max: elementProps.max,
+        step: elementProps.step,
+        id: elementProps.id,
+      }).toEqual(overrideProps);
+    });
+
+    it('passes an id to dual thumb', () => {
+      const element = mountWithAppProvider(
+        <RangeSlider value={[0, 25]} {...mockRangeSliderProps} />,
+      );
+
+      expect(element.find(DualThumb).props().id).not.toBeNull();
+    });
   });
 
-  it('renders a single thumb if value is a single number', () => {
-    const element = mountWithAppProvider(
-      <RangeSlider value={25} {...mockProps} />,
-    );
-    expect(element.find(SingleThumb)).toHaveLength(1);
+  describe('<SingleThumb />', () => {
+    it('renders a single thumb if value is a single number', () => {
+      const element = mountWithAppProvider(
+        <RangeSlider value={25} {...mockRangeSliderProps} />,
+      );
+      expect(element.find(SingleThumb)).toHaveLength(1);
+    });
+
+    it('passes default props to single thumb', () => {
+      const element = mountWithAppProvider(
+        <RangeSlider value={25} {...mockRangeSliderProps} />,
+      );
+
+      const elementProps = element.find(SingleThumb).props();
+
+      expect({
+        min: elementProps.min,
+        max: elementProps.max,
+        step: elementProps.step,
+      }).toEqual({
+        min: DEFAULT_RANGE_SLIDER_PROPS.min,
+        max: DEFAULT_RANGE_SLIDER_PROPS.max,
+        step: DEFAULT_RANGE_SLIDER_PROPS.step,
+      });
+    });
+
+    it('passes an id to single thumb', () => {
+      const element = mountWithAppProvider(
+        <RangeSlider value={25} {...mockRangeSliderProps} />,
+      );
+
+      expect(element.find(SingleThumb).props().id).not.toBeNull();
+    });
+
+    it('passes overrides to default props to single thumb', () => {
+      const overrideProps = {
+        id: 'MyRangeSlider',
+        min: 99,
+        max: 999,
+        step: 9,
+      };
+
+      const element = mountWithAppProvider(
+        <RangeSlider value={25} {...mockRangeSliderProps} {...overrideProps} />,
+      );
+
+      const elementProps = element.find(SingleThumb).props();
+
+      expect({
+        min: elementProps.min,
+        max: elementProps.max,
+        step: elementProps.step,
+        id: elementProps.id,
+      }).toEqual(overrideProps);
+    });
   });
 });

--- a/src/components/RangeSlider/tests/RangeSlider.test.tsx
+++ b/src/components/RangeSlider/tests/RangeSlider.test.tsx
@@ -1,281 +1,31 @@
 import * as React from 'react';
 import {noop} from '@shopify/javascript-utilities/other';
-import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
-import RangeSlider, {invertNumber} from '../RangeSlider';
+import {mountWithAppProvider} from 'test-utilities';
+import RangeSlider from '../RangeSlider';
+import {DualThumb, SingleThumb} from '../components';
+
+const mockProps = {
+  id: 'MyRangeSlider',
+  label: 'RangeSlider',
+  min: 10,
+  max: 20,
+  step: 0.5,
+  onChange: noop,
+};
 
 describe('<RangeSlider />', () => {
-  it('allows specific props to pass through properties on the input', () => {
-    const input = shallowWithAppProvider(
-      <RangeSlider
-        label="RangeSlider"
-        value={15}
-        min={10}
-        max={20}
-        step={0.5}
-        disabled
-        onChange={noop}
-      />,
-    ).find('input');
+  it('renders a dual thumb if value is a tuple', () => {
+    const element = mountWithAppProvider(
+      <RangeSlider value={[0, 25]} {...mockProps} />,
+    );
 
-    expect(input.prop('value')).toBe(15);
-    expect(input.prop('min')).toBe(10);
-    expect(input.prop('max')).toBe(20);
-    expect(input.prop('step')).toBe(0.5);
-    expect(input.prop('disabled')).toBe(true);
+    expect(element.find(DualThumb)).toHaveLength(1);
   });
 
-  describe('onChange()', () => {
-    it('is called with the new value', () => {
-      const spy = jest.fn();
-      const element = mountWithAppProvider(
-        <RangeSlider
-          id="MyRangeSlider"
-          label="RangeSlider"
-          value={50}
-          onChange={spy}
-        />,
-      );
-
-      (element.find('input') as any).instance().value = 40;
-      element.find('input').simulate('change');
-
-      expect(spy).toHaveBeenCalledWith(40, 'MyRangeSlider');
-    });
-  });
-
-  describe('onFocus()', () => {
-    it('is called when the input is focused', () => {
-      const spy = jest.fn();
-      shallowWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          onChange={noop}
-          onFocus={spy}
-        />,
-      )
-        .find('input')
-        .simulate('focus');
-      expect(spy).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('onBlur()', () => {
-    it('is called when the input is blurred', () => {
-      const spy = jest.fn();
-      const element = shallowWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          onChange={noop}
-          onBlur={spy}
-        />,
-      );
-
-      element.find('input').simulate('focus');
-      element.find('input').simulate('blur');
-
-      expect(spy).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('id', () => {
-    it('sets the id on the input', () => {
-      const id = shallowWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          id="MyRangeSlider"
-          value={50}
-          onChange={noop}
-        />,
-      )
-        .find('input')
-        .prop('id');
-
-      expect(id).toBe('MyRangeSlider');
-    });
-
-    it('sets a random id on the input when none is passed', () => {
-      const id = shallowWithAppProvider(
-        <RangeSlider label="RangeSlider" value={50} onChange={noop} />,
-      )
-        .find('input')
-        .prop('id');
-
-      expect(typeof id).toBe('string');
-      expect(id).toBeTruthy();
-    });
-  });
-
-  describe('output', () => {
-    it('connects the input to the output', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          id="MyRangeSlider"
-          value={50}
-          output
-          onChange={noop}
-        />,
-      );
-      const inputId = element.find('input').prop<string>('id');
-
-      expect(typeof inputId).toBe('string');
-      expect(element.find('output').prop<string>('htmlFor')).toBe(inputId);
-    });
-
-    it('contains the correct value text', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider label="RangeSlider" value={50} output onChange={noop} />,
-      );
-      const outputText = element.find('output').find('span');
-
-      expect(outputText.text()).toBe('50');
-    });
-  });
-
-  describe('helpText', () => {
-    it('connects the input to the help text', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          helpText="Some help"
-          onChange={noop}
-        />,
-      );
-      const helpTextID = element.find('input').prop<string>('aria-describedby');
-
-      expect(typeof helpTextID).toBe('string');
-      expect(element.find(`#${helpTextID}`).text()).toBe('Some help');
-    });
-  });
-
-  describe('error', () => {
-    it('marks the input as invalid', () => {
-      const element = shallowWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          error={<span>Invalid</span>}
-          onChange={noop}
-        />,
-      );
-      expect(element.find('input').prop<string>('aria-invalid')).toBe(true);
-
-      element.setProps({error: 'Some error'});
-      expect(element.find('input').prop<string>('aria-invalid')).toBe(true);
-    });
-
-    it('connects the input to the error', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          error="Some error"
-          onChange={noop}
-        />,
-      );
-      const errorID = element.find('input').prop<string>('aria-describedby');
-
-      expect(typeof errorID).toBe('string');
-      expect(element.find(`#${errorID}`).text()).toBe('Some error');
-    });
-
-    it('connects the input to both an error and help text', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          helpText="Some help"
-          error="Some error"
-          onChange={noop}
-        />,
-      );
-      const descriptions = element
-        .find('input')
-        .prop<string>('aria-describedby')
-        .split(' ');
-
-      expect(descriptions).toHaveLength(2);
-      expect(element.find(`#${descriptions[1]}`).text()).toBe('Some help');
-      expect(element.find(`#${descriptions[0]}`).text()).toBe('Some error');
-    });
-  });
-
-  describe('prefix', () => {
-    const text = 'prefix text';
-
-    it('outputs the provided prefix element', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          prefix={<p>{text}</p>}
-          onChange={noop}
-        />,
-      );
-      const prefixElement = element.find('p');
-
-      expect(prefixElement.text()).toBe(text);
-    });
-  });
-
-  describe('suffix', () => {
-    const text = 'suffix text';
-
-    it('outputs the provided suffix element', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          suffix={<p>{text}</p>}
-          onChange={noop}
-        />,
-      );
-      const suffixElement = element.find('p');
-
-      expect(suffixElement.text()).toBe(text);
-    });
-  });
-
-  describe('invertNumber', () => {
-    it('returns a negative number when the argument is positive', () => {
-      const negative = invertNumber(10);
-      expect(negative).toBe(-10);
-    });
-
-    it('returns a positive number when the argument is negative', () => {
-      const negative = invertNumber(-10);
-      expect(negative).toBe(10);
-    });
-
-    it('returns 0 when the argument is 0', () => {
-      const negative = invertNumber(0);
-      expect(negative).toBe(0);
-    });
-  });
-
-  describe('CSS custom properties', () => {
-    it('sets the correct css custom properties', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          id="MyRangeSlider"
-          value={25}
-          onChange={noop}
-        />,
-      );
-      const expected = {
-        '--Polaris-RangeSlider-min': 0,
-        '--Polaris-RangeSlider-max': 100,
-        '--Polaris-RangeSlider-current': 25,
-        '--Polaris-RangeSlider-progress': '25%',
-        '--Polaris-RangeSlider-output-factor': 0.25,
-      };
-      const actual = element.find('[style]').prop('style');
-
-      expect(expected).toEqual(actual);
-    });
+  it('renders a single thumb if value is a single number', () => {
+    const element = mountWithAppProvider(
+      <RangeSlider value={25} {...mockProps} />,
+    );
+    expect(element.find(SingleThumb)).toHaveLength(1);
   });
 });

--- a/src/components/RangeSlider/tests/RangeSlider.test.tsx
+++ b/src/components/RangeSlider/tests/RangeSlider.test.tsx
@@ -3,7 +3,7 @@ import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import RangeSlider from '../RangeSlider';
 import {DualThumb, SingleThumb} from '../components';
-import {DEFAULT_RANGE_SLIDER_PROPS} from '../utilities';
+import {RangeSliderDefault} from '../utilities';
 
 const mockRangeSliderProps = {
   label: 'RangeSlider',
@@ -32,9 +32,9 @@ describe('<RangeSlider />', () => {
         max,
         step,
       }).toEqual({
-        min: DEFAULT_RANGE_SLIDER_PROPS.min,
-        max: DEFAULT_RANGE_SLIDER_PROPS.max,
-        step: DEFAULT_RANGE_SLIDER_PROPS.step,
+        min: RangeSliderDefault.Min,
+        max: RangeSliderDefault.Max,
+        step: RangeSliderDefault.Step,
       });
     });
 
@@ -93,9 +93,9 @@ describe('<RangeSlider />', () => {
         max,
         step,
       }).toEqual({
-        min: DEFAULT_RANGE_SLIDER_PROPS.min,
-        max: DEFAULT_RANGE_SLIDER_PROPS.max,
-        step: DEFAULT_RANGE_SLIDER_PROPS.step,
+        min: RangeSliderDefault.Min,
+        max: RangeSliderDefault.Max,
+        step: RangeSliderDefault.Step,
       });
     });
 

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -33,8 +33,6 @@ export interface Props {
   prefix?: React.ReactNode;
   /** Element to display after the input */
   suffix?: React.ReactNode;
-  /** Displays text fields as the prefix and suffix for the dual thumb slider only */
-  accessibilityInputs?: boolean;
   /** Callback when the range input is changed */
   onChange(value: RangeSliderValue, id: string): void;
   /** Callback when range input is focused */

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -2,7 +2,8 @@ import {Action} from '../Labelled';
 
 import {Error} from '../../types';
 
-export type RangeSliderValue = number | [number, number];
+export type DualValue = [number, number];
+export type RangeSliderValue = number | DualValue;
 
 export interface Props {
   /** Label for the range input */

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -1,0 +1,44 @@
+import {Action} from '../Labelled';
+
+import {Error} from '../../types';
+
+export type RangeSliderValue = number | [number, number];
+
+export interface Props {
+  /** Label for the range input */
+  label: string;
+  /** Adds an action to the label */
+  labelAction?: Action;
+  /** Visually hide the label */
+  labelHidden?: boolean;
+  /** ID for range input */
+  id?: string;
+  /** Initial value for range input */
+  value: RangeSliderValue;
+  /** Minimum possible value for range input */
+  min?: number;
+  /** Maximum possible value for range input */
+  max?: number;
+  /** Increment value for range input changes */
+  step?: number;
+  /** Provide a tooltip while sliding, indicating the current value */
+  output?: boolean;
+  /** Additional text to aid in use */
+  helpText?: React.ReactNode;
+  /** Display an error message */
+  error?: Error;
+  /** Disable input */
+  disabled?: boolean;
+  /** Element to display before the input */
+  prefix?: React.ReactNode;
+  /** Element to display after the input */
+  suffix?: React.ReactNode;
+  /** Displays text fields as the prefix and suffix for the dual thumb slider only */
+  accessibilityInputs?: boolean;
+  /** Callback when the range input is changed */
+  onChange(value: RangeSliderValue, id: string): void;
+  /** Callback when range input is focused */
+  onFocus?(): void;
+  /** Callback when focus is removed */
+  onBlur?(): void;
+}

--- a/src/components/RangeSlider/utilities/index.ts
+++ b/src/components/RangeSlider/utilities/index.ts
@@ -1,0 +1,2 @@
+export const CSS_VAR_PREFIX = '--Polaris-RangeSlider-';
+export {default as invertNumber} from './invertNumber';

--- a/src/components/RangeSlider/utilities/index.ts
+++ b/src/components/RangeSlider/utilities/index.ts
@@ -1,7 +1,7 @@
 export const CSS_VAR_PREFIX = '--Polaris-RangeSlider-';
-export const DEFAULT_RANGE_SLIDER_PROPS = {
-  min: 0,
-  max: 100,
-  step: 1,
-};
+export enum RangeSliderDefault {
+  Min = 0,
+  Max = 100,
+  Step = 1,
+}
 export {default as invertNumber} from './invertNumber';

--- a/src/components/RangeSlider/utilities/index.ts
+++ b/src/components/RangeSlider/utilities/index.ts
@@ -1,2 +1,7 @@
 export const CSS_VAR_PREFIX = '--Polaris-RangeSlider-';
+export const DEFAULT_RANGE_SLIDER_PROPS = {
+  min: 0,
+  max: 100,
+  step: 1,
+};
 export {default as invertNumber} from './invertNumber';

--- a/src/components/RangeSlider/utilities/invertNumber.ts
+++ b/src/components/RangeSlider/utilities/invertNumber.ts
@@ -1,0 +1,9 @@
+export default function invertNumber(number: number) {
+  if (Math.sign(number) === 1) {
+    return -Math.abs(number);
+  } else if (Math.sign(number) === -1) {
+    return Math.abs(number);
+  } else {
+    return 0;
+  }
+}

--- a/src/components/RangeSlider/utilities/tests/invertNumber.test.ts
+++ b/src/components/RangeSlider/utilities/tests/invertNumber.test.ts
@@ -1,0 +1,18 @@
+import {invertNumber} from '../index';
+
+describe('invertNumber', () => {
+  it('returns a negative number when the argument is positive', () => {
+    const negative = invertNumber(10);
+    expect(negative).toBe(-10);
+  });
+
+  it('returns a positive number when the argument is negative', () => {
+    const negative = invertNumber(-10);
+    expect(negative).toBe(10);
+  });
+
+  it('returns 0 when the argument is 0', () => {
+    const negative = invertNumber(0);
+    expect(negative).toBe(0);
+  });
+});

--- a/src/utilities/clamp.ts
+++ b/src/utilities/clamp.ts
@@ -1,0 +1,5 @@
+export default function clamp(number: number, min: number, max: number) {
+  if (number < min) return min;
+  if (number > max) return max;
+  return number;
+}

--- a/src/utilities/tests/clamp.test.ts
+++ b/src/utilities/tests/clamp.test.ts
@@ -1,0 +1,23 @@
+import clamp from '../clamp';
+
+describe('clamp', () => {
+  it('adjusts the given number to be at least the min', () => {
+    const min = 10;
+    const number = clamp(9, min, 50);
+    expect(number).toBe(min);
+  });
+
+  it('adjusts the given number to be no more than the max', () => {
+    const max = 100;
+    const number = clamp(101, 0, max);
+    expect(number).toBe(max);
+  });
+
+  it('does not change the given number if it is between the min and max', () => {
+    const value = 50;
+    const min = 0;
+    const max = 100;
+    const number = clamp(value, min, max);
+    expect(number).toBe(value);
+  });
+});


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris-react/issues/937

### WHAT is this pull request doing?

Removes the tip from output. This might be affected by https://github.com/Shopify/polaris-react/pull/1034 and should be 🎩 and merged after that PR.

### Before

**Single**
![screen shot 2019-02-13 at 5 20 28 pm](https://user-images.githubusercontent.com/6239480/52755741-c6a71180-2fb3-11e9-8787-ae8b215643fd.jpg)

**Dual, left**

![screen shot 2019-02-13 at 5 20 36 pm](https://user-images.githubusercontent.com/6239480/52755755-d58dc400-2fb3-11e9-9bd1-97e6d769e44f.jpg)

**Dual, right**

![screen shot 2019-02-13 at 5 20 32 pm](https://user-images.githubusercontent.com/6239480/52755767-dfafc280-2fb3-11e9-833b-96f79df33807.jpg)

### After

**Single**
![screen shot 2019-02-13 at 5 23 33 pm](https://user-images.githubusercontent.com/6239480/52755817-1ede1380-2fb4-11e9-9d87-2f27612914d0.jpg)


**Dual, left**
![screen shot 2019-02-13 at 5 23 26 pm](https://user-images.githubusercontent.com/6239480/52755825-24d3f480-2fb4-11e9-9808-48da996891d8.jpg)


**Dual, right**
![screen shot 2019-02-13 at 5 23 28 pm](https://user-images.githubusercontent.com/6239480/52755830-2998a880-2fb4-11e9-9930-0e472a968ab3.jpg)



## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, RangeSlider} from '../src';

interface State {
  singleValue: number;
  dualValue: [number, number];
}

export default class Playground extends React.Component<{}, State> {
  state: State = {
    singleValue: 50,
    dualValue: [90, 1000],
  };

  handleSingleChange = (value) => {
    this.setState({singleValue: value});
  };

  handleDualChange = (value) => {
    this.setState({dualValue: value});
  };

  render() {
    const {singleValue, dualValue} = this.state;

    return (
      <Page title="Playground">
        <RangeSlider
          label=""
          value={singleValue}
          onChange={this.handleSingleChange}
          output
        />
        <div style={{marginTop: '50px'}} />
        <RangeSlider
          label=""
          value={dualValue}
          onChange={this.handleDualChange}
          output
          max={2000}
        />
      </Page>
    );
  }
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
