### PR TITLE
[documentation] DisplayText: hide Large example from mobile tabs

### DIFF
--- a/src/components/DisplayText/README.md
+++ b/src/components/DisplayText/README.md
@@ -92,6 +92,8 @@ Use this size sparingly and never multiple times on the same page.
 
 ### Large
 
+<!-- example-for: web -->
+
 Use for display text that’s more important than the medium size, but less important than extra large.
 
 ```jsx


### PR DESCRIPTION
Fixes a regression introduced in #2100

Alternatively, we could add a screenshot for the "Large" example.

### Before

![Screenshot 2019-04-29 23 37 44](https://user-images.githubusercontent.com/85783/56944401-13d95080-6ad8-11e9-8bf9-3a1673d83661.png)

### After

![Screenshot 2019-04-29 23 37 55](https://user-images.githubusercontent.com/85783/56944406-163baa80-6ad8-11e9-915c-33355cffdf6b.png)
