### PR TITLE
[App bridge] Add middleware to pass clientInterface data

### DIFF
--- a/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
+++ b/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
@@ -1,5 +1,12 @@
 import {noop} from '@shopify/javascript-utilities/other';
-import createApp, {getShopOrigin} from '@shopify/app-bridge';
+import {
+  getShopOrigin,
+  createAppWrapper,
+  LifecycleHook,
+  HooksInterface,
+  AppConfig,
+  DispatchActionHook,
+} from '@shopify/app-bridge';
 import {isServer} from '@shopify/react-utilities/target';
 import {AppProviderProps, Context} from '../../types';
 import {StickyManager} from '../withSticky';
@@ -47,4 +54,24 @@ export default function createAppProviderContext({
       appBridge,
     },
   };
+}
+
+export const setClientInterface: DispatchActionHook = function(next) {
+  return function(action) {
+    action.clientInterface = {
+      name: '@shopify/polaris',
+      version: window.Polaris.VERSION,
+    };
+    return next(action);
+  };
+};
+
+export function hookMiddleware(hooks: HooksInterface) {
+  hooks.set(LifecycleHook.DispatchAction, setClientInterface);
+}
+
+function createApp(appBridgeConfig: AppConfig) {
+  return createAppWrapper(window.top, window.location.origin, [hookMiddleware])(
+    appBridgeConfig,
+  );
 }

--- a/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
+++ b/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
@@ -1,15 +1,19 @@
 import * as React from 'react';
-import createApp from '@shopify/app-bridge';
+import {createAppWrapper, AppConfig} from '@shopify/app-bridge';
 import {noop} from '@shopify/javascript-utilities/other';
 import * as targets from '@shopify/react-utilities/target';
-import createAppProviderContext from '../createAppProviderContext';
+import createAppProviderContext, {
+  hookMiddleware,
+} from '../createAppProviderContext';
 import Intl from '../../Intl';
 import Link from '../../Link';
 import {StickyManager} from '../../withSticky';
 import ScrollLockManager from '../../ScrollLockManager';
 
 jest.mock('@shopify/app-bridge');
-(createApp as jest.Mock<{}>).mockImplementation((args) => args);
+(createAppWrapper as jest.Mock<{}>).mockImplementation(
+  () => (args: AppConfig) => args,
+);
 
 const actualIsServer = targets.isServer;
 
@@ -100,5 +104,14 @@ describe('createAppProviderContext()', () => {
     };
 
     expect(context).toEqual(mockContext);
+  });
+
+  it('adds an app bridge hook to set clientInterface data', () => {
+    const apiKey = '4p1k3y';
+    createAppProviderContext({apiKey});
+
+    expect((createAppWrapper as jest.Mock<{}>).mock.calls[0][2]).toEqual([
+      hookMiddleware,
+    ]);
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/app-bridge/issues/737 (more context: https://github.com/Shopify/app-bridge/issues/730)

> We'd like to be able to track additional information about how [App bridge] is being consumed. With the legacy EASDK we provided a way to include metadata about the interface which Polaris passed in. No such mechanism exists in App Bridge.

### WHAT is this pull request doing?

This PR adds a tiny middleware which adds a `clientInterface` property to all App bridge actions dispatched from Polaris, so we can track whether people are using App Bridge through Polaris.

### How to 🎩

Buckle up, this involves 3 repos 😅 

Make sure Core & Web are running.

If you want to see the final Monorail events, you can check out [`app-bridge/version-tracking `](https://github.com/Shopify/web/pull/10560) in Web, but it’s not strictly necessary.

In your local `app-bridge` repo, check out [`version-tracking-polaris-app`](https://github.com/Shopify/app-bridge/compare/version-tracking-polaris-app) (this changes one of the App bridge playground app’s pages to use App bridge through Polaris).

In Polaris-react, run `yarn build-consumer app-bridge`.

Back in your friendly neighbourhood app bridge repo, run `dev up && dev server`. If you haven't installed the App bridge playground app on your local shop1, go to <https://app-bridge.myshopify.io/auth/shopify?shop=shop1.myshopify.io>.

Visit <https://shop1.myshopify.io/admin/apps/app-bridge/foo>.

In the [Redux dev tools](https://github.com/zalmoxisus/redux-devtools-extension), make sure you have the `App Bridge` instance selected (top right). Find the `APP::TITLEBAR::UPDATE` action. It should contain `clientInterface` info:

```js
{
  ...
  clientInterface: {
    name: '@shopify/polaris',
    version: '3.7.0-rc.2'
  },
  ...
}
```

(make sure you have `Action` and `Raw` selected)

<img width="961" alt="screen shot 2019-02-13 at 3 45 18 pm" src="https://user-images.githubusercontent.com/3248903/52743112-4da1bd00-2fa7-11e9-95c9-f5f62399ec43.png">

If you checked out the web branch earlier, you should also be able to see a Monorail event with `clientInterfaceName` and `clientInterfaceVersion` properties.

<img width="743" alt="screen shot 2019-02-13 at 3 52 46 pm" src="https://user-images.githubusercontent.com/3248903/52743185-7033d600-2fa7-11e9-8628-fee1b320d21e.png">


### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)