### PR TITLE
Upgrade to polaris-tokens 2.5.0

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Updated `polaris-tokens` from `2.3.0` to `2.5.0` and converted all use of `duration` values ([#1268](https://github.com/Shopify/polaris-react/pull/1268))
 - More consistent use of `text-breakword` mixin ([#1306](https://github.com/Shopify/polaris-react/pull/1306))
 - Added an icon and screen reader hint when `Link` opens a new tab ([#1247](https://github.com/Shopify/polaris-react/pull/1247))
 

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "@shopify/images": "^1.1.0",
     "@shopify/javascript-utilities": "^2.2.1",
     "@shopify/polaris-icons": "^3.3.0",
-    "@shopify/polaris-tokens": "^2.3.0",
+    "@shopify/polaris-tokens": "^2.5.0",
     "@shopify/react-compose": "^0.1.6",
     "@shopify/react-utilities": "^2.0.3",
     "@types/prop-types": "^15.5.5",

--- a/src/components/Frame/Frame.scss
+++ b/src/components/Frame/Frame.scss
@@ -1,11 +1,12 @@
 $button-size: rem(32px);
-$transition-duration: 260ms;
 $skip-vertical-offset: rem(10px);
+
 .Frame {
   width: 100%;
   min-height: 100vh;
   display: flex;
   background-color: color('sky', 'light');
+
   @include when-printing {
     background-color: none;
   }
@@ -46,16 +47,19 @@ $skip-vertical-offset: rem(10px);
 .Navigation-enter {
   transform: translateX(-100%);
 }
+
 .Navigation-enterActive {
   transform: translateX(0%);
-  transition: transform $transition-duration ease;
+  transition: transform duration(slow) easing(out);
 }
+
 .Navigation-exit {
   transform: translateX(0%);
 }
+
 .Navigation-exitActive {
   transform: translateX(-100%);
-  transition: transform $transition-duration ease;
+  transition: transform duration(slow) easing(out);
 }
 
 .NavigationDismiss {
@@ -72,17 +76,20 @@ $skip-vertical-offset: rem(10px);
   opacity: 0;
   pointer-events: none;
   will-change: opacity;
-  transition: opacity duration(fast) easing();
   cursor: pointer;
+  transition: opacity duration(fast) easing();
+
   .Navigation-visible & {
     pointer-events: all;
     opacity: 1;
   }
+
   &:focus {
     border-radius: border-radius();
     background-color: rgba(color('white'), 0.16);
     outline: none;
   }
+
   @include frame-when-nav-displayed {
     display: none;
   }
@@ -104,19 +111,23 @@ $skip-vertical-offset: rem(10px);
   left: 0;
   width: 100%;
 }
+
 .ContextualSaveBar-enter {
   opacity: 0;
 }
+
 .ContextualSaveBar-enterActive {
   opacity: 1;
-  transition: opacity duration() ease;
+  transition: opacity duration() easing(out);
 }
+
 .ContextualSaveBar-exit {
   opacity: 1;
 }
+
 .ContextualSaveBar-exitActive {
   opacity: 0;
-  transition: opacity duration() ease;
+  transition: opacity duration() easing(out);
 }
 
 .Main {
@@ -158,6 +169,7 @@ $skip-vertical-offset: rem(10px);
   z-index: z-index(global-ribbon, $fixed-element-stacking-order);
   bottom: 0;
   width: 100%;
+
   @include frame-when-nav-displayed {
     .hasNav & {
       left: layout-width(nav);
@@ -174,6 +186,7 @@ $skip-vertical-offset: rem(10px);
   top: 0;
   right: 0;
   left: 0;
+
   @include frame-when-nav-displayed {
     .hasTopBar & {
       top: top-bar-height();
@@ -189,6 +202,7 @@ $skip-vertical-offset: rem(10px);
   left: spacing(tight);
   opacity: 0;
   pointer-events: none;
+
   &.focused {
     pointer-events: all;
     opacity: 1;

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {MobileCancelMajorMonotone} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
+import {durationSlow} from '@shopify/polaris-tokens';
 import {CSSTransition} from 'react-transition-group';
 import {navigationBarCollapsed} from '../../utilities/breakpoints';
 import Button from '../Button';
@@ -10,7 +11,7 @@ import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import Backdrop from '../Backdrop';
 import TrapFocus from '../TrapFocus';
 import {UserMenuProvider} from '../TopBar';
-import {dataPolarisTopBar, layer, Duration} from '../shared';
+import {dataPolarisTopBar, layer} from '../shared';
 import {setRootProperty} from '../../utilities/setRootProperty';
 import {
   ContextualSaveBarProps,
@@ -129,7 +130,7 @@ export class Frame extends React.PureComponent<CombinedProps, State> {
           appear={mobileView}
           exit={mobileView}
           in={showMobileNavigation}
-          timeout={Duration.Base}
+          timeout={durationSlow}
           classNames={navTransitionClasses}
         >
           <div

--- a/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/src/components/Modal/components/Dialog/Dialog.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import {Transition, CSSTransition} from 'react-transition-group';
 import {classNames} from '@shopify/react-utilities/styles';
+import {durationBase} from '@shopify/polaris-tokens';
 
 import {AnimationProps, Key} from '../../../../types';
 
 import KeypressListener from '../../../KeypressListener';
 import TrapFocus from '../../../TrapFocus';
-import {Duration} from '../../../shared';
 
 import styles from './Dialog.scss';
 
@@ -54,7 +54,7 @@ export default function Dialog({
       {...props}
       mountOnEnter
       unmountOnExit
-      timeout={Duration.Base}
+      timeout={durationBase}
       onEntered={onEntered}
       onExited={onExited}
     >

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -3,10 +3,11 @@ import {nodeContainsDescendant} from '@shopify/javascript-utilities/dom';
 import {write} from '@shopify/javascript-utilities/fastdom';
 import {classNames} from '@shopify/react-utilities/styles';
 import {isElementOfType, wrapWithComponent} from '@shopify/react-utilities';
+import {durationBase} from '@shopify/polaris-tokens';
 import {Transition} from 'react-transition-group';
 
 import {Key} from '../../../../types';
-import {overlay, Duration} from '../../../shared';
+import {overlay} from '../../../shared';
 import EventListener from '../../../EventListener';
 import KeypressListener from '../../../KeypressListener';
 import PositionedOverlay, {
@@ -61,12 +62,7 @@ export default class PopoverOverlay extends React.PureComponent<Props, never> {
   render() {
     const {active} = this.props;
     return (
-      <Transition
-        in={active}
-        timeout={Duration.Fast}
-        mountOnEnter
-        unmountOnExit
-      >
+      <Transition in={active} timeout={durationBase} mountOnEnter unmountOnExit>
         {this.renderOverlay}
       </Transition>
     );

--- a/src/components/ResourceList/components/BulkActions/BulkActions.tsx
+++ b/src/components/ResourceList/components/BulkActions/BulkActions.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import {CSSTransition, Transition} from 'react-transition-group';
 import debounce from 'lodash/debounce';
 import {classNames} from '@shopify/react-utilities/styles';
+import {durationBase} from '@shopify/polaris-tokens';
 import {DisableableAction, Action, ActionListSection} from '../../../../types';
-import {Duration} from '../../../shared';
 import ActionList from '../../../ActionList';
 import Popover from '../../../Popover';
 import Button from '../../../Button';
@@ -370,7 +370,7 @@ export class BulkActions extends React.PureComponent<CombinedProps, State> {
               <div className={styles.ButtonGroup}>
                 <CSSTransition
                   in={selectMode}
-                  timeout={Duration.Base}
+                  timeout={durationBase}
                   classNames={slideClasses}
                   appear
                 >

--- a/src/components/shared.ts
+++ b/src/components/shared.ts
@@ -27,13 +27,3 @@ export const headerCell = {
   props: {'data-polaris-header-cell': true},
   selector: '[data-polaris-header-cell]',
 };
-
-// these match our values in duration.scss
-export enum Duration {
-  Instant = 0,
-  Fast = 100,
-  Base = 200,
-  Slow = 300,
-  Slower = 400,
-  Slowest = 500,
-}

--- a/src/styles/foundation/duration.scss
+++ b/src/styles/foundation/duration.scss
@@ -1,24 +1,19 @@
-$unit: 100ms;
+@import '../polaris-tokens/duration.map';
 
-$duration-data: (
-  fast: $unit,
-  base: $unit * 2,
-  slow: $unit * 3,
-  slower: $unit * 4,
-  slowest: $unit * 5,
-);
+$duration-data: $polaris-duration-map;
 
 /// Returns the duration value for a given variant.
 ///
 /// @param {String} $variant - The key for the given variant.
-/// @return {Number} The spacing for the variant (in miliseconds).
+/// @return {Number} The duration for the variant (in miliseconds).
 
 @function duration($variant: base) {
-  $fetched-value: map-get($duration-data, $variant);
+  $interpolated-value: 'duration-' + $variant;
+  $fetched-value: nth(map-get($duration-data, $interpolated-value), 1);
 
   @if type-of($fetched-value) == number {
     @return $fetched-value;
   } @else {
-    @error 'Duration variant `#{$variant}` not found. Available variants: #{available-names($duration-data)}';
+    @error 'Duration variant `#{$interpolated-value}` not found. Available variants: #{available-names($duration-data)}';
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,10 +1479,10 @@
   resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-3.3.0.tgz#7031791d44bfe60e2f999c8fbf0ea67ab7a047c8"
   integrity sha512-+nB2rthx6vS8vlJms5unGbThwrdGXAPMCD2PoQG/Eq5uQU1EmhkVOIFaEK7AS62J2m+HaqbLw/zrlbBkZHZUrQ==
 
-"@shopify/polaris-tokens@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.3.0.tgz#d4e6c12dd83d6f8b1501fbf415268d60151770f2"
-  integrity sha512-/jroX2KTRYrQ9Ht7xbJrU+6pEZR2Iq38mXKT6G+9VB13jOv2Yih27MmitEV71E7g03KTIntKCDOWgR/3ECTb1A==
+"@shopify/polaris-tokens@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.5.0.tgz#3efe1f9be456565bbb26f6f555c78be8060bcea7"
+  integrity sha512-AzIXOBAdUnOIO91vhCPdtQH+W6pKi4rCrXsT6Fe/BN+KUoeMAsfOyBXRbA5lSQ1pb+gA2e9N4PGpOzFs6fI4hQ==
 
 "@shopify/react-compose@^0.1.6":
   version "0.1.6"


### PR DESCRIPTION
> We have recently added all Polaris `duration` values to the `polaris-tokens` repo and just cut a new `2.5.0` release! [Read more here](https://github.com/Shopify/polaris-tokens/releases/tag/v2.5.0).

The goal of this PR is to consume the newest `polaris-tokens` release and make sure all `duration` references in `polaris-react` are updated and consistent. This PR would resolve: https://github.com/Shopify/polaris-react/issues/1258

We have upgraded from `2.3.0` to `2.5.0`. The `2.4.0` release appears to be just an enhancement - but perhaps @tmlayton can speak more about that release?

**This PR accomplishes the following:**
- [x] Upgrades our version of `polaris-tokens`:
  - [x] Upgrades to the `polaris-tokens > 2.4.0-beta.1` package for initial tophatting.
  - [x] Upgrades to the `polaris-tokens > 2.4.0-beta.2` package for additional tophatting.
  - [x] Upgrades to the stable release of `2.5.0` after positive review.
- [x] Updates `duration.scss` to:
  - [x] Remove the hard coded SASS map.
  - [x] Begin consuming the `duration` map from `polaris-tokens`.
  - [x] Makes any necessary adjustments to the `duration()` function.
  - [x] Consume correct `duration` SASS map? cc/ @kaelig _(see more context below)_
- [x] Updates any relevant JS files:
  - [x] Remove the `enum Duration`.
  - [x] Update all files consuming the `enum Duration` and replace with appropriate `duration` value from `polaris-tokens`.
- [x] Updates `Frame.scss` to use Polaris values _(this task might be up for debate)_:
  - [x] Replace custom `$transition-duration` with closest Polaris `duration` _(`duration(slow)`)_.
  - [x] Replace browser `ease` timing-function with closest Polaris `easing` _(`easing(out)`)_.

@kaelig both `spacing` and `color` export 2 different SCSS maps... and Polaris seems to prefer the `spacing.spacing-map.scss` version. Did we accidentally omit this from the `beta` release? I ended up modifying the `duration` SCSS function to retain the same API _(I just interpolate the string to include the `duration-` prefix)_.

I'm curious what everyone thinks of me simply using `parseInt(durationValue, 10)` on the imported `duration` from `polaris-tokens`? This seems to work perfectly for stripping off the `ms` suffix and converting to a proper `ms` value for JavaScript. Are we cool with this?

I tophatted in the local `dev` storybook and everything looked good, but I'd love another tophat from someone on the Polaris team.

cc/ @AndrewMusgrave + @dleroux on the `Frame.scss` task... curious why the previous values were being used? Was that intentional?