### PR TITLE
[a11y] Add action and option list accessibility docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -30,6 +30,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added accessibility guidance for `Heading` and `Subheading`. ([#1351](https://github.com/Shopify/polaris-react/pull/1351))
 - Added accessibility documentation for `List` and `Stack`. ([#1353](https://github.com/Shopify/polaris-react/pull/1353))
 - Added accessibility guidance for `DisplayText`. ([#1354](https://github.com/Shopify/polaris-react/pull/1354))
+- Added accessibility documentation and guidance for `ActionList` and `OptionList`. ([#1365](https://github.com/Shopify/polaris-react/pull/1365))
 
 ### Development workflow
 

--- a/src/components/ActionList/README.md
+++ b/src/components/ActionList/README.md
@@ -326,3 +326,36 @@ class ActionListExample extends React.Component {
 
 - To combine more than one button in a single layout, [use the button group component](/components/actions/button-group)
 - To display a list of related content, [use the list component](/components/lists-and-tables/list)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Items in an action list are organized as list items (`<li>`) in an unordered list (`<ul>`) and are conveyed as a group of related elements to assistive technology users. Each item is implemented as a [button](/components/actions/button).
+
+### Keyboard support
+
+- Give the action list items keyboard focus with the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
+- Activate buttons with the <kbd>enter</kbd>/<kbd>return</kbd> key or the <kbd>space</kbd> key
+
+<!-- /content-for -->

--- a/src/components/OptionList/README.md
+++ b/src/components/OptionList/README.md
@@ -244,7 +244,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 Items in an option list are organized as list items (`<li>`) in an unordered list (`<ul>`) and are conveyed as a group of related elements to assistive technology users.
 
-Controls in simple options lists are [buttons](/components/actions/button), and controls in multiple option lists are [checkboxes](/components/forms/checkbox).
+Controls in simple option lists are [buttons](/components/actions/button), and controls in multiple option lists are [checkboxes](/components/forms/checkbox).
 
 If you wish to customize the option list, you can provide ARIA roles that fit your purpose. These roles must be valid according to the [W3C ARIA specification](https://www.w3.org/TR/wai-aria-1.1/) to be conveyed correctly to screen reader users.
 

--- a/src/components/OptionList/README.md
+++ b/src/components/OptionList/README.md
@@ -217,3 +217,38 @@ class OptionListExample extends React.Component {
   [use the choice list component](/components/forms/choice-list)
 - For a basic version of option list as a single choice menu,
   [use the select component](/components/forms/select)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Items in an option list are implemented in an unordered list (`<ul>`) with list items (`<li>`) so they are conveyed as a related group to screen reader users.
+
+If you wish to customize the option list, you can provide ARIA roles that fit your purpose. These roles must be valid according to the [W3C ARIA specification](https://www.w3.org/TR/wai-aria-1.1/) to be conveyed correctly to screen reader users.
+
+- The `role` prop adds an ARIA role to the option list wrapper
+- The `optionRole` prop adds an ARIA role to the option list items
+
+Controls in simple options lists are [buttons](/components/actions/button), and controls in multiple option lists are [checkboxes](/components/forms/checkbox).
+
+<!-- /content-for -->

--- a/src/components/OptionList/README.md
+++ b/src/components/OptionList/README.md
@@ -246,7 +246,7 @@ Items in an option list are organized as list items (`<li>`) in an unordered lis
 
 Controls in simple option lists are [buttons](/components/actions/button), and controls in multiple option lists are [checkboxes](/components/forms/checkbox).
 
-If you wish to customize the option list, you can provide ARIA roles that fit your purpose. These roles must be valid according to the [W3C ARIA specification](https://www.w3.org/TR/wai-aria-1.1/) to be conveyed correctly to screen reader users.
+If you customize the option list, you can provide ARIA roles that fit the context. These roles must be valid according to the [W3C ARIA specification](https://www.w3.org/TR/wai-aria-1.1/) to be conveyed correctly to screen reader users.
 
 - The `role` prop adds an ARIA role to the option list wrapper
 - The `optionRole` prop adds an ARIA role to the option list items

--- a/src/components/OptionList/README.md
+++ b/src/components/OptionList/README.md
@@ -242,13 +242,13 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-Items in an option list are implemented in an unordered list (`<ul>`) with list items (`<li>`) so they are conveyed as a related group to screen reader users.
+Items in an option list are organized as list items (`<li>`) in an unordered list (`<ul>`) and are conveyed as a group of related elements to assistive technology users.
+
+Controls in simple options lists are [buttons](/components/actions/button), and controls in multiple option lists are [checkboxes](/components/forms/checkbox).
 
 If you wish to customize the option list, you can provide ARIA roles that fit your purpose. These roles must be valid according to the [W3C ARIA specification](https://www.w3.org/TR/wai-aria-1.1/) to be conveyed correctly to screen reader users.
 
 - The `role` prop adds an ARIA role to the option list wrapper
 - The `optionRole` prop adds an ARIA role to the option list items
-
-Controls in simple options lists are [buttons](/components/actions/button), and controls in multiple option lists are [checkboxes](/components/forms/checkbox).
 
 <!-- /content-for -->


### PR DESCRIPTION
## WHY are these changes introduced?

Adds accessibility documentation and guidance for the action list and option list components, to appear in `polaris-react` docs and in the style guide.

[See the draft Google doc for editing history for these changes and updates for other components and pages.](https://docs.google.com/document/d/1ONoa4fUsqG19i5h0h2Kz2w9CvmFSN926YmoNVMsGPgw/edit)

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the action list component (web only)
* [X] Adds accessibility documentation for the option list component (web only)
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide` to get the changes that support the accessibility section.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props:
  - https://polaris.myshopify.io/components/actions/action-list (web only)
  - https://polaris.myshopify.io/components/lists-and-tables/option-list (web only)

## Screenshots

### Action list

<img width="649" alt="Screenshot of web content for action list" src="https://user-images.githubusercontent.com/1462085/56770204-2ebe6480-6768-11e9-8899-d0bced221c0b.png">

### Option list

<img width="680" alt="Screenshot for web content for option list" src="https://user-images.githubusercontent.com/1462085/56770223-3bdb5380-6768-11e9-9f8f-0bee259bf602.png">