### PR TITLE
[Banner] Add focus method

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added a public `focus` method on `Banner` ([#1219](https://github.com/Shopify/polaris-react/pull/1219))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -43,6 +43,11 @@ export interface Props {
 
 export default class Banner extends React.PureComponent<Props, never> {
   static contextTypes = contentContextTypes;
+  private wrapper = React.createRef<HTMLDivElement>();
+
+  public focus() {
+    this.wrapper.current && this.wrapper.current.focus();
+  }
 
   render() {
     const {
@@ -154,6 +159,7 @@ export default class Banner extends React.PureComponent<Props, never> {
         className={className}
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}
+        ref={this.wrapper}
         role={ariaRoleType}
         aria-live="polite"
         onMouseUp={handleMouseUp}

--- a/src/components/Banner/README.md
+++ b/src/components/Banner/README.md
@@ -500,6 +500,38 @@ class ModalExample extends React.Component {
 }
 ```
 
+### Banner with focus
+
+<!-- example-for: web -->
+
+Banner with focus receives focus programmatically when it appears. Use this component to communicate problems that merchants need to resolve before they can complete a task.
+
+```jsx
+class ModalExample extends React.Component {
+  banner = React.createRef();
+
+  componentDidMount() {
+    this.banner.current.focus();
+  }
+
+  render() {
+    return (
+      <Banner
+        title="High risk of fraud detected"
+        onDismiss={() => {}}
+        status="critical"
+        ref={this.banner}
+      >
+        <p>
+          Before fulfilling this order or capturing payment, please review the
+          fraud analysis and determine if this order is fraudulent
+        </p>
+      </Banner>
+    );
+  }
+}
+```
+
 ### Banner in a card
 
 <!-- example-for: web -->

--- a/src/components/Banner/README.md
+++ b/src/components/Banner/README.md
@@ -504,7 +504,7 @@ class ModalExample extends React.Component {
 
 <!-- example-for: web -->
 
-Banner with focus receives focus programmatically when it appears. Use this component to communicate problems that merchants need to resolve before they can complete a task.
+Banner can programmatically receive focus. Use this functionality to draw the merchant's attention to the banner.
 
 ```jsx
 class ModalExample extends React.Component {

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider} from 'test-utilities';
 import {
   CirclePlusMinor,
@@ -113,5 +114,27 @@ describe('<Banner />', () => {
   it('renders a slim button with contentContext', () => {
     const button = bannerWithContentContext.find(Button);
     expect(button.prop('size')).toBe('slim');
+  });
+
+  describe('focus', () => {
+    it('exposes a function that allows the banner to be programmatically focused', () => {
+      class Test extends React.Component {
+        banner = React.createRef<any>();
+
+        componentDidMount() {
+          this.banner.current.focus();
+        }
+
+        render() {
+          return <Banner ref={this.banner} status="critical" />;
+        }
+      }
+
+      const div = mountWithAppProvider(<Test />)
+        .find('div')
+        .filterWhere((element: ReactWrapper) => element.prop('tabIndex') === 0);
+
+      expect(div.getDOMNode()).toBe(document.activeElement);
+    });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

There are use cases in web where banner's need to be focused


### WHAT is this pull request doing?

Adding a function so Banner can focus itself

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {react} from 'babel-types';
import {Page, Banner, Button} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  node = React.createRef();

  render() {
    return (
      <Page title="Playground">
        <Banner title="Order archived" onDismiss={() => {}} ref={this.node}>
          <p>This order was archived on March 7, 2017 at 3:12pm EDT.</p>
        </Banner>
        <Button onClick={() => this.node.current && this.node.current.focus()}>
          Mr.Focus
        </Button>
      </Page>
    );
  }
}

```

</details>
