### PR TITLE
Add tertiary action guideline to modal section

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,6 +26,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Documentation
 
 - Updated accessibility testing documentation ([#1449](https://github.com/Shopify/polaris-react/pull/1449))
+- Added guidelines for tertiary actions in modals to `Modal` component documentation ([#1336](https://github.com/Shopify/polaris-react/pull/1336))
 
 ### Development workflow
 

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -14,6 +14,8 @@ keywords:
   - height
   - primary action
   - secondary action
+  - tertiary action
+  - destructive action
   - footer
   - instant
   - sectioned
@@ -86,6 +88,7 @@ class EmbeddedAppModalExample extends React.Component {
 Modals should:
 
 - Only be closed by clicking the `X` or `Cancel` button and not by clicking the backdrop outside the modal, which is a large touch target that could result in accidental presses. Modals require merchants to take an action and should prevent the merchant from accidentally closing the modal without completing the required task.
+- Avoid having more than two buttons (primary and secondary) at the bottom. This prevents unclear action hierarchy and crowding on mobile screens. Since modals are for focused tasks, they should have focused actions. In some cases however, a [tertiary action](#tertiary-actions) may be appropriate.
 
 ---
 
@@ -202,6 +205,29 @@ Actions should be:
 #### Don’t
 
 - Add a menu item
+
+<!-- end -->
+
+<a name="tertiary-actions"></a>
+
+### Tertiary actions
+
+Tertiary actions should:
+
+- Only be used when the action requires the context of the content in the modal
+- Never be used to dismiss the modal
+
+<!-- usagelist -->
+
+#### Do
+
+- Use a plain button for a tertiary action if needed
+  ![Screenshot of modal with a plain button as a tertiary action](/public_images/components/Modal/do-use-plain-button-for-tertiary-action@2x.png)
+
+#### Don’t
+
+- Use a tertiary action for a destructive action
+  ![Screenshot of modal with a destructive button as a tertiary action](/public_images/components/Modal/dont-use-destructive-tertiary-action@2x.png)
 
 <!-- end -->
 


### PR DESCRIPTION
Should be shipped with https://github.com/Shopify/polaris-styleguide/pull/2714

### WHY are these changes introduced?
Following up on Polaris day explorations on [tertiary guidelines in modals ](https://docs.google.com/presentation/d/19Dps59g-7NzxhdYeYKjHk9efxY0TKIf3Uij7dpdawtQ/edit#slide=id.g4a721b0e8c_0_110
)

### WHAT is this pull request doing?
After:
Best practices section:
![image](https://user-images.githubusercontent.com/5504605/56385011-e6dd9180-61eb-11e9-8d35-9a883154c2d3.png)
Content section:
![image](https://user-images.githubusercontent.com/5504605/56385000-dfb68380-61eb-11e9-951f-c02c8af3017f.png)