### PR TITLE
[AutoComplete] Fix issue with popover not showing if option selected w keyboard

### DIFF
--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -162,6 +162,8 @@ export default class ComboBox extends React.PureComponent<Props, State> {
       !optionsAreEqual(navigableOptions, prevState.navigableOptions);
 
     if (optionsChanged) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({popoverActive: true, popoverWasActive: true});
       this.updateIndexOfSelectedOption(navigableOptions);
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1265

If you start typing in the autoComplete, you're presented with the options that fit the input so far. You can navigate to the option you want to select with the keyboard and it will complete that option's value.

However if you delete the text input the popover does not become visible again, like it does if you do these interactions by clicking with a mouse instead of using the arrows on the keyboard.

### WHAT is this pull request doing?

The `ComboBox` subcomponent was already comparing `prevState` to `state` to see if the `navigableOptions` had changed - this PR set state to show the `popOver` if that is true.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
