### PR TITLE
add breakpoint mixin for frame with nav max width

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -24,6 +24,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Updated open styleguide pr to create multiple pull requests to update `polaris-react` across multiple repos ([#1069](https://github.com/Shopify/polaris-react/pull/1069))
 - Updated the pull request creation to retry when it fails ([#1069](https://github.com/Shopify/polaris-react/pull/1069))
 - Exported overlay and layer data attributes for use in consumer components ([#1266](https://github.com/Shopify/polaris-react/pull/1266))
+- Added new `frame-with-nav-max-width` variable and matching `frame-with-nav-when-not-max-width` mixin ([#1311](https://github.com/Shopify/polaris-react/pull/1311))
 
 - Updated `Resizer` to schedule `handleHeightCheck` to run in next animation frame ([#1301](https://github.com/Shopify/polaris-react/pull/1301))
 

--- a/src/styles/shared/breakpoints.scss
+++ b/src/styles/shared/breakpoints.scss
@@ -1,5 +1,6 @@
 $page-max-width: layout-width(primary, max) + layout-width(secondary, max) +
   layout-width(inner-spacing);
+$frame-with-nav-max-width: layout-width(nav) + $page-max-width;
 
 $stacked-content: em(
   layout-width(primary, min) + layout-width(secondary, min) +
@@ -127,6 +128,12 @@ $nav-min-window: em(layout-width(page-with-nav));
 
 @mixin breakpoint-before($breakpoint, $inclusive: true) {
   @media (max-width: #{breakpoint($breakpoint, if($inclusive, 0, -1px))}) {
+    @content;
+  }
+}
+
+@mixin frame-with-nav-when-not-max-width() {
+  @include breakpoint-before($frame-with-nav-max-width) {
     @content;
   }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

<!--
  Context about the problem that’s being addressed.
-->

We can currently use the `page-when-not-max-width` mixin to break pages as soon as they being to resize, but this is not applicable for layouts that use a frame with the nav section. For these cases we need to also take the nav width in account for the breaking width.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This PR adds a new breakpoint variable `$frame-with-nav-max-width` as well as a new mixin to break before that defined width `frame-with-nav-when-not-max-width()`. 

![image](https://user-images.githubusercontent.com/5505280/56168726-db425e80-5f90-11e9-833b-aea5b917d26b.png)
![image](https://user-images.githubusercontent.com/5505280/56168779-088f0c80-5f91-11e9-9f65-dc2f50c2ccf1.png)
![image](https://user-images.githubusercontent.com/5505280/56168812-22c8ea80-5f91-11e9-8455-7b16556f607a.png)

### 🎩 checklist

* ~[ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)~
* ~[ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)~
* ~[ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)~

The actual breakpoint doesn't line up perfectly in storybook due to the extra margins/padding involved, but the intent is still pretty clear from the screenshots above. We want the break to occur as soon as the page content begins to resize and become responsive.

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->

<details>
  <summary>
    Paste code into <code>playground/Playground.tsx</code> → <code>yarn dev</code> → open <a href="http://localhost:6006/?path=/story/playground-playground--playground">storybook</a> → 🎩
  </summary>

```tsx
import * as React from 'react';

import {Banner, Frame, Navigation, Page, TopBar} from '../src';
import * as styles from './Playground.scss';

export default class Playground extends React.PureComponent {
  render() {
    return (
      <Frame navigation={<Navigation location="/" />} topBar={<TopBar />}>
        <Page title="Playground">
          <Banner>
            <p className={styles.Content} />
          </Banner>
        </Page>
      </Frame>
    );
  }
}
```

Requires the following `Playground.scss` content
```scss
.Content::after {
  content: 'Frame Max Width Page';

  @include frame-with-nav-when-not-max-width {
    content: '*** Frame Condensed Page ***';
  }
}
```
</details>