### PR TITLE
Loading a11y docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Documentation
 
 - Made documentation for properties only available in a stand-alone context more explicit for `Modal` ([#1065] https://github.com/Shopify/polaris-react/pull/1065)
+- Added accessibility documentation for `Loading`([#1075](https://github.com/Shopify/polaris-react/pull/1075))
 
 ### Development workflow
 

--- a/src/components/Loading/README.md
+++ b/src/components/Loading/README.md
@@ -67,17 +67,6 @@ The loading component should:
 
 ---
 
-## Content guidelines
-
-### Accessibility label
-
-The loading accessibility label should:
-
-- Accurately explain the state of the requested action. For example, “Loading your search results”.
-- Use as few words as possible to describe the state.
-
----
-
 ## Related components
 
 - To indicate that an action has been received, use the [Spinner](/components/feedback-indicators/spinner)

--- a/src/components/Loading/README.md
+++ b/src/components/Loading/README.md
@@ -83,3 +83,31 @@ The loading accessibility label should:
 - To indicate that an action has been received, use the [Spinner](/components/feedback-indicators/spinner)
 - To improve user experience and reduce the appearance of long loading times, use the [Progress bar](/components/feedback-indicators/progress-bar) component.
 - To better represent loading content, use [Skeleton page](/components/feedback-indicators/skeleton-page) along with [Skeleton body text](/components/feedback-indicators/skeleton-body-text) and [Skeleton display text](/components/feedback-indicators/skeleton-display-text) components.
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+The loading component is implemented using the [ARIA 1.1 progressbar pattern](https://www.w3.org/TR/wai-aria-1.1/#progressbar). It outputs an ARIA `role="progressbar"` and uses `aria-valuemin`, `aria-value-max`, and `aria-valuenow` to convey the loaded percentage to screen reader users.
+
+<!-- /content-for -->


### PR DESCRIPTION
## WHY are these changes introduced?

Adds accessibility guidance for the loading component, to appear in `polaris-react` docs and in the style guide.

[See the draft Google doc for editing history for these changes and updates for other components and pages.](https://docs.google.com/document/d/1ONoa4fUsqG19i5h0h2Kz2w9CvmFSN926YmoNVMsGPgw/edit#heading=h.w5x5ph7nfna7)

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the loading component
* [X] Removes recommendations for labeling, since this component has no labeling props and accessibility-related information is provided in code
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props: https://polaris.myshopify.io/components/feedback-indicators/loading

## Screenshot

Web content:
<img width="667" alt="Loading component accessibility docs" src="https://user-images.githubusercontent.com/1462085/53134022-370ce000-352a-11e9-9645-5226edc350ea.png">