### PR TITLE
Remove redundant styling from Modal Header

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -24,4 +24,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Code quality
 
+Removed an unneeded media query from Modal's `Header` component ([#1272](https://github.com/Shopify/polaris-react/pull/1272))
+
 ### Deprecations

--- a/src/components/Modal/components/Header/Header.scss
+++ b/src/components/Modal/components/Header/Header.scss
@@ -10,8 +10,4 @@
   flex: 1;
   margin-top: spacing(extra-tight);
   word-break: break-word;
-
-  @include breakpoint-after($typography-condensed) {
-    margin-top: rem(4px);
-  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Modal header titles css look like this:

```scss
.Title {
  flex: 1;
  margin-top: spacing(extra-tight);
  word-break: break-word;

  @include breakpoint-after($typography-condensed) {
    margin-top: rem(4px);
  }
}
```

Both `spacing(extra-tight)` and `rem(4px)` resolve to 0.4rem, which means that mixin is pointless.

### WHAT is this pull request doing?

Removes that media query.

### How to 🎩

Look at the modal dialog in storybook and assert that the title does not change position.
