### PR TITLE
[Autocomplete] Fix incorrect selected state in examples

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -25,6 +25,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added accessibility documentation for `InlineError` ([#1073](https://github.com/Shopify/polaris-react/pull/1073))
 - Added accessibility documentation for `Loading`([#1075](https://github.com/Shopify/polaris-react/pull/1075))
 - Fixed documentation about the `ariaPressed` prop for `Button` ([#1097](https://github.com/Shopify/polaris-react/pull/1097))
+- Fixed examples using the `selected` prop for `Autocomplete` ([#1053](https://github.com/Shopify/polaris-react/pull/1053))
 
 ### Development workflow
 

--- a/src/components/Autocomplete/README.md
+++ b/src/components/Autocomplete/README.md
@@ -98,14 +98,14 @@ class AutocompleteExample extends React.Component {
     });
   };
 
-  updateSelection = (updatedSelection) => {
-    const selectedText = updatedSelection.map((selectedItem) => {
-      const matchedOption = this.options.filter((option) => {
+  updateSelection = (selected) => {
+    const selectedText = selected.map((selectedItem) => {
+      const matchedOption = this.options.find((option) => {
         return option.value.match(selectedItem);
       });
-      return matchedOption[0] && matchedOption[0].label;
+      return matchedOption && matchedOption.label;
     });
-    this.setState({selected: selectedText, inputText: selectedText});
+    this.setState({selected, inputText: selectedText});
   };
 }
 ```
@@ -202,9 +202,7 @@ class MultiAutocompleteExample extends React.Component {
     });
   };
 
-  updateSelection = (updatedSelection) => {
-    this.setState({selected: updatedSelection});
-  };
+  updateSelection = (selected) => this.setState({selected});
 }
 
 function titleCase(string) {
@@ -291,14 +289,14 @@ class AutocompleteExample extends React.Component {
     }, 300);
   };
 
-  updateSelection = (updatedSelection) => {
-    const selectedText = updatedSelection.map((selectedItem) => {
-      const matchedOption = this.options.filter((option) => {
+  updateSelection = (selected) => {
+    const selectedText = selected.map((selectedItem) => {
+      const matchedOption = this.options.find((option) => {
         return option.value.match(selectedItem);
       });
-      return matchedOption[0] && matchedOption[0].label;
+      return matchedOption && matchedOption.label;
     });
-    this.setState({selected: selectedText, inputText: selectedText});
+    this.setState({selected, inputText: selectedText});
   };
 }
 ```
@@ -385,14 +383,14 @@ class AutocompleteExample extends React.Component {
     }, 300);
   };
 
-  updateSelection = (updatedSelection) => {
-    const selectedText = updatedSelection.map((selectedItem) => {
-      const matchedOption = this.options.filter((option) => {
+  updateSelection = (selected) => {
+    const selectedText = selected.map((selectedItem) => {
+      const matchedOption = this.options.find((option) => {
         return option.value.match(selectedItem);
       });
-      return matchedOption[0] && matchedOption[0].label;
+      return matchedOption && matchedOption.label;
     });
-    this.setState({selected: selectedText, inputText: selectedText});
+    this.setState({selected, inputText: selectedText});
   };
 }
 ```


### PR DESCRIPTION
### WHY are these changes introduced?
Few README examples in autocomplete component use label of selected options as selected state in `onSelect` callbacks.
This causes selected options not to be highlighted and developers wondering what `selected` prop does in Autocomplete component.

### WHAT is this pull request doing?
Update `selected` state with selected props received from `onSelect` callback so selected options are highlighted.

<img width="468" alt="screen shot 2019-02-15 at 4 01 08 pm" src="https://user-images.githubusercontent.com/39597748/52887532-10276600-3146-11e9-9733-3c59f7c51c61.png">