### PR TITLE
[a11y] Added an accessibility section to the text style component docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Added accessibility documentation for `TextStyle`. ([#1350](https://github.com/Shopify/polaris-react/pull/1350))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/TextStyle/README.md
+++ b/src/components/TextStyle/README.md
@@ -146,3 +146,47 @@ Use to display inline snippets of code or code-like text.
 ![Code text style](/public_images/components/TextStyle/ios/code@2x.png)
 
 <!-- /content-for -->
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Don’t rely on text style alone to convey information to merchants. Ensure that text styles are used to enhance the information provided in text.
+
+<!-- usageblock -->
+
+#### Do
+
+```
+<TextStyle variation="positive">Orders increased</TextStyle>
+```
+
+#### Don’t
+
+```
+<TextStyle variation="positive">Orders</TextStyle>
+```
+
+<!-- end -->
+
+<!-- /content-for -->


### PR DESCRIPTION
## WHY are these changes introduced?

Adds accessibility guidance for the text style component, to appear in `polaris-react` docs and in the style guide.

[See the draft Google doc for editing history for these changes and updates for other components and pages.](https://docs.google.com/document/d/1ONoa4fUsqG19i5h0h2Kz2w9CvmFSN926YmoNVMsGPgw/edit)

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the text style component (web, iOS, and Android)
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props: https://polaris.myshopify.io/components/titles-and-text/text-style (web, iOS, and Android)

## Screenshots

### Web

<img width="916" alt="Screenshot of the web content view for the component docs" src="https://user-images.githubusercontent.com/1462085/56690060-69090280-6691-11e9-89b1-f6b53a17dcad.png">

### Android

<img width="609" alt="Screenshot of the Android view for the component docs" src="https://user-images.githubusercontent.com/1462085/56690081-7a520f00-6691-11e9-9e4b-ecf4a2c2606b.png">


### iOS

<img width="569" alt="Screenshot of the iOS view for the component docs" src="https://user-images.githubusercontent.com/1462085/56690103-850ca400-6691-11e9-82de-e2a2d0ca2811.png">
