### PR TITLE
Revert "Merge pull request #1082 from Shopify/card-subdued-spacing"

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed unnecessary height on `TextField` due to unhandled carriage returns ([#901](https://github.com/Shopify/polaris-react/pull/901))
+- Reverted a change that adjusted padding in the `Card` component introduced in ([#1205](https://github.com/Shopify/polaris-react/pull/1205))
 
 ### Documentation
 

--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -42,11 +42,6 @@
 
 .Section-subdued {
   background-color: color('sky', 'lighter');
-
-  .Header + & {
-    border-top: border-width() solid color('sky');
-    margin-top: spacing(loose);
-  }
 }
 
 .SectionHeader {
@@ -70,10 +65,5 @@
 
   @include page-content-when-not-fully-condensed {
     padding: 0 spacing(loose) spacing(loose);
-  }
-
-  .Section-subdued + & {
-    border-top: border-width() solid color('sky');
-    padding: spacing(loose);
   }
 }


### PR DESCRIPTION
#1082 is causing regressions, for example #1204
