### PR TITLE
Resolve unsupported React Fragment syntax

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Resolved an unsupported `React.Fragment` syntax ([#1080](https://github.com/Shopify/polaris-react/pull/1080))
 - Constrained `DropZone` height based on inherited wrapper height [#908](https://github.com/Shopify/polaris-react/pull/908)
 
 ### Documentation

--- a/src/components/TopBar/components/UserMenu/components/UserMenu/UserMenu.tsx
+++ b/src/components/TopBar/components/UserMenu/components/UserMenu/UserMenu.tsx
@@ -37,7 +37,7 @@ function UserMenu({
   const showIndicator = Boolean(message);
 
   const activatorContentMarkup = (
-    <>
+    <React.Fragment>
       <MessageIndicator active={showIndicator}>
         <Avatar
           size="small"
@@ -49,7 +49,7 @@ function UserMenu({
         <p className={styles.Name}>{name}</p>
         <p className={styles.Detail}>{detail}</p>
       </span>
-    </>
+    </React.Fragment>
   );
 
   return (


### PR DESCRIPTION
[This PR](https://github.com/Shopify/polaris-react/pull/1006) merged an unsupported `React.Fragment` syntax _(`<>...</>`)_, which resulted in build container failures for my app.

All I have done here is convert to the supported `<React.Fragment>` syntax.