### PR TITLE
Remove core-js

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -39,6 +39,7 @@ Upgraded Storybook to v5 ([#1140](https://github.com/Shopify/polaris-react/pull/
 
 ### Dependency upgrades
 
+- Remove core-js ([#1328](https://github.com/Shopify/polaris-react/pull/1328))
 - Upgraded Polaris icons to include the full icon set ([#1284](https://github.com/Shopify/polaris-react/pull/1284))
 
 ### Code quality

--- a/package.json
+++ b/package.json
@@ -188,7 +188,6 @@
     "@types/react": "^16.4.7",
     "@types/react-dom": "^16.0.6",
     "@types/react-transition-group": "^2.0.7",
-    "core-js": "^2.5.1",
     "hoist-non-react-statics": "^2.5.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.1",

--- a/src/components/DropZone/utils/index.ts
+++ b/src/components/DropZone/utils/index.ts
@@ -1,6 +1,3 @@
-import 'core-js/fn/array/some';
-import 'core-js/fn/string/ends-with';
-
 import {DropZoneEvent} from '../types';
 
 const dragEvents = ['dragover', 'dragenter', 'drop'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -5411,7 +5411,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.0.0, core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.1, core-js@^2.5.3, core-js@^2.5.6, core-js@^2.5.7, core-js@^2.6.5:
+core-js@^2.0.0, core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.3, core-js@^2.5.6, core-js@^2.5.7, core-js@^2.6.5:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==


### PR DESCRIPTION
I noticed we're only using `core-js` in one location. [Some](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some#Browser_compatibility) and [endsWith](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith#Browser_compatibility) appear to have great support and are already used elsewhere in our code base without polyfills

https://github.com/Shopify/polaris-react/blob/d0e6ca5ce82ff6e90d901d617ad9c182cce92c91/src/components/Navigation/components/Item/Item.tsx#L349 
https://github.com/Shopify/polaris-react/blob/9b83385263571a272a6c15dadc92acbf2cc16981/src/components/Navigation/components/Section/Section.tsx#L125
https://github.com/Shopify/polaris-react/blob/d0e6ca5ce82ff6e90d901d617ad9c182cce92c91/src/components/Navigation/components/Item/Item.tsx#L375
https://github.com/Shopify/polaris-react/blob/d0e6ca5ce82ff6e90d901d617ad9c182cce92c91/src/components/Navigation/components/Item/Item.tsx#L380