### PR TITLE
[Tabs] Add Action Element to Tab Header

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Improved the performance of `ResourceList` ([#1313](https://github.com/Shopify/polaris-react/pull/1313))
+- Added an action prop to `Tabs` ([#1373](https://github.com/Shopify/polaris-react/pull/1373))
 
 ### Bug fixes
 

--- a/src/components/Tabs/README.md
+++ b/src/components/Tabs/README.md
@@ -197,3 +197,66 @@ Also known as [Segmented controls](https://developer.apple.com/design/human-inte
 ![Fixed tabs on iOS](/public_images/components/Tabs/ios/fixed@2x.png)
 
 <!-- /content-for -->
+
+### Tab with Action
+
+Use when tabs contain a few (2 or 3) items within a narrow column.
+
+```jsx
+class FittedTabsExample extends React.Component {
+  state = {
+    selected: 0,
+  };
+
+  handleTabChange = (selectedTabIndex) => {
+    this.setState({selected: selectedTabIndex});
+  };
+
+  render() {
+    const {selected} = this.state;
+
+    const tabs = [
+      {
+        id: 'all-customers',
+        content: 'All',
+        accessibilityLabel: 'All customers',
+        panelID: 'all-customers-content',
+      },
+      {
+        id: 'accepts-marketing',
+        content: 'Accepts marketing',
+        panelID: 'accepts-marketing-content',
+      },
+    ];
+
+    return (
+      <Card>
+        <Tabs
+          tabs={tabs}
+          selected={selected}
+          onSelect={this.handleTabChange}
+          action={{content: 'More Info'}}
+        >
+          <Card.Section title={tabs[selected].content}>
+            <p>Tab {selected} selected</p>
+          </Card.Section>
+        </Tabs>
+      </Card>
+    );
+  }
+}
+```
+
+<!-- content-for: android -->
+
+![Fixed tabs on Android](/public_images/components/Tabs/android/fixed@2x.png)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+Also known as [Segmented controls](https://developer.apple.com/design/human-interface-guidelines/ios/controls/segmented-controls/) on iOS.
+
+![Fixed tabs on iOS](/public_images/components/Tabs/ios/fixed@2x.png)
+
+<!-- /content-for -->

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -2,6 +2,7 @@ $item-min-height: rem(16px);
 $item-min-width: rem(50px);
 $item-vertical-padding: $item-min-height / 2;
 $focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
+$action-horizontal-padding: (1.5 * spacing(tight));
 
 .Tabs {
   display: flex;
@@ -157,6 +158,13 @@ $focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
 
 .DisclosureTab-visible {
   display: flex;
+}
+
+.ActionTab {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex: 1;
 }
 
 .DisclosureActivator {

--- a/src/components/Tabs/components/Action/Action.scss
+++ b/src/components/Tabs/components/Action/Action.scss
@@ -1,0 +1,64 @@
+$difference-between-touch-area-and-backdrop: control-height() -
+  control-slim-height();
+
+.Action {
+  @include unstyled-button;
+  @include text-style-body;
+  position: relative;
+  display: inline-flex;
+  height: 100%;
+  background-color: transparent;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  text-align: center;
+  text-decoration: none;
+  color: color('blue');
+
+  &:hover,
+  &:active {
+    outline: none;
+    color: color('blue', 'dark');
+
+    .ActionIcon {
+      @include recolor-icon(color('ink'), color('white'));
+    }
+  }
+
+  &:focus,
+  &:active {
+    &::after {
+      background: plain-button-background();
+    }
+  }
+
+  &.disabled {
+    color: color('ink', 'lightest');
+    cursor: default;
+    pointer-events: none;
+
+    .ActionIcon {
+      @include recolor-icon(color('ink', 'lightest'));
+      padding: 0 spacing();
+    }
+  }
+}
+
+.ActionContent {
+  height: 100%;
+  padding: 0 spacing();
+}
+
+.ActionIcon {
+  @include recolor-icon(color('ink', 'lighter'), color('white'));
+  padding: 0 spacing();
+}
+
+.Action-outline {
+  @include button-base;
+  @include button-outline(color('ink', 'lighter'));
+
+  &.disabled {
+    @include button-outline-disabled(color('ink', 'lighter'));
+  }
+}

--- a/src/components/Tabs/components/Action/Action.tsx
+++ b/src/components/Tabs/components/Action/Action.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import {classNames} from '@shopify/react-utilities';
+import {IconableAction, DisableableAction} from '../../../../types';
+import {handleMouseUpByBlurring} from '../../../../utilities/focus';
+import Icon from '../../../Icon';
+import UnstyledLink from '../../../UnstyledLink';
+import styles from './Action.scss';
+
+export interface Props {
+  children?: string;
+  url?: IconableAction['url'];
+  external?: IconableAction['external'];
+  icon?: IconableAction['icon'];
+  onAction?: IconableAction['onAction'];
+  accessibilityLabel?: IconableAction['accessibilityLabel'];
+  disabled?: DisableableAction['disabled'];
+}
+
+export default function Action({
+  icon,
+  url,
+  external,
+  onAction,
+  children,
+  accessibilityLabel,
+  disabled,
+}: Props) {
+  const contentMarkup = icon ? (
+    <span className={styles.ActionIcon}>
+      <Icon source={icon} />
+    </span>
+  ) : (
+    <span className={styles.ActionContent}>{children}</span>
+  );
+
+  if (url) {
+    return (
+      <UnstyledLink
+        key={children}
+        external={external}
+        onMouseUp={handleMouseUpByBlurring}
+        className={styles.Action}
+        url={url}
+        aria-label={accessibilityLabel}
+      >
+        {contentMarkup}
+      </UnstyledLink>
+    );
+  }
+
+  const className = classNames(styles.Action, disabled && styles.disabled);
+
+  return (
+    <button
+      key={children}
+      className={className}
+      onClick={onAction}
+      onMouseUp={handleMouseUpByBlurring}
+      aria-label={accessibilityLabel}
+      type="button"
+      disabled={disabled}
+    >
+      {contentMarkup}
+    </button>
+  );
+}

--- a/src/components/Tabs/components/Action/index.ts
+++ b/src/components/Tabs/components/Action/index.ts
@@ -1,0 +1,4 @@
+import Action from './Action';
+
+export {Props} from './Action';
+export default Action;

--- a/src/components/Tabs/components/Action/tests/Action.test.tsx
+++ b/src/components/Tabs/components/Action/tests/Action.test.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import {CancelSmallMinor} from '@shopify/polaris-icons';
+import {mountWithAppProvider, trigger} from 'test-utilities';
+import Icon from '../../../../Icon';
+import UnstyledLink from '../../../../UnstyledLink';
+import Action from '../Action';
+
+describe('<Action />', () => {
+  describe('icon', () => {
+    it('renders the given icon', () => {
+      const icon = CancelSmallMinor;
+      const action = mountWithAppProvider(<Action icon={icon} />);
+      expect(action.find(Icon).prop('source')).toBe(icon);
+    });
+  });
+
+  describe('url', () => {
+    it('renders a link', () => {
+      const action = mountWithAppProvider(<Action url="http://google.com" />);
+      expect(action.find(UnstyledLink).exists()).toBeTruthy();
+    });
+
+    it('passes the url into the link', () => {
+      const url = 'http://google.com';
+      const action = mountWithAppProvider(<Action url={url} />);
+      expect(action.find(UnstyledLink).prop('url')).toBe(url);
+    });
+  });
+
+  describe('external', () => {
+    it('gets passed into the link', () => {
+      const action = mountWithAppProvider(
+        <Action url="http://google.com" external />,
+      );
+      expect(action.find(UnstyledLink).prop('external')).toBeTruthy();
+    });
+  });
+
+  describe('accessibilityLabel', () => {
+    it('gets passed into the link', () => {
+      const accessibilityLabel = 'Go to Google';
+      const action = mountWithAppProvider(
+        <Action
+          url="http://google.com"
+          accessibilityLabel={accessibilityLabel}
+        />,
+      );
+      expect(action.find(UnstyledLink).prop('aria-label')).toBe(
+        accessibilityLabel,
+      );
+    });
+
+    it('gets passed into the button', () => {
+      const accessibilityLabel = 'Go to Google';
+      const action = mountWithAppProvider(
+        <Action accessibilityLabel={accessibilityLabel} />,
+      );
+      expect(action.find('button').prop('aria-label')).toBe(accessibilityLabel);
+    });
+  });
+
+  describe('disabled', () => {
+    it('gets passed into the button', () => {
+      const action = mountWithAppProvider(<Action disabled />);
+      expect(action.find('button').prop('disabled')).toBeTruthy();
+    });
+  });
+
+  describe('children', () => {
+    it(' does not render when an icon is present', () => {
+      const children = 'Click me!';
+      const action = mountWithAppProvider(
+        <Action icon={CancelSmallMinor}>{children}</Action>,
+      );
+      expect(action.contains(children)).toBeFalsy();
+    });
+
+    it('gets rendered when icon is not present', () => {
+      const children = 'Click me!';
+      const action = mountWithAppProvider(<Action>{children}</Action>);
+      expect(action.contains(children)).toBeTruthy();
+    });
+  });
+
+  describe('onAction()', () => {
+    it('triggers when the button gets clicked', () => {
+      const onActionSpy = jest.fn();
+      const action = mountWithAppProvider(<Action onAction={onActionSpy} />);
+      trigger(action.find('button'), 'onClick');
+      expect(onActionSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
+++ b/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
@@ -12,6 +12,7 @@ import styles from '../../Tabs.scss';
 export interface TabMeasurements {
   containerWidth: number;
   disclosureWidth: number;
+  actionWidth: number;
   hiddenTabWidths: number[];
 }
 
@@ -19,6 +20,7 @@ export interface Props {
   tabToFocus: number;
   siblingTabHasFocus: boolean;
   activator: React.ReactElement<{}>;
+  action: JSX.Element | null;
   selected: number;
   tabs: TabDescriptor[];
   handleMeasurement(measurements: TabMeasurements): void;
@@ -48,6 +50,7 @@ export default class TabMeasurer extends React.PureComponent<Props, never> {
       selected,
       tabs,
       activator,
+      action,
       tabToFocus,
       siblingTabHasFocus,
     } = this.props;
@@ -76,6 +79,7 @@ export default class TabMeasurer extends React.PureComponent<Props, never> {
         <EventListener event="resize" handler={this.handleMeasurement} />
         {tabsMarkup}
         {activator}
+        {action}
       </div>
     );
   }
@@ -89,7 +93,7 @@ export default class TabMeasurer extends React.PureComponent<Props, never> {
       return;
     }
 
-    const {handleMeasurement} = this.props;
+    const {handleMeasurement, action} = this.props;
     const containerWidth = this.containerNode.offsetWidth;
     const tabMeasurerNode = findDOMNode(this);
     const hiddenTabNodes =
@@ -98,11 +102,15 @@ export default class TabMeasurer extends React.PureComponent<Props, never> {
     const hiddenTabWidths = hiddenTabNodesArray.map((node) => {
       return node.getBoundingClientRect().width;
     });
+
+    const actionWidth = action ? (hiddenTabWidths.pop() as number) : 0;
+
     const disclosureWidth = hiddenTabWidths.pop() as number;
 
     handleMeasurement({
       containerWidth,
       disclosureWidth,
+      actionWidth,
       hiddenTabWidths,
     });
   };

--- a/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
+++ b/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
@@ -4,11 +4,18 @@ import {mountWithAppProvider} from 'test-utilities';
 import TabMeasurer from '../TabMeasurer';
 import Tab from '../../Tab';
 import Item from '../../Item';
+import Action from '../../Action';
 
 describe('<TabMeasurer />', () => {
   const mockProps = {
     tabToFocus: 0,
     activator: <Item id="id" focused />,
+    action: (
+      <div>
+        {' '}
+        <Action />{' '}
+      </div>
+    ),
     selected: 1,
     tabs: [
       {

--- a/src/components/Tabs/components/index.ts
+++ b/src/components/Tabs/components/index.ts
@@ -6,6 +6,8 @@ export {default as Panel, Props as PanelProps} from './Panel';
 
 export {default as Tab, Props as TabProps} from './Tab';
 
+export {default as Action, Props as ActionProps} from './Action';
+
 export {
   default as TabMeasurer,
   Props as TabMeasurerProps,

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -139,6 +139,18 @@ describe('<Tabs />', () => {
     });
   });
 
+  describe('action', () => {
+    it('sets an action tab when given the action prop', () => {
+      const actions = {content: 'title'};
+
+      const wrapper = mountWithAppProvider(
+        <Tabs {...mockProps} action={actions} />,
+      );
+
+      expect(wrapper.prop('action')).toEqual(actions);
+    });
+  });
+
   describe('selected', () => {
     let panelStub: {focus: jest.Mock<any>};
     let originalGetElementByID: (typeof document)['getElementById'];
@@ -353,10 +365,12 @@ describe('<Tabs />', () => {
       const disclosureWidth = 50;
       const tabWidths = [82, 160, 150, 100, 80, 120];
       const containerWidth = 300;
+      const actionWidth = 0;
       const actualIndices = getVisibleAndHiddenTabIndices(
         mockTabs,
         selected,
         disclosureWidth,
+        actionWidth,
         tabWidths,
         containerWidth,
       );

--- a/src/components/Tabs/utilities.ts
+++ b/src/components/Tabs/utilities.ts
@@ -4,10 +4,14 @@ export function getVisibleAndHiddenTabIndices(
   tabs: TabDescriptor[],
   selected: number,
   disclosureWidth: number,
+  actionWidth: number,
   tabWidths: number[],
   containerWidth: number,
 ) {
-  const sumTabWidths = tabWidths.reduce((sum, width) => sum + width, 0);
+  const sumTabWidths = tabWidths.reduce(
+    (sum, width) => sum + width + actionWidth,
+    0,
+  );
 
   const arrayOfTabIndices = tabs.map((_, index) => {
     return index;
@@ -24,7 +28,10 @@ export function getVisibleAndHiddenTabIndices(
 
     arrayOfTabIndices.forEach((index) => {
       if (index !== selected) {
-        if (newTabWidth + tabWidths[index] > containerWidth - disclosureWidth) {
+        if (
+          newTabWidth + tabWidths[index] >
+          containerWidth - (disclosureWidth + actionWidth)
+        ) {
           hiddenTabs.push(index);
           return;
         }


### PR DESCRIPTION
### WHY are these changes introduced?

Before there was no way to include an action into the Tabs header. This PR adds a action prop to the Tabs Header section.

Fixes #995  <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Adds an IconableAction prop to the `Tabs` component. Some updates were done to the `TabMeasurer` component and the `getVisibleAndHiddenTabIndices` utility to handle different states of the size of the action Tab and the disclosure activator tab.

 Before:
![](https://screenshot.click/26-31-01tye-147qu.jpg)

After: 
action takes either an Icon or content (with or without a URL for each) 
If an Icon is present, content will not show. 


![](https://screenshot.click/01-36-6zfuq-yycvt.jpg)




<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {CancelSmallMinor} from '@shopify/polaris-icons';
import {Page, Card, Tabs, Icon} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  state = {
    selected: 0,
  };

  handleTabChange = (selectedTabIndex) => {
    this.setState({selected: selectedTabIndex});
  };

  render() {
    const {selected} = this.state;
    const tabs = [
      {
        id: 'all-customers',
        content: 'Pineapple',
        accessibilityLabel: 'All customers',
        panelID: 'all-customers-content',
      },
      {
        id: 'accepts-marketing',
        content: 'Accepts marketing',
        panelID: 'accepts-marketing-content',
      },
      {
        id: 'repeat-customers',
        content: 'Repeat customers',
        panelID: 'repeat-customers-content',
      },
      {
        id: 'prospects',
        content: 'Prospects',
        panelID: 'prospects-content',
      },
    ];

    const makeMeADisclusoreTabs = [
      {
        id: 'all-customers',
        content: 'Pineapple',
        accessibilityLabel: 'All customers',
        panelID: 'all-customers-content',
      },
      {
        id: 'accepts-marketing',
        content: 'Accepts marketing',
        panelID: 'accepts-marketing-content',
      },
      {
        id: 'repeat-customers',
        content: 'Repeat customers',
        panelID: 'repeat-customers-content',
      },
      {
        id: 'prospects',
        content: 'Prospects',
        panelID: 'prospects-content',
      },
      {
        id: 'notProspects',
        content: 'Not Prospects',
        panelID: 'notprospects-content',
      },
      {
        id: 'maybeProspects',
        content: 'Maybe Prospects',
        panelID: 'maybeprospects-content',
      },
    ];

    return (
      <Page title="Playground">
        <p> With Icon fitted</p>
        <Card>
          <Tabs
            tabs={tabs}
            selected={selected}
            onSelect={this.handleTabChange}
            fitted
            action={{
              disabled: true,
              icon: <Icon source={CancelSmallMinor} />,
              external: true,
              url: 'https://facebook.com',
              content: 'GoToThere',
            }}
          >
            <Card.Section title={tabs[selected].content}>
              <p>Tab {selected} selected</p>
            </Card.Section>
          </Tabs>
        </Card>
        <p> With Content fitted</p>
        <Card>
          <Tabs
            tabs={tabs}
            selected={selected}
            onSelect={this.handleTabChange}
            fitted
            action={{
              external: true,
              url: 'https://facebook.com',
              content: 'GoToThere',
            }}
          >
            <Card.Section title={tabs[selected].content}>
              <p>Tab {selected} selected</p>
            </Card.Section>
          </Tabs>
        </Card>
        <p> With Icon Regular</p>
        <Card>
          <Tabs
            tabs={tabs}
            selected={selected}
            onSelect={this.handleTabChange}
            action={{
              icon: <Icon source={CancelSmallMinor} />,
              external: true,
              url: 'https://facebook.com',
              content: 'GoToThere',
            }}
          >
            <Card.Section title={tabs[selected].content}>
              <p>Tab {selected} selected</p>
            </Card.Section>
          </Tabs>
        </Card>
        <p> With Content Regular</p>
        <Card>
          <Tabs
            tabs={tabs}
            selected={selected}
            onSelect={this.handleTabChange}
            action={{
              external: true,
              url: 'https://facebook.com',
              content: 'GoToThere',
            }}
          >
            <Card.Section title={tabs[selected].content}>
              <p>Tab {selected} selected</p>
            </Card.Section>
          </Tabs>
        </Card>
        <p> With Icon regular</p>
        <Card>
          <Tabs
            tabs={tabs}
            selected={selected}
            onSelect={this.handleTabChange}
            action={{
              icon: <Icon source={CancelSmallMinor} />,
              external: true,
              url: 'https://facebook.com',
              content: 'GoToThere',
            }}
          >
            <Card.Section title={tabs[selected].content}>
              <p>Tab {selected} selected</p>
            </Card.Section>
          </Tabs>
        </Card>

        <p> With Icon regular and Disclosure</p>
        <Card>
          <Tabs
            tabs={makeMeADisclusoreTabs}
            selected={selected}
            onSelect={this.handleTabChange}
            action={{
              icon: <Icon source={CancelSmallMinor} />,
              external: true,
              url: 'https://facebook.com',
              content: 'GoToThere',
            }}
          >
            <Card.Section title={tabs[selected].content}>
              <p>Tab {selected} selected</p>
            </Card.Section>
          </Tabs>
        </Card>
        <p> With Content regular and Disclosure</p>
        <Card>
          <Tabs
            tabs={makeMeADisclusoreTabs}
            selected={selected}
            onSelect={this.handleTabChange}
            action={{
              external: true,
              url: 'https://facebook.com',
              content: 'GoToThere',
            }}
          >
            <Card.Section title={tabs[selected].content}>
              <p>Tab {selected} selected</p>
            </Card.Section>
          </Tabs>
        </Card>
      </Page>
    );
  }
}


```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
