### PR TITLE
[a11y] Add documentation for the badge component

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -30,6 +30,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added accessibility guidance for `Heading` and `Subheading`. ([#1351](https://github.com/Shopify/polaris-react/pull/1351))
 - Added accessibility documentation for `List` and `Stack`. ([#1353](https://github.com/Shopify/polaris-react/pull/1353))
 - Added accessibility guidance for `DisplayText`. ([#1354](https://github.com/Shopify/polaris-react/pull/1354))
+- Added accessibility documentation for `Badge`. ([#1364](https://github.com/Shopify/polaris-react/pull/1364))
 
 ### Development workflow
 

--- a/src/components/Badge/README.md
+++ b/src/components/Badge/README.md
@@ -265,3 +265,31 @@ Use to indicate when a given task has been completed. For example, when merchant
 ## Related components
 
 - To represent an interactive list of categories provided by merchants, [use tags](/components/forms/tag)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Badges that convey information with icons or color include text provided by the [visually hidden component](/components/titles-and-text/visually-hidden#navigation). This text is read out by assistive technologies like screen readers so that merchants with vision issues can access the meaning of the badge in context.
+
+<!-- /content-for -->


### PR DESCRIPTION
## WHY are these changes introduced?

Adds accessibility guidance for the badge component, to appear in `polaris-react` docs and in the style guide.

[See the draft Google doc for editing history for these changes and updates for other components and pages.](https://docs.google.com/document/d/1ONoa4fUsqG19i5h0h2Kz2w9CvmFSN926YmoNVMsGPgw/edit)

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the badge component (web, iOS, and Android)
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide` to get the changes that support the accessibility section.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props: /components/images-and-icons/badge (web, iOS, and Android)

## Screenshots

### Web

<img width="644" alt="Screenshot of the web view for the component docs" src="https://user-images.githubusercontent.com/1462085/56768598-ae960000-6763-11e9-8869-98895ee30b24.png">

### Android

<img width="609" alt="Screenshot of the Android view for the component docs" src="https://user-images.githubusercontent.com/1462085/56690081-7a520f00-6691-11e9-9e4b-ecf4a2c2606b.png">


### iOS

<img width="569" alt="Screenshot of the iOS view for the component docs" src="https://user-images.githubusercontent.com/1462085/56690103-850ca400-6691-11e9-82de-e2a2d0ca2811.png">
