### PR TITLE
Design styles for toggle button

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Updates `TopBar.UserMenu` interaction states styling ([#1006](https://github.com/Shopify/polaris-react/pull/1006))
 - Added `download` prop to `Button` and `UnstyledLink` components that enables setting the download attribute ([#1027](https://github.com/Shopify/polaris-react/pull/1027))
 - Extract months and week names into translation files ([#1005](https://github.com/Shopify/polaris-react/pull/1005))
+- Deprecated `ariaPressed` in favour of `pressed` prop in `Button` ([#984](https://github.com/Shopify/polaris-react/pull/984))
 
 ### Bug fixes
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -54,12 +54,55 @@ $spinner-size: rem(20px);
   margin-left: -($spinner-size / 2);
 }
 
+.pressed {
+  background: linear-gradient(
+    to bottom,
+    color('sky', 'light'),
+    color('sky', 'light')
+  );
+  border-color: color('sky', 'dark');
+  box-shadow: inset 0 1px 1px 0 rgba(color('ink', 'lighter'), 0.1),
+    inset 0 1px 4px 0 rgba(color('ink', 'lighter'), 0.2);
+
+  &:focus {
+    border-color: color('indigo');
+    box-shadow: inset 0 1px 1px 0 rgba(color('ink', 'lighter'), 0.1),
+      inset 0 1px 4px 0 rgba(color('ink', 'lighter'), 0.2),
+      0 0 0 1px color('indigo');
+  }
+
+  @media (-ms-high-contrast: active) {
+    &.pressed {
+      color: ms-high-contrast-color('button-text');
+      background: ms-high-contrast-color('button-text-background');
+    }
+  }
+}
+
 .primary {
   @include button-filled(color('indigo'), color('indigo', 'dark'));
   @include recolor-icon(color('white'));
 
   &.disabled {
     @include button-filled-disabled(color('indigo'));
+  }
+
+  &.pressed {
+    background: linear-gradient(
+      to bottom,
+      darken(color('indigo'), 10%),
+      darken(color('indigo'), 10%)
+    );
+    border-color: darken(color('indigo', 'dark'), 15%);
+    box-shadow: inset 0 0 0 0 transparent, shadow(faint),
+      0 0 1px 0 darken(color('indigo', 'dark'), 15%);
+  }
+
+  @media (-ms-high-contrast: active) {
+    &.pressed {
+      color: ms-high-contrast-color('button-text');
+      background: ms-high-contrast-color('button-text-background');
+    }
   }
 }
 
@@ -77,6 +120,19 @@ $spinner-size: rem(20px);
 
   &.disabled {
     @include button-outline-disabled(color('ink', 'lighter'));
+  }
+
+  &.pressed {
+    background: rgba(color('ink', 'lighter'), 0.1);
+    border-color: color('ink', 'lighter');
+    box-shadow: none;
+  }
+
+  @media (-ms-high-contrast: active) {
+    &.pressed {
+      color: ms-high-contrast-color('button-text');
+      background: ms-high-contrast-color('button-text-background');
+    }
   }
 }
 
@@ -124,7 +180,8 @@ $spinner-size: rem(20px);
 
   &:hover,
   &:focus,
-  &:active {
+  &:active,
+  &.pressed:hover {
     @include recolor-icon(color('blue', 'dark'));
     background: transparent;
     border: 0;

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -55,27 +55,46 @@ $spinner-size: rem(20px);
 }
 
 .pressed {
-  background: linear-gradient(
-    to bottom,
-    color('sky', 'light'),
-    color('sky', 'light')
-  );
-  border-color: color('sky', 'dark');
-  box-shadow: inset 0 1px 1px 0 rgba(color('ink', 'lighter'), 0.1),
-    inset 0 1px 4px 0 rgba(color('ink', 'lighter'), 0.2);
+  background: color(sky);
+  border-color: darken(color(sky, dark), 4%);
+  box-shadow: 0 0 0 0 transparent,
+    inset 0 1px 1px 0 rgba(color('ink', 'lighter'), 0.1),
+    inset 0 1px 4px 0 rgba(color('ink', 'lighter'), 0.1);
+
+  &:hover {
+    transition-duration: duration(fast);
+    background: darken(color(sky), 2%);
+    border-color: darken(color(sky, dark), 4%);
+    box-shadow: 0 0 0 0 transparent,
+      inset 0 1px 1px 0 rgba(color('ink', 'lighter'), 0.1),
+      inset 0 1px 4px 0 rgba(color('ink', 'lighter'), 0.1);
+  }
 
   &:focus {
     border-color: color('indigo');
-    box-shadow: inset 0 1px 1px 0 rgba(color('ink', 'lighter'), 0.1),
-      inset 0 1px 4px 0 rgba(color('ink', 'lighter'), 0.2),
-      0 0 0 1px color('indigo');
+    box-shadow: 0 0 0 1px color('indigo'),
+      inset 0 1px 1px 0 rgba(color('ink', 'lighter'), 0.1),
+      inset 0 1px 4px 0 rgba(color('ink', 'lighter'), 0.1);
+  }
+
+  &:active {
+    background: darken(color(sky), 4%);
+    border-color: darken(color(sky, dark), 4%);
+    box-shadow: 0 0 0 0 transparent,
+      inset 0 1px 1px 0 rgba(color('ink', 'lighter'), 0.1),
+      inset 0 1px 4px 0 rgba(color('ink', 'lighter'), 0.2);
+  }
+
+  &.disabled {
+    background: lighten(color(sky), 4%);
+    color: color('ink', 'lightest');
+    border-color: color(sky, dark);
+    box-shadow: inset 0 1px 1px 0 rgba(color('ink', 'lighter'), 0.1);
   }
 
   @media (-ms-high-contrast: active) {
-    &.pressed {
-      color: ms-high-contrast-color('button-text');
-      background: ms-high-contrast-color('button-text-background');
-    }
+    color: ms-high-contrast-color('button-text');
+    background: ms-high-contrast-color('button-text-background');
   }
 }
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -50,13 +50,15 @@ export interface Props {
   download?: string | boolean;
   /** Icon to display to the left of the button content */
   icon?: React.ReactNode | IconSource;
+  /** Displays the button in a pressed state */
+  pressed?: boolean;
   /** Visually hidden text for screen readers */
   accessibilityLabel?: string;
   /** Id of the element the button controls */
   ariaControls?: string;
   /** Tells screen reader the controlled element is expanded */
   ariaExpanded?: boolean;
-  /** Tells screen reader the element is pressed */
+  /** @deprecated Use pressed instead. */
   ariaPressed?: boolean;
   /** Callback when clicked */
   onClick?(): void;
@@ -104,6 +106,7 @@ function Button({
   submit,
   size = DEFAULT_SIZE,
   fullWidth,
+  pressed,
   polaris: {intl},
 }: CombinedProps) {
   const isDisabled = disabled || loading;
@@ -119,6 +122,7 @@ function Button({
     size && size !== DEFAULT_SIZE && styles[variationName('size', size)],
     fullWidth && styles.fullWidth,
     icon && children == null && styles.iconOnly,
+    pressed && styles.pressed,
   );
 
   const disclosureIconMarkup = disclosure ? (
@@ -173,6 +177,12 @@ function Button({
 
   const type = submit ? 'submit' : 'button';
 
+  const isAriaPressed = ariaPressed || pressed;
+  if (ariaPressed) {
+    // eslint-disable-next-line no-console
+    console.log('`ariaPressed` is deprecated. Use `pressed` instead.');
+  }
+
   if (url) {
     return isDisabled ? (
       // Render an `<a>` so toggling disabled/enabled state changes only the
@@ -215,7 +225,7 @@ function Button({
       aria-label={accessibilityLabel}
       aria-controls={ariaControls}
       aria-expanded={ariaExpanded}
-      aria-pressed={ariaPressed}
+      aria-pressed={isAriaPressed}
       role={loading ? 'alert' : undefined}
       aria-busy={loading ? true : undefined}
     >

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -253,6 +253,16 @@ Use for buttons placed in a narrow column (especially when stacking multiple but
 <Button fullWidth>Add customer</Button>
 ```
 
+### Pressed button
+
+<!-- example-for: web -->
+
+Use to display the button in a pressed state.
+
+```jsx
+<Button pressed>Toggle me</Button>
+```
+
 ### Disabled state
 
 Use for actions that aren’t currently available. The surrounding interface should make it clear why the button is disabled and what needs to be done to enable it.

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -221,6 +221,13 @@ describe('<Button />', () => {
     });
   });
 
+  describe('pressed', () => {
+    it('sets an aria-pressed on the button', () => {
+      const button = shallowWithAppProvider(<Button pressed />);
+      expect(button.find('button').prop('aria-pressed')).toBeTruthy();
+    });
+  });
+
   describe('onClick()', () => {
     it('is called when the button is clicked', () => {
       const onClickSpy = jest.fn();


### PR DESCRIPTION
Design for toggle button states

### WHY are these changes introduced?

It was easier to design this in code than in a static design tool.

### WHAT is this pull request doing?

Adds styles for the “on” state of toggle buttons (`<Button pressed />`).

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Button, ButtonGroup} from '../src';

interface State {
  pressed: boolean;
}

export default class Playground extends React.Component<{}, State> {
  state = {
    pressed: false,
  };

  handleClick = () => {
    this.setState((prevState) => {
      return {
        pressed: !prevState.pressed,
      };
    });
  };

  render() {
    return (
      <Page title="Playground">
        <ButtonGroup>
          <Button pressed={this.state.pressed} onClick={this.handleClick}>
            Button
          </Button>
          <Button pressed disabled>
            Disabled
          </Button>
        </ButtonGroup>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
