### PR TITLE
[FilterControl] Adds placeholder prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added a public `focus` method on `Banner` ([#1219](https://github.com/Shopify/polaris-react/pull/1219))
 - Added an `onScrollToBottom` prop to `Popover.Pane` ([#1248](https://github.com/Shopify/polaris-react/pull/1248))
 
+- Added a `placeholder` prop to `FilterControl` ([#1257](https://github.com/Shopify/polaris-react/pull/1257))
+
 ### Bug fixes
 
 - Fixed disabled states while loading for `ResourceList` ([#1237](https://github.com/Shopify/polaris-react/pull/1237))

--- a/src/components/ResourceList/components/FilterControl/FilterControl.tsx
+++ b/src/components/ResourceList/components/FilterControl/FilterControl.tsx
@@ -23,6 +23,7 @@ export interface Props {
   additionalAction?: ComplexAction;
   focused?: boolean;
   filters?: Filter[];
+  placeholder?: string;
   onSearchBlur?(): void;
   onSearchChange(searchValue: string, id: string): void;
   onFiltersChange?(appliedFilters: AppliedFilter[]): void;
@@ -40,18 +41,18 @@ export class FilterControl extends React.Component<CombinedProps> {
       additionalAction,
       focused = false,
       filters = [],
+      placeholder,
       onSearchBlur,
       onSearchChange,
       polaris: {intl},
       context: {selectMode, resourceName},
     } = this.props;
 
-    const textFieldLabel = intl.translate(
-      'Polaris.ResourceList.FilterControl.textFieldLabel',
-      {
-        resourceNamePlural: resourceName.plural.toLocaleLowerCase(),
-      },
-    );
+    const textFieldLabel = placeholder
+      ? placeholder
+      : intl.translate('Polaris.ResourceList.FilterControl.textFieldLabel', {
+          resourceNamePlural: resourceName.plural.toLocaleLowerCase(),
+        });
 
     if (additionalAction) {
       additionalAction.disabled = selectMode;

--- a/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
@@ -22,7 +22,7 @@ describe('<FilterControl />', () => {
     selectMode: false,
     resourceName: {
       singular: 'item',
-      plural: 'items,',
+      plural: 'items',
     },
     selectable: false,
   };
@@ -633,6 +633,37 @@ describe('<FilterControl />', () => {
 
       expect(filterControl.find(FilterCreator).prop('filters')).toMatchObject(
         mockFilters,
+      );
+    });
+  });
+
+  describe('placeholder', () => {
+    it('renders default text if no placeholder passed.', () => {
+      const filterControl = mountWithAppProvider(
+        <Provider value={mockDefaultContext}>
+          <FilterControl {...mockDefaultProps} filters={mockFilters} />
+        </Provider>,
+      );
+
+      expect(filterControl.find(TextField).prop('placeholder')).toBe(
+        'Search items',
+      );
+    });
+
+    it('renders the placeholder prop value if provided', () => {
+      const placeholder = 'Search by name, email or phone';
+      const filterControl = mountWithAppProvider(
+        <Provider value={mockDefaultContext}>
+          <FilterControl
+            {...mockDefaultProps}
+            filters={mockFilters}
+            placeholder={placeholder}
+          />
+        </Provider>,
+      );
+
+      expect(filterControl.find(TextField).prop('placeholder')).toBe(
+        'Search by name, email or phone',
       );
     });
   });


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1256 <!-- link to issue if one exists -->

Currently the `FilterControl` component will use the `resourceName.plural` as the placeholder to the `TextField`. This PR adds a `placeholder` prop to `FilterControl` to allow users to have a custom placeholder.

### WHAT is this pull request doing?

I added an optional `placeholder` prop to the `FilterControl` component. If passed the `placeholder` on the `TextField` will use the value provided, if not passed it will default to the `resourceName.plural` value.

I also removed a `,` from the `mockDefaultContext` plural string, as it seemed unused. Correct me if i am wrong!

I didn't test accessibility since it is passing a string to the `TextField` so I don't think that is required?

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, ResourceList, Avatar, TextStyle, FilterType, Card} from '../src';

interface State {}

class ResourceListExample extends React.Component {
  state = {
    searchValue: '',
  };

  handleSearchChange = (searchValue) => {
    this.setState({searchValue});
  };

  renderItem = (item) => {
    const {id, url, name, location} = item;
    const media = <Avatar customer size="medium" name={name} />;

    return (
      <ResourceList.Item id={id} url={url} media={media}>
        <h3>
          <TextStyle variation="strong">{name}</TextStyle>
        </h3>
        <div>{location}</div>
      </ResourceList.Item>
    );
  };

  render() {
    const resourceName = {
      singular: 'customer',
      plural: 'customers',
    };

    const items = [
      {
        id: 341,
        url: 'customers/341',
        name: 'Mae Jemison',
        location: 'Decatur, USA',
      },
    ];

    const filterControl = (
      <ResourceList.FilterControl
        placeholder="by name, email or phone"
        searchValue={this.state.searchValue}
        onSearchChange={this.handleSearchChange}
        additionalAction={{
          content: 'Save',
          onAction: () => console.log('New filter saved'),
        }}
      />
    );

    return (
      <Card>
        <ResourceList
          resourceName={resourceName}
          items={items}
          renderItem={this.renderItem}
          filterControl={filterControl}
        />
      </Card>
    );
  }
}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        {/* Add the code you want to test in here */}
        <ResourceListExample />
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
