### PR TITLE
Fix for ariaPressed documentation

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Made documentation for properties only available in a stand-alone context more explicit for `Modal` ([#1065] https://github.com/Shopify/polaris-react/pull/1065)
 - Added accessibility documentation for `Loading`([#1075](https://github.com/Shopify/polaris-react/pull/1075))
+- Fixes documentation about the `ariaPressed` prop for `Button` ([...](...))
 
 ### Development workflow
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,7 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Made documentation for properties only available in a stand-alone context more explicit for `Modal` ([#1065] https://github.com/Shopify/polaris-react/pull/1065)
 - Added accessibility documentation for `Loading`([#1075](https://github.com/Shopify/polaris-react/pull/1075))
-- Fixes documentation about the `ariaPressed` prop for `Button` ([...](...))
+- Fixes documentation about the `ariaPressed` prop for `Button` ([#1097](https://github.com/Shopify/polaris-react/pull/1097))
 
 ### Development workflow
 

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -319,7 +319,7 @@ Buttons can have different states that are visually and programmatically conveye
 - Use the `ariaControls` prop to add an `aria-controls` attribute to the button. Use the attribute to point to the unique `id` of the content that the button manages.
 - If a button expands or collapses adjacent content, then use the `ariaExpanded` prop to add the `aria-expanded` attribute to the button. Set the value to convey the current expanded (`true`) or collapsed (`false`) state of the content.
 - Use the `disabled` prop to set the `disabled` state of the button. This prevents merchants from being able to interact with the button, and conveys its inactive state to assistive technologies.
-- Use the `pressed` prop to add an `aria-pressed` attribute and enable a pressed style to the button.
+- Use the `ariaPressed` prop to add an `aria-pressed` attribute to the button.
 
 #### Navigation
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes documentation of the `ariaPressed` prop to remove reference to an unmerged change (#984).

### WHAT is this pull request doing?

- Updates the button `README.md`.
- Adds an entry to `UNRELEASED.md`.