### PR TITLE
[eslint] Add no-vague-titles rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,6 @@
     "import/no-named-as-default": "off",
     "react/button-has-type": "off",
     "react/no-array-index-key": "off",
-    "shopify/jest/no-vague-titles": "off",
     "shopify/jsx-no-complex-expressions": "off",
     "shopify/no-ancestor-directory-import": "error",
     "jsx-a11y/label-has-for": [

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -28,6 +28,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Development workflow
 
 - Added a test that builds Polaris for web and polaris-styleguide. This test takes ~20 minutes to run so it’s only configured to run for master ([931](https://github.com/Shopify/polaris-react/pull/931))
+- Enabled `no-vague-titles eslint` rule ([#1051](https://github.com/Shopify/polaris-react/pull/1051))
 
 ### Dependency upgrades
 

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -20,7 +20,7 @@ describe('<Banner />', () => {
     expect(banner.find(Heading).prop('element')).toBe('p');
   });
 
-  it('passes the correct icon source to Icon', () => {
+  it('passes the provided icon source to Icon', () => {
     const banner = mountWithAppProvider(<Banner icon="circlePlus" />);
     expect(banner.find(Icon).prop('source')).toBe('circlePlus');
   });
@@ -86,7 +86,7 @@ describe('<Banner />', () => {
     expect(unstyledLink.prop('target')).toBe('_blank');
   });
 
-  it('adds the correct accessibility attributes to external link in secondaryAction', () => {
+  it('adds the noopener and noreferrer accessibility attributes to external link in secondaryAction', () => {
     expect(unstyledLink.prop('rel')).toBe('noopener noreferrer');
   });
 

--- a/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
@@ -39,7 +39,7 @@ describe('<Breadcrumbs />', () => {
       expect(breadcrumbs.find('button')).toHaveLength(1);
     });
 
-    it('calls the correct function when clicked', () => {
+    it('triggers the callback function when clicked', () => {
       const spy = jest.fn();
       const callbackBreadcrumbs: CallbackAction[] = [
         {

--- a/src/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/Checkbox/tests/Checkbox.test.tsx
@@ -4,7 +4,7 @@ import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import Checkbox from '../Checkbox';
 
 describe('<Checkbox />', () => {
-  it('sets all pass through properties on the input', () => {
+  it('sets pass through properties on the input', () => {
     const input = shallowWithAppProvider(
       <Checkbox label="Checkbox" checked name="Checkbox" value="Some value" />,
     ).find('input');
@@ -25,7 +25,7 @@ describe('<Checkbox />', () => {
       expect(spy).toHaveBeenCalledWith(true, 'MyCheckbox');
     });
 
-    it('renders with the correct focus when checkbox is toggled off', () => {
+    it('sets focus on the input when checkbox is toggled off', () => {
       const input = mountWithAppProvider(
         <Checkbox checked id="checkboxId" label="Checkbox" onChange={noop} />,
       ).find('input');

--- a/src/components/ChoiceList/tests/ChoiceList.test.tsx
+++ b/src/components/ChoiceList/tests/ChoiceList.test.tsx
@@ -213,7 +213,7 @@ describe('<ChoiceList />', () => {
   });
 
   describe('selected', () => {
-    it('sets the appropriate choices to be selected', () => {
+    it('sets the provided choices to be selected', () => {
       const selectedIndexes = [0, 2];
       const selected = selectedIndexes.map((index) => choices[index].value);
       const choiceElements = shallowWithAppProvider(

--- a/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -11,7 +11,7 @@ describe('<ContextualSaveBar />', () => {
     message: 'Unsaved changes',
   };
 
-  it('calls the contextual save bar on mount with correct values', () => {
+  it('calls the contextual save bar on mount with provided values', () => {
     const {frame} = mountWithContext(<ContextualSaveBar {...props} />);
     expect(frame.setContextualSaveBar).toHaveBeenCalledWith({
       ...props,
@@ -27,7 +27,7 @@ describe('<ContextualSaveBar />', () => {
     expect(frame.removeContextualSaveBar).toHaveBeenCalled();
   });
 
-  it('calls the contextual save bar with correct values if its props change after it mounted', () => {
+  it('calls the contextual save bar with new values if its props change after it mounted', () => {
     const {frame, contextualSaveBar} = mountWithContext(
       <ContextualSaveBar {...props} />,
     );

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -53,7 +53,7 @@ function setup(propOverrides?: DataTableTestProps) {
 }
 
 describe('<DataTable />', () => {
-  it('renders a table, thead and all table body rows', () => {
+  it('renders a table, thead and table body rows', () => {
     const {dataTable} = setup();
 
     expect(dataTable.find('table')).toHaveLength(1);
@@ -93,7 +93,7 @@ describe('<DataTable />', () => {
 
   describe('<Cell />', () => {
     const {dataTable} = setup();
-    it('passes all props', () => {
+    it('passes props', () => {
       expect(
         dataTable
           .find(Cell)
@@ -156,7 +156,7 @@ describe('<DataTable />', () => {
   });
 
   describe('getPrevAndCurrentColumns()', () => {
-    it('returns the correct measurements', () => {
+    it('returns the calculated measurements', () => {
       const columnVisibilityData = [
         {leftEdge: 145, rightEdge: 236, isVisible: true},
         {leftEdge: 236, rightEdge: 357, isVisible: true},

--- a/src/components/DatePicker/components/Day/tests/Day.test.tsx
+++ b/src/components/DatePicker/components/Day/tests/Day.test.tsx
@@ -12,7 +12,7 @@ describe('<Day />', () => {
   });
 
   describe('tabIndex', () => {
-    it('sets the correct tabIndex value if day is today', () => {
+    it('sets the tabIndex to 0 if day is today', () => {
       const currentDay = new Date();
       const day = mountWithAppProvider(
         <Day focused day={currentDay} selected disabled={false} />,
@@ -20,7 +20,7 @@ describe('<Day />', () => {
       expect(day.find('button').prop('tabIndex')).toBe(0);
     });
 
-    it('sets the correct tabIndex value if day is disabled', () => {
+    it('sets the tabIndex to -1 if day is disabled', () => {
       const currentDay = new Date();
       const day = mountWithAppProvider(
         <Day focused day={currentDay} selected disabled />,

--- a/src/components/DatePicker/components/Month/tests/Month.test.tsx
+++ b/src/components/DatePicker/components/Month/tests/Month.test.tsx
@@ -7,7 +7,7 @@ import Day from '../../Day';
 
 describe('<Month />', () => {
   describe('title', () => {
-    it('passes the correct value to Weekday', () => {
+    it('passes the abbreviated value to the title prop of Weekday', () => {
       const month = mountWithAppProvider(
         <Month month={0} year={2018} weekStartsOn={Weekdays.Monday} />,
       );
@@ -21,7 +21,7 @@ describe('<Month />', () => {
   });
 
   describe('label', () => {
-    it('passes the correct value to Weekday', () => {
+    it('passes the numeric value to the label prop of Weekday', () => {
       const month = mountWithAppProvider(
         <Month month={0} year={2018} weekStartsOn={Weekdays.Monday} />,
       );

--- a/src/components/DatePicker/tests/DatePicker.test.tsx
+++ b/src/components/DatePicker/tests/DatePicker.test.tsx
@@ -44,7 +44,7 @@ describe('<DatePicker />', () => {
   });
 
   describe('month', () => {
-    it('passes the correct value to Month', () => {
+    it('passes the month value to Month', () => {
       const datePicker = mountWithAppProvider(
         <DatePicker month={1} year={2018} />,
       );
@@ -55,7 +55,7 @@ describe('<DatePicker />', () => {
   });
 
   describe('year', () => {
-    it('passes the correct year to Month', () => {
+    it('passes the year value to Month', () => {
       const datePicker = mountWithAppProvider(
         <DatePicker month={1} year={2016} />,
       );
@@ -115,7 +115,7 @@ describe('<DatePicker />', () => {
   });
 
   describe('focusDate', () => {
-    it('passes the correct value to Month if day has focus', () => {
+    it('passes the focused month value to Month if day has focus', () => {
       const datePicker = mountWithAppProvider(
         <DatePicker month={3} year={2018} />,
       );

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -69,14 +69,14 @@ describe('<DropZone />', () => {
     expect(spy).toBeCalledWith(duplicateFiles, duplicateFiles, []);
   });
 
-  it('calls the onDrop callback when a drop event is fired on document', () => {
+  it('calls the onDrop callback with files when a drop event is fired on document', () => {
     mountWithAppProvider(<DropZone dropOnPage onDrop={spy} />);
     const event = createEvent('drop', files);
     document.dispatchEvent(event);
     expect(spy).toBeCalledWith(files, files, []);
   });
 
-  it('calls the onDrop callback correctly when it accepts only jpeg', () => {
+  it('calls the onDrop callback with files, acceptedFiles, and rejectedFiles when it accepts only jpeg', () => {
     const dropZone = mountWithAppProvider(
       <DropZone onDrop={spy} accept="image/jpeg" />,
     );
@@ -85,7 +85,7 @@ describe('<DropZone />', () => {
     expect(spy).toBeCalledWith(files, acceptedFiles, rejectedFiles);
   });
 
-  it('calls the onDropAccepted callback correctly when it accepts only jpeg', () => {
+  it('calls the onDropAccepted callback with acceptedFiles when it accepts only jpeg', () => {
     const dropZone = mountWithAppProvider(
       <DropZone onDropAccepted={spy} accept="image/jpeg" />,
     );
@@ -94,7 +94,7 @@ describe('<DropZone />', () => {
     expect(spy).toBeCalledWith(acceptedFiles);
   });
 
-  it('calls the onDropRejected callback correctly when it accepts only jpeg', () => {
+  it('calls the onDropRejected callback with rejectedFiles when it accepts only jpeg', () => {
     const dropZone = mountWithAppProvider(
       <DropZone onDropRejected={spy} accept="image/jpeg" />,
     );
@@ -124,7 +124,7 @@ describe('<DropZone />', () => {
     expect(spy).toBeCalled();
   });
 
-  it('validates correctly when customValidator propertly added', () => {
+  it('validates files, acceptedFiles, and rejectedFiles when customValidator property is added', () => {
     const customValidator = (file: File) => {
       return file.type === 'image/jpeg';
     };
@@ -136,7 +136,7 @@ describe('<DropZone />', () => {
     expect(spy).toBeCalledWith(files, acceptedFiles, rejectedFiles);
   });
 
-  it('should not call any callbacks when disabled', () => {
+  it('does not call any callbacks when disabled', () => {
     const dropZone = mountWithAppProvider(
       <DropZone
         disabled
@@ -158,7 +158,7 @@ describe('<DropZone />', () => {
     expect(spy).not.toBeCalled();
   });
 
-  it('should not call callbacks when not allowed multiple and a file is uploaded', () => {
+  it('does not call callbacks when not allowed multiple and a file is uploaded', () => {
     const dropZone = mountWithAppProvider(
       <DropZone
         allowMultiple={false}

--- a/src/components/EmptySearchResult/tests/EmptySearchResult.test.tsx
+++ b/src/components/EmptySearchResult/tests/EmptySearchResult.test.tsx
@@ -31,7 +31,7 @@ describe('<EmptySearchResult />', () => {
     expect(images).toHaveLength(0);
   });
 
-  it('displays the correct illustration when `withIllustration` is true', () => {
+  it('displays the illustration when `withIllustration` is true', () => {
     const wrapper = mountWithAppProvider(
       <EmptySearchResult title="Foo" description="Bar" withIllustration />,
     );

--- a/src/components/EmptyState/tests/EmptyState.test.tsx
+++ b/src/components/EmptyState/tests/EmptyState.test.tsx
@@ -31,7 +31,7 @@ describe('<EmptyState />', () => {
   });
 
   describe('img', () => {
-    it('passes the correct source to Image', () => {
+    it('passes the provided source to Image', () => {
       expect(emptyState.find(Image).prop('source')).toBe(imgSrc);
     });
   });
@@ -49,7 +49,7 @@ describe('<EmptyState />', () => {
   });
 
   describe('heading', () => {
-    it('passes the correct heading to DisplayText', () => {
+    it('passes the provided heading to DisplayText', () => {
       expect(emptyState.find(DisplayText).prop('size')).toBe('medium');
       expect(
         emptyState

--- a/src/components/EventListener/tests/EventListener.test.tsx
+++ b/src/components/EventListener/tests/EventListener.test.tsx
@@ -4,7 +4,7 @@ import {mountWithAppProvider} from 'test-utilities';
 import EventListener from '../EventListener';
 
 describe('<EventListener />', () => {
-  it('calls handler when the appropriate event is fired', () => {
+  it('calls handler when the resize event is fired', () => {
     const spy = jest.fn();
     mountWithAppProvider(<EventListener event="resize" handler={spy} />);
     window.dispatchEvent(new Event('resize'));

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -201,7 +201,7 @@ describe('<Frame />', () => {
     expect(documentHasStyle('--global-ribbon-height', '0px')).toBe(true);
   });
 
-  it('should render a Frame ContextualSavebar if Polaris ContextualSavebar is rendered', () => {
+  it('renders a Frame ContextualSavebar if Polaris ContextualSavebar is rendered', () => {
     const frame = mountWithAppProvider(
       <Frame>
         <PolarisContextualSavebar />
@@ -210,7 +210,7 @@ describe('<Frame />', () => {
     expect(frame.find(FrameContextualSavebar).exists()).toBe(true);
   });
 
-  it('should render a Frame Loading if Polaris Loading is rendered', () => {
+  it('renders a Frame Loading if Polaris Loading is rendered', () => {
     const frame = mountWithAppProvider(
       <Frame>
         <PolarisLoading />

--- a/src/components/Modal/components/Dialog/tests/Dialog.test.tsx
+++ b/src/components/Modal/components/Dialog/tests/Dialog.test.tsx
@@ -13,7 +13,7 @@ describe('<Dialog>', () => {
     animationFrame.restore();
   });
 
-  it('renders CloseKeypressListener with correct props when `in` is true', () => {
+  it('sets CloseKeypressListener when `in` is true', () => {
     const listener = mountWithAppProvider(
       <Dialog labelledBy="test" onClose={jest.fn()} in>
         something

--- a/src/components/OptionList/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/OptionList/components/Checkbox/tests/Checkbox.test.tsx
@@ -13,7 +13,7 @@ describe('<Checkbox />', () => {
     onChange: noop,
   };
 
-  it('sets all pass through props for input', () => {
+  it('sets pass through props for input', () => {
     const input = mountWithAppProvider(<Checkbox {...defaultProps} />).find(
       'input',
     );

--- a/src/components/OptionList/components/Option/tests/Option.test.tsx
+++ b/src/components/OptionList/components/Option/tests/Option.test.tsx
@@ -28,7 +28,7 @@ describe('<Option />', () => {
     expect(button.exists()).toBe(true);
   });
 
-  it('calls onClick with correct section and index if option is not disabled', () => {
+  it('calls onClick with section and index if option is not disabled', () => {
     const spy = jest.fn();
     const {section, index} = defaultProps;
 
@@ -52,7 +52,7 @@ describe('<Option />', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it('calls onClick with correct section and index if option is not disabled and multiple options are allowed', () => {
+  it('calls onClick with section and index if option is not disabled and multiple options are allowed', () => {
     const spy = jest.fn();
     const {section, index} = defaultProps;
 
@@ -76,7 +76,7 @@ describe('<Option />', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it('correctly sets the pass through props for Checkbox if multiple items are allowed', () => {
+  it('sets the pass through props for Checkbox if multiple items are allowed', () => {
     const {id, value, select, disabled} = defaultProps;
     const checkbox = mountWithAppProvider(
       <Option {...defaultProps} allowMultiple />,

--- a/src/components/OptionList/tests/OptionList.test.tsx
+++ b/src/components/OptionList/tests/OptionList.test.tsx
@@ -253,7 +253,7 @@ describe('<OptionList />', () => {
     expect(optionWrappers).toHaveLength(totalOptions(newOptions, undefined));
   });
 
-  it('calls onChange with the correct value', () => {
+  it('calls onChange with options and sections', () => {
     const spy = jest.fn();
     const {options, sections} = defaultProps;
 

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -271,7 +271,7 @@ describe('<Page />', () => {
       restoreTitleBarCreateMock();
     });
 
-    it('receives all neccesary transformed props', () => {
+    it('receives neccesary transformed props', () => {
       const primaryAction: PrimaryActionProps = {
         content: 'Foo',
         url: '/foo',

--- a/src/components/RadioButton/tests/RadioButton.test.tsx
+++ b/src/components/RadioButton/tests/RadioButton.test.tsx
@@ -3,19 +3,49 @@ import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import RadioButton from '../RadioButton';
 
 describe('<RadioButton />', () => {
-  it('sets all pass through properties on the input', () => {
-    const input = shallowWithAppProvider(
-      <RadioButton
-        label="RadioButton"
-        checked
-        name="RadioButton"
-        value="Some value"
-      />,
-    ).find('input');
+  describe('checked', () => {
+    it('gets passed to the input', () => {
+      const input = shallowWithAppProvider(
+        <RadioButton
+          label="RadioButton"
+          checked
+          name="RadioButton"
+          value="Some value"
+        />,
+      ).find('input');
 
-    expect(input.prop('checked')).toBe(true);
-    expect(input.prop('name')).toBe('RadioButton');
-    expect(input.prop('value')).toBe('Some value');
+      expect(input.prop('checked')).toBe(true);
+    });
+  });
+
+  describe('name', () => {
+    it('gets passed to the input', () => {
+      const input = shallowWithAppProvider(
+        <RadioButton
+          label="RadioButton"
+          checked
+          name="RadioButton"
+          value="Some value"
+        />,
+      ).find('input');
+
+      expect(input.prop('name')).toBe('RadioButton');
+    });
+  });
+
+  describe('value', () => {
+    it('gets passed to the input', () => {
+      const input = shallowWithAppProvider(
+        <RadioButton
+          label="RadioButton"
+          checked
+          name="RadioButton"
+          value="Some value"
+        />,
+      ).find('input');
+
+      expect(input.prop('value')).toBe('Some value');
+    });
   });
 
   describe('onChange()', () => {

--- a/src/components/RangeSlider/tests/RangeSlider.test.tsx
+++ b/src/components/RangeSlider/tests/RangeSlider.test.tsx
@@ -124,7 +124,7 @@ describe('<RangeSlider />', () => {
       expect(element.find('output').prop<string>('htmlFor')).toBe(inputId);
     });
 
-    it('contains the correct value text', () => {
+    it('contains the provided value text', () => {
       const element = mountWithAppProvider(
         <RangeSlider label="RangeSlider" value={50} output onChange={noop} />,
       );
@@ -257,7 +257,7 @@ describe('<RangeSlider />', () => {
   });
 
   describe('CSS custom properties', () => {
-    it('sets the correct css custom properties', () => {
+    it('sets the css custom properties', () => {
       const element = mountWithAppProvider(
         <RangeSlider
           label="RangeSlider"

--- a/src/components/ResourceList/components/BulkActions/tests/BulkActions.test.tsx
+++ b/src/components/ResourceList/components/BulkActions/tests/BulkActions.test.tsx
@@ -57,7 +57,7 @@ function searchCheckableButton(
 
 describe('<BulkActions />', () => {
   describe('actions', () => {
-    it('promotedActions render in the correct position on intial load', () => {
+    it('promotedActions render in the last position on intial load', () => {
       const {promotedActions} = bulkActionProps;
       const bulkActions = mountWithAppProvider(
         <BulkActions {...bulkActionProps} promotedActions={promotedActions} />,
@@ -74,7 +74,7 @@ describe('<BulkActions />', () => {
       expect(count).toBe(promotedActions.length);
     });
 
-    it('bulkActions render in the correct position on initial load', () => {
+    it('bulkActions render in the first position on initial load', () => {
       const {bulkActions} = bulkActionProps;
       const bulkActionsElement = mountWithAppProvider(
         <BulkActions {...bulkActionProps} />,
@@ -103,7 +103,7 @@ describe('<BulkActions />', () => {
 
   describe('props', () => {
     describe('accessibilityLabel', () => {
-      it('correctly passes down to CheckableButton', () => {
+      it('is passed down to CheckableButton', () => {
         const {accessibilityLabel} = bulkActionProps;
         const bulkActions = mountWithAppProvider(
           <BulkActions {...bulkActionProps} />,
@@ -132,7 +132,7 @@ describe('<BulkActions />', () => {
     });
 
     describe('label', () => {
-      it('correctly passes down to CheckableButton', () => {
+      it('is passed down to CheckableButton', () => {
         const {label} = bulkActionProps;
         const bulkActions = mountWithAppProvider(
           <BulkActions {...bulkActionProps} />,
@@ -151,7 +151,7 @@ describe('<BulkActions />', () => {
     });
 
     describe('selected', () => {
-      it('correctly passes down to CheckableButton', () => {
+      it('is passed down to CheckableButton', () => {
         const {selected} = bulkActionProps;
         const bulkActions = mountWithAppProvider(
           <BulkActions {...bulkActionProps} />,
@@ -172,7 +172,7 @@ describe('<BulkActions />', () => {
     });
 
     describe('selectMode', () => {
-      it('correctly passes down to Transition', () => {
+      it('is passed down to Transition', () => {
         const bulkActions = mountWithAppProvider(
           <BulkActions {...bulkActionProps} selectMode />,
         );
@@ -180,7 +180,7 @@ describe('<BulkActions />', () => {
         expect(transition.first().prop('in')).toBe(true);
       });
 
-      it('correctly passes down to CSSTransition', () => {
+      it('is passed down to CSSTransition', () => {
         const bulkActions = mountWithAppProvider(
           <BulkActions {...bulkActionProps} selectMode />,
         );
@@ -190,7 +190,7 @@ describe('<BulkActions />', () => {
         });
       });
 
-      it('correctly passes down to CheckableButton', () => {
+      it('is passed down to CheckableButton', () => {
         const bulkActions = mountWithAppProvider(
           <BulkActions {...bulkActionProps} selectMode />,
         );
@@ -258,7 +258,7 @@ describe('<BulkActions />', () => {
         disabled: true,
       };
 
-      it('correctly passes down to CheckableButton', () => {
+      it('is passed down to CheckableButton', () => {
         const {disabled} = bulkActionProps;
         const bulkActions = mountWithAppProvider(
           <BulkActions {...bulkActionProps} />,
@@ -271,7 +271,7 @@ describe('<BulkActions />', () => {
     });
 
     describe('paginatedSelectAllText', () => {
-      it('correctly renders when provided', () => {
+      it('renders when provided', () => {
         const {paginatedSelectAllText} = bulkActionProps;
         const bulkActions = mountWithAppProvider(
           <BulkActions {...bulkActionProps} />,
@@ -292,7 +292,7 @@ describe('<BulkActions />', () => {
     });
 
     describe('paginatedSelectAllAction', () => {
-      it('onAction is correctly called when CheckableButton is clicked', () => {
+      it('onAction is called when CheckableButton is clicked', () => {
         const spy = jest.fn();
         const bulkActions = mountWithAppProvider(
           <BulkActions

--- a/src/components/ResourceList/components/CheckableButton/tests/CheckableButton.test.tsx
+++ b/src/components/ResourceList/components/CheckableButton/tests/CheckableButton.test.tsx
@@ -13,7 +13,7 @@ const CheckableButtonProps = {
 
 describe('<CheckableButton />', () => {
   describe('select', () => {
-    it('correctly passes down to Checkbox', () => {
+    it('is passed down to Checkbox', () => {
       const {selected} = CheckableButtonProps;
       const element = shallowWithAppProvider(
         <CheckableButton {...CheckableButtonProps} />,
@@ -23,7 +23,7 @@ describe('<CheckableButton />', () => {
   });
 
   describe('label', () => {
-    it('is correctly passed down to span', () => {
+    it('is passed down to span', () => {
       const {label} = CheckableButtonProps;
       const element = shallowWithAppProvider(
         <CheckableButton {...CheckableButtonProps} />,
@@ -47,7 +47,7 @@ describe('<CheckableButton />', () => {
     });
 
     describe('disabled', () => {
-      it('is correctly passed down to checkbox', () => {
+      it('is passed down to checkbox', () => {
         const {disabled} = CheckableButtonProps;
         const element = shallowWithAppProvider(
           <CheckableButton {...CheckableButtonProps} />,

--- a/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
@@ -173,7 +173,7 @@ describe('<DateSelector />', () => {
   });
 
   describe('timezones adjustments', () => {
-    it('sets the correct selected date with negative timezone offset on DatePicker and TextField', () => {
+    it('sets the selected date with negative timezone offset on DatePicker and TextField', () => {
       const nextUserInputDate = '2019-01-01';
       const timezoneOffset = -540;
       const timezoneOffsetInHours = Math.abs(timezoneOffset / 60);
@@ -198,7 +198,7 @@ describe('<DateSelector />', () => {
       expect(selectedInputDate).toBe(nextUserInputDate);
     });
 
-    it('sets the correct selected date with fringe timezone offset on DatePicker and TextField', () => {
+    it('sets the selected date with fringe timezone offset on DatePicker and TextField', () => {
       const nextUserInputDate = '2019-01-01';
       getTimezoneOffset.mockImplementation(() => -720);
 
@@ -219,7 +219,7 @@ describe('<DateSelector />', () => {
       expect(selectedInputDate).toBe(nextUserInputDate);
     });
 
-    it('sets the correct selected date with positive timezone offset on DatePicker and TextField', () => {
+    it('sets the selected date with positive timezone offset on DatePicker and TextField', () => {
       const nextUserInputDate = '2019-01-01';
       const timezoneOffset = 300;
       const timezoneOffsetInHours = Math.abs(timezoneOffset / 60);

--- a/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
@@ -147,7 +147,7 @@ describe('<FilterCreator />', () => {
   });
 
   describe('filters', () => {
-    it('has the correct options prop when popover is active', () => {
+    it('sets the options when popover is active', () => {
       const wrapper = mountWithAppProvider(
         <FilterCreator {...mockDefaultProps} />,
       );
@@ -196,7 +196,7 @@ describe('<FilterCreator />', () => {
       expect(wrapper.find(FilterValueSelector).prop('value')).toBeUndefined();
     });
 
-    it('updates value correctly when user selects a filter value', () => {
+    it('updates value with provided string when user selects a filter value', () => {
       const wrapper = mountWithAppProvider(
         <FilterCreator {...mockDefaultProps} />,
       );

--- a/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
@@ -125,7 +125,7 @@ describe('<FilterControl />', () => {
       ]);
     });
 
-    it('renders the correct applied filter string when applied filter label exist', () => {
+    it('renders the provided applied filter string when applied filter label exist', () => {
       const appliedFilterLabel = 'shorten electronic';
       const filter: FilterSelect = {
         key: 'filterKey1',
@@ -159,7 +159,7 @@ describe('<FilterControl />', () => {
       );
     });
 
-    it('renders the correct applied filter string when filter value exist in FilterSelect as an option string', () => {
+    it('renders the provided applied filter string when filter value exist in FilterSelect as an option string', () => {
       const filterValue = 'Bundle';
       const filter: FilterSelect = {
         key: 'filterKey1',
@@ -188,7 +188,7 @@ describe('<FilterControl />', () => {
       );
     });
 
-    it('renders the correct applied filter string when filter value exist in FilterSelect as an option object', () => {
+    it('renders the provided applied filter string when filter value exist in FilterSelect as an option object', () => {
       const filterValue = 'Electronic';
       const filter: FilterSelect = {
         key: 'filterKey1',
@@ -222,7 +222,7 @@ describe('<FilterControl />', () => {
       );
     });
 
-    it('renders the correct applied filter string when filter value cannot be found in FilterSelect options', () => {
+    it('renders the provided applied filter string when filter value cannot be found in FilterSelect options', () => {
       const appliedFilterValue = 'new Bundle';
       const filter: FilterSelect = {
         key: 'filterKey1',
@@ -251,7 +251,7 @@ describe('<FilterControl />', () => {
       );
     });
 
-    it('renders the correct applied filter string when filter is a FilterTextField', () => {
+    it('renders the provided applied filter string when filter is a FilterTextField', () => {
       const appliedFilterValue = 'new Bundle';
       const filter: FilterTextField = {
         key: 'filterKey2',
@@ -279,7 +279,7 @@ describe('<FilterControl />', () => {
       );
     });
 
-    it('renders the correct localized applied filter string when filter is a FilterDateSelector without date predicate', () => {
+    it('renders the provided localized applied filter string when filter is a FilterDateSelector without date predicate', () => {
       const appliedFilterValue = DateFilterOption.PastWeek;
 
       const filter: FilterDateSelector = {
@@ -317,7 +317,7 @@ describe('<FilterControl />', () => {
       );
     });
 
-    it('renders the correct localized applied filter string when filter is a FilterDateSelector with minimum date predicate (on or after)', () => {
+    it('renders the provided localized applied filter string when filter is a FilterDateSelector with minimum date predicate (on or after)', () => {
       const selectedDate = '2018-09-16';
       const filter: FilterDateSelector = {
         key: 'starts',
@@ -358,7 +358,7 @@ describe('<FilterControl />', () => {
       expect(firstTag.text()).toBe(`${filter.label} ${expectedLocalizedLabel}`);
     });
 
-    it('renders the correct localized applied filter string when filter is a FilterDateSelector with maximum date predicate (on or before)', () => {
+    it('renders the provided localized applied filter string when filter is a FilterDateSelector with maximum date predicate (on or before)', () => {
       const selectedDate = '2018-09-16';
       const filter: FilterDateSelector = {
         key: 'starts',
@@ -436,7 +436,7 @@ describe('<FilterControl />', () => {
       expect(firstTag.text()).toBe(`${filter.label} ${expectedLocalizedLabel}`);
     });
 
-    it('renders the correct applied filter string when filter uses operators with filter label', () => {
+    it('renders the provided applied filter string when filter uses operators with filter label', () => {
       const appliedFilterValue = '20';
       const appliedFilterKey = 'times_used';
       const appliedFilterLabel = 'is';
@@ -479,7 +479,7 @@ describe('<FilterControl />', () => {
       );
     });
 
-    it('renders the correct applied filter string when filter uses operators without filter label', () => {
+    it('renders the provided applied filter string when filter uses operators without filter label', () => {
       const appliedFilterValue = '20';
       const appliedFilterKey = 'times_used';
       const appliedOperatorOptionLabel = 'equal to';
@@ -520,7 +520,7 @@ describe('<FilterControl />', () => {
       );
     });
 
-    it('renders the correct applied filter string when filter key cannot be found', () => {
+    it('renders the provided applied filter string when filter key cannot be found', () => {
       const appliedFilterValue = 'new Bundle';
       const appliedFilters = {
         key: 'filter key',

--- a/src/components/ResourceList/components/Item/tests/Item.test.tsx
+++ b/src/components/ResourceList/components/Item/tests/Item.test.tsx
@@ -264,7 +264,7 @@ describe('<Item />', () => {
       expect(wrapper.find(Checkbox).props().checked).toBe(true);
     });
 
-    it('should not call window.open when clicking the item with metaKey', () => {
+    it('does not call window.open when clicking the item with metaKey', () => {
       const wrapper = mountWithAppProvider(
         <Provider value={mockSelectModeContext}>
           <Item id={selectedItemId} url={url} />
@@ -276,7 +276,7 @@ describe('<Item />', () => {
       expect(spy).not.toBeCalled();
     });
 
-    it('should not call window.open when clicking the item with ctrlKey', () => {
+    it('does not call window.open when clicking the item with ctrlKey', () => {
       const wrapper = mountWithAppProvider(
         <Provider value={mockSelectModeContext}>
           <Item id={selectedItemId} url={url} />

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -218,7 +218,7 @@ describe('<ResourceList />', () => {
       );
     });
 
-    it('provides the BulkActions with the right accessibilityLabel if there’s multiple items and they are all selected', () => {
+    it('provides the BulkActions with the right accessibilityLabel if there are multiple items and they are selected', () => {
       const resourceList = mountWithAppProvider(
         <ResourceList
           items={itemsWithID}

--- a/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
+++ b/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
@@ -68,7 +68,7 @@ describe('<SkeletonPage />', () => {
     });
   });
 
-  it('renders the correct number of secondary actions as SkeletonBodyText', () => {
+  it('renders the provided number of secondary actions as SkeletonBodyText', () => {
     const skeletonPage = mountWithAppProvider(
       <SkeletonPage secondaryActions={3} />,
     );

--- a/src/components/Tabs/components/List/tests/List.test.tsx
+++ b/src/components/Tabs/components/List/tests/List.test.tsx
@@ -94,7 +94,7 @@ describe('<List />', () => {
       expect(list.find(Item)).toHaveLength(2);
     });
 
-    it('renders the correct content', () => {
+    it('renders the provided content', () => {
       const list = mountWithAppProvider(
         <List {...mockProps} disclosureTabs={disclosureTabs} />,
       );

--- a/src/components/Tabs/components/Panel/tests/Panel.test.tsx
+++ b/src/components/Tabs/components/Panel/tests/Panel.test.tsx
@@ -3,7 +3,7 @@ import {mountWithAppProvider} from 'test-utilities';
 import Panel from '../Panel';
 
 describe('<Panel />', () => {
-  it('adds the correct role', () => {
+  it('adds the tabpanel role', () => {
     const panel = mountWithAppProvider(<Panel id="panel" tabID="tab" />);
     expect(panel.find('div').prop('role')).toBe('tabpanel');
   });

--- a/src/components/Tabs/components/Tab/tests/Tab.test.tsx
+++ b/src/components/Tabs/components/Tab/tests/Tab.test.tsx
@@ -3,7 +3,7 @@ import {mountWithAppProvider} from 'test-utilities';
 import Tab from '../Tab';
 
 describe('<Tab />', () => {
-  it('has the correct role', () => {
+  it('has the tab role', () => {
     const tab = mountWithAppProvider(<Tab id="my-tab">Tab</Tab>);
     expect(tab.find('button').prop('role')).toBe('tab');
   });

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -240,7 +240,7 @@ describe('<Tabs />', () => {
       expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(-1);
     });
 
-    it('passes the correct selected value if given', () => {
+    it('passes the provided selected value if given', () => {
       const tabs = mountWithAppProvider(
         <Tabs {...mockProps} selected={1} tabs={mockTabs} />,
       );
@@ -351,7 +351,7 @@ describe('<Tabs />', () => {
   });
 
   describe('getVisibleAndHiddenTabIndices()', () => {
-    it('properly sets getVisibleAndHiddenTabIndices', () => {
+    it('sets getVisibleAndHiddenTabIndices with visibleTabs and hiddenTabs', () => {
       const mockTabs = [
         {content: 'Tab 1', id: 'tab-1'},
         {content: 'Tab 2', id: 'tab-2'},

--- a/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
+++ b/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
@@ -20,7 +20,7 @@ describe('<Resizer />', () => {
       expect(contentsNode.text()).toBe(contents);
     });
 
-    it('properly encodes HTML entities', () => {
+    it('encodes HTML entities', () => {
       const contents = `<div>&\nContents</div>`;
       const resizer = mountWithAppProvider(
         <Resizer {...mockProps} contents={contents} />,

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -554,7 +554,7 @@ describe('<TextField />', () => {
         expect(buttons).toHaveLength(0);
       });
 
-      it('increments correctly when a value step or both are float numbers', () => {
+      it('increments by step when value, step, or both are float numbers', () => {
         const spy = jest.fn();
         const element = mountWithAppProvider(
           <TextField
@@ -573,7 +573,7 @@ describe('<TextField />', () => {
         expect(spy).toHaveBeenCalledWith('4.064', 'MyTextField');
       });
 
-      it('decrements correctly when a value step or both are float numbers', () => {
+      it('decrements by step when value, step, or both are float numbers', () => {
         const spy = jest.fn();
         const element = mountWithAppProvider(
           <TextField

--- a/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
+++ b/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
@@ -31,7 +31,7 @@ describe('<UnstyledLink />', () => {
   });
 
   describe('external', () => {
-    it('adds the correct attributes', () => {
+    it('adds rel and target attributes', () => {
       const anchorElement = mountWithAppProvider(
         <UnstyledLink external url="https://shopify.com" />,
       ).find('a');
@@ -41,14 +41,14 @@ describe('<UnstyledLink />', () => {
   });
 
   describe('download', () => {
-    it('adds the correct boolean attributes', () => {
+    it('adds true as a boolean attribute', () => {
       const anchorElement = mountWithAppProvider(
         <UnstyledLink download url="https://shopify.com" />,
       ).find('a');
       expect(anchorElement.prop('download')).toBe(true);
     });
 
-    it('adds the correct string attributes', () => {
+    it('adds the provided string', () => {
       const anchorElement = mountWithAppProvider(
         <UnstyledLink download="file.txt" url="https://shopify.com" />,
       ).find('a');

--- a/src/utilities/tests/color-transformers.test.ts
+++ b/src/utilities/tests/color-transformers.test.ts
@@ -37,7 +37,7 @@ describe('colorUtilities', () => {
   });
 
   describe('hsbToRgb()', () => {
-    it('returns the correct rgb value for an hsb color', () => {
+    it('returns 128/64/128 rgb value for an hsb color', () => {
       const {red, green, blue} = hsbToRgb({
         hue: 300,
         saturation: 0.5,
@@ -48,7 +48,7 @@ describe('colorUtilities', () => {
       expect(blue).toBe(128);
     });
 
-    it('returns the correct rgb value for black', () => {
+    it('returns 0/0/0 rgb value for black', () => {
       const {red, green, blue} = hsbToRgb({
         hue: 23,
         saturation: 0,
@@ -59,7 +59,7 @@ describe('colorUtilities', () => {
       expect(blue).toBe(0);
     });
 
-    it('returns the correct rgb value for white', () => {
+    it('returns 255/255/255 rgb value for white', () => {
       const {red, green, blue} = hsbToRgb({
         hue: 23,
         saturation: 0,
@@ -72,7 +72,7 @@ describe('colorUtilities', () => {
   });
 
   describe('rgbToHsb', () => {
-    it('returns the correct hsb value for white', () => {
+    it('returns 0/0/1 hsb value for white', () => {
       const {hue, saturation, brightness} = rgbToHsb({
         red: 255,
         green: 255,
@@ -83,7 +83,7 @@ describe('colorUtilities', () => {
       expect(brightness).toBe(1);
     });
 
-    it('returns the correct hsb value for black', () => {
+    it('returns 0/0/0 hsb value for black', () => {
       const {hue, saturation, brightness} = rgbToHsb({
         red: 0,
         green: 0,
@@ -95,7 +95,7 @@ describe('colorUtilities', () => {
     });
 
     // Corner case that was misscalculating hue
-    it('returns the correct hsb value when red is the largest number', () => {
+    it('returns 0/1/1 hsb value when red is the largest number', () => {
       const {hue, saturation, brightness} = rgbToHsb({
         red: 255,
         green: 0,

--- a/src/utilities/tests/compose.test.ts
+++ b/src/utilities/tests/compose.test.ts
@@ -28,7 +28,7 @@ describe('compose', () => {
     expect(name).toBe('WE_ARE_POLARIS');
   });
 
-  it('will invoke all composed functions when returned function is called', () => {
+  it('will invoke composed functions when returned function is called', () => {
     const sanitizeSpy = jest.fn();
     const toSnakeCaseFromUpperSpy = jest.fn();
     const toUpperCaseSpy = jest.fn();

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -80,7 +80,7 @@ describe('build', () => {
     expect(fs.existsSync('./types/index.d.ts')).toBe(true);
   });
 
-  it('replaces all occurrences of POLARIS_VERSION', () => {
+  it('replaces every occurrence of POLARIS_VERSION', () => {
     const files = glob.sync('./build/**/*.{js,scss,css}', {
       ignore: './build/cache/**',
     });
@@ -92,7 +92,7 @@ describe('build', () => {
     expect(total).toBe(0);
   });
 
-  it('features the version of Polaris in all compiled files', () => {
+  it('features the version of Polaris in every compiled file', () => {
     const files = glob.sync('./build/**/*.{js,scss,css}', {
       ignore: './build/cache/**',
     });


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves https://github.com/Shopify/polaris-react/issues/530

### WHAT is this pull request doing?

enables `no-vague-titles` eslint rule

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

`yarn lint`

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
