### PR TITLE
Added a11y docs for list and stack

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -24,6 +24,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added accessibility documentation for `VisuallyHidden`. ([#1348](https://github.com/Shopify/polaris-react/pull/1348))
 - Added accessibility documentation for `TextStyle`. ([#1350](https://github.com/Shopify/polaris-react/pull/1350))
 - Added accessibility guidance for `Heading` and `Subheading`. ([#1351](https://github.com/Shopify/polaris-react/pull/1351))
+- Added accessibility documentation for `List` and `Stack`. ([#1353](https://github.com/Shopify/polaris-react/pull/1353))
 
 ### Development workflow
 

--- a/src/components/List/README.md
+++ b/src/components/List/README.md
@@ -136,3 +136,33 @@ Use for a text-only list of related items when an inherent order, priority, or s
 - To create a list of checkboxes or radio buttons, [use the choice list component](/components/forms/choice-list)
 - To present a collection of objects of the same type such as customers, products, or orders, [use the resource list component](/components/lists-and-tables/resource-list)
 - When text labels for each item are useful for describing the content, [use the Description List component](/components/lists-and-tables/description-list)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+The list component outputs list items (`<li>`) inside a list wrapper (`<ul>` for bullet lists or `<ol>` for numbered lists). By default, list items are conveyed as a group of related elements to assistive technology users.
+
+To group items for layout only, consider using the [stack component](/components/structure/stack).
+
+<!-- /content-for -->

--- a/src/components/Stack/README.md
+++ b/src/components/Stack/README.md
@@ -160,3 +160,31 @@ The stack component will treat multiple elements wrapped in a stack item compone
 ## Related components
 
 - To create the large-scale structure of pages, [use the layout component](/components/structure/layout)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+The stack component is for alignment only. It does not provide any structural information for assistive technologies. To convey relationships between specific items, consider using the [list component](https://polaris.shopify.com/components/lists-and-tables/list).
+
+<!-- /content-for -->

--- a/src/components/Stack/README.md
+++ b/src/components/Stack/README.md
@@ -185,6 +185,6 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-The stack component is for alignment only. It does not provide any structural information for assistive technologies. To convey relationships between specific items, consider using the [list component](https://polaris.shopify.com/components/lists-and-tables/list).
+The stack component is for alignment only. It does not provide any structural information for assistive technologies. To convey relationships between specific items, consider using the [list component](/components/lists-and-tables/list).
 
 <!-- /content-for -->

--- a/src/components/Stack/README.md
+++ b/src/components/Stack/README.md
@@ -185,6 +185,6 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-The stack component is for alignment only. It does not provide any structural information for assistive technologies. To convey relationships between specific items, consider using the [list component](/components/lists-and-tables/list).
+The stack component is for alignment only and doesn’t provide any structural information for assistive technologies. To convey relationships between specific items, consider using the [list component](/components/lists-and-tables/list).
 
 <!-- /content-for -->


### PR DESCRIPTION
## WHY are these changes introduced?

Adds accessibility information for the list and stack components, to appear in `polaris-react` docs and in the style guide.

[See the draft Google doc for editing history for these changes and updates for other components and pages.](https://docs.google.com/document/d/1ONoa4fUsqG19i5h0h2Kz2w9CvmFSN926YmoNVMsGPgw/edit)

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the list component (web, iOS, and Android)
* [X] Adds accessibility documentation for the stack component (web only)
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props:
  - https://polaris.myshopify.io/components/lists-and-tables/list (web, Android, iOS)
  - https://polaris.shopify.com/components/structure/stack (web only)

## Screenshots

### List

<img width="645" alt="Screenshot of the list information for web" src="https://user-images.githubusercontent.com/1462085/56698084-a081aa00-66a5-11e9-82f5-fccc8afd3599.png">

### Stack

<img width="635" alt="Screenshot of the stack information for web" src="https://user-images.githubusercontent.com/1462085/56698095-ac6d6c00-66a5-11e9-9fdb-95919fc13927.png">

### Android

<img width="609" alt="Screenshot of the Android view for the component docs" src="https://user-images.githubusercontent.com/1462085/56690081-7a520f00-6691-11e9-9e4b-ecf4a2c2606b.png">


### iOS

<img width="569" alt="Screenshot of the iOS view for the component docs" src="https://user-images.githubusercontent.com/1462085/56690103-850ca400-6691-11e9-82de-e2a2d0ca2811.png">
