### PR TITLE
[TextField] Allow autoComplete prop of TextField to accept string values

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed disabled states while loading for `ResourceList` ([#1237](https://github.com/Shopify/polaris-react/pull/1237))
 - Fixed `Checkbox` from losing focus and not receiving some modified events([#1112](https://github.com/Shopify/polaris-react/pull/1112))
 - Added translation for the cancel button on the `ResourceList` `BulkActions` ([#1243](https://github.com/Shopify/polaris-react/pull/1243))
+- TextField autoComplete prop can now also accept string values and set the html input element's autocomplete to that string. The behavior for null, true and false values remains as it was.
 
 ### Documentation
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -76,7 +76,7 @@ export interface BaseProps {
   /** Limit increment value for numeric and date-time inputs */
   step?: number;
   /** Enable automatic completion by the browser */
-  autoComplete?: boolean;
+  autoComplete?: boolean | string;
   /** Mimics the behavior of the native HTML attribute, limiting how high the spinner can increment the value */
   max?: number;
   /** Maximum character length for an input */
@@ -452,11 +452,16 @@ class TextField extends React.PureComponent<CombinedProps, State> {
   };
 }
 
-function normalizeAutoComplete(autoComplete?: boolean) {
+function normalizeAutoComplete(autoComplete?: boolean | string) {
   if (autoComplete == null) {
     return autoComplete;
+  } else if (autoComplete === true) {
+    return 'on';
+  } else if (autoComplete === false) {
+    return 'off';
+  } else {
+    return autoComplete;
   }
-  return autoComplete ? 'on' : 'off';
 }
 
 export default withAppProvider<Props>()(TextField);

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -190,6 +190,17 @@ describe('<TextField />', () => {
       );
       expect(textField.find('input').prop('autoComplete')).toBe('on');
     });
+
+    it('sets autoComplete to string value when string is given', () => {
+      const textField = shallowWithAppProvider(
+        <TextField
+          label="TextField"
+          autoComplete="happyString"
+          onChange={noop}
+        />,
+      );
+      expect(textField.find('input').prop('autoComplete')).toBe('happyString');
+    });
   });
 
   describe('helpText', () => {

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -195,11 +195,11 @@ describe('<TextField />', () => {
       const textField = shallowWithAppProvider(
         <TextField
           label="TextField"
-          autoComplete="happyString"
+          autoComplete="firstName"
           onChange={noop}
         />,
       );
-      expect(textField.find('input').prop('autoComplete')).toBe('happyString');
+      expect(textField.find('input').prop('autoComplete')).toBe('firstName');
     });
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1244  This will allow the autoComplete prop of TextField to accept a string and set the autocomplete value of the html input to a string. This is because Chrome is known to ignore autocomplete=off, but setting autocomplete=fieldname seems to disable wrongful autocompletion by chrome. 

For background on how chrome ignores autocomplete=off when it comes to autofill: https://developers.google.com/web/updates/2015/06/checkout-faster-with-autofill

Longer term if would be good to directly support autofill, but this is an urgent quick fix in the meantime.

cc: @axelerator @Senjai 

### WHAT is this pull request doing?

Allows autoComplete prop to accept string value and set the value of html input autocomplete to that string (while keeping origin behavior when true, false, or null are given as prop value)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        {/* Add the code you want to test here */}
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
