### PR TITLE
Add support note about App Bridge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ ReactDOM.render(
 
 We provide React wrappers around the Shopify App Bridge (formerly known as the EASDK). You don’t need to go through the initialization of the Shopify App Bridge as described in the docs. Instead, [configure the connection to the Shopify admin through the app provider component](https://github.com/Shopify/polaris-react/blob/master/documentation/Embedded%20apps.md).
 
+If you need help using Shopify App Bridge, the Embedded App SDK, or the POS App SDK, please visit our [API & SDK forum](https://community.shopify.com/c/Shopify-APIs-SDKs/bd-p/shopify-apis-and-technology). It is the best place to discuss the libraries, get support, notify us about bugs, or request features.
+
 ## Using the CSS components
 
 If React doesn’t make sense for your application, you can use a CSS-only version of our components. This includes all the styles you need for every component in the library, but you’ll be responsible for writing the correct markup and updating classes and DOM attributes in response to user events.


### PR DESCRIPTION
### WHY are these changes introduced?

This repo gets a number of questions/issues about App Bridge. By redirecting support requests to the API & SDK forum we hope to (a) reduce support load on the Polaris team, and (b) give partners a better support experience. See also [this PR](https://github.com/Shopify/help/pull/6856) in our help docs.

### WHAT is this pull request doing?

Adds a paragraph to README