### PR TITLE
Deprecate passing iconBody into Navigation Items

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,10 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Breaking changes
 
+### Deprecations
+
+- Deprecated Navigation `Item`'s `iconBody` prop. Pass a string into the `icon` prop instead. ([#1299](https://github.com/Shopify/polaris-react/pull/1299))
+
 ### New components
 
 ### Enhancements

--- a/src/components/Navigation/README.md
+++ b/src/components/Navigation/README.md
@@ -123,7 +123,7 @@ The content of the navigation component consists of navigation items. Each item 
 | matchPaths         | string[]            | A string property providing a collection of additional paths for the navigation item to respond to                                         |
 | excludePaths       | string[]            | A string property providing an explicit collection of paths the navigation item should not respond to                                      |
 | icon               | IconProps['source'] | An icon to be displayed next to the navigation item                                                                                        |
-| iconBody           | string              | An `SVG` element passed as a string from a server and displayed next to the navigation item                                                |
+| iconBody           | string              | (deprecated) Pass a string representing an `SVG` element into the `icon` prop instead                                                      |
 | badge              | string \| null      | A string property allowing content to be displayed in a badge next to the navigation item                                                  |
 | label              | string              | A string property allowing content to be displayed as link text in the navigation item                                                     |
 | disabled           | boolean             | A boolean property indicating whether the navigation item is disabled                                                                      |

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -38,6 +38,7 @@ interface SecondaryAction {
 
 export interface Props extends ItemURLDetails {
   icon?: IconProps['source'];
+  /** @deprecated The iconBody prop is deprecated and will be removed. Pass a string into the icon prop instead */
   iconBody?: string;
   badge?: React.ReactNode;
   label: string;
@@ -115,17 +116,19 @@ export class BaseItem extends React.Component<CombinedProps, State> {
       </span>
     ) : null;
 
-    const iconMarkup = iconBody ? (
+    if (iconBody) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Deprecation: The iconBody prop is deprecated. Pass a string into the icon prop instead',
+      );
+    }
+
+    const iconBodyOrIcon = iconBody || icon;
+    const iconMarkup = iconBodyOrIcon ? (
       <div className={styles.Icon}>
-        <Icon source={iconBody} />
+        <Icon source={iconBodyOrIcon} />
       </div>
-    ) : (
-      icon && (
-        <div className={styles.Icon}>
-          <Icon source={icon} />
-        </div>
-      )
-    );
+    ) : null;
 
     let badgeMarkup: React.ReactNode = null;
     if (isNew) {


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/polaris-react/pull/1042 deprecated Icon's `untrusted` prop and made it so that passing a string into `<Icon>` would render an untrusted icon - i.e. rendering it as an img with a data URI instead of an inline svg.

Since that point passing an `icon` and and `iconBody` into Navigation's `<Item>` are functionally identical. Having two ways to do the same thing seems silly, so remove `iconBody` and tell people to pass a string into `icon` instead.


### WHAT is this pull request doing?

 Deprecates the iconBody prop. Tweak the logic slightly to remove a conditional that did almost the same thing on both paths.

/cc @theodoretan and @danrosenthal as people who have looked at icon and iconBody before

### How to 🎩

Checkout the following playground example, and see that passing an icon and iconBody to navigation items still continue to work as before.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Navigation} from '../src';

interface State {}

const onlinestore = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="currentColor" d="M19 6c0 1.657-1.343 3-3 3s-3-1.343-3-3c0 1.657-1.343 3-3 3S7 7.657 7 6c0 1.657-1.343 3-3 3S1 7.657 1 6V5l2-4h14l2 4v1z"></path><path d="M16 8c-1.103 0-2-.897-2-2h4c0 1.103-.897 2-2 2zm0 6H4v-4c1.193 0 2.267-.525 3-1.357C7.733 9.475 8.807 10 10 10s2.267-.525 3-1.357c.733.832 1.807 1.357 3 1.357v4zm-3.28 4H7.28c.358-.702.537-1.434.628-2h4.184c.09.566.27 1.298.627 2zM12 6c0 1.103-.897 2-2 2s-2-.897-2-2h4zM2 6h4c0 1.103-.897 2-2 2s-2-.897-2-2zm1.618-4h12.764l1 2H2.618l1-2zm16.277 2.553l-2-4C17.725.213 17.38 0 17 0H3c-.38 0-.725.214-.895.553l-2 4C.035 4.69 0 4.845 0 5v1c0 1.474.81 2.75 2 3.444V15c0 .552.447 1 1 1h2.87c-.156.747-.507 1.7-1.317 2.105-.415.208-.633.673-.527 1.125.108.45.51.77.974.77h10c.464 0 .866-.32.974-.77.106-.452-.112-.917-.527-1.125-.8-.4-1.153-1.356-1.313-2.105H17c.553 0 1-.448 1-1V9.444c1.19-.694 2-1.97 2-3.444V5c0-.155-.036-.31-.105-.447z"></path></svg>`;

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <Navigation location="/">
          <Navigation.Section
            items={[
              {
                url: '/path/to/place',
                label: 'icon as string',
                icon: onlinestore,
              },
              {
                url: '/path/to/place',
                label: 'iconBody as string',
                iconBody: onlinestore,
              },
              {
                url: '/path/to/place',
                label: 'specifying iconBody and icon means iconBody wins',
                icon: 'add',
                iconBody: onlinestore,
              },
            ]}
          />
        </Navigation>
      </Page>
    );
  }
}
```

</details>
