### PR TITLE
[a11y] Add docs for card and callout card components

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -30,6 +30,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added accessibility guidance for `Heading` and `Subheading`. ([#1351](https://github.com/Shopify/polaris-react/pull/1351))
 - Added accessibility documentation for `List` and `Stack`. ([#1353](https://github.com/Shopify/polaris-react/pull/1353))
 - Added accessibility guidance for `DisplayText`. ([#1354](https://github.com/Shopify/polaris-react/pull/1354))
+- Added accessibility documentation for `Card` and `CalloutCard`. ([#1366](https://github.com/Shopify/polaris-react/pull/1366))
 
 ### Development workflow
 

--- a/src/components/CalloutCard/README.md
+++ b/src/components/CalloutCard/README.md
@@ -226,3 +226,35 @@ Make all callout cards dismissible so merchants can get rid of cards about featu
 - To group similar concepts and tasks together, [use the card component](/components/structure/card)
 - To create page-level layout, [use the layout component](/components/structure/layout)
 - To explain a feature that merchants haven’t tried yet, [use the empty state component](/components/structure/empty-state)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+The required `title` prop gives the callout card a level 2 heading (`<h2>`). This helps with readability and provides structure to screen reader users.
+
+Illustrations included in callout cards are implemented as decorative images with empty `alt` attributes (`alt=""` ), so that they’re skipped by screen readers.
+
+Use [actionable language](/content/actionable-language#navigation) to ensure that the purpose of the callout card is clear to all merchants, including those with issues related to reading and language.
+
+<!-- /content-for -->

--- a/src/components/CalloutCard/README.md
+++ b/src/components/CalloutCard/README.md
@@ -253,7 +253,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 The required `title` prop gives the callout card a level 2 heading (`<h2>`). This helps with readability and provides structure to screen reader users.
 
-Illustrations included in callout cards are implemented as decorative images with empty `alt` attributes (`alt=""` ), so that they’re skipped by screen readers.
+Illustrations included in callout cards are implemented as decorative images with empty `alt` attributes (`alt=""` ) so that they’re skipped by screen readers.
 
 Use [actionable language](/content/actionable-language#navigation) to ensure that the purpose of the callout card is clear to all merchants, including those with issues related to reading and language.
 

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -578,7 +578,9 @@ The required `title` prop gives the callout card a level 2 heading (`<h2>`) . Th
 
 If you use the `subdued` prop on a card or section, make sure that the card or section `title` conveys the reason for using `subdued`. This ensures that merchants with low vision, including those who use screen readers, can identify that the content is inactive or less important.
 
-Do
+<!-- usage block -->
+
+#### Do
 
 ```
 <Card title="Deactivated staff accounts" sectioned subdued>
@@ -589,7 +591,7 @@ Do
 </Card>
 ```
 
-Don’t
+#### Don’t
 
 ```
 <Card title="Staff accounts" sectioned subdued>
@@ -599,5 +601,7 @@ Don’t
   </List>
 </Card>
 ```
+
+<!-- end -->
 
 <!-- /content-for -->

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -578,7 +578,7 @@ The required `title` prop gives the callout card a level 2 heading (`<h2>`) . Th
 
 If you use the `subdued` prop on a card or section, make sure that the card or section `title` conveys the reason for using `subdued`. This ensures that merchants with low vision, including those who use screen readers, can identify that the content is inactive or less important.
 
-<!-- usage block -->
+<!-- usageblock -->
 
 #### Do
 

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -574,7 +574,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-The required `title` prop gives the callout card a level 2 heading (`<h2>`) . This helps with readability and provides structure to screen reader users.
+The required `title` prop gives the card a level 2 heading (`<h2>`) . This helps with readability and provides structure to screen reader users.
 
 If you use the `subdued` prop on a card or section, make sure that the card or section `title` conveys the reason for using `subdued`. This ensures that merchants with low vision, including those who use screen readers, can identify that the content is inactive or less important.
 

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -549,3 +549,55 @@ Use as a broad example that includes most props available to card.
 
 - To create page-level layout, [use the layout component](/components/structure/layout)
 - To highlight a Shopify feature, [use the callout card component](/components/structure/callout-card)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+The required `title` prop gives the callout card a level 2 heading (`<h2>`) . This helps with readability and provides structure to screen reader users.
+
+If you use the `subdued` prop on a card or section, make sure that the card or section `title` conveys the reason for using `subdued`. This ensures that merchants with low vision, including those who use screen readers, can identify that the content is inactive or less important.
+
+Do
+
+```
+<Card title="Deactivated staff accounts" sectioned subdued>
+  <List>
+    <List.Item>Felix Crafford</List.Item>
+    <List.Item>Ezequiel Manno</List.Item>
+  </List>
+</Card>
+```
+
+Don’t
+
+```
+<Card title="Staff accounts" sectioned subdued>
+  <List>
+    <List.Item>Felix Crafford</List.Item>
+    <List.Item>Ezequiel Manno</List.Item>
+  </List>
+</Card>
+```
+
+<!-- /content-for -->

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -574,7 +574,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-The required `title` prop gives the card a level 2 heading (`<h2>`) . This helps with readability and provides structure to screen reader users.
+The required `title` prop gives the card a level 2 heading (`<h2>`). This helps with readability and provides structure to screen reader users.
 
 If you use the `subdued` prop on a card or section, make sure that the card or section `title` conveys the reason for using `subdued`. This ensures that merchants with low vision, including those who use screen readers, can identify that the content is inactive or less important.
 


### PR DESCRIPTION
## WHY are these changes introduced?

Adds accessibility documentation and guidance for the card and callout card components, to appear in `polaris-react` docs and in the style guide.

[See the draft Google doc for editing history for these changes and updates for other components and pages.](https://docs.google.com/document/d/1ONoa4fUsqG19i5h0h2Kz2w9CvmFSN926YmoNVMsGPgw/edit)

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the card component (web, iOS, and Android)
* [X] Adds accessibility documentation for the callout card component (web only)
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide` to get the changes that support the accessibility section.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props:
  - https://polaris.myshopify.io/components/structure/card (web, iOS, and Android)
  - https://polaris.myshopify.io/components/structure/callout-card (web only)

## Screenshots

### Card

<img width="921" alt="Screenshot of card content for the web" src="https://user-images.githubusercontent.com/1462085/56772042-91662f00-676d-11e9-93cc-7fde620d16f9.png">

### Callout card

<img width="663" alt="Screenshot of callout card content for the web" src="https://user-images.githubusercontent.com/1462085/56772058-a04ce180-676d-11e9-869b-95da8b7bdada.png">

### Android

<img width="597" alt="Screenshot of content for Android" src="https://user-images.githubusercontent.com/1462085/56772100-c5415480-676d-11e9-9409-5f9da9662538.png">

### iOS

<img width="569" alt="Screenshot of content for iOS" src="https://user-images.githubusercontent.com/1462085/56772120-d4c09d80-676d-11e9-9613-a2950b683e03.png">