### PR TITLE
[Card] Fix missing header (actions) when title is empty or not specified

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Changed the offset from 5px to 4px in `Tooltip` between activator and message to be consistent with `Popover` ([#1019](https://github.com/Shopify/polaris-react/pull/1019))
+- Fixed `Card` header not showing when `title` empty or not set ([#1031](https://github.com/Shopify/polaris-react/pull/1032))
 
 ### Documentation
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -49,9 +49,8 @@ export default class Card extends React.PureComponent<Props, never> {
 
     const className = classNames(styles.Card, subdued && styles.subdued);
 
-    const headerMarkup = title ? (
-      <Header actions={actions} title={title} />
-    ) : null;
+    const headerMarkup =
+      title || actions ? <Header actions={actions} title={title} /> : null;
 
     const content = sectioned ? <Section>{children}</Section> : children;
 

--- a/src/components/Card/tests/Card.test.tsx
+++ b/src/components/Card/tests/Card.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
-import {Card, Badge} from 'components';
+import {Card, Badge, Button} from 'components';
 import {contentContextTypes} from '../../../types';
 
 describe('<Card />', () => {
@@ -52,5 +52,16 @@ describe('<Card />', () => {
       </Card>,
     );
     expect(card.find(Card.Header).exists()).toBeTruthy();
+  });
+
+  it('renders a <Header /> component with actions and no title', () => {
+    const card = mountWithAppProvider(
+      <Card actions={[{content: 'test action'}]}>
+        <p>Some card content.</p>
+      </Card>,
+    );
+
+    expect(card.find(Button)).toHaveLength(1);
+    expect(card.find(Card.Header)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #1031 

When `Card` is missing `title` or it's empty, the header of the `Card` wouldn't show even if there were `actions` specified. 

### WHAT is this pull request doing?

What @danrosenthal suggested in #1031 comments -- shows the header if at least one of title or actions is truthy.

### 🎩 checklist

(Not really tested because I don't have the means or the knowledge to do it efficiently. To test it with my app code I did `yarn build` in polaris-react, then `yarn remove shopify/polaris`, `yarn add file:/path/to/local/polaris-react`, `rm -rf node_modules` and `yarn install` in my app project` which takes a lot of time and probably is not how it's to be done)

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

