### PR TITLE
Add download attribute to Button and UnstyledLink

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Updates `TopBar.UserMenu` interaction states styling ([#1006](https://github.com/Shopify/polaris-react/pull/1006))
+- Added `download` prop to `Button` and `UnstyledLink` components that enables setting the download attribute ([#1027](https://github.com/Shopify/polaris-react/pull/1027))
 
 ### Bug fixes
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -46,6 +46,8 @@ export interface Props {
   monochrome?: boolean;
   /** Forces url to open in a new tab */
   external?: boolean;
+  /** Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value. */
+  download?: string | boolean;
   /** Icon to display to the left of the button content */
   icon?: React.ReactNode | IconSource;
   /** Visually hidden text for screen readers */
@@ -91,6 +93,7 @@ function Button({
   onKeyPress,
   onKeyUp,
   external,
+  download,
   icon,
   primary,
   outline,
@@ -183,6 +186,7 @@ function Button({
         id={id}
         url={url}
         external={external}
+        download={download}
         onClick={onClick}
         onFocus={onFocus}
         onBlur={onBlur}

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -137,6 +137,25 @@ describe('<Button />', () => {
     });
   });
 
+  describe('download', () => {
+    it('gets passed into the link as a boolean', () => {
+      const button = shallowWithAppProvider(<Button url="/foo" download />);
+      expect(button.find(UnstyledLink).prop('download')).toBe(true);
+    });
+
+    it('gets passed into the link as a string', () => {
+      const button = shallowWithAppProvider(
+        <Button url="/foo" download="file.txt" />,
+      );
+      expect(button.find(UnstyledLink).prop('download')).toBe('file.txt');
+    });
+
+    it('is false when not set', () => {
+      const button = shallowWithAppProvider(<Button url="http://google.com" />);
+      expect(button.find(UnstyledLink).prop('download')).toBeFalsy();
+    });
+  });
+
   describe('icon', () => {
     it('renders an icon if it’s a string', () => {
       const source = 'delete';

--- a/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/src/components/UnstyledLink/UnstyledLink.tsx
@@ -10,6 +10,8 @@ export interface Props extends React.HTMLProps<HTMLAnchorElement> {
   url: string;
   /** Forces url to open in a new tab */
   external?: boolean;
+  /** Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value. */
+  download?: string | boolean;
   /**	Content to display inside the link */
   children?: React.ReactNode;
   [key: string]: any;

--- a/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
+++ b/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
@@ -39,4 +39,27 @@ describe('<UnstyledLink />', () => {
       expect(anchorElement.prop('rel')).toBe('noopener noreferrer');
     });
   });
+
+  describe('download', () => {
+    it('adds the correct boolean attributes', () => {
+      const anchorElement = mountWithAppProvider(
+        <UnstyledLink download url="https://shopify.com" />,
+      ).find('a');
+      expect(anchorElement.prop('download')).toBe(true);
+    });
+
+    it('adds the correct string attributes', () => {
+      const anchorElement = mountWithAppProvider(
+        <UnstyledLink download="file.txt" url="https://shopify.com" />,
+      ).find('a');
+      expect(anchorElement.prop('download')).toBe('file.txt');
+    });
+
+    it('does not add the attribute when not set', () => {
+      const anchorElement = mountWithAppProvider(
+        <UnstyledLink url="https://shopify.com" />,
+      ).find('a');
+      expect(anchorElement.prop('download')).toBeFalsy();
+    });
+  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

I've got a use case where I want a Button that triggers the download of a file instead of opening it.

The web provides support for this using the download attribute (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download) but there's no way to expose that currently

### WHAT is this pull request doing?

Adds a `download` prop to the Button and UnstyledLink components. It may either be `true` to render `<a href="foo" download>` or a string to render `<a href="foo" download="downloadPropValue">` which acts as a hint for the filename to use when saving the file.

This only has an effect when you pass a `url` to a button but I think that's ok, as `external` acts in a similar way.

### How to 🎩

On the playground click the various buttons and see the behaviour.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Button, Page, UnstyledLink} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        {/* Add the code you want to test in here */}
        <Button url="/">Link (no download attribute)</Button>
        <br />
        <Button url="/" download={false}>
          Link (download attribute is false)
        </Button>
        <br />
        <Button url="/" download>
          Download without hint (same as download attribute being true)
        </Button>
        <br />
        <Button url="/" download="page.html">
          Download with hint
        </Button>

        <hr />

        <UnstyledLink url="/">Link (no download attribute)</UnstyledLink>
        <br />
        <UnstyledLink url="/" download={false}>
          Link (download attribute is false)
        </UnstyledLink>
        <br />
        <UnstyledLink url="/" download>
          Download without hint (same as download attribute being true)
        </UnstyledLink>
        <br />
        <UnstyledLink url="/" download="page.html">
          Download with hint
        </UnstyledLink>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)