### PR TITLE
[TextField] `prefix/suffix` props: Allow clickable actions but retain unselectable text

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,8 +10,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - `Page > Header` now must pass `content` to the `actions` within `secondaryActions` and `actionGroups` ([#1653](https://github.com/Shopify/polaris-react/pull/1653))
 
-### Deprecations
-
 ### New components
 
 - `ActionMenu`: Use for display of actions and action groups within the context of a header ([#1653](https://github.com/Shopify/polaris-react/pull/1653))
@@ -19,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Add `selectable` prop to `ResourceList` component ([#1614](https://github.com/Shopify/polaris-react/pull/1614))
+- Allow `Link` and `Button` interactions when rendered as `prefix/suffix` within `<TextField />` ([#1394](https://github.com/Shopify/polaris-react/pull/1394))
 - `ActionList` can now pass a unique `accessibilityLabel` to each `Item` ([#1653](https://github.com/Shopify/polaris-react/pull/1653))
 - Greatly reduced complexity of `Page > Header` ([#1653](https://github.com/Shopify/polaris-react/pull/1653))
 - Long `Page > Header` breadcrumb labels will now truncate instead of breaking layout ([#1653](https://github.com/Shopify/polaris-react/pull/1653))

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -191,22 +191,23 @@ $stacking-order: (
   }
 }
 
-.Prefix {
-  position: relative;
-  z-index: z-index(contents, $stacking-order);
-  flex: 0 0 auto;
-  margin: 0 $prefix-horizontal-spacing 0 $backdrop-horizontal-spacing;
-  color: currentColor;
-  pointer-events: none;
-}
-
+.Prefix,
 .Suffix {
   position: relative;
   z-index: z-index(contents, $stacking-order);
   flex: 0 0 auto;
-  margin: 0 $backdrop-horizontal-spacing 0 $addon-horizontal-spacing;
   color: currentColor;
-  pointer-events: none;
+  user-select: none;
+}
+
+.Prefix {
+  margin-left: $backdrop-horizontal-spacing;
+  margin-right: $prefix-horizontal-spacing;
+}
+
+.Suffix {
+  margin-left: $addon-horizontal-spacing;
+  margin-right: $backdrop-horizontal-spacing;
 }
 
 .CharacterCount {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -137,6 +137,8 @@ class TextField extends React.PureComponent<CombinedProps, State> {
 
   private input: HTMLElement;
   private buttonPressTimer: number;
+  private prefix = React.createRef<HTMLDivElement>();
+  private suffix = React.createRef<HTMLDivElement>();
 
   constructor(props: CombinedProps) {
     super(props);
@@ -224,13 +226,13 @@ class TextField extends React.PureComponent<CombinedProps, State> {
     const inputType = type === 'currency' ? 'text' : type;
 
     const prefixMarkup = prefix ? (
-      <div className={styles.Prefix} id={`${id}Prefix`}>
+      <div className={styles.Prefix} id={`${id}Prefix`} ref={this.prefix}>
         {prefix}
       </div>
     ) : null;
 
     const suffixMarkup = suffix ? (
-      <div className={styles.Suffix} id={`${id}Suffix`}>
+      <div className={styles.Suffix} id={`${id}Suffix`} ref={this.suffix}>
         {suffix}
       </div>
     ) : null;
@@ -311,9 +313,11 @@ class TextField extends React.PureComponent<CombinedProps, State> {
     }
 
     const labelledBy: string[] = [];
+
     if (prefix) {
       labelledBy.push(`${id}Prefix`);
     }
+
     if (suffix) {
       labelledBy.push(`${id}Suffix`);
     }
@@ -458,7 +462,11 @@ class TextField extends React.PureComponent<CombinedProps, State> {
     onChange && onChange(event.currentTarget.value, this.state.id);
   };
 
-  private handleFocus = () => {
+  private handleFocus = ({target}: React.FocusEvent) => {
+    if (this.containsAffix(target)) {
+      return;
+    }
+
     this.setState({focus: true});
   };
 
@@ -466,9 +474,21 @@ class TextField extends React.PureComponent<CombinedProps, State> {
     this.setState({focus: false});
   };
 
-  private handleClick = () => {
+  private handleClick = ({target}: React.MouseEvent) => {
+    if (this.containsAffix(target)) {
+      return;
+    }
+
     this.input.focus();
   };
+
+  private containsAffix(target: HTMLElement | EventTarget) {
+    return (
+      target instanceof HTMLElement &&
+      ((this.prefix.current && this.prefix.current.contains(target)) ||
+        (this.suffix.current && this.suffix.current.contains(target)))
+    );
+  }
 
   private handleButtonPress = (onChange: Function) => {
     const minInterval = 50;

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -329,6 +329,49 @@ describe('<TextField />', () => {
       expect(textField.find(`#${labels[1]}`).text()).toBe('$');
       expect(textField.find(`#${labels[2]}`).text()).toBe('.00');
     });
+
+    it('does not set focus `onClick` for the <input /> if the `target` is the `prefix`', () => {
+      const onClickSpy = jest.fn();
+      const mockButtonId = 'MockPrefix';
+      const mockPrefixButton = (
+        <button id={mockButtonId} onClick={onClickSpy} />
+      );
+      const textField = mountWithAppProvider(
+        <TextField
+          label="TextField"
+          prefix={mockPrefixButton}
+          onChange={noop}
+        />,
+      );
+
+      textField.find(`#${mockButtonId}`).simulate('click');
+
+      expect(onClickSpy).toHaveBeenCalled();
+      expect(textField.getDOMNode().querySelector('input')).not.toBe(
+        document.activeElement,
+      );
+    });
+
+    it('does not set focus `onFocus` for the <input /> if the `target` is the `prefix`', () => {
+      const mockButtonId = 'MockPrefix';
+      const mockPrefixButton = <button id={mockButtonId} onClick={noop} />;
+      const textField = mountWithAppProvider(
+        <TextField
+          label="TextField"
+          prefix={mockPrefixButton}
+          onChange={noop}
+        />,
+      );
+
+      textField.find(`#${mockButtonId}`).simulate('focus');
+
+      const connectedInteriorWrapper = textField
+        .find(Connected)
+        .find('div')
+        .first();
+
+      expect(connectedInteriorWrapper.hasClass('focus')).toBe(false);
+    });
   });
 
   describe('suffix', () => {
@@ -343,6 +386,49 @@ describe('<TextField />', () => {
       expect(labels).toHaveLength(2);
       expect(textField.find(`#${labels[0]}`).text()).toBe('TextField');
       expect(textField.find(`#${labels[1]}`).text()).toBe('kg');
+    });
+
+    it('does not set focus `onClick` for the <input /> if the `target` is the `suffix`', () => {
+      const onClickSpy = jest.fn();
+      const mockButtonId = 'MockSuffix';
+      const mockSuffixButton = (
+        <button id={mockButtonId} onClick={onClickSpy} />
+      );
+      const textField = mountWithAppProvider(
+        <TextField
+          label="TextField"
+          suffix={mockSuffixButton}
+          onChange={noop}
+        />,
+      );
+
+      textField.find(`#${mockButtonId}`).simulate('click');
+
+      expect(onClickSpy).toHaveBeenCalled();
+      expect(textField.getDOMNode().querySelector('input')).not.toBe(
+        document.activeElement,
+      );
+    });
+
+    it('does not set focus `onFocus` for the <input /> if the `target` is the `suffix`', () => {
+      const mockButtonId = 'MockSuffix';
+      const mockSuffixButton = <button id={mockButtonId} onClick={noop} />;
+      const textField = mountWithAppProvider(
+        <TextField
+          label="TextField"
+          suffix={mockSuffixButton}
+          onChange={noop}
+        />,
+      );
+
+      textField.find(`#${mockButtonId}`).simulate('focus');
+
+      const connectedInteriorWrapper = textField
+        .find(Connected)
+        .find('div')
+        .first();
+
+      expect(connectedInteriorWrapper.hasClass('focus')).toBe(false);
     });
   });
 
@@ -842,6 +928,41 @@ describe('<TextField />', () => {
       expect(textField.find(Connected).prop('right')).toStrictEqual(
         connectedRight,
       );
+    });
+
+    it('sets focus to the <input /> `onClick`', () => {
+      const textField = mountWithAppProvider(
+        <TextField label="TextField" onChange={noop} />,
+      );
+      const connectedChild = textField
+        .find(Connected)
+        .find('div')
+        .first();
+
+      connectedChild.simulate('click');
+
+      expect(textField.getDOMNode().querySelector('input')).toBe(
+        document.activeElement,
+      );
+    });
+
+    it('applies focus variant style `onFocus`', () => {
+      const textField = mountWithAppProvider(
+        <TextField label="TextField" onChange={noop} />,
+      );
+      let connectedInteriorWrapper = textField
+        .find(Connected)
+        .find('div')
+        .first();
+
+      connectedInteriorWrapper.simulate('focus');
+
+      connectedInteriorWrapper = textField
+        .find(Connected)
+        .find('div')
+        .first();
+
+      expect(connectedInteriorWrapper.hasClass('focus')).toBe(true);
     });
   });
 


### PR DESCRIPTION
2 years ago, @ry5n added the following code: https://github.com/Shopify/polaris-react/commit/cbbe3df9a95e7934786174eb183c022658e4dd04

This was specifically to:
> Fix left and right ends of `TextField` not responding to clicks

So the intention was definitely to prevent clicks on any `prefix` or `suffix` and have those clicks pass through, allowing the `focus` state to be triggered for the component.

2 years later I find myself attempting to achieve the following design:

<img width="277" alt="online-store" src="https://user-images.githubusercontent.com/643944/57037296-d1715a00-6c24-11e9-996b-1e6f2bf095df.png">

In the screenshot above, you will see a `<TextField />` that uses:
- An `icon` for a `prefix`
- A "Visit" `<Link />` as a `suffix`
- And a  "X" `<Button />` for `connectedRight`

It turns out, my "Visit" `Link` was not interactable... and after some digging, I arrived on the `pointer-events: none;` code that @ry5n had added.

### Solution Proposed

I am proposing that we swap `pointer-events: none;` for `user-select: none;`. This allows me to have an interactable `Button` or `Link` as `prefix/suffix` while still allowing unselectable and _click-throughable_ `prefix/suffix` text.

<img width="572" alt="Screen Shot 2019-05-01 at 3 16 30 PM" src="https://user-images.githubusercontent.com/643944/57037610-a9cec180-6c25-11e9-995d-5d514550a722.png">

### Playground

<details>
<summary>Please 🎩 using the following Playground code:</summary>

```jsx
/* eslint-disable shopify/react-no-multiple-render-methods */

import * as React from 'react';
import {CancelSmallMinor} from '@shopify/polaris-icons';
import {Button, Link, FormLayout, TextField, Page} from '../src';

interface State {
  exampleOneValue?: string;
  exampleTwoValue?: string;
  exampleThreeValue?: string;
  exampleFourValue?: string;
}

export default class Playground extends React.Component<{}, State> {
  state: State = {
    exampleOneValue: '2.00',
    exampleTwoValue: 'hello there',
    exampleThreeValue: undefined,
    exampleFourValue: undefined,
  };

  handleExampleOneChange = (value) => {
    this.setState({exampleOneValue: value});
  };

  handleExampleTwoChange = (value) => {
    this.setState({exampleTwoValue: value});
  };

  handleExampleThreeChange = (value) => {
    this.setState({exampleThreeValue: value});
  };

  handleExampleFourChange = (value) => {
    this.setState({exampleFourValue: value});
  };

  render() {
    return (
      <Page title="Playground">
        <FormLayout>
          {this.renderExampleOne()}
          {this.renderExampleTwo()}
          {this.renderExampleThree()}
          {this.renderExampleFour()}
        </FormLayout>
      </Page>
    );
  }

  renderExampleOne() {
    const {exampleOneValue} = this.state;

    return (
      <TextField
        label="Example 1"
        type="number"
        value={exampleOneValue}
        placeholder="Placeholder text"
        prefix="$$$"
        onChange={this.handleExampleOneChange}
      />
    );
  }

  renderExampleTwo() {
    const {exampleTwoValue} = this.state;

    return (
      <TextField
        label="Example 2"
        type="text"
        value={exampleTwoValue}
        placeholder="Placeholder text"
        suffix={
          <Button onClick={this.handleOnClick} plain external>
            Log to console
          </Button>
        }
        onChange={this.handleExampleTwoChange}
      />
    );
  }

  renderExampleThree() {
    const {exampleThreeValue} = this.state;

    return (
      <TextField
        label="Example 3"
        type="text"
        value={exampleThreeValue}
        placeholder="Placeholder text"
        prefix={
          <Link url="https://help.shopify.com/manual" external>
            Clickable
          </Link>
        }
        suffix="Not selectable"
        onChange={this.handleExampleThreeChange}
      />
    );
  }

  renderExampleFour() {
    const {exampleFourValue} = this.state;
    const connectedActions = (
      <div className="MyConnectedActions">
        <Button url="https://shopify.ca" external>
          Visit
        </Button>
        <Button icon={CancelSmallMinor} disabled />
      </div>
    );

    return (
      <TextField
        label="Example 4 (using connectedRight instead)"
        type="text"
        value={exampleFourValue}
        placeholder="Placeholder text"
        prefix="Prefix"
        suffix="Suffix"
        connectedRight={connectedActions}
        onChange={this.handleExampleFourChange}
      />
    );
  }

  private handleOnClick(event: any) {
    // Try commenting this out, and you will see the `focus` state/className remain on the input
    event.stopPropagation();
    console.log('Just stopped propagation');
  }
}
```

</details>