### PR TITLE
[a11y] Docs for checkbox, radio button, and choice list

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Added accessibility documentation for `Checkbox`, `RadioButton`, and `ChoiceList` ([#1145](https://github.com/Shopify/polaris-react/pull/1145))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/Checkbox/README.md
+++ b/src/components/Checkbox/README.md
@@ -175,21 +175,17 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-Screen readers convey the checked, unchecked, indeterminate, or disabled state of the checkbox automatically.
+Screen readers convey the state of the checkbox automatically.
 
-If the `disabled` prop is used, the HTML `disabled` attribute is added to the checkbox `<input>`. The checkbox will not receive keyboard focus and will be conveyed as unavailable to screen reader users.
-
-If the `checked` prop is set to `indeterminate`, the state is conveyed using `aria-checked=”mixed”`.
-
-The `id` prop can be used to provide a unique `id` attribute value for the checkbox. If none is provided, the component with generate one automatically. All checkboxes must have unique `id` values.
+- Use the `disabled` prop to apply the HTML `disabled` attribute to the checkbox `<input>`. This prevents merchants from being able to interact with the checkbox, and conveys its inactive state to assistive technologies.
+- Use the `id` prop to provide a unique `id` attribute value for the checkbox. If an `id` isn’t provided, then the component generates one. All checkboxes must have unique `id` values to work correctly with assistive technologies.
+- If you set the `checked` prop to `indeterminate`, then the state of the checkbox is conveyed using `aria-checked=”mixed”`.
 
 ### Labeling
 
-The `label` prop is required to convey the purpose of the checkbox to all users.
-
-If there are separate visual cues that convey the purpose of the checkbox label to sighted users, it can be visually hidden using the `labelHidden` prop. Unless a visual label is provided, refrain from using `labelHidden`.
-
-If help text or an inline error message is provided via the `helpText` or `error` prop, it is conveyed to screen reader users with the `aria-describedby` attribute. This causes it to be read along with the label and state, either immediately or after a short delay.
+- The required `label` prop conveys the purpose of the checkbox to all merchants
+- Use the `labelHidden` prop to visually hide the label but make it available to assistive technologies
+- When you provide help text via the `helpText` prop or an inline error message via the `error` prop, the help or error content is conveyed to screen reader users with the `aria-describedby` attribute
 
 ### Keyboard support
 

--- a/src/components/Checkbox/README.md
+++ b/src/components/Checkbox/README.md
@@ -179,7 +179,7 @@ Screen readers convey the state of the checkbox automatically.
 
 - Use the `disabled` prop to apply the HTML `disabled` attribute to the checkbox `<input>`. This prevents merchants from being able to interact with the checkbox, and conveys its inactive state to assistive technologies.
 - Use the `id` prop to provide a unique `id` attribute value for the checkbox. If an `id` isn’t provided, then the component generates one. All checkboxes must have unique `id` values to work correctly with assistive technologies.
-- If you set the `checked` prop to `indeterminate`, then the state of the checkbox is conveyed using `aria-checked="mixed"`.
+- Setting `checked="indeterminate"` conveys the state of the checkbox using `aria-checked="mixed"`.
 
 ### Labeling
 

--- a/src/components/Checkbox/README.md
+++ b/src/components/Checkbox/README.md
@@ -150,3 +150,50 @@ class CheckboxExample extends React.Component {
 - To present a list of options where merchants can only make a single choice, [use the radio button component](/components/forms/radio-button)
 - To display a list of related content, [use the choice list component](/components/forms/choice-list)
 - To create an ungrouped list, [use the content list component](/components/lists-and-tables/list)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Screen readers convey the checked, unchecked, indeterminate, or disabled state of the checkbox automatically.
+
+If the `disabled` prop is used, the HTML `disabled` attribute is added to the checkbox `<input>`. The checkbox will not receive keyboard focus and will be conveyed as unavailable to screen reader users.
+
+If the `checked` prop is set to `indeterminate`, the state is conveyed using `aria-checked=”mixed”`.
+
+The `id` prop can be used to provide a unique `id` attribute value for the checkbox. If none is provided, the component with generate one automatically. All checkboxes must have unique `id` values.
+
+### Labeling
+
+The `label` prop is required to convey the purpose of the checkbox to all users.
+
+If there are separate visual cues that convey the purpose of the checkbox label to sighted users, it can be visually hidden using the `labelHidden` prop. Unless a visual label is provided, refrain from using `labelHidden`.
+
+If help text or an inline error message is provided via the `helpText` or `error` prop, it is conveyed to screen reader users with the `aria-describedby` attribute. This causes it to be read along with the label and state, either immediately or after a short delay.
+
+### Keyboard support
+
+- Move focus to each checkbox using the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
+- To interact with the checkbox when it has keyboard focus, press the <kbd>space</kbd> key
+
+<!-- /content-for -->

--- a/src/components/Checkbox/README.md
+++ b/src/components/Checkbox/README.md
@@ -179,7 +179,7 @@ Screen readers convey the state of the checkbox automatically.
 
 - Use the `disabled` prop to apply the HTML `disabled` attribute to the checkbox `<input>`. This prevents merchants from being able to interact with the checkbox, and conveys its inactive state to assistive technologies.
 - Use the `id` prop to provide a unique `id` attribute value for the checkbox. If an `id` isn’t provided, then the component generates one. All checkboxes must have unique `id` values to work correctly with assistive technologies.
-- If you set the `checked` prop to `indeterminate`, then the state of the checkbox is conveyed using `aria-checked=”mixed”`.
+- If you set the `checked` prop to `indeterminate`, then the state of the checkbox is conveyed using `aria-checked="mixed"`.
 
 ### Labeling
 

--- a/src/components/ChoiceList/README.md
+++ b/src/components/ChoiceList/README.md
@@ -417,6 +417,6 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-The choice list component uses the accessibility features of the [checkbox](/components/forms/checkbox) and [radio button](/forms/radio-button) components.
+The choice list component uses the accessibility features of the [checkbox](/components/forms/checkbox) and [radio button](/components/forms/radio-button) components.
 
 <!-- /content-for -->

--- a/src/components/ChoiceList/README.md
+++ b/src/components/ChoiceList/README.md
@@ -392,3 +392,31 @@ class ChoiceListExample extends React.Component {
 - To present a long list of radio buttons or when space is constrained, [use the select component](/components/forms/select)
 - To build a group of radio buttons or checkboxes with a custom layout, use the [radio button component](/components/forms/radio-button) or [checkbox component](/components/forms/checkbox)
 - To display a simple, non-interactive list of related content, [use the list component](/components/lists-and-tables/list)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+The choice list component uses the accessibility features of the [checkbox](/components/forms/checkbox) and [radio button](/forms/radio-button) components.
+
+<!-- /content-for -->

--- a/src/components/RadioButton/README.md
+++ b/src/components/RadioButton/README.md
@@ -170,3 +170,45 @@ Use toggles when merchants need to make a binary choice (on or off).
 - For long lists of options, [consider the select component](/components/forms/select) to avoid overwhelming merchants
 - To present merchants with a list of checkboxes, [use the choice list component](/components/forms/choice-list) with the “allow multiple” option
 - To display non-interactive list of related content, [use the content list component](/components/lists-and-tables/list)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Screen readers convey the state of the radio button automatically.
+
+- Use the `disabled` prop to apply the HTML `disabled` attribute to the radio button `<input>`. This prevents merchants from being able to interact with the radio button, and conveys its inactive state to assistive technologies.
+- Use the `id` prop to provide a unique `id` attribute value for the radio button. If an `id` isn’t provided, then the component generates one. All radio buttons must have unique `id` values to work correctly with assistive technologies.
+
+### Labeling
+
+- The required `label` prop conveys the purpose of the radio button to all merchants
+- Use the `labelHidden` prop to visually hide the label but make it available to assistive technologies
+- When you provide help text via the `helpText` prop or an inline error message via the `error` prop, the help or error content is conveyed to screen reader users with the `aria-describedby` attribute
+
+### Keyboard support
+
+- Move focus to the radio button group using the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
+- Use the up and down arrow keys to change which radio button is selected
+
+<!-- /content-for -->


### PR DESCRIPTION
## WHY are these changes introduced?

Adds accessibility guidance for the checkbox, radio button, and choice list components, to appear in `polaris-react` docs and in the style guide. The choice list documentation points readers to the other components.

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the checkbox `README.md`
* [X] Adds accessibility documentation for the radio button `README.md`
* [X] Adds accessibility documentation for the choice list `README.md`
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props:
  * https://polaris.myshopify.io/components/forms/choice-list (web, iOS, and Android)
  * https://polaris.myshopify.io/components/forms/checkbox (web, iOS, and Android)
  * https://polaris.myshopify.io/components/forms/radio-button (web, iOS, and Android)

### Screenshots

#### Choice list (web)

<img width="611" alt="Choice list web documentation" src="https://user-images.githubusercontent.com/1462085/54001283-9d375c80-40ff-11e9-96a9-d0ed35eb6cd3.png">

#### Checkbox (web)

<img width="661" alt="Checkbox web documentation" src="https://user-images.githubusercontent.com/1462085/54001300-aaece200-40ff-11e9-8e40-b78e67c33ab5.png">

#### Radio button (web)

<img width="667" alt="Radio button web documentation" src="https://user-images.githubusercontent.com/1462085/54001321-bfc97580-40ff-11e9-86da-c009789511fc.png">