### PR TITLE
[a11y] Updated accessibility documentation for the external prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Updated `Link` accessibility documentation for the `external` prop to reflect new behavior. ([#1347](https://github.com/Shopify/polaris-react/pull/1347))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/Link/README.md
+++ b/src/components/Link/README.md
@@ -157,12 +157,7 @@ To provide consistency and clarity:
 
 #### External links
 
-Use the `external` prop to make the link open in a new tab (or window, depending on the merchant’s browser settings). Open a page in a new tab only when opening a page in the same tab might disrupt the merchant’s workflow.
-
-To make the external link functionality clear to all merchants:
-
-- Use the [icon component](/components/images-and-icons/icon) to add the `external` icon to the link
-- Use the `accessibilityLabel` on the icon prop to include the warning about opening a new tab in the button text for non-visual screen reader users
+The `external` prop adds an icon and a notification that the link opens a new window. Use the `external` prop to make the link open in a new window (or tab, depending on the merchant’s browser settings). Open a page in a new window or tab only when opening a page in the same tab might disrupt the merchant’s workflow.
 
 ### Keyboard support
 


### PR DESCRIPTION
### WHY are these changes introduced?

Updated to reflect accessibility behavior changes in the `external` prop introduced in 3.13.0 in PR #1247.

### WHAT is this pull request doing?

- Updates the `README.md` for the link component
- Updates `UNRELEASED.md`

### Screenshot

Here's what it looks like in the style guide:

<img width="630" alt="Screenshot of the updated content after the 'External links' heading" src="https://user-images.githubusercontent.com/1462085/56686569-1e838800-6689-11e9-870f-80bfff828b49.png">
