### PR TITLE
[Stack] Remove margin from vertical

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed missing rounded corners on `Tag` button states ([#1078](https://github.com/Shopify/polaris-react/pull/1078))
 - Removed reference to `window.Polaris`, which in some cases could be undefined ([#1104](https://github.com/Shopify/polaris-react/issues/1104))
 - Added padding and margin to `subdued` sections for proper spacing between the header and footer ([#1082](https://github.com/Shopify/polaris-react/pull/1082))
+- Removed left margin from vertical `Stack` to prevent overflow ([#1024](https://github.com/Shopify/polaris-react/pull/1024))
 
 ### Documentation
 

--- a/src/components/Stack/Stack.scss
+++ b/src/components/Stack/Stack.scss
@@ -23,10 +23,6 @@
   flex-wrap: nowrap;
 }
 
-.vertical {
-  flex-direction: column;
-}
-
 .spacingNone {
   @include stack-spacing(none);
 }
@@ -94,6 +90,15 @@
 
 .alignmentBaseline {
   align-items: baseline;
+}
+
+.vertical {
+  flex-direction: column;
+  margin-left: spacing(none);
+
+  > .Item {
+    margin-left: spacing(none);
+  }
 }
 
 .Item {


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris-react/issues/947

When using a vertical `Stack` the contents appear to break out of the container and "bleed" into surrounding padding when one of the children starts to wrap.

### WHAT is this pull request doing?

Removes negative left margin from stack and left margin from item when vertical.

🤓 *1024 - the gigabyte PR*

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Card, Stack, Badge} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <Card sectioned>
          <Stack vertical>
            <div style={{backgroundColor: 'red'}}>Testing</div>
            <div>
              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus
              sit amet rutrum tortor, quis condimentum lectus. Duis dui ligula,
              bibendum vel pharetra non, vulputate ut risus. Nam semper
              consequat nisl, sit amet consectetur purus vestibulum non. Duis
              molestie facilisis diam sit amet imperdiet. Praesent malesuada et
              nulla in mattis. Nullam aliquam luctus dui, id fermentum magna
              faucibus vitae. Ut ultrices dui vel lacus sodales, vel imperdiet
              quam facilisis. Curabitur dictum odio sit amet enim pretium
              consequat. Duis luctus sapien mattis sapien luctus tempor. Quisque
              vel purus quis orci dignissim pharetra sed sit amet turpis. Nam
              porttitor libero risus, ut facilisis lorem lobortis nec. Sed nec
              placerat sapien, eu auctor ex. Aliquam vel mattis neque. Integer
              pellentesque viverra fermentum.
            </div>
          </Stack>
        </Card>
        <br />
        <div style={{width: '200px'}}>
          <Card>
            <Stack vertical>
              <Badge>Badge with many words that wrap</Badge>
              <Badge>Badge with many words that wrap</Badge>
              <Badge>Badge with many words that wrap</Badge>
              <Badge>Badge with many words that wrap</Badge>
            </Stack>
          </Card>
        </div>
        <br />
        <div style={{width: '200px'}}>
          <Card>
            <Stack>
              <Badge>Badge</Badge>
              <Badge>Badge</Badge>
              <Badge>Badge</Badge>
              <Badge>Badge</Badge>
            </Stack>
          </Card>
        </div>
      </Page>
    );
  }
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
