### PR TITLE
Remove button group example

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -25,6 +25,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Removed `button group joined to the bottom of a component` example ([#38](https://github.com/Shopify/polaris-react/pull/1267))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/ButtonGroup/README.md
+++ b/src/components/ButtonGroup/README.md
@@ -102,40 +102,6 @@ Use to emphasize several buttons as a thematically-related set among other contr
 
 <!-- /content-for -->
 
-### Button group joined to the bottom of a preceeding component
-
-<!-- example-for: web -->
-
-Use a combination of props (segmented, fullWidth, and connectedTop) to attach ButtonGroup to a preceeding element.
-
-```jsx
-<React.Fragment>
-  <div
-    style={{
-      border: '1px solid #c4cdd5',
-      borderBottom: 0,
-      borderRadius: '3px 3px 0 0',
-    }}
-  >
-    <DropZone outline={false}>
-      <DropZone.FileUpload />
-    </DropZone>
-  </div>
-
-  <ButtonGroup segmented fullWidth connectedTop>
-    <Button size="slim" fullWidth>
-      Left one
-    </Button>
-    <Button size="slim" fullWidth>
-      Middle two
-    </Button>
-    <Button size="slim" fullWidth>
-      Right three
-    </Button>
-  </ButtonGroup>
-</React.Fragment>
-```
-
 ---
 
 ## Related components


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-styleguide/issues/2676

Button group example pinned to a component is confusing.

### WHAT is this pull request doing?

Removes `Button group joined to the bottom of a proceeding component` example.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


**To view changes in the stylguide:**

`dev cd polaris-react`
`git checkout button-group-example`
`yarn run build-consumer polaris-styleguide`

in a new tab

`dev cd polaris-styleguide`
`yarn run build:development`
`dev server`


### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
