### PR TITLE
[TextField] Fix the spinner buttons behaviour when readOnly

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixed unnecessary height on `TextField` due to unhandled carriage returns ([#901](https://github.com/Shopify/polaris-react/pull/901))
 - Ensured server side rendering matches client side rendering for [embedded app components](https://github.com/Shopify/polaris-react/blob/master/documentation/Embedded%20apps.md#components-which-wrap-shopify-app-bridge) ([#976](https://github.com/Shopify/polaris-react/pull/976))
+- Fixed rendering of the spinner on `TextField` when setting to readOnly ([#1118](https://github.com/Shopify/polaris-react/pull/1199))
 
 ### Documentation
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -253,7 +253,7 @@ class TextField extends React.PureComponent<CombinedProps, State> {
     ) : null;
 
     const spinnerMarkup =
-      type === 'number' && !disabled ? (
+      type === 'number' && !disabled && !readOnly ? (
         <Spinner
           onChange={this.handleNumberChange}
           onMouseDown={this.handleButtonPress}

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -580,6 +580,19 @@ describe('<TextField />', () => {
         expect(buttons).toHaveLength(0);
       });
 
+      it('removes increment and decrement buttons when readOnly', () => {
+        const element = mountWithAppProvider(
+          <TextField
+            id="MyNumberField"
+            label="NumberField"
+            type="number"
+            readOnly
+          />,
+        );
+        const buttons = element.find('[role="button"]');
+        expect(buttons).toHaveLength(0);
+      });
+
       it('increments by step when value, step, or both are float numbers', () => {
         const spy = jest.fn();
         const element = mountWithAppProvider(

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {noop} from '@shopify/javascript-utilities/other';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import {InlineError, Labelled, Connected, Select} from 'components';
-import {Resizer} from '../components';
+import {Resizer, Spinner} from '../components';
 import TextField from '../TextField';
 
 describe('<TextField />', () => {
@@ -589,8 +589,7 @@ describe('<TextField />', () => {
             readOnly
           />,
         );
-        const buttons = element.find('[role="button"]');
-        expect(buttons).toHaveLength(0);
+        expect(element.find(Spinner)).toHaveLength(0);
       });
 
       it('increments by step when value, step, or both are float numbers', () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Resolves #1118 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Add a condition to not render the spinner buttons on TextField when readOnly is 'true' and type is 'number'
- Add a test to confirm the spinner buttons are not rendering when type='number' and readOnly is 'true'
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
