### PR TITLE
[Pagination] Fix styling for Pagination buttons with tooltips

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -30,6 +30,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added background into media query for Microsoft high contrast to fix skeleton accessibility ([#1341](https://github.com/Shopify/polaris-react/pull/1341))
 - Added high contrast colour to `Loading` to make it visible in the high contrast mode in Windows ([#1389](https://github.com/Shopify/polaris-react/pull/1389))
 - Fixed the position calculation of the `PositionedOverlay` component after scroll ([#1382](https://github.com/Shopify/polaris-react/pull/1382))
+- Fixed styling issue for Pagination component previous/next buttons when tooltips present ([#1277](https://github.com/Shopify/polaris-react/pull/1277))
 
 ### Documentation
 

--- a/src/components/Pagination/Pagination.scss
+++ b/src/components/Pagination/Pagination.scss
@@ -65,18 +65,6 @@ $stacking-order: (
       box-shadow: none;
     }
 
-    &:not(:first-child) {
-      margin-left: rem(2px);
-    }
-
-    &:first-child {
-      margin-left: -1 * $plain-horizontal-adjustment;
-    }
-
-    &:last-child {
-      margin-right: -1 * $plain-horizontal-adjustment;
-    }
-
     &::after {
       content: '';
       position: absolute;
@@ -91,6 +79,15 @@ $stacking-order: (
       transition-duration: duration();
       transition-timing-function: easing();
     }
+  }
+
+  .PreviousButton {
+    margin-left: -1 * $plain-horizontal-adjustment;
+  }
+
+  .NextButton {
+    margin-right: -1 * $plain-horizontal-adjustment;
+    margin-left: rem(2px);
   }
 }
 
@@ -155,18 +152,15 @@ $stacking-order: (
     cursor: default;
     box-shadow: none;
   }
+}
 
-  &:not(:first-child) {
-    margin-left: -1px;
-  }
+.PreviousButton {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
 
-  &:first-child {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
-  &:last-child {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  }
+.NextButton {
+  margin-left: -1px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -69,10 +69,12 @@ function Pagination({
   }
 
   const className = classNames(styles.Pagination, plain && styles.plain);
+  const previousClassName = classNames(styles.Button, styles.PreviousButton);
+  const nextClassName = classNames(styles.Button, styles.NextButton);
 
   const previousButton = previousURL ? (
     <UnstyledLink
-      className={styles.Button}
+      className={previousClassName}
       url={previousURL}
       onMouseUp={handleMouseUpByBlurring}
       aria-label={intl.translate('Polaris.Pagination.previous')}
@@ -85,7 +87,7 @@ function Pagination({
       onClick={onPrevious}
       type="button"
       onMouseUp={handleMouseUpByBlurring}
-      className={styles.Button}
+      className={previousClassName}
       aria-label={intl.translate('Polaris.Pagination.previous')}
       disabled={!hasPrevious}
     >
@@ -95,7 +97,7 @@ function Pagination({
 
   const nextButton = nextURL ? (
     <UnstyledLink
-      className={styles.Button}
+      className={nextClassName}
       url={nextURL}
       onMouseUp={handleMouseUpByBlurring}
       aria-label={intl.translate('Polaris.Pagination.next')}
@@ -108,7 +110,7 @@ function Pagination({
       onClick={onNext}
       type="button"
       onMouseUp={handleMouseUpByBlurring}
-      className={styles.Button}
+      className={nextClassName}
       aria-label={intl.translate('Polaris.Pagination.next')}
       disabled={!hasNext}
     >


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1276

There's an issue with how the styling is applied to the previous and next buttons in the Pagination component. 

The issue affects how `margin-left` and `border-radius` properties are applied to the buttons. Its assumed the buttons will be siblings, with the styling based on `first-child` and `last-child`.

As a result several styles aren't applied properly, for example, when a `nextTooltip` is specified, the next button gets styles for both `first-child` and `last-child` & doesn't receive the negative `margin-left` for `:not(:first-child)`.

There's also similar issues when a `previousTooltip` is present or both tooltips.

Similarly there are issues with the `plain` buttons when they have tooltips.

Here are screenshots of different combinations of `previousTooltip` & `nextTooltip` before and after the changes in this PR are applied (code for button combinations below):

**Before:**

![https://screenshot.click/2019-04-05_12-32-56.png](https://screenshot.click/2019-04-05_12-32-56.png)

**After:**

![https://screenshot.click/2019-04-05_12-33-54.png](https://screenshot.click/2019-04-05_12-33-54.png)

### WHAT is this pull request doing?

This PR adds classes specific to both the previous and next buttons. The reason new classes were introduced is that we couldn't properly target the buttons without them (we would have had to target previous and next siblings if we continued to just use the `Button` class).

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

_Has different combinations of previous/next buttons with/without tooltips to highlight the different issues present_

```jsx
import React from 'react';
import {Pagination, Tooltip} from '@shopify/polaris';

export default class App extends React.Component {
  render() {
    return (
      <div>
        <Pagination
          hasPrevious
          onPrevious={() => {
            console.log('Previous');
          }}
          nextURL="https://github.com/Shopify/polaris-react"
          hasNext
          onNext={() => {
            console.log('Next');
          }}
        />
        <br />
        <br />
        <Pagination
          hasPrevious
          onPrevious={() => {
            console.log('Previous');
          }}
          hasNext
          onNext={() => {
            console.log('Next');
          }}
          nextTooltip="saadw"
        />
        <br />
        <br />
        <Pagination
          hasPrevious
          onPrevious={() => {
            console.log('Previous');
          }}
          previousTooltip="jkhk"
          hasNext
          onNext={() => {
            console.log('Next');
          }}
        />
        <br />
        <br />
        <Pagination
          hasPrevious
          onPrevious={() => {
            console.log('Previous');
          }}
          nextTooltip="wqweqewq"
          previousTooltip="uijii"
          hasNext
          onNext={() => {
            console.log('Next');
          }}
        />
        <br />
        <br />
        <Pagination
          hasPrevious
          onPrevious={() => {
            console.log('Previous');
          }}
          nextURL="https://github.com/Shopify/polaris-react"
          hasNext
          plain
          onNext={() => {
            console.log('Next');
          }}
        />
        <br />
        <br />
        <Pagination
          hasPrevious
          onPrevious={() => {
            console.log('Previous');
          }}
          hasNext
          plain
          onNext={() => {
            console.log('Next');
          }}
          nextTooltip="saadw"
        />
        <br />
        <br />
        <Pagination
          hasPrevious
          onPrevious={() => {
            console.log('Previous');
          }}
          previousTooltip="jkhk"
          hasNext
          plain
          onNext={() => {
            console.log('Next');
          }}
        />
        <br />
        <br />
        <Pagination
          hasPrevious
          onPrevious={() => {
            console.log('Previous');
          }}
          nextTooltip="wqweqewq"
          previousTooltip="uijii"
          hasNext
          plain
          onNext={() => {
            console.log('Next');
          }}
        />
      </div>
    );
  }
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
