### PR TITLE
Update polaris-icons to include the full icon set

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,6 +26,8 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 
 ### Dependency upgrades
 
+- Upgraded Polaris icons to include the full icon set ([#1284](https://github.com/Shopify/polaris-react/pull/1284))
+
 ### Code quality
 
 - Updated `ResourceList` to no longer use `componentWillReceiveProps`([#1235](https://github.com/Shopify/polaris-react/pull/1235))

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "@shopify/app-bridge": "^1.1.2",
     "@shopify/images": "^1.1.0",
     "@shopify/javascript-utilities": "^2.2.1",
-    "@shopify/polaris-icons": "^3.0.0",
+    "@shopify/polaris-icons": "^3.3.0",
     "@shopify/polaris-tokens": "^2.3.0",
     "@shopify/react-compose": "^0.1.6",
     "@shopify/react-utilities": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1474,10 +1474,10 @@
     mime-types "2.1.12"
     request "2.78.0"
 
-"@shopify/polaris-icons@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-3.0.0.tgz#81e83cc8143b2bd3a95bcfb63749be3bda260399"
-  integrity sha512-T0tStoGH/8HCZgsVe+hPIIihS2zS9gjK3hkcAmt/mnZ6hduJHRuOLIjk7xxeq6j9sGL7dDThnZdlIJARabXXLw==
+"@shopify/polaris-icons@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-3.3.0.tgz#7031791d44bfe60e2f999c8fbf0ea67ab7a047c8"
+  integrity sha512-+nB2rthx6vS8vlJms5unGbThwrdGXAPMCD2PoQG/Eq5uQU1EmhkVOIFaEK7AS62J2m+HaqbLw/zrlbBkZHZUrQ==
 
 "@shopify/polaris-tokens@^2.3.0":
   version "2.3.0"


### PR DESCRIPTION
### WHY are these changes introduced?

Until the most recent release, Polaris React didn’t have access to the full Polaris icon set. One of the newer icons is required for #1247.

### WHAT is this pull request doing?

Updates Shopify/polaris-icons to 3.3.0

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Percy should catch any issues, but please spot check in Storybook for any broken or missing icons.

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

* [N/A] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [N/A] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [N/A] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
