### PR TITLE
Applying font-family to button elements

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Applied `font-family` to `button` elements which were being overridden by User Agent Stylesheet ([#1397](https://github.com/Shopify/polaris-react/pull/1397))
 - Allowed `Tooltip` content to wrap no nonbreaking strings [#1395](https://github.com/Shopify/polaris-react/pull/1395)
 - Fixed `Checkbox` being toggled when disabled ([#1369](https://github.com/Shopify/polaris-react/pull/1369))
 - Fixed `DropZone.FileUpload` from incorrectly displaying action hint and title when the default is used and removed ([#1233](https://github.com/Shopify/polaris-react/pull/1233))

--- a/src/styles/global/elements.scss
+++ b/src/styles/global/elements.scss
@@ -6,6 +6,11 @@ html,
 body {
   @include text-style-body;
   @include text-emphasis-normal;
+}
+
+html,
+body,
+button {
   font-family: font-family();
 }
 


### PR DESCRIPTION
Due to the [cascade order](https://www.w3.org/TR/CSS21/cascade.html#cascading-order), the browser's User Agent Stylesheet, which defines a style for `button` is overriding the `font-family` value [specified by Polaris](https://github.com/Shopify/polaris-react/blob/master/src/styles/global/elements.scss#L9) on `html, body`. This causes the style not to be inherited as intended for the `button` element. It's why we see different fonts when an `ActionList` contains both `a` and a `button` items.

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1340

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adding `button` to the elements targeted by the `font-family` style rule separating out `html, body` so that only `font-family` is applied to all three.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        {/* Add the code you want to test here */}
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->