### PR TITLE
[DataTable] Fix sortable header clickable area

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixed Search overlay stretching below the viewport
 - Stopped passing the `polaris` context into the div rendered by `Scrollable` ([#1271](https://github.com/Shopify/polaris-react/pull/1271))
+- Fixed clickable area on sortable column headers on `DataTable` ([#1273](https://github.com/Shopify/polaris-react/pull/1273))
 
 ### Documentation
 

--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -132,18 +132,7 @@ $breakpoint: 768px;
 }
 
 .Cell-sortable {
-  cursor: pointer;
-
-  &:hover {
-    .Heading {
-      @include recolor-icon(color('indigo'));
-      color: color('indigo');
-    }
-
-    .Icon {
-      opacity: 1;
-    }
-  }
+  padding: 0;
 }
 
 .Icon {
@@ -160,6 +149,8 @@ $breakpoint: 768px;
   justify-content: flex-end;
   align-items: baseline;
   transition: color duration() easing();
+  padding: spacing();
+  cursor: pointer;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1230

When a `DataTable` column is sortable, hovering over the column header with your mouse changes the colour and reveals the sorting icon, indicating that it is clickable.

However, the area where it is actually clickable is smaller than the area where the hover styles are applied, making the user think they can click to sort when they can't.

In this GIF I'm clicking, it has no effect until it's right on the text label:

![sortable-data-table-click](https://user-images.githubusercontent.com/1470768/54713008-010c4d00-4b24-11e9-9da5-6d33dbbdecf7.gif)

### WHAT is this pull request doing?

Remove padding from the surrounding `Cell` and add it to the `button` when the column is sortable, to expand the clickable area to the whole cell. The button CSS seems to already have the hover styles that now apply to the whole area.

The whole cell area is now clickable:

![table sort good](https://user-images.githubusercontent.com/1470768/55415077-64da4100-553a-11e9-95b7-23c0cd8ae512.gif)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Can be 🎩 on the sortable `DataTable` examples on Storybook

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
