### PR TITLE
[a11y] Added a11y docs to the visually hidden component

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Added accessibility documentation for `VisuallyHidden`. ([#1348](https://github.com/Shopify/polaris-react/pull/1348))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/VisuallyHidden/README.md
+++ b/src/components/VisuallyHidden/README.md
@@ -120,7 +120,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-The visually hidden component styles text so that it is not visible, but it is available to assistive technologies like screen readers and other text to speech programs.
+The visually hidden component styles text so that it’s not visible, but it is available to assistive technologies like screen readers and other text to speech programs.
 
 The component shouldn’t be used to hide interactive content.
 

--- a/src/components/VisuallyHidden/README.md
+++ b/src/components/VisuallyHidden/README.md
@@ -95,3 +95,33 @@ Whenever one or more table columns has no need for a visible header, hide the he
   </tbody>
 </table>
 ```
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+The visually hidden component styles text so that it is not visible, but it is available to assistive technologies like screen readers and other text to speech programs.
+
+The component should not be used to hide content that is interactive.
+
+<!-- /content-for -->

--- a/src/components/VisuallyHidden/README.md
+++ b/src/components/VisuallyHidden/README.md
@@ -122,6 +122,6 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 The visually hidden component styles text so that it is not visible, but it is available to assistive technologies like screen readers and other text to speech programs.
 
-The component should not be used to hide content that is interactive.
+The component shouldn’t be used to hide interactive content.
 
 <!-- /content-for -->


### PR DESCRIPTION
## WHY are these changes introduced?

Adds accessibility guidance for the visually hidden components, to appear in `polaris-react` docs and in the style guide.

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the visually hidden component (web only)
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props: https://polaris.myshopify.io/components/titles-and-text/visually-hidden

### Screenshots

#### Visually hidden

<img width="658" alt="Screenshot of the new accessibility section added to the page" src="https://user-images.githubusercontent.com/1462085/56688131-c64e8500-668c-11e9-9375-228bfef65dc1.png">
