### PR TITLE
[ResourceList] Add data-href to ResourceList.Item wrapper

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added `download` prop to `Button` and `UnstyledLink` components that enables setting the download attribute ([#1027](https://github.com/Shopify/polaris-react/pull/1027))
 - Extract months and week names into translation files ([#1005](https://github.com/Shopify/polaris-react/pull/1005))
 - Added `untrusted` prop to `Icon` to render SVG strings in an img tag ([#926](https://github.com/Shopify/polaris-react/pull/926))
+- Added a `data-href` to `ResourceList.Item`s that have a `url` prop ([#1054](https://github.com/Shopify/polaris-react/pull/1054))
 
 ### Bug fixes
 

--- a/src/components/ResourceList/components/Item/Item.tsx
+++ b/src/components/ResourceList/components/Item/Item.tsx
@@ -254,6 +254,7 @@ export class Item extends React.PureComponent<CombinedProps, State> {
         onMouseDown={this.handleMouseDown}
         onKeyUp={this.handleKeypress}
         testID="Item-Wrapper"
+        data-href={url}
       >
         {accessibleMarkup}
         {containerMarkup}

--- a/src/components/ResourceList/components/Item/tests/Item.test.tsx
+++ b/src/components/ResourceList/components/Item/tests/Item.test.tsx
@@ -13,6 +13,7 @@ import Item from '../Item';
 
 describe('<Item />', () => {
   let spy: jest.SpyInstance;
+
   beforeEach(() => {
     spy = jest.spyOn(window, 'open');
   });
@@ -121,6 +122,16 @@ describe('<Item />', () => {
       );
 
       expect(element.find(UnstyledLink).prop('aria-label')).toBe(ariaLabel);
+    });
+
+    it('adds a data-href to the wrapper element', () => {
+      const element = mountWithAppProvider(
+        <Provider value={mockDefaultContext}>
+          <Item id="itemId" url={url} />
+        </Provider>,
+      );
+
+      expect(element.prop('data-href')).toBe(url);
     });
   });
 

--- a/src/components/ResourceList/components/Item/tests/Item.test.tsx
+++ b/src/components/ResourceList/components/Item/tests/Item.test.tsx
@@ -131,7 +131,7 @@ describe('<Item />', () => {
         </Provider>,
       );
 
-      expect(element.prop('data-href')).toBe(url);
+      expect(findByTestID(element, 'Item-Wrapper').prop('data-href')).toBe(url);
     });
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

A resource list item with a URL does not get wrapped in an actual anchor tag in order to prevent having nested links. This is problematic for some stuff we are working on for web where we want to transparently see what URL is being hovered over at any given time (in order to preload that next page).

### WHAT is this pull request doing?

This PR adds a `data-href` around the top-level wrapper for the item, which will be used alongside normal `href` to find the closest link being hovered over.
