### PR TITLE
Disable web build step in consumer build test

### DIFF
--- a/.shopify-build/polaris-react.yml
+++ b/.shopify-build/polaris-react.yml
@@ -41,5 +41,4 @@ shared:
 
 steps:
   - <<: *build-styleguide
-  - <<: *build-web
   - <<: *unit-tests


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

This step has been broken ever since web broke up its build process and increased memory usage. I've tried to fix it but there doesn't seem to be an easy solution besides making web use less memory. This being broken reduces trust in the consumer build test so I believe we should disable it.

### WHAT is this pull request doing?

See title