### PR TITLE
Prevent Firefox from showing an inner dotted border on focused buttons

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Made the `action` prop optional on `EmptyState` ([#1583](https://github.com/Shopify/polaris-react/pull/1583))
+- Prevented Firefox from showing an extra dotted border on focused buttons ([#1409](https://github.com/Shopify/polaris-react/pull/1409))
 
 ### Bug fixes
 

--- a/src/styles/global/elements.scss
+++ b/src/styles/global/elements.scss
@@ -50,3 +50,10 @@ p {
   font-size: 1em;
   font-weight: 400;
 }
+
+button::-moz-focus-inner,
+[type='button']::-moz-focus-inner,
+[type='reset']::-moz-focus-inner,
+[type='submit']::-moz-focus-inner {
+  border-style: none;
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Firefox adds a special, separate dotted inner border to focused buttons. Since we already define focus styles, we can remove this using [the same basic approach as projects like Normalize.css](https://github.com/necolas/normalize.css/blob/fc091cce1534909334c1911709a39c22d406977b/normalize.css#L203).

<img width="292" alt="Screen Shot 2019-05-03 at 7 21 58 PM" src="https://user-images.githubusercontent.com/804014/57172751-1b02a600-6dd9-11e9-98e6-84ed9c05c69a.png">

### WHAT is this pull request doing?

Removes the extra border from buttons and inputs in Firefox.

### 🎩 checklist

* [N/A] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [N/A] Updated the component's `README.md` with documentation changes
* [N/A] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
