### PR TITLE
Fix changelog skip failing with new label

### DIFF
--- a/.github/changelog.yml
+++ b/.github/changelog.yml
@@ -13,5 +13,5 @@ include:
   - /^package.json$/
   - /^tsconfig.json$/
 inProgressMessage: missing an entry in UNRELEASED.md
-skipLabel: skip changelog
+skipLabel: 🤖 Skip changelog
 detailsUrl: https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md

--- a/.github/changelog.yml
+++ b/.github/changelog.yml
@@ -13,5 +13,5 @@ include:
   - /^package.json$/
   - /^tsconfig.json$/
 inProgressMessage: missing an entry in UNRELEASED.md
-skipLabel: test
+skipLabel: 🤖 Skip Changelog
 detailsUrl: https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md

--- a/.github/changelog.yml
+++ b/.github/changelog.yml
@@ -13,5 +13,5 @@ include:
   - /^package.json$/
   - /^tsconfig.json$/
 inProgressMessage: missing an entry in UNRELEASED.md
-skipLabel: 🤖 Skip changelog
+skipLabel: 🤖 Skip Changelog
 detailsUrl: https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md

--- a/.github/changelog.yml
+++ b/.github/changelog.yml
@@ -13,5 +13,5 @@ include:
   - /^package.json$/
   - /^tsconfig.json$/
 inProgressMessage: missing an entry in UNRELEASED.md
-skipLabel: 🤖 Skip Changelog
+skipLabel: 🤖Skip Changelog
 detailsUrl: https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md

--- a/.github/changelog.yml
+++ b/.github/changelog.yml
@@ -13,5 +13,5 @@ include:
   - /^package.json$/
   - /^tsconfig.json$/
 inProgressMessage: missing an entry in UNRELEASED.md
-skipLabel: 🤖 Skip Changelog
+skipLabel: test
 detailsUrl: https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,7 +2,7 @@
 
 Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to format new entries. 💜
 
-**Use the `Skip Changelog` label to ignore a failing changelog check** in your pull request if you feel the code changes do not warrant a changelog entry.
+**Use the `🤖 Skip Changelog` label to ignore a failing changelog check** in your pull request if you feel the code changes do not warrant a changelog entry.
 
 ---
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,7 +2,7 @@
 
 Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to format new entries. 💜
 
-**Use the `🤖 Skip Changelog` label to ignore a failing changelog check** in your pull request if you feel the code changes do not warrant a changelog entry.
+**Use the `🤖Skip Changelog` label to ignore a failing changelog check** in your pull request if you feel the code changes do not warrant a changelog entry.
 
 ---
 


### PR DESCRIPTION
### WHY are these changes introduced?

New label broke the changelog bot.

### WHAT is this pull request doing?

Changing the label name