### PR TITLE
Provide an internal reference to Polaris version that is compile-safe

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed missing rounded corners on `Tag` button states ([#1078](https://github.com/Shopify/polaris-react/pull/1078))
+- Removed reference to `window.Polaris`, which in some cases could be undefined ([#1104](https://github.com/Shopify/polaris-react/issues/1104))
 
 ### Documentation
 

--- a/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
+++ b/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
@@ -10,7 +10,7 @@ import {StickyManager} from '../withSticky';
 import ScrollLockManager from '../ScrollLockManager';
 import Intl from '../Intl';
 import Link from '../Link';
-import {POLARIS_VERSION} from '../../../../configure';
+import {polarisVersion} from '../../../../configure';
 
 export interface CreateAppProviderContext extends AppProviderProps {
   stickyManager?: StickyManager;
@@ -62,7 +62,7 @@ export const setClientInterfaceHook: DispatchActionHook = function(next) {
   return function(action) {
     action.clientInterface = {
       name: '@shopify/polaris',
-      version: POLARIS_VERSION,
+      version: polarisVersion,
     };
     return next(action);
   };

--- a/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
+++ b/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
@@ -10,6 +10,7 @@ import {StickyManager} from '../withSticky';
 import ScrollLockManager from '../ScrollLockManager';
 import Intl from '../Intl';
 import Link from '../Link';
+import {POLARIS_VERSION} from '../../../../configure';
 
 export interface CreateAppProviderContext extends AppProviderProps {
   stickyManager?: StickyManager;
@@ -61,7 +62,7 @@ export const setClientInterfaceHook: DispatchActionHook = function(next) {
   return function(action) {
     action.clientInterface = {
       name: '@shopify/polaris',
-      version: window.Polaris.VERSION,
+      version: POLARIS_VERSION,
     };
     return next(action);
   };

--- a/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
+++ b/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
@@ -120,8 +120,6 @@ describe('createAppProviderContext()', () => {
   });
 
   it('setClientInterfaceHook augments app bridge actions with clientInterface property', () => {
-    window.Polaris = {VERSION: '9000'};
-
     const next = jest.fn((args) => args);
     const baseAction = {type: 'actionType'};
 

--- a/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
+++ b/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
@@ -129,7 +129,7 @@ describe('createAppProviderContext()', () => {
       type: 'actionType',
       clientInterface: {
         name: '@shopify/polaris',
-        version: '9000',
+        version: '{{POLARIS_VERSION}}',
       },
     });
   });

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -13,4 +13,4 @@ if (typeof window !== 'undefined') {
   window.Polaris.VERSION = '{{POLARIS_VERSION}}';
 }
 
-export const POLARIS_VERSION = '{{POLARIS_VERSION}}';
+export const polarisVersion = '{{POLARIS_VERSION}}';

--- a/src/configure.ts
+++ b/src/configure.ts
@@ -12,3 +12,5 @@ if (typeof window !== 'undefined') {
   window.Polaris = window.Polaris || {};
   window.Polaris.VERSION = '{{POLARIS_VERSION}}';
 }
+
+export const POLARIS_VERSION = '{{POLARIS_VERSION}}';


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #1104

### WHAT is this pull request doing?

Providing an internal method to reference Polaris version.

### Tophat

Run an embedded app using Polaris, compiled using sewing kit [in production mode](https://github.com/Shopify/sewing_kit#how-can-i-test-a-production-verison-of-my-changes). Should be no errors when dispatching App Bridge actions (ie opening a modal, resource picker, etc).

Additionally, `APP::` prefixed actions in the Redux inspector should have an actual version number for `clientInterface.version`, not `'{{POLARIS_VERSION}}'`.

I'm working on getting a repo case up and running.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
