### PR TITLE
[Labelled] Contents can now wrap onto multiple lines

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added an onChange handler to `CheckableButton` ([#1326](https://github.com/Shopify/polaris-react/pull/1326))
+- `Labelled` now wraps its content, no longer causing a `label + action` to get unreasonably squished ([#1309](https://github.com/Shopify/polaris-react/pull/1309))
 - Updated `polaris-tokens` from `2.3.0` to `2.5.0` and converted all use of `duration` values ([#1268](https://github.com/Shopify/polaris-react/pull/1268))
 - More consistent use of `text-breakword` mixin ([#1306](https://github.com/Shopify/polaris-react/pull/1306))
 - Added an icon and screen reader hint when `Link` opens a new tab ([#1247](https://github.com/Shopify/polaris-react/pull/1247))

--- a/src/components/Labelled/Labelled.scss
+++ b/src/components/Labelled/Labelled.scss
@@ -4,10 +4,11 @@
 
 .LabelWrapper {
   @include text-breakword;
-  margin-bottom: spacing(extra-tight);
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: baseline;
+  margin-bottom: spacing(extra-tight);
 }
 
 .HelpText {
@@ -19,4 +20,8 @@
 .Error {
   @include text-breakword;
   margin-top: spacing(extra-tight);
+}
+
+.Action {
+  flex: 0 0 auto;
 }

--- a/src/components/Labelled/Labelled.tsx
+++ b/src/components/Labelled/Labelled.tsx
@@ -40,7 +40,9 @@ export default function Labelled({
 }: Props) {
   const className = classNames(labelHidden && styles.hidden);
 
-  const actionMarkup = action ? buttonFrom(action, {plain: true}) : null;
+  const actionMarkup = action ? (
+    <div className={styles.Action}>{buttonFrom(action, {plain: true})}</div>
+  ) : null;
 
   const helpTextMarkup = helpText ? (
     <div className={styles.HelpText} id={helpTextID(id)}>
@@ -60,6 +62,7 @@ export default function Labelled({
       <Label id={id} {...rest} hidden={false}>
         {label}
       </Label>
+
       {actionMarkup}
     </div>
   ) : null;


### PR DESCRIPTION
In our app, we use forms in a `width` restricted space _(max width of around `260px`)_. When using a form that uses `Labelled` under the hood, and renders both a `label` + `action`, we can get some very ugly squished unwrapping content. Now that we are utilizing more translations in our app, this "ugly squishy" problem is more and more prevalent.

All this PR does is allow `Labelled` to use `flex-wrap: wrap;`, and then wraps the `action` in a `div` so I can apply `flex: 0 0 auto;`.

### Current (less than ideal) behaviour
![less-than-ideal](https://user-images.githubusercontent.com/643944/56048649-ef2e5c00-5d15-11e9-8f7b-76c5087ffa83.gif)

### New wrapping behaviour
![fixed](https://user-images.githubusercontent.com/643944/56048666-f6ee0080-5d15-11e9-800c-8bd61b53d738.gif)
