### PR TITLE
[ThemeProvider] Remove componentWillReceiveProps

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -23,6 +23,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Code quality
 
 - Updated `AppProvider` to no longer use `componentWillReceiveProps`([#1255](https://github.com/Shopify/polaris-react/pull/1255))
+- Updated `ThemeProvider` to no longer use `componentWillReceiveProps`([#1254](https://github.com/Shopify/polaris-react/pull/1254))
 - Upgraded the `Banner`, `Card`, and `Modal` components from legacy context API to use createContext ([#786](https://github.com/Shopify/polaris-react/pull/786))
 - Refactored `Frame` and its subcomponents to use the `createContext` API instead of legacy context ([#803](https://github.com/Shopify/polaris-react/pull/803))
 

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -3,6 +3,11 @@ import isEqual from 'lodash/isEqual';
 import {setColors} from './utils';
 import {Theme, ThemeProviderContext, THEME_CONTEXT_TYPES} from './types';
 
+export interface State {
+  theme: Theme;
+  colors: string[][] | undefined;
+}
+
 export interface Props {
   /** Custom logos and colors provided to select components */
   theme: Theme;
@@ -16,41 +21,48 @@ const defaultTheme = {
   '--top-bar-background-lighter': '#1d9ba4',
 };
 
-export default class ThemeProvider extends React.Component<Props> {
+export default class ThemeProvider extends React.Component<Props, State> {
   static childContextTypes = THEME_CONTEXT_TYPES;
-  public themeContext: ThemeProviderContext;
   private subscriptions: {(): void}[] = [];
-  private colors: string[][] | undefined;
 
   constructor(props: Props) {
     super(props);
 
-    this.themeContext = setThemeContext(
-      this.props.theme,
-      this.subscribe,
-      this.unsubscribe,
-    );
-
-    this.colors = setColors(props.theme);
+    const {theme} = this.props;
+    this.state = {
+      theme: setThemeContext(theme),
+      colors: setColors(theme),
+    };
   }
 
-  componentWillReceiveProps({theme}: Props) {
-    if (isEqual(theme, this.props.theme)) {
+  componentDidUpdate({theme: prevTheme}: Props) {
+    const {theme} = this.props;
+    if (isEqual(prevTheme, theme)) {
       return;
     }
 
-    this.themeContext = setThemeContext(
-      theme,
-      this.subscribe,
-      this.unsubscribe,
-    );
+    // eslint-disable-next-line react/no-did-update-set-state
+    this.setState({
+      theme: setThemeContext(theme),
+      colors: setColors(theme),
+    });
 
     this.subscriptions.forEach((subscriberCallback) => subscriberCallback());
-    this.colors = setColors(theme);
   }
 
-  getChildContext() {
-    return this.themeContext;
+  getChildContext(): ThemeProviderContext {
+    const {
+      theme: {logo = null, ...rest},
+    } = this.state;
+
+    return {
+      polarisTheme: {
+        ...rest,
+        logo,
+        subscribe: this.subscribe,
+        unsubscribe: this.unsubscribe,
+      },
+    };
   }
 
   render() {
@@ -70,20 +82,14 @@ export default class ThemeProvider extends React.Component<Props> {
   };
 
   createStyles() {
-    return this.colors
-      ? this.colors.reduce(
-          (state, [key, value]) => ({...state, [key]: value}),
-          {},
-        )
+    const {colors} = this.state;
+    return colors
+      ? colors.reduce((state, [key, value]) => ({...state, [key]: value}), {})
       : null;
   }
 }
 
-function setThemeContext(
-  ctx: Theme,
-  subscribe: (callback: () => void) => void,
-  unsubscribe: (callback: () => void) => void,
-): ThemeProviderContext {
-  const {colors, logo = null, ...rest} = ctx;
-  return {polarisTheme: {logo, subscribe, unsubscribe, ...rest}};
+function setThemeContext(ctx: Theme): Theme {
+  const {colors, ...theme} = ctx;
+  return {...theme};
 }

--- a/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -96,4 +96,37 @@ describe('<ThemeProvider />', () => {
       '--top-bar-color': 'rgb(255, 255, 255)',
     });
   });
+
+  it('updates themes', () => {
+    const wrapper = mountWithAppProvider(
+      <ThemeProvider
+        theme={{
+          colors: {
+            topBar: {
+              background: '#108043',
+            },
+          },
+        }}
+      >
+        <p />
+      </ThemeProvider>,
+    );
+
+    wrapper.setProps({
+      theme: {
+        colors: {
+          topBar: {
+            background: '#021123',
+          },
+        },
+      },
+    });
+    wrapper.update();
+
+    expect(wrapper.find('div').props().style).toEqual({
+      '--top-bar-background': '#021123',
+      '--top-bar-background-lighter': 'hsl(213, 74%, 22%, 1)',
+      '--top-bar-color': 'rgb(255, 255, 255)',
+    });
+  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Remove deprecated lifecycle methods. This is in preparation for using the new context api.

### WHAT is this pull request doing?

Storing context on state, getChildContext will be ran every time state changes and making use of componentDidUpdate.

### How to 🎩

* try out theming examples
* https://github.com/Shopify/polaris-react-deprecated/pull/1947 has quite a few playgrounds from when the theme provider was originally added

</details>
