### PR TITLE
[Checkbox] Fix focus and problem with events not firing

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed disabled states while loading for `ResourceList` ([#1237](https://github.com/Shopify/polaris-react/pull/1237))
+- Fixed `Checkbox` from losing focus and not receiving some modified events([#1112](https://github.com/Shopify/polaris-react/pull/1112))
 
 ### Documentation
 

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -70,6 +70,7 @@
   bottom: 0;
   left: 0;
   right: 0;
+  pointer-events: none;
 }
 
 .Icon {
@@ -80,6 +81,7 @@
   transform: translate(-50%, -50%) scale(0);
   transform-origin: 50% 50%;
   transition: control-icon-transition();
+  pointer-events: none;
 
   @media (-ms-high-contrast: active) {
     fill: ms-high-contrast-color('text');

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {MinusMinor, TickSmallMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {createUniqueIDFactory, noop} from '@shopify/javascript-utilities/other';
-import {autobind} from '@shopify/javascript-utilities/decorators';
 
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import Choice, {helpTextID} from '../Choice';
@@ -46,8 +45,7 @@ const getUniqueID = createUniqueIDFactory('Checkbox');
 class Checkbox extends React.PureComponent<CombinedProps, never> {
   private inputNode = React.createRef<HTMLInputElement>();
 
-  @autobind
-  handleInput() {
+  handleInput = () => {
     const {onChange, id} = this.props;
 
     if (onChange == null || this.inputNode.current == null) {
@@ -56,15 +54,14 @@ class Checkbox extends React.PureComponent<CombinedProps, never> {
 
     onChange(!this.inputNode.current.checked, id as any);
     this.inputNode.current.focus();
-  }
+  };
 
-  @autobind
-  handleKeyUp(event: React.KeyboardEvent) {
+  handleKeyUp = (event: React.KeyboardEvent) => {
     const {keyCode} = event;
 
     if (keyCode !== Key.Space) return;
     this.handleInput();
-  }
+  };
 
   render() {
     const {
@@ -100,7 +97,7 @@ class Checkbox extends React.PureComponent<CombinedProps, never> {
       ? {indeterminate: 'true', 'aria-checked': 'mixed' as 'mixed'}
       : {'aria-checked': isChecked};
 
-    const iconSource = isIndeterminate ? 'subtract' : 'checkmark';
+    const iconSource = isIndeterminate ? MinusMinor : TickSmallMinor;
 
     const inputClassName = classNames(
       styles.Input,

--- a/src/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/Checkbox/tests/Checkbox.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {noop} from '@shopify/javascript-utilities/other';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
+import {Key} from '../../../types';
 import Checkbox from '../Checkbox';
 
 describe('<Checkbox />', () => {
@@ -14,25 +15,68 @@ describe('<Checkbox />', () => {
     expect(input.prop('value')).toBe('Some value');
   });
 
+  it('does not change checked states when onChange is not provided', () => {
+    const element = mountWithAppProvider(
+      <Checkbox id="MyCheckbox" label="Checkbox" checked />,
+    );
+    element.simulate('click');
+    expect(element.find('input').prop('checked')).toBe(true);
+  });
+
+  it('does not propagation click events from input element', () => {
+    const spy = jest.fn();
+    const element = mountWithAppProvider(
+      <Checkbox id="MyCheckbox" label="Checkbox" onChange={spy} />,
+    );
+
+    element.find('input').simulate('click');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   describe('onChange()', () => {
-    it('is called with the new checked value of the input on change', () => {
+    it('is called with the updated checked value of the input on click', () => {
       const spy = jest.fn();
       const element = mountWithAppProvider(
         <Checkbox id="MyCheckbox" label="Checkbox" onChange={spy} />,
       );
       (element.find('input') as any).instance().checked = true;
-      element.find('input').simulate('change');
-      expect(spy).toHaveBeenCalledWith(true, 'MyCheckbox');
+      element.simulate('click');
+      expect(spy).toHaveBeenCalledWith(false, 'MyCheckbox');
+    });
+
+    it('is called when space is pressed', () => {
+      const spy = jest.fn();
+      const element = mountWithAppProvider(
+        <Checkbox id="MyCheckbox" label="Checkbox" onChange={spy} />,
+      );
+
+      element.find('input').simulate('keyup', {
+        keyCode: Key.Space,
+      });
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('is not from keys other than space', () => {
+      const spy = jest.fn();
+      const element = mountWithAppProvider(
+        <Checkbox id="MyCheckbox" label="Checkbox" onChange={spy} />,
+      );
+
+      element.find('input').simulate('keyup', {
+        keyCode: Key.Enter,
+      });
+
+      expect(spy).not.toHaveBeenCalled();
     });
 
     it('sets focus on the input when checkbox is toggled off', () => {
-      const input = mountWithAppProvider(
+      const checkbox = mountWithAppProvider(
         <Checkbox checked id="checkboxId" label="Checkbox" onChange={noop} />,
-      ).find('input');
-      (input.getDOMNode() as HTMLInputElement).checked = false;
-      input.simulate('change');
-
-      expect(input.getDOMNode()).toBe(document.activeElement);
+      );
+      (checkbox.find('input') as any).instance().checked = false;
+      checkbox.simulate('click');
+      expect(checkbox.find('input').instance()).toBe(document.activeElement);
     });
   });
 

--- a/src/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/Checkbox/tests/Checkbox.test.tsx
@@ -23,7 +23,7 @@ describe('<Checkbox />', () => {
     expect(element.find('input').prop('checked')).toBe(true);
   });
 
-  it('does not propagation click events from input element', () => {
+  it('does not propagate click events from input element', () => {
     const spy = jest.fn();
     const element = mountWithAppProvider(
       <Checkbox id="MyCheckbox" label="Checkbox" onChange={spy} />,

--- a/src/components/Choice/Choice.tsx
+++ b/src/components/Choice/Choice.tsx
@@ -21,6 +21,8 @@ export interface Props {
   children?: React.ReactNode;
   /** Additional text to aide in use */
   helpText?: React.ReactNode;
+  /** Callback when clicked */
+  onClick?(): void;
 }
 
 export default function Choice({
@@ -31,6 +33,7 @@ export default function Choice({
   children,
   labelHidden,
   helpText,
+  onClick,
 }: Props) {
   const className = classNames(
     styles.Choice,
@@ -39,7 +42,7 @@ export default function Choice({
   );
 
   const labelMarkup = (
-    <label className={className} htmlFor={id}>
+    <label className={className} htmlFor={id} onClick={onClick}>
       <span className={styles.Control}>{children}</span>
       <span className={styles.Label}>{label}</span>
     </label>

--- a/src/components/Choice/tests/Choice.test.tsx
+++ b/src/components/Choice/tests/Choice.test.tsx
@@ -4,6 +4,16 @@ import {InlineError} from 'components';
 import Choice from '../Choice';
 
 describe('<Choice />', () => {
+  it('calls the provided onClick when clicked', () => {
+    const spy = jest.fn();
+    const element = mountWithAppProvider(
+      <Choice id="MyChoice" label="Label" onClick={spy} />,
+    );
+    element.find('label').simulate('click');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
   it('uses the id as the for attribute of a label', () => {
     const element = mountWithAppProvider(
       <Choice id="MyChoice" label="Label" />,

--- a/src/components/ChoiceList/tests/ChoiceList.test.tsx
+++ b/src/components/ChoiceList/tests/ChoiceList.test.tsx
@@ -245,33 +245,24 @@ describe('<ChoiceList />', () => {
       );
       const choiceElements = choiceList.find(Checkbox);
 
-      changeCheckedForChoice(choiceElements.at(1), true);
+      changeCheckedForChoice(choiceElements.at(1));
       expect(spy).toHaveBeenLastCalledWith(['one', 'two'], 'MyChoiceList');
       choiceList.setProps({selected});
 
-      changeCheckedForChoice(choiceElements.at(2), true);
+      changeCheckedForChoice(choiceElements.at(2));
       expect(spy).toHaveBeenLastCalledWith(
         ['one', 'two', 'three'],
         'MyChoiceList',
       );
       choiceList.setProps({selected});
 
-      changeCheckedForChoice(choiceElements.at(0), false);
+      changeCheckedForChoice(choiceElements.at(0));
       expect(spy).toHaveBeenLastCalledWith(['two', 'three'], 'MyChoiceList');
       choiceList.setProps({selected});
     });
 
-    function changeCheckedForChoice(
-      choice: ReactWrapper<any, any>,
-      checked: boolean,
-      triggerChange = true,
-    ) {
-      const input = choice.find('input');
-      (input as any).instance().checked = checked;
-
-      if (triggerChange) {
-        input.simulate('change');
-      }
+    function changeCheckedForChoice(choice: ReactWrapper<any, any>) {
+      choice.simulate('click');
     }
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

`Checkbox` can lose focus or not receive events.

### Gifs

#### Shift clicks
https://cl.ly/44715b1c9430

#### Losing focus
https://cl.ly/4ca13de5131c

### WHAT is this pull request doing?

* Removing pointer events on adjacent elements to precent blocking and bubbling
* Switch from functional to class components. We can utilize on shallow prop comparison with `PureComponent` and removes the need for scoped functions
* Focus input after every change
* Use event delegation with onClick / onKeyUp handlers
* Use a no-op for onChange (input element)

### Question

Is this a good approach? Are there good alternatives?

### How to 🎩

Load up the playground and test checkboxes on multiple browsers and devices 😄 

* Fast clicks
* Slow clicks
* Modified clicks (e.g shift)
* Clicks with focus and without focus
* Keyboard interactions

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

cc/ @dpersing How does this look to you in terms of accessibility? Previously the focus state was a little off, now the checkbox should remained focused after every interaction with it.