### PR TITLE
[Collapsible] Remove context

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed unnecessary height on `TextField` due to unhandled carriage returns ([#901](https://github.com/Shopify/polaris-react/pull/901))
+- Removed unused context in `Collapsible` ([#1114](https://github.com/Shopify/polaris-react/issues/1114))
 
 ### Documentation
 

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -43,7 +43,6 @@ export class Collapsible extends React.Component<CombinedProps, State> {
   private node: HTMLElement | null = null;
   private heightNode: HTMLElement | null = null;
 
-  // eslint-disable-next-line react/no-deprecated
   componentWillReceiveProps({open: willOpen}: Props) {
     const {open} = this.props;
 

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
 import {autobind} from '@shopify/javascript-utilities/decorators';
 import {classNames} from '@shopify/react-utilities/styles';
 import {
@@ -35,20 +34,7 @@ export interface State {
   animationState: AnimationState;
 }
 
-export interface Context {
-  parentCollapsibleExpanding: boolean;
-}
-
-const CONTEXT_TYPES = {
-  parentCollapsibleExpanding: PropTypes.bool,
-};
-
 export class Collapsible extends React.Component<CombinedProps, State> {
-  static contextTypes = CONTEXT_TYPES;
-  static childContextTypes = CONTEXT_TYPES;
-
-  context: Partial<Context>;
-
   state: State = {
     height: null,
     animationState: 'idle',
@@ -57,17 +43,7 @@ export class Collapsible extends React.Component<CombinedProps, State> {
   private node: HTMLElement | null = null;
   private heightNode: HTMLElement | null = null;
 
-  getChildContext(): Context {
-    const {open} = this.props;
-    const {animationState} = this.state;
-    const {parentCollapsibleExpanding} = this.context;
-
-    return {
-      parentCollapsibleExpanding:
-        parentCollapsibleExpanding || (open && animationState !== 'idle'),
-    };
-  }
-
+  // eslint-disable-next-line react/no-deprecated
   componentWillReceiveProps({open: willOpen}: Props) {
     const {open} = this.props;
 
@@ -78,16 +54,6 @@ export class Collapsible extends React.Component<CombinedProps, State> {
 
   componentDidUpdate({open: wasOpen}: Props) {
     const {animationState} = this.state;
-    const {parentCollapsibleExpanding} = this.context;
-
-    if (parentCollapsibleExpanding && animationState !== 'idle') {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({
-        animationState: 'idle',
-      });
-
-      return;
-    }
 
     read(() => {
       switch (animationState) {


### PR DESCRIPTION
### WHY are these changes introduced?

While pairing with @alex-page we noticed this context is not being used and removed it.

### WHAT is this pull request doing?

Removing the context 🔥 

### How to 🎩

Collapsible exaple
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Collapsible, Stack, TextContainer, Button, Card} from '../src';

interface State {}

export default class CollapsibleExample extends React.Component {
  state = {
    open: false,
  };

  render() {
    const {open} = this.state;

    return (
      <div style={{height: '200px'}}>
        <Card sectioned>
          <Stack vertical>
            <Button onClick={this.handleToggleClick} ariaExpanded={open}>
              Toggle
            </Button>
            <Collapsible open={open} id="basic-collapsible">
              <TextContainer>
                Your mailing list lets you contact customers or visitors who
                have shown an interest in your store. Reach out to them with
                exclusive offers or updates about your products.
              </TextContainer>
            </Collapsible>
          </Stack>
        </Card>
      </div>
    );
  }

  handleToggleClick = () => {
    this.setState((state) => {
      const open = !state.open;
      return {
        open,
      };
    });
  };
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->

cc/ @alex-page 

### Notes
* I'll do another 🎩 in the morning
* Needs changelog