### PR TITLE
Fix typo with App Bridge version in UNRELEASED log

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -37,7 +37,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Bump react-utilites to remove a transitive dependency on core-js. ([#1343](https://github.com/Shopify/polaris-react/pull/1343))
 
-- Updated App Bridge to version 1.3.3 ([#1349](https://github.com/Shopify/polaris-react/pull/1349))
+- Updated App Bridge to version 1.3.0 ([#1349](https://github.com/Shopify/polaris-react/pull/1349))
 
 ### Code quality
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fix a typo in the log. The version of App Bridge should be v1.3.0