### PR TITLE
Pre-fill labels for new issues opened using GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request
 about: Suggest an addition or improvement to Polaris or the documentation
+labels: Feature request
 ---
 
 # Feature request summary

--- a/.github/ISSUE_TEMPLATE/ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE.md
@@ -1,6 +1,7 @@
 ---
 name: Issue
 about: Ask a question or report a problem with Polaris or the documentation
+labels: Bug
 ---
 
 <!-- For feature requests, please use the following template: https://github.com/Shopify/polaris-react/issues/new?template=FEATURE_REQUEST.md -->

--- a/.github/ISSUE_TEMPLATE/NEW_COMPONENT.md
+++ b/.github/ISSUE_TEMPLATE/NEW_COMPONENT.md
@@ -1,6 +1,7 @@
 ---
 name: New component proposal
 about: For proposing new components or changes to existing components
+label: New component
 ---
 
 # Component name


### PR DESCRIPTION
Pre-filling these labels will help triage and find new issues:

- Feature requests: https://github.com/Shopify/polaris-react/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Feature+request%22
- New components: https://github.com/Shopify/polaris-react/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22New+component%22
- Bugs: https://github.com/Shopify/polaris-react/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22Bug%22+

This PR doesn't apply any labels to the ["ISSUE" template](https://github.com/Shopify/polaris-react/blob/master/.github/ISSUE_TEMPLATE/ISSUE.md), as it could be a bug, but also something else. Thoughts on that?