### PR TITLE
[Code Quality] Consistent use of `text-breakword` mixin

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,7 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-- Added an icon and screen reader hint when `Link` opens a new tab ([#1142](https://github.com/Shopify/polaris-react/pull/1247))
+- More consistent use of `text-breakword` mixin ([#1306](https://github.com/Shopify/polaris-react/pull/1306))
+- Added an icon and screen reader hint when `Link` opens a new tab ([#1247](https://github.com/Shopify/polaris-react/pull/1247))
 
 ### Bug fixes
 

--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -136,9 +136,8 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 }
 
 .Content {
+  @include text-breakword;
   padding: spacing(extra-tight) 0;
-  word-break: break-word;
-  overflow-wrap: break-word;
 }
 
 .Ribbon {

--- a/src/components/Labelled/Labelled.scss
+++ b/src/components/Labelled/Labelled.scss
@@ -3,12 +3,11 @@
 }
 
 .LabelWrapper {
+  @include text-breakword;
   margin-bottom: spacing(extra-tight);
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  word-break: break-word;
-  overflow-wrap: break-word;
 }
 
 .HelpText {
@@ -18,7 +17,6 @@
 }
 
 .Error {
+  @include text-breakword;
   margin-top: spacing(extra-tight);
-  word-break: break-word;
-  overflow-wrap: break-word;
 }

--- a/src/components/Modal/components/Header/Header.scss
+++ b/src/components/Modal/components/Header/Header.scss
@@ -7,7 +7,7 @@
 }
 
 .Title {
+  @include text-breakword;
   flex: 1;
   margin-top: spacing(extra-tight);
-  word-break: break-word;
 }


### PR DESCRIPTION
Was cruisin' through the codes and noticed some missed opportunities to use a `typography mixin`.

All I have done is consistently employ the `text-breakword` mixin.