### PR TITLE
Pass icon components into `<Icon>` instead of the bundled icon name

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -38,5 +38,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Replaced all occurrences of `_.pick` with a custom pick function ([#1020](https://github.com/Shopify/polaris-react/pull/1020))
 - Deleted the icons index file that would re-export icons, and replaced it with direct imports ([#1195](https://github.com/Shopify/polaris-react/pull/1195))
+- Replaces all instances where we pass a string representing a bundled icon into `Icon`. Prefer passing in the React Component from `@shopify/polaris-icons` ([#1196](https://github.com/Shopify/polaris-react/pull/1196))
 
 ### Deprecations

--- a/src/components/Autocomplete/tests/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/tests/Autocomplete.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {CirclePlusMinor} from '@shopify/polaris-icons';
 import {noop} from '@shopify/javascript-utilities/other';
 import Autocomplete from '..';
 import {mountWithAppProvider} from 'test-utilities';
@@ -43,7 +44,7 @@ describe('<Autocomplete/>', () => {
       const actionBefore = [
         {
           content: "Add 'f'",
-          icon: 'circlePlus',
+          icon: CirclePlusMinor,
           id: 'Autocomplete-ID-0',
         },
       ];
@@ -61,7 +62,7 @@ describe('<Autocomplete/>', () => {
           allowMultiple
           actionBefore={{
             content: "Add 'f'",
-            icon: 'circlePlus',
+            icon: CirclePlusMinor,
             id: 'ComboBox3-0',
           }}
           onSelect={handleOnSelect}

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {
+  CirclePlusMinor,
   CircleAlertMajorTwotone,
   CircleDisabledMajorTwotone,
   CircleTickMajorTwotone,
@@ -23,8 +24,8 @@ describe('<Banner />', () => {
   });
 
   it('passes the provided icon source to Icon', () => {
-    const banner = mountWithAppProvider(<Banner icon="circlePlus" />);
-    expect(banner.find(Icon).prop('source')).toBe('circlePlus');
+    const banner = mountWithAppProvider(<Banner icon={CirclePlusMinor} />);
+    expect(banner.find(Icon).prop('source')).toBe(CirclePlusMinor);
   });
 
   it('uses a greenDark circleCheckMark if status is success', () => {

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {ChevronLeftMinor} from '@shopify/polaris-icons';
 
 import Icon from '../Icon';
 import UnstyledLink from '../UnstyledLink';
@@ -25,7 +26,7 @@ export default class Breadcrumbs extends React.PureComponent<Props, never> {
     const contentMarkup = (
       <React.Fragment>
         <span className={styles.Icon}>
-          <Icon source="chevronLeft" />
+          <Icon source={ChevronLeftMinor} />
         </span>
         <span className={styles.Content}>{content}</span>
       </React.Fragment>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {CaretDownMinor} from '@shopify/polaris-icons';
 import {classNames, variationName} from '@shopify/react-utilities';
 
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
@@ -123,7 +124,7 @@ function Button({
 
   const disclosureIconMarkup = disclosure ? (
     <IconWrapper>
-      <Icon source={loading ? 'placeholder' : 'caretDown'} />
+      <Icon source={loading ? 'placeholder' : CaretDownMinor} />
     </IconWrapper>
   ) : null;
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {MinusMinor, TickSmallMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 
@@ -87,7 +88,7 @@ function Checkbox({
     ? {indeterminate: 'true', 'aria-checked': 'mixed' as 'mixed'}
     : {'aria-checked': isChecked};
 
-  const iconSource = isIndeterminate ? 'subtract' : 'checkmark';
+  const iconSource = isIndeterminate ? MinusMinor : TickSmallMinor;
 
   const inputClassName = classNames(
     styles.Input,

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
+import {CaretUpMinor, CaretDownMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 
 import {headerCell} from '../../../shared';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
-import Icon, {IconSource} from '../../../Icon';
+import Icon from '../../../Icon';
 import {SortDirection} from '../../types';
 
 import styles from '../../DataTable.scss';
@@ -71,7 +72,7 @@ function Cell({
   };
 
   const direction = sorted ? sortDirection : defaultSortDirection;
-  const source = `caret${direction === 'ascending' ? 'Up' : 'Down'}`;
+  const source = direction === 'ascending' ? CaretUpMinor : CaretDownMinor;
   const oppositeDirection =
     sortDirection === 'ascending' ? 'descending' : 'ascending';
 
@@ -82,10 +83,7 @@ function Cell({
 
   const iconMarkup = (
     <span className={iconClassName}>
-      <Icon
-        source={source as IconSource}
-        accessibilityLabel={sortAccessibilityLabel}
-      />
+      <Icon source={source} accessibilityLabel={sortAccessibilityLabel} />
     </span>
   );
 

--- a/src/components/ExceptionList/tests/ExceptionList.test.tsx
+++ b/src/components/ExceptionList/tests/ExceptionList.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {CirclePlusMinor, NoteMinor} from '@shopify/polaris-icons';
 import {mountWithAppProvider} from 'test-utilities';
 import {Icon} from 'components';
 import ExceptionList from '../ExceptionList';
@@ -9,12 +10,12 @@ describe('<ExceptionList />', () => {
       <ExceptionList
         items={[
           {
-            icon: 'notes',
+            icon: NoteMinor,
             description:
               'This customer is awesome. Make sure to treat them right!',
           },
           {
-            icon: 'circlePlus',
+            icon: CirclePlusMinor,
             description: 'Add a gift to this order',
           },
         ]}
@@ -28,7 +29,7 @@ describe('<ExceptionList />', () => {
       <ExceptionList
         items={[
           {
-            icon: 'notes',
+            icon: NoteMinor,
             description:
               'This customer is awesome. Make sure to treat them right!',
           },

--- a/src/components/FooterHelp/FooterHelp.tsx
+++ b/src/components/FooterHelp/FooterHelp.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {QuestionMarkMajorTwotone} from '@shopify/polaris-icons';
 import Icon from '../Icon';
 import styles from './FooterHelp.scss';
 
@@ -12,7 +13,7 @@ export default function FooterHelp({children}: Props) {
     <div className={styles.FooterHelp}>
       <div className={styles.Content}>
         <div className={styles.Icon}>
-          <Icon source="help" color="teal" backdrop />
+          <Icon source={QuestionMarkMajorTwotone} color="teal" backdrop />
         </div>
         <div className={styles.Text}>{children}</div>
       </div>

--- a/src/components/FooterHelp/tests/FooterHelp.test.tsx
+++ b/src/components/FooterHelp/tests/FooterHelp.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {QuestionMarkMajorTwotone} from '@shopify/polaris-icons';
 import {mountWithAppProvider} from 'test-utilities';
 import {Icon} from 'components';
 import FooterHelp from '../FooterHelp';
@@ -17,6 +18,6 @@ describe('<FooterHelp />', () => {
   });
 
   it('renders the help icon', () => {
-    expect(footerHelp.find(Icon).prop('source')).toBe('help');
+    expect(footerHelp.find(Icon).prop('source')).toBe(QuestionMarkMajorTwotone);
   });
 });

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {MobileCancelMajorMonotone} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {CSSTransition} from 'react-transition-group';
 import {navigationBarCollapsed} from '../../utilities/breakpoints';
@@ -151,7 +152,7 @@ export class Frame extends React.PureComponent<CombinedProps, State> {
               )}
               tabIndex={tabIndex}
             >
-              <Icon source="cancel" color="white" />
+              <Icon source={MobileCancelMajorMonotone} color="white" />
             </button>
           </div>
         </CSSTransition>

--- a/src/components/Frame/components/Toast/Toast.tsx
+++ b/src/components/Frame/components/Toast/Toast.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {MobileCancelMajorMonotone} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities';
 
 import {Key} from '../../../../types';
@@ -38,7 +39,7 @@ export default class Toast extends React.Component<Props, never> {
         onClick={onDismiss}
         testID="closeButton"
       >
-        <Icon source="cancel" />
+        <Icon source={MobileCancelMajorMonotone} />
       </button>
     );
 

--- a/src/components/InlineError/InlineError.tsx
+++ b/src/components/InlineError/InlineError.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {AlertMinor} from '@shopify/polaris-icons';
 
 import Icon from '../Icon';
 import {Error} from '../../types';
@@ -20,7 +21,7 @@ function InlineError({message, fieldID}: Props) {
   return (
     <div id={`${fieldID}Error`} className={styles.InlineError}>
       <div className={styles.Icon}>
-        <Icon source="alert" />
+        <Icon source={AlertMinor} />
       </div>
       {message}
     </div>

--- a/src/components/Modal/components/CloseButton/CloseButton.tsx
+++ b/src/components/Modal/components/CloseButton/CloseButton.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {MobileCancelMajorMonotone} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities';
 
 import Icon from '../../../Icon';
@@ -18,7 +19,7 @@ export default function CloseButton({title = true, onClick}: Props) {
 
   return (
     <button onClick={onClick} className={className}>
-      <Icon source="cancel" color="inkLighter" />
+      <Icon source={MobileCancelMajorMonotone} color="inkLighter" />
     </button>
   );
 }

--- a/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {PlusMinor} from '@shopify/polaris-icons';
 import {noop} from '@shopify/javascript-utilities/other';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {Icon, UnstyledLink, Indicator, Badge} from 'components';
@@ -193,12 +194,12 @@ describe('<Nav.Item />', () => {
   describe('delegated props', () => {
     it('delegates icon to <Icon />', () => {
       const item = mountWithAppProvider(
-        <Item label="some label" url="foo" disabled={false} icon="add" />,
+        <Item label="some label" url="foo" disabled={false} icon={PlusMinor} />,
         {
           context: {location: 'bar'},
         },
       );
-      expect(item.find(Icon).prop('source')).toBe('add');
+      expect(item.find(Icon).prop('source')).toBe(PlusMinor);
     });
 
     it('delegates iconBody to <Icon />', () => {

--- a/src/components/Navigation/components/Section/Section.tsx
+++ b/src/components/Navigation/components/Section/Section.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-
+import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 
@@ -106,7 +106,7 @@ export default class Section extends React.Component<Props, State> {
             testID="ToggleViewAll"
           >
             <span className={styles.Icon}>
-              <Icon source="horizontalDots" />
+              <Icon source={HorizontalDotsMinor} />
             </span>
             {ariaLabel}
           </button>

--- a/src/components/OptionList/components/Checkbox/Checkbox.tsx
+++ b/src/components/OptionList/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {TickSmallMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import Icon from '../../../Icon';
@@ -45,7 +46,7 @@ export default function Checkbox({
       />
       <div className={styles.Backdrop} />
       <div className={styles.Icon}>
-        <Icon source="checkmark" />
+        <Icon source={TickSmallMinor} />
       </div>
     </div>
   );

--- a/src/components/Page/components/Header/components/Action/Action.tsx
+++ b/src/components/Page/components/Header/components/Action/Action.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {CaretDownMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities';
 import {IconableAction, DisableableAction} from '../../../../../../types';
 import {handleMouseUpByBlurring} from '../../../../../../utilities/focus';
@@ -35,7 +36,7 @@ export default function Action({
 
   const disclosureIconMarkup = disclosure && (
     <span className={styles.ActionIcon}>
-      <Icon source="caretDown" />
+      <Icon source={CaretDownMinor} />
     </span>
   );
 

--- a/src/components/Page/components/Header/components/Action/tests/Action.test.tsx
+++ b/src/components/Page/components/Header/components/Action/tests/Action.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {SaveMinor} from '@shopify/polaris-icons';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import Icon from '../../../../../../Icon';
 import UnstyledLink from '../../../../../../UnstyledLink';
@@ -7,7 +8,7 @@ import Action from '../Action';
 describe('<Action />', () => {
   describe('icon', () => {
     it('renders the given icon', () => {
-      const icon = 'save';
+      const icon = SaveMinor;
       const action = mountWithAppProvider(<Action icon={icon} />);
       expect(action.find(Icon).prop('source')).toBe(icon);
     });
@@ -69,7 +70,7 @@ describe('<Action />', () => {
     it('gets rendered when an icon is present', () => {
       const children = 'Click me!';
       const action = mountWithAppProvider(
-        <Action icon="save">{children}</Action>,
+        <Action icon={SaveMinor}>{children}</Action>,
       );
       expect(action.contains(children)).toBeTruthy();
     });

--- a/src/components/Page/components/Header/components/ActionGroup/tests/ActionGroup.test.tsx
+++ b/src/components/Page/components/Header/components/ActionGroup/tests/ActionGroup.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {ReactWrapper} from 'enzyme';
+import {SaveMinor} from '@shopify/polaris-icons';
 import {noop} from '@shopify/javascript-utilities/other';
 import {Popover, ActionList} from 'components';
 import {mountWithAppProvider, trigger} from 'test-utilities';
@@ -33,7 +34,7 @@ describe('<ActionGroup />', () => {
 
   describe('icon', () => {
     it('gets passed into the action', () => {
-      const icon = 'save';
+      const icon = SaveMinor;
       const actionGroup = mountWithAppProvider(
         <ActionGroup {...mockProps} icon={icon} />,
       );

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {SaveMinor} from '@shopify/polaris-icons';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {Breadcrumbs, buttonsFrom, Pagination} from 'components';
 import {LinkAction, ActionListItemDescriptor} from '../../../../../types';
@@ -160,7 +161,7 @@ describe('<Header />', () => {
     });
 
     it('receives the group’s icon', () => {
-      const icon = 'save';
+      const icon = SaveMinor;
       const actionGroups = [fillActionGroup({icon})];
       const header = mountWithAppProvider(
         <Header {...mockProps} actionGroups={actionGroups} />,

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {ArrowLeftMinor, ArrowRightMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities';
 import isInputFocused from '../../utilities/isInputFocused';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
@@ -77,7 +78,7 @@ function Pagination({
       aria-label={intl.translate('Polaris.Pagination.previous')}
       id="previousURL"
     >
-      <Icon source="arrowLeft" />
+      <Icon source={ArrowLeftMinor} />
     </UnstyledLink>
   ) : (
     <button
@@ -88,7 +89,7 @@ function Pagination({
       aria-label={intl.translate('Polaris.Pagination.previous')}
       disabled={!hasPrevious}
     >
-      <Icon source="arrowLeft" />
+      <Icon source={ArrowLeftMinor} />
     </button>
   );
 
@@ -100,7 +101,7 @@ function Pagination({
       aria-label={intl.translate('Polaris.Pagination.next')}
       id="nextURL"
     >
-      <Icon source="arrowRight" />
+      <Icon source={ArrowRightMinor} />
     </UnstyledLink>
   ) : (
     <button
@@ -111,7 +112,7 @@ function Pagination({
       aria-label={intl.translate('Polaris.Pagination.next')}
       disabled={!hasNext}
     >
-      <Icon source="arrowRight" />
+      <Icon source={ArrowRightMinor} />
     </button>
   );
 

--- a/src/components/ResourceList/components/BulkActions/components/BulkActionButton/BulkActionButton.tsx
+++ b/src/components/ResourceList/components/BulkActions/components/BulkActionButton/BulkActionButton.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {findDOMNode} from 'react-dom';
+import {CaretDownMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities';
 
 import Icon from '../../../../../Icon';
@@ -44,7 +45,7 @@ export default class BulkActionButton extends React.PureComponent<
 
     const disclosureIconMarkup = disclosure ? (
       <span className={styles.ActionIcon}>
-        <Icon source="caretDown" />
+        <Icon source={CaretDownMinor} />
       </span>
     ) : null;
 

--- a/src/components/ResourceList/components/FilterControl/FilterControl.tsx
+++ b/src/components/ResourceList/components/FilterControl/FilterControl.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {SearchMinor} from '@shopify/polaris-icons';
 import compose from '@shopify/react-compose';
 import {ComplexAction, WithContextTypes} from '../../../../types';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
@@ -97,7 +98,7 @@ export class FilterControl extends React.Component<CombinedProps> {
           label={textFieldLabel}
           labelHidden
           placeholder={textFieldLabel}
-          prefix={<Icon source="search" color="skyDark" />}
+          prefix={<Icon source={SearchMinor} color="skyDark" />}
           value={searchValue}
           onChange={onSearchChange}
           onBlur={onSearchBlur}

--- a/src/components/ResourceList/components/FilterControl/components/DateSelector/DateSelector.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/DateSelector/DateSelector.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {CalendarMinor} from '@shopify/polaris-icons';
 import DatePicker, {Months, Year, Range} from '../../../../../DatePicker';
 import Select from '../../../../../Select';
 import TextField from '../../../../../TextField';
@@ -95,7 +96,7 @@ class DateSelector extends React.PureComponent<CombinedProps, State> {
             )}
             value={this.dateTextFieldValue}
             error={userInputDateError}
-            prefix={<Icon source="calendar" color="skyDark" />}
+            prefix={<Icon source={CalendarMinor} color="skyDark" />}
             autoComplete={false}
             onChange={this.handleDateFieldChange}
             onBlur={this.handleDateBlur}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {ArrowUpDownMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 
@@ -146,7 +147,7 @@ export default function Select({
       {inlineLabelMarkup}
       <span className={styles.SelectedOption}>{selectedOption}</span>
       <span className={styles.Icon}>
-        <Icon source="arrowUpDown" />
+        <Icon source={ArrowUpDownMinor} />
       </span>
     </div>
   );

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {noop} from '@shopify/javascript-utilities/other';
 
@@ -104,7 +105,7 @@ export default class Tabs extends React.PureComponent<Props, State> {
         className={styles.DisclosureActivator}
         onClick={this.handleDisclosureActivatorClick}
       >
-        <Icon source="horizontalDots" />
+        <Icon source={HorizontalDotsMinor} />
       </button>
     );
 

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {CancelSmallMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import Icon from '../Icon';
@@ -38,7 +39,7 @@ function Tag({
         onMouseUp={handleMouseUpByBlurring}
         disabled={disabled}
       >
-        <Icon source="cancelSmall" />
+        <Icon source={CancelSmallMinor} />
       </button>
     </span>
   );

--- a/src/components/TextField/components/Spinner/Spinner.tsx
+++ b/src/components/TextField/components/Spinner/Spinner.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {CaretDownMinor, CaretUpMinor} from '@shopify/polaris-icons';
 import Icon from '../../../Icon';
 
 import styles from '../../TextField.scss';
@@ -38,7 +39,7 @@ export default function Spinner({
         onMouseUp={onMouseUp}
       >
         <div className={styles.SpinnerIcon}>
-          <Icon source="caretUp" />
+          <Icon source={CaretUpMinor} />
         </div>
       </div>
 
@@ -51,7 +52,7 @@ export default function Spinner({
         onMouseUp={onMouseUp}
       >
         <div className={styles.SpinnerIcon}>
-          <Icon source="caretDown" />
+          <Icon source={CaretDownMinor} />
         </div>
       </div>
     </div>

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {MobileHamburgerMajorMonotone} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 
 import {getWidth} from '../../utilities/getWidth';
@@ -78,7 +79,7 @@ export class TopBar extends React.PureComponent<ComposedProps, State> {
         onBlur={this.handleBlur}
         aria-label="Toggle menu"
       >
-        <Icon source="menu" color="white" />
+        <Icon source={MobileHamburgerMajorMonotone} color="white" />
       </button>
     ) : null;
 

--- a/src/components/TopBar/components/SearchField/SearchField.tsx
+++ b/src/components/TopBar/components/SearchField/SearchField.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {CircleCancelMinor, SearchMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 
 import {noop} from '../../../../utilities/other';
@@ -66,7 +67,7 @@ export default class SearchField extends React.Component<Props, never> {
         className={styles.Clear}
         onClick={this.handleClear}
       >
-        <Icon source="circleCancel" />
+        <Icon source={CircleCancelMinor} />
       </button>
     );
 
@@ -94,7 +95,7 @@ export default class SearchField extends React.Component<Props, never> {
           onKeyDown={preventDefault}
         />
         <span className={styles.Icon}>
-          <Icon source="search" />
+          <Icon source={SearchMinor} />
         </span>
 
         {clearMarkup}

--- a/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
+++ b/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {CircleCancelMinor} from '@shopify/polaris-icons';
 import {noop} from '@shopify/javascript-utilities/other';
 import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider} from 'test-utilities';
@@ -62,7 +63,7 @@ describe('<TextField />', () => {
       expect(
         textField
           .find('Icon')
-          .filterWhere((el) => el.prop('source') === 'circleCancel'),
+          .filterWhere((el) => el.prop('source') === CircleCancelMinor),
       ).toHaveLength(1);
     });
 

--- a/src/components/TopBar/components/UserMenu/components/UserMenu/tests/UserMenu.test.tsx
+++ b/src/components/TopBar/components/UserMenu/components/UserMenu/tests/UserMenu.test.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
+import {NotificationMajorMonotone} from '@shopify/polaris-icons';
+
 import {ReactWrapper} from 'enzyme';
 import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import Menu from '../../../../Menu';
 import UserMenu from '../UserMenu';
 
-const actions = [
-  {items: [{icon: 'notification' as 'notification', onAction: noop}]},
-];
+const actions = [{items: [{icon: NotificationMajorMonotone, onAction: noop}]}];
 const message = {
   title: 'test message',
   description: 'test description',

--- a/src/components/TopBar/components/UserMenu/context/tests/Modifier.test.tsx
+++ b/src/components/TopBar/components/UserMenu/context/tests/Modifier.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {ViewMinor} from '@shopify/polaris-icons';
 import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import {UserMenuProps} from '../../components';
@@ -7,7 +8,7 @@ import Modifier from '../Modifier';
 
 describe('<Modifier />', () => {
   const userMenuProps: UserMenuProps = {
-    actions: [{items: [{icon: 'view'}]}],
+    actions: [{items: [{icon: ViewMinor}]}],
     name: '',
     initials: '',
     open: false,

--- a/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
+++ b/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {ViewMinor} from '@shopify/polaris-icons';
 import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import {UserMenuContext} from '../context';
@@ -8,7 +9,7 @@ import UserMenu from '../UserMenu';
 describe('<UserMenu />', () => {
   describe('<UserMenuConsumer />', () => {
     const userMenuProps: UserMenuProps = {
-      actions: [{items: [{icon: 'view'}]}],
+      actions: [{items: [{icon: ViewMinor}]}],
       name: '',
       initials: '',
       open: false,


### PR DESCRIPTION
### WHY are these changes introduced?

We are looking at deprecating the concept of bundled icons in the
future so lets get our house in order first.

### WHAT is this pull request doing?

Replaces usage of bundled icon strings with passsing in a React Component into `<Icon>`

### How to 🎩

Click around storybook, ensuring you can still see the same icons