### PR TITLE
Use `envinfo` to retrieve the specs when creating an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE.md
@@ -41,7 +41,14 @@ The best way to get your bug fixed is to provide a reduced test case. This [Code
 
 ## Specifications
 
-Run `npx envinfo --system --binaries --browsers --npmPackages react,react-dom,@shopify/polaris` to provide specifications on your environment including version numbers, browser, device, and operating system.
+- Are you using the React components? (Y/N):
+- Polaris version number:
+- Browser:
+- Device:
+- Operating System:
+
+
+Or run `npx envinfo --system --binaries --browsers --npmPackages react,react-dom,@shopify/polaris` to provide specifications on your environment including version numbers, browser, device, and operating system.
 
 Paste the results here:
 

--- a/.github/ISSUE_TEMPLATE/ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE.md
@@ -41,8 +41,10 @@ The best way to get your bug fixed is to provide a reduced test case. This [Code
 
 ## Specifications
 
-- Are you using the React components? (Y/N):
-- Polaris version number:
-- Browser:
-- Device:
-- Operating System:
+Run `npx envinfo --system --binaries --browsers --npmPackages react,react-dom,@shopify/polaris`
+
+Paste the results here:
+
+```bash
+
+```

--- a/.github/ISSUE_TEMPLATE/ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE.md
@@ -41,7 +41,7 @@ The best way to get your bug fixed is to provide a reduced test case. This [Code
 
 ## Specifications
 
-Run `npx envinfo --system --binaries --browsers --npmPackages react,react-dom,@shopify/polaris`
+Run `npx envinfo --system --binaries --browsers --npmPackages react,react-dom,@shopify/polaris` to provide specifications on your environment including version numbers, browser, device, and operating system.
 
 Paste the results here:
 


### PR DESCRIPTION
### WHY are these changes introduced?

envinfo: https://github.com/tabrindle/envinfo

I believe this will make life easier for everybody. Here's an example of the result from the command:

```
❯ npx envinfo --system --binaries --browsers --npmPackages react,react-dom,@shopify/polaris
npx: installed 1 in 1.356s

  System:
    OS: macOS 10.14.3
    CPU: (8) x64 Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
    Memory: 242.77 MB / 16.00 GB
    Shell: 3.0.2 - /usr/local/bin/fish
  Binaries:
    Node: 10.15.0 - ~/.nvm/versions/node/v10.15.0/bin/node
    Yarn: 1.10.1 - ~/.dev/yarn/1.10.1/bin/yarn
    npm: 6.4.1 - ~/.nvm/versions/node/v10.15.0/bin/npm
    Watchman: 4.9.0 - /usr/local/bin/watchman
  Browsers:
    Chrome: 73.0.3683.75
    Chrome Canary: 75.0.3734.0
    Firefox: 63.0.3
    Safari: 12.0.3
  npmPackages:
    @shopify/polaris: ^3.9.0 => 3.9.0 
    react: ^16.8.2 => 16.8.2 
    react-dom: ^16.8.2 => 16.8.2 
```

We could also suggest to ask a preset in `envinfo` (see https://github.com/tabrindle/envinfo/blob/master/src/presets.js). Which will give an even smaller command to run.