### PR TITLE
Switching Transition component for CSSTransition

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed `Popover` fade-in flutter on iOS by switching Transition component for CSSTransition [#1400](https://github.com/Shopify/polaris-react/pull/1400)
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -6,11 +6,31 @@ $content-max-width: rem(400px);
 .Popover {
   max-width: calc(100vw - #{2 * spacing()});
   margin: $visible-portion-of-arrow spacing(tight) spacing();
-  opacity: 1;
   box-shadow: shadow(deep);
   border-radius: border-radius();
   will-change: opacity, left, top;
+}
+
+.entering {
+  opacity: 0;
+}
+
+.entered {
+  opacity: 1;
   transition: opacity duration() easing(in);
+}
+
+.exiting {
+  opacity: 1;
+}
+
+.exited {
+  opacity: 0;
+  transition: opacity duration() easing(out);
+}
+
+.measuring:not(.exiting) {
+  opacity: 0;
 }
 
 .fullWidth {
@@ -22,19 +42,10 @@ $content-max-width: rem(400px);
   }
 }
 
-.measuring:not(.exiting),
-.exiting {
-  opacity: 0;
-}
-
 .measuring {
   .Content {
     display: block;
   }
-}
-
-.exiting {
-  transition-timing-function: easing(out);
 }
 
 .positionedAbove {

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -4,7 +4,7 @@ import {write} from '@shopify/javascript-utilities/fastdom';
 import {classNames} from '@shopify/react-utilities/styles';
 import {isElementOfType, wrapWithComponent} from '@shopify/react-utilities';
 import {durationBase} from '@shopify/polaris-tokens';
-import {Transition} from 'react-transition-group';
+import {CSSTransition} from 'react-transition-group';
 
 import {Key} from '../../../../types';
 import {overlay} from '../../../shared';
@@ -62,9 +62,20 @@ export default class PopoverOverlay extends React.PureComponent<Props, never> {
   render() {
     const {active} = this.props;
     return (
-      <Transition in={active} timeout={durationBase} mountOnEnter unmountOnExit>
+      <CSSTransition
+        in={active}
+        timeout={durationBase}
+        mountOnEnter
+        unmountOnExit
+        classNames={{
+          enter: styles.entering,
+          enterActive: styles.entered,
+          exit: styles.exiting,
+          exitActive: styles.exited,
+        }}
+      >
         {this.renderOverlay}
-      </Transition>
+      </CSSTransition>
     );
   }
 
@@ -120,7 +131,6 @@ export default class PopoverOverlay extends React.PureComponent<Props, never> {
 
     const className = classNames(
       styles.Popover,
-      transitionStatus && animationVariations(transitionStatus),
       positioning === 'above' && styles.positionedAbove,
       fullWidth && styles.fullWidth,
       measuring && styles.measuring,
@@ -215,13 +225,4 @@ function renderPopoverContent(
     return childrenArray;
   }
   return wrapWithComponent(childrenArray, Pane, props);
-}
-
-function animationVariations(status: TransitionStatus) {
-  switch (status) {
-    case 'exiting':
-      return styles.exiting;
-    default:
-      return null;
-  }
 }

--- a/src/components/ResourceList/components/BulkActions/tests/BulkActions.test.tsx
+++ b/src/components/ResourceList/components/BulkActions/tests/BulkActions.test.tsx
@@ -207,7 +207,9 @@ describe('<BulkActions />', () => {
         const bulkActions = mountWithAppProvider(
           <BulkActions {...bulkActionProps} selectMode />,
         );
-        const cssTransition = bulkActions.find(CSSTransition);
+        const cssTransition = bulkActions
+          .find(CSSTransition)
+          .filterWhere((component) => component.prop('appear') === true);
         cssTransition.forEach((cssTransitionComponent) => {
           expect(cssTransitionComponent.prop('in')).toBe(true);
         });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Popovers were [seen to "flutter"](https://github.com/Shopify/online-store-web/issues/2636) when animating on iOS. The `<Transition>` component was calling `renderOverlay` 5 times per `render` which had the effect of interrupting the CSS transition of the `.Popover` element and causing a flutter. By using the `<CSSTransition>` component instead, we better manage the transition and avoid the flutter.

Fixes https://github.com/Shopify/polaris-react/issues/1315

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Swapping `<Transition>` component for `<CSSTransition>`.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
|Before | After|
|--|--|
|![flickery_popover](https://user-images.githubusercontent.com/351842/55034738-927c3300-4fec-11e9-92bf-45c18b5142b7.gif)|![May-02-2019 17-59-00](https://user-images.githubusercontent.com/70582/57109709-2cc64980-6d04-11e9-864f-7748e3e04988.gif)|


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        {/* Add the code you want to test here */}
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->