### PR TITLE
[AppProvider] Remove componentWillReceiveProps

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Code quality
 
+- Updated `AppProvider` to no longer use `componentWillReceiveProps`([#1255](https://github.com/Shopify/polaris-react/pull/1255))
 - Upgraded the `Banner`, `Card`, and `Modal` components from legacy context API to use createContext ([#786](https://github.com/Shopify/polaris-react/pull/786))
 - Refactored `Frame` and its subcomponents to use the `createContext` API instead of legacy context ([#803](https://github.com/Shopify/polaris-react/pull/803))
 

--- a/src/components/AppProvider/tests/AppProvider.test.tsx
+++ b/src/components/AppProvider/tests/AppProvider.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import TestUtils from 'react-dom/test-utils';
+import {mount} from 'enzyme';
 import {createThemeContext} from '../../ThemeProvider';
 import {StickyManager, createAppProviderContext} from '../utilities';
 import {polarisAppProviderContextTypes} from '../types';
@@ -49,5 +50,32 @@ describe('<AppProvider />', () => {
 
     // https://github.com/facebook/jest/issues/1772
     expect(JSON.stringify(child.context)).toBe(JSON.stringify(context));
+  });
+
+  it('updates polaris context when props change', () => {
+    const CustomLinkComponent = () => {
+      return <a href="test">Custom Link Component</a>;
+    };
+
+    // eslint-disable-next-line react/prefer-stateless-function
+    class Child extends React.Component {
+      static contextTypes = polarisAppProviderContextTypes;
+
+      render() {
+        return <div />;
+      }
+    }
+
+    const wrapper = mount(
+      <AppProvider>
+        <Child />
+      </AppProvider>,
+    );
+
+    wrapper.setProps({linkComponent: CustomLinkComponent});
+
+    expect(
+      wrapper.find(Child).instance().context.polaris.link.linkComponent,
+    ).toBe(CustomLinkComponent);
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Remove deprecated lifecycle methods. This is in preparation for using the new context api.

### WHAT is this pull request doing?

Storing context on state, getChildContext will be ran every time state changes and making use of componentDidUpdate.

### How to 🎩

* storybook has some good examples 👍 