### PR TITLE
[Tabs] Remove componentWillReceiveProps

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -28,6 +28,7 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 
 ### Code quality
 
-Removed an unneeded media query from Modal's `Header` component ([#1272](https://github.com/Shopify/polaris-react/pull/1272))
+- Updated `Tabs` to no longer use `componentWillReceiveProps`([#1221](https://github.com/Shopify/polaris-react/pull/1221))
+- Removed an unneeded media query from Modal's `Header` component ([#1272](https://github.com/Shopify/polaris-react/pull/1272))
 
 ### Deprecations

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -39,6 +39,23 @@ export interface State {
 export default class Tabs extends React.PureComponent<Props, State> {
   static Panel = Panel;
 
+  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+    const {disclosureWidth, tabWidths, containerWidth} = prevState;
+    const {visibleTabs, hiddenTabs} = getVisibleAndHiddenTabIndices(
+      nextProps.tabs,
+      nextProps.selected,
+      disclosureWidth,
+      tabWidths,
+      containerWidth,
+    );
+
+    return {
+      visibleTabs,
+      hiddenTabs,
+      selected: nextProps.selected,
+    };
+  }
+
   state: State = {
     disclosureWidth: 0,
     containerWidth: Infinity,
@@ -48,25 +65,6 @@ export default class Tabs extends React.PureComponent<Props, State> {
     showDisclosure: false,
     tabToFocus: -1,
   };
-
-  componentWillReceiveProps(nextProps: Props) {
-    const {selected} = this.props;
-    const {disclosureWidth, tabWidths, containerWidth, tabToFocus} = this.state;
-    const {visibleTabs, hiddenTabs} = getVisibleAndHiddenTabIndices(
-      nextProps.tabs,
-      nextProps.selected,
-      disclosureWidth,
-      tabWidths,
-      containerWidth,
-    );
-
-    this.setState({
-      visibleTabs,
-      hiddenTabs,
-      tabToFocus: selected === nextProps.selected ? -1 : tabToFocus,
-      showDisclosure: false,
-    });
-  }
 
   render() {
     const {tabs, selected, fitted, children} = this.props;

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -229,17 +229,6 @@ describe('<Tabs />', () => {
       expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(-1);
     });
 
-    it('resets focus when selected gets updated to the previously selected value', () => {
-      const tabs = mountWithAppProvider(
-        <Tabs {...mockProps} selected={0} tabs={mockTabs} />,
-      );
-      trigger(tabs.find('ul'), 'onKeyUp', {
-        key: 'ArrowRight',
-      });
-      tabs.setProps({selected: 0});
-      expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(-1);
-    });
-
     it('passes the provided selected value if given', () => {
       const tabs = mountWithAppProvider(
         <Tabs {...mockProps} selected={1} tabs={mockTabs} />,


### PR DESCRIPTION
### WHY are these changes introduced?

Removes a deprecated lifecycle method

### WHAT is this pull request doing?

* Makes use of `getDerivedStateFromProps`
* Doesn't close the disclosure everytime props are changed
* Doesn't removed focus outline when a tab is selected from the disclosure

### How to 🎩

Checkout the tabs examples  at different screen sizes
