### PR TITLE
[a11y] Add accessibility guidance for display text

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -24,6 +24,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added accessibility documentation for `VisuallyHidden`. ([#1348](https://github.com/Shopify/polaris-react/pull/1348))
 - Added accessibility documentation for `TextStyle`. ([#1350](https://github.com/Shopify/polaris-react/pull/1350))
 - Added accessibility guidance for `Heading` and `Subheading`. ([#1351](https://github.com/Shopify/polaris-react/pull/1351))
+- Added accessibility guidance for `DisplayText`. ([#1354](https://github.com/Shopify/polaris-react/pull/1354))
 
 ### Development workflow
 

--- a/src/components/DisplayText/README.md
+++ b/src/components/DisplayText/README.md
@@ -127,3 +127,45 @@ Use for text that would otherwise use body text, but that needs to scale with ot
 ```jsx
 <DisplayText size="small">Good evening, Dominic.</DisplayText>
 ```
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Although display text creates an interesting visual experience, it doesn’t replace the semantic structure provided by HTML headings.
+
+By default, the display text component outputs text in an HTML paragraph (`<p>`). If a heading tag is needed for display text, use the `element` prop to set the heading level.
+
+<!-- usageblock -->
+
+#### Do
+
+Use display text to create visual interest along with a meaningful heading structure.
+
+#### Don’t
+
+Use display text in place of standard headings. Use the heading component and subheading component to provide structure.
+
+<!-- end -->
+
+<!-- /content-for -->

--- a/src/components/DisplayText/README.md
+++ b/src/components/DisplayText/README.md
@@ -164,7 +164,7 @@ Use display text to create visual interest along with a meaningful heading struc
 
 #### Don’t
 
-Use display text in place of standard headings. Use the heading component and subheading component to provide structure.
+Use display text in place of standard headings. Use the [heading component](/components/titles-and-text/heading) and [subheading component](/components/titles-and-text/subheading) to provide structure.
 
 <!-- end -->
 


### PR DESCRIPTION
## WHY are these changes introduced?

Adds accessibility information for the display text component, to appear in `polaris-react` docs and in the style guide.

[See the draft Google doc for editing history for these changes and updates for other components and pages.](https://docs.google.com/document/d/1ONoa4fUsqG19i5h0h2Kz2w9CvmFSN926YmoNVMsGPgw/edit)

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the display text component (web, iOS, and Android)
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props: https://polaris.myshopify.io/components/titles-and-text/display-text (web, Android, iOS)

## Screenshots

### Web

<img width="895" alt="Screenshot of the web view for the component docs" src="https://user-images.githubusercontent.com/1462085/56700036-fc036600-66ac-11e9-8abc-1450ff1e303a.png">


### Android

<img width="609" alt="Screenshot of the Android view for the component docs" src="https://user-images.githubusercontent.com/1462085/56690081-7a520f00-6691-11e9-9e4b-ecf4a2c2606b.png">


### iOS

<img width="569" alt="Screenshot of the iOS view for the component docs" src="https://user-images.githubusercontent.com/1462085/56690103-850ca400-6691-11e9-82de-e2a2d0ca2811.png">
