### PR TITLE
[Link] Warn users when links open in a new window

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added an icon and screen reader hint when `Link` opens a new tab ([#1142](https://github.com/Shopify/polaris-react/pull/1247))
+
 ### Bug fixes
 
 - Fixed Search overlay stretching below the viewport

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -1,4 +1,5 @@
 .Link {
+  @include recolor-icon(currentColor);
   appearance: none;
   display: inline;
   text-align: inherit;
@@ -15,6 +16,23 @@
   &:active {
     outline: none;
     color: color('blue', 'dark');
+  }
+}
+
+.IconLockup {
+  display: inline;
+  white-space: nowrap;
+
+  &::before {
+    content: '\2060';
+  }
+}
+
+.IconLayout {
+  display: inline-flex;
+
+  &::before {
+    content: '\2060';
   }
 }
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 
 import {classNames} from '@shopify/react-utilities';
+import {ExternalSmallMinor} from '@shopify/polaris-icons';
 
+import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import UnstyledLink from '../UnstyledLink';
+import Icon from '../Icon';
 
 import styles from './Link.scss';
 
@@ -22,16 +25,37 @@ export interface BaseProps {
 }
 
 export interface Props extends BaseProps {}
+export type CombinedProps = Props & WithAppProviderProps;
 
-export default function Link({
+function Link({
   url,
   children,
   onClick,
   external,
   id,
   monochrome,
-}: Props) {
+  polaris,
+}: CombinedProps) {
   const className = classNames(styles.Link, monochrome && styles.monochrome);
+  let childrenMarkup = children;
+
+  if (external && typeof children === 'string') {
+    const iconLabel = polaris.intl.translate(
+      'Polaris.Common.newWindowAccessibilityHint',
+    );
+
+    childrenMarkup = (
+      <React.Fragment>
+        {children}
+        <span className={styles.IconLockup}>
+          <span className={styles.IconLayout}>
+            <Icon accessibilityLabel={iconLabel} source={ExternalSmallMinor} />
+          </span>
+        </span>
+      </React.Fragment>
+    );
+  }
+
   return url ? (
     <UnstyledLink
       onClick={onClick}
@@ -39,12 +63,15 @@ export default function Link({
       url={url}
       external={external}
       id={id}
+      polaris={polaris}
     >
-      {children}
+      {childrenMarkup}
     </UnstyledLink>
   ) : (
     <button type="button" onClick={onClick} className={className} id={id}>
-      {children}
+      {childrenMarkup}
     </button>
   );
 }
+
+export default withAppProvider<Props>()(Link);

--- a/src/components/Link/README.md
+++ b/src/components/Link/README.md
@@ -92,6 +92,16 @@ Use for text links that are the same color as the surrounding text.
 </Link>
 ```
 
+### External link
+
+Use for text links that point to a different website. They will open in a new browser tab or window.
+
+```jsx
+<Link url="https://help.shopify.com/manual" external>
+  Shopify Help Center
+</Link>
+```
+
 ---
 
 ## Related components

--- a/src/components/Link/tests/Link.test.tsx
+++ b/src/components/Link/tests/Link.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
-import {UnstyledLink} from 'components';
+import {UnstyledLink, Icon} from 'components';
+import en from '../../../locales/en.json';
 import Link from '../Link';
 
 describe('<Link />', () => {
@@ -36,6 +37,48 @@ describe('<Link />', () => {
         <Link url="https://shopify.com" id={id} />,
       );
       expect(link.find(UnstyledLink).prop('id')).toBe(id);
+    });
+  });
+
+  describe('external link', () => {
+    it('has a trailing icon', () => {
+      const link = mountWithAppProvider(
+        <Link url="https://help.shopify.com/" external>
+          Shopify Help Center
+        </Link>,
+      );
+      expect(
+        link
+          .children()
+          .last()
+          .find(Icon)
+          .exists(),
+      ).toBe(true);
+    });
+
+    it('informs screen readers that it opens in a new window', () => {
+      const link = mountWithAppProvider(
+        <Link url="https://help.shopify.com/" external>
+          Shopify Help Center
+        </Link>,
+      );
+      const hintText = en.Polaris.Common.newWindowAccessibilityHint;
+      expect(
+        link
+          .children()
+          .last()
+          .find(Icon)
+          .prop('accessibilityLabel'),
+      ).toBe(hintText);
+    });
+
+    it('doesn’t have a trailing icon for non-string children', () => {
+      const link = mountWithAppProvider(
+        <Link url="https://help.shopify.com/" external>
+          <span>Shopify Help Center</span>
+        </Link>,
+      );
+      expect(link.find(Icon).exists()).toBe(false);
     });
   });
 });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -31,7 +31,8 @@
     "Common": {
       "checkbox": "checkbox",
       "undo": "Undo",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "newWindowAccessibilityHint": "(opens a new window)"
     },
 
     "ContextualSaveBar": {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes Shopify/polaris-ux#146 

### WHAT is this pull request doing?

This PR takes the position that we should automatically do the right thing for accessibility whenever possible. It automatically adds screen reader text and an icon when the `external` prop is `true`.

Unfortunately, implementation is complicated by CSS things, historical things, and international things (see comments below).

**I’m looking for comments on this approach before going any further.**

### How to 🎩

- The icon will be blank when tophatting—we’re waiting on the correct icon to be available (should be in the next release of Polaris Icons).
- Change the viewport width to make sure the icon wraps with the last word in the link, never on its own.

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Link, TextContainer} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <TextContainer>
          <p>
            This is some sample text to make the paragraph longer, in order to
            test text wrapping. Links to external sites, like the{' '}
            <Link url="https://help.shopify.com/manual" external>
              Shopify Help Center
            </Link>
            , have a trailing icon and open in a new browser tab.
          </p>
          <p>
            これはテキストの折り返しをテストするために段落を長くするためのサンプルテキストです。{' '}
            <Link url="https://help.shopify.com/manual" external>
              Andersonヘルプセンター
            </Link>
            などの外部サイトへのリンクには末尾のアイコンがあり、新しいブラウザタブで開きます。
          </p>
        </TextContainer>
      </Page>
    );
  }
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
