### PR TITLE
[Range slider] Use spacing base-tight

### DIFF
--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -27,7 +27,7 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
   height: $range-thumb-size;
 
   input {
-    padding: rem(12px) 0;
+    padding: spacing(base-tight) 0;
     background-color: transparent;
     cursor: pointer;
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Follow-up to https://github.com/Shopify/polaris-react/pull/1044

### WHAT is this pull request doing?

Uses new polaris-tokens `spacing(base-tight)` instead of `rem(12px)`.