### PR TITLE
[ResourceList] Hide header when EmptySearchResult is displayed

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -30,6 +30,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed Search overlay stretching below the viewport ([#1260](https://github.com/Shopify/polaris-react/pull/1260))
 - Added `onChange` and `value` to select `AppProvider` examples to remove console errors ([#1320](https://github.com/Shopify/polaris-react/pull/1320))
 - Fixed promoted bulk actions in `ResourceList` not properly disabling ([#1317](https://github.com/Shopify/polaris-react/pull/1317)) (thanks [@jineshshah36](https://github.com/jineshshah36) for the [issue report](https://github.com/Shopify/polaris-react/issues/1316))
+- Fixed `ResourceList` header from displaying when `EmptySearchResult` exists ([#1286](https://github.com/Shopify/polaris-react/pull/1286))
 - Stopped passing the `polaris` context into the div rendered by `Scrollable` ([#1271](https://github.com/Shopify/polaris-react/pull/1271))
 - Fixed clickable area on sortable column headers on `DataTable` ([#1273](https://github.com/Shopify/polaris-react/pull/1273))
 

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -458,7 +458,10 @@ export class ResourceList extends React.Component<CombinedProps, State> {
       <div className={styles['HeaderWrapper-overlay']} />
     ) : null;
 
-    const headerMarkup = (showHeader || needsHeader) &&
+    const showEmptyState = filterControl && !this.itemsExist() && !loading;
+
+    const headerMarkup = !showEmptyState &&
+      (showHeader || needsHeader) &&
       this.listRef.current && (
         <div className={styles.HeaderOuterWrapper}>
           <Sticky boundingElement={this.listRef.current}>
@@ -495,12 +498,11 @@ export class ResourceList extends React.Component<CombinedProps, State> {
         </div>
       );
 
-    const emptyStateMarkup =
-      filterControl && !this.itemsExist() && !loading ? (
-        <div className={styles.EmptySearchResultWrapper}>
-          <EmptySearchResult {...this.emptySearchResultText} withIllustration />
-        </div>
-      ) : null;
+    const emptyStateMarkup = showEmptyState ? (
+      <div className={styles.EmptySearchResultWrapper}>
+        <EmptySearchResult {...this.emptySearchResultText} withIllustration />
+      </div>
+    ) : null;
 
     const defaultTopPadding = 8;
     const topPadding =

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -399,6 +399,19 @@ describe('<ResourceList />', () => {
       resourceList.update();
       expect(findByTestID(resourceList, 'ResourceList-Header')).toHaveLength(1);
     });
+
+    it('does not render when EmptySearchResult exists', () => {
+      const resourceList = mountWithAppProvider(
+        <ResourceList
+          items={[]}
+          renderItem={renderItem}
+          filterControl={<div>fake filterControl</div>}
+        />,
+      );
+
+      expect(resourceList.find(EmptySearchResult).exists()).toBe(true);
+      expect(findByTestID(resourceList, 'ResourceList-Header')).toHaveLength(0);
+    });
   });
 
   describe('filterControl', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1252 

### WHAT is this pull request doing?

* Applying the logic to display `EmptySeachResult` to header markup
* Add a test

### Gif

#### After

https://cl.ly/64ba392ef321

### How to 🎩

* Playground provided below
* Can test against discount index in web

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from "react";
import { Avatar, Card, ResourceList, TextStyle } from "@shopify/polaris";

export default class ResourceListExample extends React.Component {
  constructor(props) {
    super(props);

    this.state = {
      searchValue: "",
      items: []
    };
  }

  handleSearchChange = searchValue => {
    this.setState({ searchValue });
  };

  componentDidMount() {
    setTimeout(() => {
      this.setState({
        items: [
          {
            id: 341,
            url: "customers/341",
            name: "Mae Jemison",
            location: "Decatur, USA"
          },
          {
            id: 256,
            url: "customers/256",
            name: "Ellen Ochoa",
            location: "Los Angeles, USA"
          }
        ]
      });
    }, 1000);
  }

  renderItem = item => {
    const { id, url, name, location } = item;
    const media = <Avatar customer size="medium" name={name} />;

    return (
      <ResourceList.Item id={id} url={url} media={media}>
        <h3>
          <TextStyle variation="strong">{name}</TextStyle>
        </h3>
        <div>{location}</div>
      </ResourceList.Item>
    );
  };

  render() {
    const bulkActions = [
      {
        content: "Activate",
        onAction: () => {
          console.log("Sets enabled");
        }
      },
      {
        content: "Deactivate",
        onAction: () => {
          console.log("Sets disabled");
        }
      },
      {
        content: "Delete",
        destructive: true,
        onAction: () => this.handleBulkDelete(selectedItems)
      }
    ];

    const resourceName = {
      singular: "customer",
      plural: "customers"
    };

    const { items, searchValue } = this.state;

    const filteredItems = items.filter(item => {
      return item.name.toLowerCase().match(searchValue.toLowerCase());
    });

    const filterControl = (
      <ResourceList.FilterControl
        searchValue={this.state.searchValue}
        onSearchChange={this.handleSearchChange}
        additionalAction={{
          content: "Save",
          onAction: () => console.log("New filter saved")
        }}
      />
    );

    return (
      <Card>
        <ResourceList
          resourceName={resourceName}
          items={filteredItems}
          bulkActions={bulkActions}
          renderItem={this.renderItem}
          filterControl={filterControl}
        />
      </Card>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
