### PR TITLE
[TextContainer] Fix child specificity for margin-top

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -31,6 +31,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added high contrast colour to `Loading` to make it visible in the high contrast mode in Windows ([#1389](https://github.com/Shopify/polaris-react/pull/1389))
 - Fixed the position calculation of the `PositionedOverlay` component after scroll ([#1382](https://github.com/Shopify/polaris-react/pull/1382))
 - Fixed styling issue for Pagination component previous/next buttons when tooltips present ([#1277](https://github.com/Shopify/polaris-react/pull/1277))
+- Fixed a regression introduced in Polaris v3 where certain children of a `TextContainer` would have no top margin ([#1357](https://github.com/Shopify/polaris-react/pull/1357))
 
 ### Documentation
 

--- a/src/components/TextContainer/TextContainer.scss
+++ b/src/components/TextContainer/TextContainer.scss
@@ -1,6 +1,5 @@
 @mixin text-container-spacing($spacing: base) {
-  // stylelint-disable-next-line selector-max-combinators
-  > * + * {
+  > *:not(:first-child) {
     margin-top: (spacing($spacing));
   }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/670

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Change from using:

```
.TextContainer > * + * {
  margin-top: (spacing($spacing));
}
```
to:
```
.TextContainer > *:not(:first-child) {
  margin-top: (spacing($spacing));
}
```

This adds the styling to the same elements (i.e. all direct child elements, except the first one), but increases the specificity so it isn't overwritten by the styling applied to the individual child elements.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {
  Heading,
  Subheading,
  TextContainer,
  DisplayText,
  TextStyle,
  Page,
} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        <TextContainer>
          <Heading>This is a Heading</Heading>
          <Subheading>This is a Subheading</Subheading>
          <DisplayText size="large">This is DisplayText large</DisplayText>
          <DisplayText size="small">This is DisplayText small</DisplayText>
          <TextStyle variation="subdued">This is TextStyle subdued</TextStyle>
          <h1>Test H1</h1>
          <h2>Test H2</h2>
          <p>This is a paragraph tag.</p>
        </TextContainer>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
