### PR TITLE
[ComboBox] Change tabindex prop to a negative number

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed `Popover` fade-in flutter on iOS by switching Transition component for CSSTransition [#1400](https://github.com/Shopify/polaris-react/pull/1400)
+- Removed `tabIndex={0}` prop from `ComboBox` to allow proper tab key navigation of `Autocomplete` ([#1089](https://github.com/Shopify/polaris-react/issues/1089))
 
 ### Documentation
 

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -236,6 +236,7 @@ export default class ComboBox extends React.PureComponent<Props, State> {
       emptyState && <div className={styles.EmptyState}>{emptyState}</div>;
 
     return (
+      /*  eslint-disable-next-line jsx-a11y/interactive-supports-focus */
       <div
         onClick={this.handleClick}
         role="combobox"
@@ -245,7 +246,6 @@ export default class ComboBox extends React.PureComponent<Props, State> {
         aria-haspopup
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
-        tabIndex={0}
       >
         <KeypressListener
           keyCode={Key.DownArrow}


### PR DESCRIPTION
### WHY are these changes introduced?
Resolves https://github.com/Shopify/polaris-react/issues/1089

Fixes tab navigation behaviour in the Autocomplete component by not selecting the ComboBox when tabbing through the component.

### WHAT is this pull request doing?
Changes the `tabIndex` prop value from `0` to `-1` for the `ComboBox` component.  ~~Adds a regression test.~~
