### PR TITLE
[Tooltip] Allow overflow for non-breaking content

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Allow `Tooltip` content to wrap no nonbreaking strings [#1395](https://github.com/Shopify/polaris-react/pull/1395)
 - Fixed `Checkbox` being toggled when disabled ([#1369](https://github.com/Shopify/polaris-react/pull/1369))
 - Fixed `DropZone.FileUpload` from incorrectly displaying action hint and title when the default is used and removed ([#1233](https://github.com/Shopify/polaris-react/pull/1233))
 - Fixed `ResourceList.Item` interaction states from being incorrectly applied ([#1312](https://github.com/Shopify/polaris-react/pull/1312)

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -38,12 +38,12 @@ $content-max-width: rem(200px);
 
 .Content {
   position: relative;
-  margin-top: spacing(extra-tight);
   border-radius: border-radius();
   max-width: $content-max-width;
   max-height: $content-max-height;
 }
 
 .Label {
-  padding: 0 spacing(tight) spacing(extra-tight);
+  padding: spacing(extra-tight) spacing(tight);
+  word-break: break-word;
 }

--- a/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -51,7 +51,7 @@ export default class TooltipOverlay extends React.PureComponent<Props, never> {
       positioning === 'above' && styles.positionedAbove,
     );
 
-    const contentStyles = measuring ? undefined : {maxHeight: desiredHeight};
+    const contentStyles = measuring ? undefined : {minHeight: desiredHeight};
 
     return (
       <div className={containerClassName} {...layer.props}>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/205551/56827675-81158900-682d-11e9-8341-aed2d5bd31da.png)

After:
![image](https://screenshot.click/screencast_2019-05-01_16-03-12.gif)

### WHY are these changes introduced?

This addresses an issue where super long unbroken tooltip content is hidden
Fixes: https://github.com/Shopify/core/issues/5822

### WHAT is this pull request doing?

Three things:
1. Force word-break using `word-break: break-word;`
1. Using min-height vs max-height for wrapped rows of text (Risk: not sure of the implications here)
1. Switch to simpler padding for tooltip content alignment

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Stack, Tooltip} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <Stack vertical spacing="tight">
          <Tooltip content="#1061abcdefghijklmnopqrstuvwxyz">
            <span>...pqrstuvwxyz</span>
          </Tooltip>
          <Tooltip content="This order has shipping labels">
            <span>#1001</span>
          </Tooltip>
        </Stack>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
