### PR TITLE
[a11y] Added doc updates for the heading and subheading components

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Added accessibility guidance for `Heading` and `Subheading`. ([#1351](https://github.com/Shopify/polaris-react/pull/1351))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/Heading/README.md
+++ b/src/components/Heading/README.md
@@ -108,3 +108,47 @@ Use for the title of each top-level page section.
 ## Related components
 
 - To break up a section with a heading into sub-sections, [use the subheading component](/components/subheading)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+A clear and consistent heading structure helps merchants who have difficulty with reading or language. It also helps screen reader users to navigate the page using keystrokes that are custom to their screen reader.
+
+Use the `element` prop to determine the specific HTML element that’s output for the heading. The component defaults to a level 2 heading (`<h2>`). Use a different value for the `element` prop if a different heading fits the context better.
+
+Learn more about writing helpful [headings and subheadings](/content/grammar-and-mechanics#section-headings-and-subheadings).
+
+<!-- usageblock -->
+
+#### Do
+
+Use headings to support the hierarchy and structure of the page.
+
+#### Don’t
+
+Use headings for style alone.
+
+<!-- end -->
+
+<!-- /content-for -->

--- a/src/components/Subheading/README.md
+++ b/src/components/Subheading/README.md
@@ -92,3 +92,48 @@ Use to structure content in a card.
 
 - To learn how a card is structured to group similar concepts and tasks together, [use the card component](/components/structure/card)
 - To create a title for a card or top-level page section, [use the heading component](/components/titles-and-text/heading)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+A clear and consistent heading structure helps merchants who have difficulty with reading or language. It also helps screen reader users to navigate the page using keystrokes that are custom to their screen reader.
+
+Use the `element` prop to determine the specific HTML element that’s output for the subheading. The component defaults to a level 3 heading (`<h3>`). Use a different value for the `element` prop if a different subheading fits the context better.
+
+Learn more about writing helpful [headings and subheadings](/content/grammar-and-mechanics#section-headings-and-subheadings).
+
+<!-- usageblock -->
+
+#### Do
+
+Use subheadings to support the hierarchy and structure of the page.
+
+#### Don’t
+
+- Use subheadings for style alone.
+- Use subheadings for major sections of the page.
+
+<!-- end -->
+
+<!-- /content-for -->


### PR DESCRIPTION
## WHY are these changes introduced?

Adds accessibility guidance for the heading and subheading components, to appear in `polaris-react` docs and in the style guide.

[See the draft Google doc for editing history for these changes and updates for other components and pages.](https://docs.google.com/document/d/1ONoa4fUsqG19i5h0h2Kz2w9CvmFSN926YmoNVMsGPgw/edit)

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the heading component (web, iOS, and Android)
* [X] Adds accessibility documentation for the subheading component (web, iOS, and Android)
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props:
  - https://polaris.myshopify.io/components/titles-and-text/heading (web, iOS, and Android)
  - https://polaris.myshopify.io/components/titles-and-text/subheading (web, iOS, and Android)

## Screenshots

### Heading

<img width="912" alt="Screenshot of the web content for the heading component" src="https://user-images.githubusercontent.com/1462085/56693200-b046c180-6698-11e9-841f-23bcccc7a775.png">

### Subheading

<img width="915" alt="Screenshot of the web content for the subheading component" src="https://user-images.githubusercontent.com/1462085/56693157-9a390100-6698-11e9-9af9-cd10594f126e.png">

### Android

<img width="609" alt="Screenshot of the Android view for the component docs" src="https://user-images.githubusercontent.com/1462085/56690081-7a520f00-6691-11e9-9e4b-ecf4a2c2606b.png">


### iOS

<img width="569" alt="Screenshot of the iOS view for the component docs" src="https://user-images.githubusercontent.com/1462085/56690103-850ca400-6691-11e9-82de-e2a2d0ca2811.png">
