### PR TITLE
Remove duplicate declaration of top-bar-height()

### DIFF
--- a/src/styles/foundation.scss
+++ b/src/styles/foundation.scss
@@ -11,4 +11,3 @@
 @import 'foundation/shadows';
 @import 'foundation/typography';
 @import 'foundation/z-index';
-@import 'foundation/settings';

--- a/src/styles/foundation/settings.scss
+++ b/src/styles/foundation/settings.scss
@@ -1,3 +1,0 @@
-@function top-bar-height() {
-  @return rem(56px);
-}


### PR DESCRIPTION
### WHY are these changes introduced?

top-bar-height() is already defined in [src/styles/foundation/layout.scss](https://github.com/Shopify/polaris-react/blob/47fce710baa99adbd7ab85221d83f2a71d8c5386/src/styles/foundation/layout.scss#L58-L60).

I'm kinda suprised that sass lets you redefine functions like that but 🤷‍♂️ 

Fixes #1296

### WHAT is this pull request doing?

🔥 
