### PR TITLE
[Popover] add support for lazy loading

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added a public `focus` method on `Banner` ([#1219](https://github.com/Shopify/polaris-react/pull/1219))
+- Added an `onScrollToBottom` prop to `Popover.Pane` ([#1248](https://github.com/Shopify/polaris-react/pull/1248))
 
 ### Bug fixes
 

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -289,6 +289,111 @@ class PopoverFormExample extends React.Component {
 }
 ```
 
+### Popover with lazy loaded list
+
+<!-- example-for: web -->
+
+Use to present merchants with a list that dynamically loads more items on scroll or arrow down.
+
+```jsx
+class PopoverLazyLoadExample extends React.Component {
+  state = {
+    visibleStaffIndex: 5,
+    active: true,
+  };
+
+  staff = [
+    'Abbey Mayert',
+    'Abbi Senger',
+    'Abdul Goodwin',
+    'Abdullah Borer',
+    'Abe Nader',
+    'Abigayle Smith',
+    'Abner Torphy',
+    'Abraham Towne',
+    'Abraham Vik',
+    'Ada Fisher',
+    'Adah Pouros',
+    'Adam Waelchi',
+    'Adan Zemlak',
+    'Addie Wehner',
+    'Addison Wexler',
+    'Alex Hernandez',
+  ];
+
+  render() {
+    const {active, visibleStaffIndex} = this.state;
+
+    const activator = (
+      <Button onClick={this.togglePopover} disclosure>
+        View staff
+      </Button>
+    );
+
+    const staffList = this.staff.slice(0, visibleStaffIndex).map((name) => ({
+      name,
+      initials: this.getInitials(name),
+    }));
+
+    return (
+      <Card sectioned>
+        <div style={{height: '280px'}}>
+          <Popover
+            sectioned
+            active={active}
+            activator={activator}
+            onClose={this.togglePopover}
+          >
+            <Popover.Pane onScrolledToBottom={this.handleScrolledToBottom}>
+              <ResourceList items={staffList} renderItem={this.renderItem} />
+            </Popover.Pane>
+          </Popover>
+        </div>
+      </Card>
+    );
+  }
+
+  handleScrolledToBottom = () => {
+    const {visibleStaffIndex} = this.state;
+    const totalIndexes = this.staff.length;
+    const interval =
+      visibleStaffIndex + 3 < totalIndexes
+        ? 3
+        : totalIndexes - visibleStaffIndex;
+
+    if (interval > 0) {
+      this.setState({visibleStaffIndex: visibleStaffIndex + interval});
+    }
+  };
+
+  togglePopover = () => {
+    this.setState(({active}) => {
+      return {active: !active};
+    });
+  };
+
+  renderItem = ({name, initials}) => {
+    return (
+      <ResourceList.Item
+        id={name}
+        media={<Avatar size="medium" name={name} initials={initials} />}
+      >
+        {name}
+      </ResourceList.Item>
+    );
+  };
+
+  getInitials = (name) => {
+    return name
+      .split(' ')
+      .map((surnameOrFamilyName) => {
+        return surnameOrFamilyName.slice(0, 1);
+      })
+      .join('');
+  };
+}
+```
+
 ### Action sheet
 
 <!-- example-for: ios -->

--- a/src/components/Popover/components/Pane/Pane.tsx
+++ b/src/components/Popover/components/Pane/Pane.tsx
@@ -8,20 +8,34 @@ import Section from '../Section';
 import styles from '../../Popover.scss';
 
 export interface Props {
+  /** Fix the pane to the top of the popover */
   fixed?: boolean;
+  /** Automatically wrap children in padded sections */
   sectioned?: boolean;
+  /** The pane content */
   children?: React.ReactNode;
+  /** Callback when the bottom of the popover is reached by mouse or keyboard  */
+  onScrolledToBottom?(): void;
 }
 
-export default function Pane({fixed, sectioned, children}: Props) {
+export default function Pane({
+  fixed,
+  sectioned,
+  children,
+  onScrolledToBottom,
+}: Props) {
   const className = classNames(styles.Pane, fixed && styles['Pane-fixed']);
-
   const content = sectioned ? wrapWithComponent(children, Section) : children;
 
   return fixed ? (
     <div className={className}>{content}</div>
   ) : (
-    <Scrollable hint shadow className={className}>
+    <Scrollable
+      hint
+      shadow
+      className={className}
+      onScrolledToBottom={onScrolledToBottom}
+    >
       {content}
     </Scrollable>
   );

--- a/src/components/Popover/components/Pane/tests/Pane.test.tsx
+++ b/src/components/Popover/components/Pane/tests/Pane.test.tsx
@@ -1,40 +1,110 @@
 import * as React from 'react';
-import {mountWithAppProvider} from 'test-utilities';
 import {TextContainer, Scrollable} from 'components';
+import {mountWithAppProvider, trigger} from 'test-utilities';
 import Pane from '../Pane';
+import Section from '../../Section';
 
 describe('<Pane />', () => {
-  it('renders its children', () => {
-    const children = (
-      <TextContainer>
-        <p>Content</p>
-      </TextContainer>
-    );
-    const pane = mountWithAppProvider(<Pane>{children}</Pane>);
+  describe('fixed', () => {
+    it('does not render content in a Scrollable when set to true', async () => {
+      const children = () => (
+        <TextContainer>
+          <p>Text</p>
+        </TextContainer>
+      );
 
-    expect(pane.contains(children)).toBe(true);
+      const popoverPane = await mountWithAppProvider(
+        <Pane fixed>{children}</Pane>,
+      );
+
+      expect(popoverPane.find(Scrollable)).toHaveLength(0);
+    });
+
+    it('renders content in a Scrollable when set to false', async () => {
+      const children = () => (
+        <TextContainer>
+          <p>Text</p>
+        </TextContainer>
+      );
+
+      const popoverPane = await mountWithAppProvider(
+        <Pane fixed={false}>{children}</Pane>,
+      );
+
+      expect(popoverPane.find(Scrollable)).toHaveLength(1);
+    });
+
+    it('renders content in a Scrollable when unset', async () => {
+      const children = () => (
+        <TextContainer>
+          <p>Text</p>
+        </TextContainer>
+      );
+
+      const popoverPane = await mountWithAppProvider(<Pane>{children}</Pane>);
+
+      expect(popoverPane.find(Scrollable)).toHaveLength(1);
+    });
   });
 
-  it('renders a div if fixed', () => {
-    const children = (
-      <TextContainer>
-        <p>Content</p>
-      </TextContainer>
-    );
-    const pane = mountWithAppProvider(<Pane fixed>{children}</Pane>);
+  describe('sectioned', () => {
+    it('renders children in a Section when set to true', async () => {
+      const children = () => (
+        <TextContainer>
+          <p>Text</p>
+        </TextContainer>
+      );
 
-    expect(pane.find('div').exists()).toBe(true);
-    expect(pane.find(Scrollable).exists()).toBe(false);
+      const popoverPane = await mountWithAppProvider(
+        <Pane sectioned>{children}</Pane>,
+      );
+
+      expect(popoverPane.find(Section)).toHaveLength(1);
+    });
+
+    it('does not render content in a Section when set to false', async () => {
+      const children = () => (
+        <TextContainer>
+          <p>Text</p>
+        </TextContainer>
+      );
+
+      const popoverPane = await mountWithAppProvider(
+        <Pane sectioned={false}>{children}</Pane>,
+      );
+
+      expect(popoverPane.find(Section)).toHaveLength(0);
+    });
+
+    it('does not render content in a Section when unset', async () => {
+      const children = () => (
+        <TextContainer>
+          <p>Text</p>
+        </TextContainer>
+      );
+
+      const popoverPane = await mountWithAppProvider(<Pane>{children}</Pane>);
+
+      expect(popoverPane.find(Section)).toHaveLength(0);
+    });
   });
 
-  it('renders Scrollable if not fixed', () => {
-    const children = (
-      <TextContainer>
-        <p>Content</p>
-      </TextContainer>
-    );
-    const pane = mountWithAppProvider(<Pane>{children}</Pane>);
+  describe('onScrolledToBottom', () => {
+    it('is set on the Scrollable when provided', async () => {
+      const onScrolledToBottom = jest.fn();
+      const children = () => (
+        <TextContainer>
+          <p>Text</p>
+        </TextContainer>
+      );
 
-    expect(pane.find(Scrollable).exists()).toBe(true);
+      const popoverPane = await mountWithAppProvider(
+        <Pane onScrolledToBottom={onScrolledToBottom}>{children}</Pane>,
+      );
+
+      trigger(popoverPane.find(Scrollable).first(), 'onScrolledToBottom');
+
+      expect(onScrolledToBottom).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Part one of two for fixing #1246 

### WHAT is this pull request doing?

Adds an `onScrolledToBottom` prop to the `Popover.Pane` that gets set on the pane's `Scrollable`.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
state = {
    visibleStaffIndex: 5,
    active: false,
  };

  staff = [
    'Abbey Mayert',
    'Abbi Senger',
    'Abdul Goodwin',
    'Abdullah Borer',
    'Abe Nader',
    'Abigayle Smith',
    'Abner Torphy',
    'Abraham Towne',
    'Abraham Vik',
    'Ada Fisher',
    'Adah Pouros',
    'Adam Waelchi',
    'Adan Zemlak',
    'Addie Wehner',
    'Addison Wexler',
    'Alex Hernandez',
  ];

  render() {
    const {visibleStaffIndex} = this.state;

    const activator = (
      <Button onClick={this.togglePopover} disclosure>
        View staff
      </Button>
    );

    const staffList = this.staff.slice(0, visibleStaffIndex).map((name) => ({
      name,
      initials: this.getInitials(name),
    }));

    return (
      <Card sectioned>
        <Popover
          sectioned
          active={this.state.active}
          activator={activator}
          onClose={this.togglePopover}
        >
          <Popover.Pane onScrolledToBottom={this.handleScrolledToBottom}>
            <ResourceList items={staffList} renderItem={this.renderItem} />
          </Popover.Pane>
        </Popover>
      </Card>
    );
  }

  handleScrolledToBottom = () => {
    const {visibleStaffIndex} = this.state;
    const totalIndexes = this.staff.length;
    const interval =
      visibleStaffIndex + 3 < totalIndexes
        ? 3
        : totalIndexes - visibleStaffIndex;

    if (interval > 0) {
      this.setState({visibleStaffIndex: visibleStaffIndex + interval});
    }
  };

  togglePopover = () => {
    this.setState(({active}) => {
      return {active: !active};
    });
  };

  renderItem = ({name, initials}) => {
    return (
      <ResourceList.Item
        id={name}
        media={<Avatar size="medium" name={name} initials={initials} />}
      >
        {name}
      </ResourceList.Item>
    );
  };

  getInitials = (name) => {
    return name
      .split(' ')
      .map((surnameOrFamilyName) => {
        return surnameOrFamilyName.slice(0, 1);
      })
      .join('');
  };
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
