### PR TITLE
Use headings level 2 in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -4,7 +4,7 @@ about: Suggest an addition or improvement to Polaris or the documentation
 labels: Feature request
 ---
 
-# Feature request summary
+## Feature request summary
 
 <!--
 Write a short description of the feature here ↓

--- a/.github/ISSUE_TEMPLATE/ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE.md
@@ -6,7 +6,7 @@ labels: Bug
 
 <!-- For feature requests, please use the following template: https://github.com/Shopify/polaris-react/issues/new?template=FEATURE_REQUEST.md -->
 
-# Issue summary
+## Issue summary
 
 <!--
 Write a short description of the issue here ↓

--- a/.github/ISSUE_TEMPLATE/NEW_COMPONENT.md
+++ b/.github/ISSUE_TEMPLATE/NEW_COMPONENT.md
@@ -4,7 +4,7 @@ about: For proposing new components or changes to existing components
 label: New component
 ---
 
-# Component name
+## Component name
 
 Short intro description (try and keep to two sentences):
 > {Component name} are used to {x}. Merchants can use it to {x}.


### PR DESCRIPTION
Let's use headings level 2 for the first heading in issue templates so when displayed on GitHub (the issue's name already is a h1), the heading layout makes sense (one h1, followed by multiple h2s).