### PR TITLE
[DropZone] Use createRef() API 

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -47,6 +47,7 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 
 ### Code quality
 
+- Migrated the refs in `DropZone` to use the new createRef API ([#1063](https://github.com/Shopify/polaris-react/pull/1063))
 - Updated `ResourceList` to no longer use `componentWillReceiveProps`([#1235](https://github.com/Shopify/polaris-react/pull/1235))
 - Updated `Tabs` to no longer use `componentWillReceiveProps`([#1221](https://github.com/Shopify/polaris-react/pull/1221))
 - Removed an unneeded media query from Modal's `Header` component ([#1272](https://github.com/Shopify/polaris-react/pull/1272))

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -153,19 +153,18 @@ export class DropZone extends React.Component<CombinedProps, State> {
     return Object.keys(newState).length ? newState : null;
   }
 
-  private node: HTMLElement | null = null;
-  private dropNode: HTMLElement | HTMLDocument | null = null;
+  private node = React.createRef<HTMLDivElement>();
   private dragTargets: EventTarget[] = [];
-  private fileInputNode: HTMLInputElement;
+  private fileInputNode = React.createRef<HTMLInputElement>();
 
   private adjustSize = debounce(
     () => {
-      if (!this.node) {
+      if (!this.node.current) {
         return;
       }
 
       let size = 'extraLarge';
-      const width = this.node.getBoundingClientRect().width;
+      const width = this.node.current.getBoundingClientRect().width;
 
       if (width < 100) {
         size = 'small';
@@ -211,6 +210,10 @@ export class DropZone extends React.Component<CombinedProps, State> {
     };
   }
 
+  get dropNode() {
+    return this.props.dropOnPage ? document : this.node.current;
+  }
+
   render() {
     const {
       id,
@@ -239,7 +242,7 @@ export class DropZone extends React.Component<CombinedProps, State> {
       disabled,
       type: 'file',
       multiple: allowMultiple,
-      ref: this.setInputNode,
+      ref: this.fileInputNode,
       onChange: this.handleDrop,
       autoComplete: 'off',
     };
@@ -291,7 +294,7 @@ export class DropZone extends React.Component<CombinedProps, State> {
 
     const dropZoneMarkup = (
       <div
-        ref={this.setNode}
+        ref={this.node}
         className={classes}
         aria-disabled={disabled}
         onClick={this.handleClick}
@@ -339,6 +342,8 @@ export class DropZone extends React.Component<CombinedProps, State> {
     addEventListener(this.dropNode, 'dragleave', this.handleDragLeave);
     addEventListener(window, 'resize', this.adjustSize);
 
+    this.adjustSize();
+
     if (this.props.openFileDialog) {
       this.triggerFileDialog();
     }
@@ -371,11 +376,11 @@ export class DropZone extends React.Component<CombinedProps, State> {
   };
 
   private open = () => {
-    if (!this.fileInputNode) {
+    if (!this.fileInputNode.current) {
       return;
     }
 
-    this.fileInputNode.click();
+    this.fileInputNode.current.click();
   };
 
   private getValidatedFiles = (files: File[] | DataTransferItem[]) => {
@@ -405,19 +410,6 @@ export class DropZone extends React.Component<CombinedProps, State> {
       acceptedFiles,
       rejectedFiles,
     };
-  };
-
-  private setNode = (node: HTMLElement | null) => {
-    const {dropOnPage} = this.props;
-
-    this.node = node;
-    this.dropNode = dropOnPage ? document : node;
-
-    this.adjustSize();
-  };
-
-  private setInputNode = (node: HTMLInputElement) => {
-    this.fileInputNode = node;
   };
 
   private handleClick = (event: React.MouseEvent<HTMLElement>) => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
These changes capitalize on the enhancements made for refs in >React 16.3.
Resolves https://github.com/Shopify/polaris-react/issues/910

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
The refs to the DOM nodes are now initialized using createRef(). These refs are linked to the respective DOM elements in the render method, through the ref prop. The refs are now accessed using _this.refname.current_. There are no visible UI changes.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
