### PR TITLE
[a11y] Popover accessibility docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -39,6 +39,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added accessibility documentation and guidance for `ActionList` and `OptionList`. ([#1365](https://github.com/Shopify/polaris-react/pull/1365))
 - Added accessibility documentation for `Card` and `CalloutCard`. ([#1366](https://github.com/Shopify/polaris-react/pull/1366))
 - Added accessibility documentation for `Badge`. ([#1364](https://github.com/Shopify/polaris-react/pull/1364))
+- Added accessibility documentation for `Popover`. ([#1408](https://github.com/Shopify/polaris-react/pull/1408))
 
 ### Development workflow
 

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -437,7 +437,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-Popovers usually contain an[option list](/components/lists-and-tables/option-list) or an [action list](/components/actions/action-list), but can also contain other controls or content.
+Popovers usually contain an [option list](/components/lists-and-tables/option-list) or an [action list](/components/actions/action-list), but can also contain other controls or content.
 
 ### Keyboard support
 

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -412,3 +412,38 @@ Use when you have few actions that affects the whole page. Action sheets doesnâ€
 
 - To put a list of actions in a popover, [use the action list component](/components/actions/action-list)
 - To let merchants select simple options from a list, [use the select component](/components/forms/select)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Appleâ€™s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Popovers usually contain an[option list](/components/lists-and-tables/option-list) or an [action list](/components/actions/action-list), but can also contain other controls or content.
+
+### Keyboard support
+
+- When a popover opens, focus moves to the popover container
+- Once focus is in the popover, merchants can access controls in the popover using the <kbd>tab</kbd> key (and <kbd>shift</kbd> + <kbd>tab</kbd> backwards) and standard keystrokes for interacting
+- Merchants can dismiss the popover by tabbing out of it, pressing the <kbd>esc</kbd> key, or clicking outside of it
+- When the popover is closed, focus returns to the button that launched it
+
+<!-- /content-for -->

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -444,6 +444,6 @@ Popovers usually contain an [option list](/components/lists-and-tables/option-li
 - When a popover opens, focus moves to the popover container
 - Once focus is in the popover, merchants can access controls in the popover using the <kbd>tab</kbd> key (and <kbd>shift</kbd> + <kbd>tab</kbd> backwards) and standard keystrokes for interacting
 - Merchants can dismiss the popover by tabbing out of it, pressing the <kbd>esc</kbd> key, or clicking outside of it
-- When the popover is closed, focus returns to the button that launched it
+- When the popover is closed, focus returns to the element that launched it
 
 <!-- /content-for -->


### PR DESCRIPTION
## WHY are these changes introduced?

Adds accessibility guidance for the popover component, to appear in `polaris-react` docs and in the style guide.

[See the draft Google doc for editing history for these changes and updates for other components and pages.](https://docs.google.com/document/d/1ONoa4fUsqG19i5h0h2Kz2w9CvmFSN926YmoNVMsGPgw/edit)

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the popover component (web, iOS, and Android)
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props: https://polaris.myshopify.io/components/overlays/popover (web, iOS, and Android)

## Screenshots

### Web

<img width="689" alt="Screenshot of the new content for web" src="https://user-images.githubusercontent.com/1462085/57164998-b6c8ed80-6daa-11e9-9b28-d0b7f36915fe.png">

### Android

<img width="605" alt="Screenshot of the new content for Android" src="https://user-images.githubusercontent.com/1462085/57165010-be889200-6daa-11e9-8a40-7264c745bc73.png">

### iOS

<img width="570" alt="Screenshot of the new content for iOS" src="https://user-images.githubusercontent.com/1462085/57165015-c3e5dc80-6daa-11e9-8f53-64beafed8cfe.png">