### PR TITLE
Update eslint-plugin-shopify

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,6 +31,7 @@
     "import/no-named-as-default": "off",
     "react/button-has-type": "off",
     "react/no-array-index-key": "off",
+    "react/jsx-fragments": ["error", "element"],
     "shopify/jsx-no-complex-expressions": "off",
     "shopify/no-ancestor-directory-import": "error",
     "jsx-a11y/label-has-for": [

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -45,7 +45,6 @@ export default class AppProvider extends React.Component<Props> {
     }
   }
 
-  // eslint-disable-next-line react/no-deprecated
   componentWillReceiveProps({
     i18n,
     linkComponent,

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -68,7 +68,6 @@ export class Collapsible extends React.Component<CombinedProps, State> {
     };
   }
 
-  // eslint-disable-next-line react/no-deprecated
   componentWillReceiveProps({open: willOpen}: Props) {
     const {open} = this.props;
 

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -68,12 +68,10 @@ export class FileUpload extends React.Component<CombinedProps, State> {
     }
   }
 
-  // eslint-disable-next-line react/no-deprecated
   componentWillReceiveProps(props: Props) {
     this.updateStateFromProps(props);
   }
 
-  // eslint-disable-next-line react/no-deprecated
   componentWillMount() {
     this.updateStateFromProps(this.props);
   }

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -73,7 +73,6 @@ export class OptionList extends React.Component<CombinedProps, State> {
 
   private id = this.props.id || getUniqueId();
 
-  // eslint-disable-next-line react/no-deprecated
   componentWillReceiveProps({
     options: nextOptions = [],
     sections: nextSections = [],

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -93,7 +93,6 @@ export default class PositionedOverlay extends React.PureComponent<
     }
   }
 
-  // eslint-disable-next-line react/no-deprecated
   componentWillReceiveProps() {
     this.handleMeasurement();
   }

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -299,7 +299,6 @@ export class ResourceList extends React.Component<CombinedProps, State> {
     };
   }
 
-  // eslint-disable-next-line react/no-deprecated
   componentWillReceiveProps(nextProps: Props) {
     const {selectedItems} = this.props;
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -49,7 +49,6 @@ export default class Tabs extends React.PureComponent<Props, State> {
     tabToFocus: -1,
   };
 
-  // eslint-disable-next-line react/no-deprecated
   componentWillReceiveProps(nextProps: Props) {
     const {selected} = this.props;
     const {disclosureWidth, tabWidths, containerWidth, tabToFocus} = this.state;

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -35,7 +35,6 @@ export default class ThemeProvider extends React.Component<Props> {
     this.colors = setColors(props.theme);
   }
 
-  // eslint-disable-next-line react/no-deprecated
   componentWillReceiveProps({theme}: Props) {
     if (isEqual(theme, this.props.theme)) {
       return;

--- a/src/utilities/react-compose.tsx
+++ b/src/utilities/react-compose.tsx
@@ -19,6 +19,7 @@ export default function compose<Props>(
     const Result = reactCompose(...wrappingFunctions)(
       OriginalComponent,
     ) as ReactComponent<ComposedProps>;
+    // eslint-disable-next-line react/display-name
     return React.forwardRef<Props>(
       (props: Props, ref: React.RefObject<any>) => {
         return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -6276,21 +6276,23 @@ eslint-plugin-promise@4.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.0.0.tgz#bc15a4aa04fa6116113b6c47488c421821b758fc"
   integrity sha512-3on8creJifkmNHvT425jCWSuVK0DG0Quf3H75ENZFqvHl6/s2xme8z6bfxww13XwqfELYWKxc/N3AtBXyV1hdg==
 
-eslint-plugin-react@7.11.1:
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz#c01a7af6f17519457d6116aa94fc6d2ccad5443c"
-  integrity sha512-cVVyMadRyW7qsIUh3FHp3u6QHNhOgVrLQYdQEB1bPWBsgbNCHdFAeNMquBMCcZJu59eNthX053L70l7gRt4SCw==
+eslint-plugin-react@7.12.4:
+  version "7.12.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"
+  integrity sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==
   dependencies:
     array-includes "^3.0.3"
     doctrine "^2.1.0"
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
+    object.fromentries "^2.0.0"
     prop-types "^15.6.2"
+    resolve "^1.9.0"
 
 eslint-plugin-shopify@^26.1.2:
-  version "26.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-shopify/-/eslint-plugin-shopify-26.2.0.tgz#95bf0ae39f1e0d77a900ca072a46fe1970ce214b"
-  integrity sha512-OVnsGaa85B/kB2enZoqnXZG5QqSN+a4L99TPVgXSpBn2Y+iQaP40969MqJP9Mg6S5EqUXAmeS/4KMAknL0r4zQ==
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-shopify/-/eslint-plugin-shopify-26.3.0.tgz#368649e0603a785093ee4d9cbe942f46983900cc"
+  integrity sha512-btIvevMzkND3iT5oTeXk+DeknRy52T3DLrYSH+AysTFjbbkzQpYvetlVFLUl33qfq9df7wOth4KmbrHAQJBfAg==
   dependencies:
     babel-eslint "9.0.0"
     common-tags "^1.8.0"
@@ -6311,7 +6313,7 @@ eslint-plugin-shopify@^26.1.2:
     eslint-plugin-node "7.0.1"
     eslint-plugin-prettier "3.0.1"
     eslint-plugin-promise "4.0.0"
-    eslint-plugin-react "7.11.1"
+    eslint-plugin-react "7.12.4"
     eslint-plugin-sort-class-members "1.3.1"
     eslint-plugin-typescript "0.12.0"
     merge "1.2.0"
@@ -11863,6 +11865,16 @@ object.fromentries@^1.0.0:
     function-bind "^1.1.1"
     has "^1.0.1"
 
+object.fromentries@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.0.tgz#49a543d92151f8277b3ac9600f1e930b189d30ab"
+  integrity sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.11.0"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz#8758c846f5b407adab0f236e0986f14b051caa16"
@@ -12406,6 +12418,11 @@ path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
   integrity sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=
+
+path-parse@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -14440,6 +14457,13 @@ resolve@^1.6.0, resolve@^1.8.1:
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
   dependencies:
     path-parse "^1.0.5"
+
+resolve@^1.9.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
+  integrity sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==
+  dependencies:
+    path-parse "^1.0.6"
 
 responselike@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### WHY are these changes introduced?

We recently got bit by using `<>` instead of `<React.Fragment>`. We should always use `<React.Fragment>` and people shouldn't be expected to remember that.

### WHAT is this pull request doing?

- Update eslint-plugin-shopify and thus our transitive dependency on eslint-plugin-react
- Add a linting check to ensure we always use `<React.Fragment>` over `</>`
- Remove react deprecation notices that are no longer triggered (see
https://github.com/yannickcr/eslint-plugin-react/pull/2069)


### How to 🎩

Ensure linting passes