### PR TITLE
[Navigation] badge accepts react element

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Updated `Navigation` badge prop to accept a react node ([#1142](https://github.com/Shopify/polaris-react/pull/1142))
+
 ### Bug fixes
 
 - Fixed unnecessary height on `TextField` due to unhandled carriage returns ([#901](https://github.com/Shopify/polaris-react/pull/901))

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -40,7 +40,7 @@ interface SecondaryAction {
 export interface Props extends ItemURLDetails {
   icon?: IconProps['source'];
   iconBody?: string;
-  badge?: string | null;
+  badge?: React.ReactNode;
   label: string;
   disabled?: boolean;
   accessibilityLabel?: string;
@@ -90,16 +90,16 @@ export class BaseItem extends React.Component<CombinedProps, State> {
       url,
       icon,
       label,
-      badge,
       subNavigationItems = [],
       secondaryAction,
       disabled,
       onClick,
       accessibilityLabel,
       iconBody,
+      selected: selectedOverride,
+      badge,
       new: isNew,
       polaris: {intl},
-      selected: selectedOverride,
     } = this.props;
 
     const {location, onNavigationDismiss} = this.context;
@@ -116,15 +116,6 @@ export class BaseItem extends React.Component<CombinedProps, State> {
       </span>
     ) : null;
 
-    const badgeMarkup =
-      badge || isNew ? (
-        <div className={styles.Badge}>
-          <Badge status="new" size="small">
-            {badge || intl.translate('Polaris.Badge.STATUS_LABELS.new')}
-          </Badge>
-        </div>
-      ) : null;
-
     const iconMarkup = iconBody ? (
       <div className={styles.Icon}>
         <Icon source={iconBody} />
@@ -137,6 +128,28 @@ export class BaseItem extends React.Component<CombinedProps, State> {
       )
     );
 
+    let badgeMarkup: React.ReactNode = null;
+    if (isNew) {
+      badgeMarkup = (
+        <Badge status="new" size="small">
+          {intl.translate('Polaris.Badge.STATUS_LABELS.new')}
+        </Badge>
+      );
+    } else if (typeof badge === 'string') {
+      badgeMarkup = (
+        <Badge status="new" size="small">
+          {badge}
+        </Badge>
+      );
+    } else {
+      badgeMarkup = badge;
+    }
+
+    const wrappedBadgeMarkup =
+      badgeMarkup == null ? null : (
+        <div className={styles.Badge}>{badgeMarkup}</div>
+      );
+
     const itemContentMarkup = (
       <React.Fragment>
         {iconMarkup}
@@ -144,7 +157,7 @@ export class BaseItem extends React.Component<CombinedProps, State> {
           {label}
           {indicatorMarkup}
         </span>
-        {badgeMarkup}
+        {wrappedBadgeMarkup}
       </React.Fragment>
     );
 

--- a/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -100,6 +100,34 @@ describe('<Nav.Item />', () => {
       const link = item.find(UnstyledLink);
       expect(link.exists()).toBe(true);
     });
+
+    it('renders a small badge with new status if the prop is provided with a string', () => {
+      const item = mountWithAppProvider(<Item label="some label" badge="1" />);
+
+      expect(item.find(Badge).props()).toMatchObject({
+        status: 'new',
+        size: 'small',
+        children: '1',
+      });
+    });
+
+    it('renders a badge if the prop is provided with an element', () => {
+      const item = mountWithAppProvider(
+        <Item label="some label" badge={<Badge>Custom badge</Badge>} />,
+      );
+
+      expect(item.find(Badge).text()).toContain('Custom badge');
+    });
+
+    it('renders a single new badge even if a badge prop is also provided', () => {
+      const item = mountWithAppProvider(
+        <Item label="some label" badge={<Badge>Custom badge</Badge>} new />,
+      );
+      const badge = item.find(Badge);
+
+      expect(badge).toHaveLength(1);
+      expect(badge.text()).toContain('New');
+    });
   });
 
   describe('with SubNavigationItems', () => {


### PR DESCRIPTION
### WHY are these changes introduced?
Minimizes impact of re-rendering navigation if the badge relies on a query to resolve. More detail here: https://github.com/Shopify/web/issues/10481

### WHAT is this pull request doing?
Allows the nav items badge property to take a react node prop value.

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```tsx
import * as React from 'react';
import {Page, Navigation, Badge} from '../src';

export default class Playground extends React.Component<{}, never> {
  render() {
    return (
      <Page title="Playground">
        <Navigation location="/">
          <Navigation.Section
            items={[
              {
                url: '/path/to/place',
                label: 'Orders',
                icon: 'orders',
                badge: <Badge>Hello world</Badge>,
              },
            ]}
          />
        </Navigation>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
