### PR TITLE
[a11y] Icon accessibility docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -41,7 +41,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added accessibility documentation for `Badge`. ([#1364](https://github.com/Shopify/polaris-react/pull/1364))
 - Added accessibility documentation for `Icon`. ([#1404](https://github.com/Shopify/polaris-react/pull/1404))
 
-
 ### Development workflow
 
 ### Dependency upgrades

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -39,6 +39,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added accessibility documentation and guidance for `ActionList` and `OptionList`. ([#1365](https://github.com/Shopify/polaris-react/pull/1365))
 - Added accessibility documentation for `Card` and `CalloutCard`. ([#1366](https://github.com/Shopify/polaris-react/pull/1366))
 - Added accessibility documentation for `Badge`. ([#1364](https://github.com/Shopify/polaris-react/pull/1364))
+- Added accessibility documentation for `Icon`. ([#1404](https://github.com/Shopify/polaris-react/pull/1404))
 
 ### Development workflow
 

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -65,9 +65,9 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 Using icons can be a great help to merchants who have difficulties with reading, language, attention, and low vision.
 
-If the icon appears without adjacent text, then use the `accessibilityLabel` prop to give the icon a text alternative. This adds an `aria-label` that’s conveyed to screen reader users.
+If the icon appears without text, then use the `accessibilityLabel` prop to give the icon a text alternative. This adds an `aria-label` that’s conveyed to screen reader users.
 
-<!-- usage block -->
+<!-- usageblock -->
 
 #### Do
 

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -76,7 +76,7 @@ If the icon appears without text, then use the `accessibilityLabel` prop to give
 - Review our [alternative text](/content/alternative-text) guidelines to make sure your use of icon works for all merchants
 
 ```
-<Icon source={OrdersMajorMonotone} />
+<Icon source="orders" />
 <p>No orders yet</p>
 ```
 

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -33,7 +33,7 @@ Use to visually communicate core parts of the product and available actions.
 
 ### User provided icon
 
-Specify an svg as a string to render it in an image tag, instead of an inline svg to prevent script injection.
+Specify an SVG as a string to render it in an image tag, instead of an inline SVG to prevent script injection.
 
 ```jsx
 <Icon source="<svg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'><path d='M10.707 17.707l5-5a.999.999 0 1 0-1.414-1.414L11 14.586V3a1 1 0 1 0-2 0v11.586l-3.293-3.293a.999.999 0 1 0-1.414 1.414l5 5a.999.999 0 0 0 1.414 0' /></svg>" />

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -80,7 +80,7 @@ If the icon appears without text, then use the `accessibilityLabel` prop to give
 <p>No orders yet</p>
 ```
 
-```
+```jsx
 <Button icon="circlePlus">Add a product</Button>
 ```
 
@@ -91,7 +91,7 @@ If the icon appears without text, then use the `accessibilityLabel` prop to give
 - Duplicate adjacent text in the alternative text
 - Duplicate information provided programmatically
 
-```
+```jsx
 <Icon source="circlePlus" accessibilityLabel="Circle plus icon" />
 ```
 

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -11,7 +11,6 @@ keywords:
   - icon alternative text
   - alt text
   - alternative text
-  - accessibility
   - wayfinding
   - alert
 ---
@@ -19,26 +18,6 @@ keywords:
 # Icon
 
 Icons are used to visually communicate core parts of the product and available actions. They can act as wayfinding tools to help merchants more easily understand where they are in the product, and common interaction patterns that are available.
-
----
-
-## Best practices
-
-- Icons should be accessible: remember that people with limited vision may not be able to see icons. Review our [alternative text guidelines](/content/alternative-text) to make sure your use of icon works for all merchants.
-
----
-
-## Content guidelines
-
-### Alternative text (alt text)
-
-Screen readers read alt text for icons on hover. Use alt text (`accessibilityLabel` prop or `aria-label` attribute) to communicate icon meaning.
-
-Alt text should be written in [plain language](/content/grammar-and-mechanics#plain-language):
-
-- Keep it short by excluding unnecessary words
-- Write in the [active voice](/content/grammar-and-mechanics#active-and-passive-voice)
-- Use words and language that our merchants use (avoid technical jargon)
 
 ---
 
@@ -59,3 +38,63 @@ Specify an svg as a string to render it in an image tag, instead of an inline sv
 ```jsx
 <Icon source="<svg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'><path d='M10.707 17.707l5-5a.999.999 0 1 0-1.414-1.414L11 14.586V3a1 1 0 1 0-2 0v11.586l-3.293-3.293a.999.999 0 1 0-1.414 1.414l5 5a.999.999 0 0 0 1.414 0' /></svg>" />
 ```
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Using icons can be a great help to merchants who have difficulties with reading, language, attention, and low vision.
+
+If the icon appears without adjacent text, then use the `accessibilityLabel` prop to give the icon a text alternative. This adds an `aria-label` that’s conveyed to screen reader users.
+
+<!-- usage block -->
+
+#### Do
+
+- Pair text and icons for clarity
+- Give the icon a text equivalent if its purpose isn’t conveyed in another way
+- Review our [alternative text](/content/alternative-text) guidelines to make sure your use of icon works for all merchants
+
+```
+<Icon source={OrdersMajorMonotone} />
+<p>No orders yet</p>
+```
+
+```
+<Button icon="circlePlus">Add a product</Button>
+```
+
+#### Don’t
+
+- Describe what the icon looks like
+- Include “icon” in the text equivalent
+- Duplicate adjacent text in the alternative text
+- Duplicate information provided programmatically
+
+```
+<Icon source="circlePlus" accessibilityLabel="Circle plus icon" />
+```
+
+<!-- end -->
+
+<!-- /content-for -->

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -75,7 +75,7 @@ If the icon appears without text, then use the `accessibilityLabel` prop to give
 - Give the icon a text equivalent if its purpose isn’t conveyed in another way
 - Review our [alternative text](/content/alternative-text) guidelines to make sure your use of icon works for all merchants
 
-```
+```jsx
 <Icon source="orders" />
 <p>No orders yet</p>
 ```


### PR DESCRIPTION
### WHY are these changes introduced?

Adds accessibility documentation and guidance for the icon component.

### WHAT is this pull request doing?

- [X] Adds an accessibility section
- [X] Moves the best practices content into the new accessibility section
- [X] Removes the content guidelines since these duplicate guidance on the [alternative text](https://polaris.shopify.com/content/alternative-text) page
- [X] Tidies the keywords
- [x] Adds an entry to `UNRELEASED.md`

## <!-- ℹ️ Delete the following for small / trivial changes -->

## How to 🎩

1. Check out `master` from `polaris-styleguide`
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project)
1. In the `polaris-styleguide` tab, run `dev up && dev start`
1. View changes after examples and props: https://polaris.myshopify.io/components/images-and-icons/icon (web only)

## Screenshot

<img width="924" alt="Screenshot of the new content for web" src="https://user-images.githubusercontent.com/1462085/57113326-e0c1d780-6cf8-11e9-907a-407123d824ae.png">