### PR TITLE
[ToolTip] Add border for high contrast mode

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -32,6 +32,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed the position calculation of the `PositionedOverlay` component after scroll ([#1382](https://github.com/Shopify/polaris-react/pull/1382))
 - Fixed styling issue for Pagination component previous/next buttons when tooltips present ([#1277](https://github.com/Shopify/polaris-react/pull/1277))
 - Fixed a regression introduced in Polaris v3 where certain children of a `TextContainer` would have no top margin ([#1357](https://github.com/Shopify/polaris-react/pull/1357))
+- Added border to `Tooltip` in Windows high contrast mode ([#1405](https://github.com/Shopify/polaris-react/pull/1405))
 
 ### Documentation
 

--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -10,6 +10,10 @@ $content-max-width: rem(200px);
   pointer-events: none;
   will-change: opacity, left, top;
   transition: opacity duration() easing(in) duration(fast);
+
+  @media screen and (-ms-high-contrast: active) {
+    border: border-width(thick) solid ms-high-contrast-color('text');
+  }
 }
 
 .measuring {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Partially fixes https://github.com/Shopify/polaris-react/issues/793

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This PR adds a border to the `Tooltip` in Windows high contrast mode to allow it to be differentiated from the background.

Before: 

![https://screenshot.click/2019-05-03_11-07-53.png](https://screenshot.click/2019-05-03_11-07-53.png)

After:

![https://screenshot.click/2019-05-02_12-22-55.png](https://screenshot.click/2019-05-02_12-22-55.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

- Navigate to `Tooltip -> All Examples` in the Polaris Storybook on a Windows machine/VM running in high contrast mode

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
