### PR TITLE
[Tooltip] Remove leftover styles from tip in tooltip

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Changed the offset from 5px to 4px in `Tooltip` between activator and message to be consistent with `Popover` ([#1019](https://github.com/Shopify/polaris-react/pull/1019))
+
 ### Documentation
 
 - Added all props example to `Card` in the [style guide](https://polaris.shopify.com) ([#939](https://github.com/Shopify/polaris-react/pull/939))

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -1,10 +1,9 @@
-$arrow-size: rem(14px);
-$visible-portion-of-arrow: rem(5px);
+$offset-from-activator: rem(4px);
 $content-max-height: rem(100px);
 $content-max-width: rem(200px);
 
 .Tooltip {
-  margin: $visible-portion-of-arrow spacing() spacing();
+  margin: $offset-from-activator spacing() spacing();
   opacity: 1;
   box-shadow: shadow(deep);
   border-radius: border-radius();
@@ -18,22 +17,13 @@ $content-max-width: rem(200px);
 }
 
 .positionedAbove {
-  margin: spacing() spacing() $visible-portion-of-arrow;
-
-  .Tip {
-    top: inherit;
-    bottom: 0;
-  }
+  margin: spacing() spacing() $offset-from-activator;
 }
 
 .light {
   .Wrapper {
     background: color('white');
     color: color('ink');
-  }
-
-  .Tip {
-    background: color('white');
   }
 }
 
@@ -52,17 +42,6 @@ $content-max-width: rem(200px);
   border-radius: border-radius();
   max-width: $content-max-width;
   max-height: $content-max-height;
-}
-
-.Tip {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%) rotate(45deg);
-  height: $arrow-size;
-  width: $arrow-size;
-  background: color('ink');
-  box-shadow: shadow(deep);
 }
 
 .Label {


### PR DESCRIPTION
### WHY are these changes introduced?

The [tip was removed](https://github.com/Shopify/polaris-react-deprecated/commit/17c2ef5e2b868f85295112706d4067a65f0af038) from tooltip and popover. There were some leftover styles that weren't deleted from the tooltip. The distance between the tip and its activator was 5px in tooltip and 4px in popover.

### WHAT is this pull request doing?

Removes the styles and sets the offset as 4px.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        {/* Add the code you want to test here */}
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
