### PR TITLE
Dont pass "polaris" context as a prop to the div within Scrollable

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Stopped passing the `polaris` context into the div rendered by `Scrollable` ([#1271](https://github.com/Shopify/polaris-react/pull/1271))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Scrollable/Scrollable.tsx
+++ b/src/components/Scrollable/Scrollable.tsx
@@ -123,6 +123,7 @@ class Scrollable extends React.Component<CombinedProps, State> {
       shadow,
       hint,
       onScrolledToBottom,
+      polaris,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
### WHY are these changes introduced?

Currently the Scrollable is trying to pass the `polaris` context object into a div in the Scrollable component. That seems somewhat silly, lets not do that.

You can see this in action by visiting https://polaris-react.herokuapp.com/?selectedKind=All%20Components%7CScrollable&selectedStory=Default%20scrollable%20container&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel then running `document.querySelector('[class^="Scrollable-Scrollable"]')` in your console and seeing that it has an attribute `polaris="[object Object]"`

### WHAT is this pull request doing?

This PR plucks the polaris context out of the list of properties that get passed into the `div`.

### How to 🎩

Follow the above steps in your local storybook and see that the `polaris="[object Object]"` attribute is removed
