### PR TITLE
[ColorPicker] Improve touch interactions

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Resolve console `[Intervention]` errors for touch interactions on `ColorPicker`, along with preventing page scrolling while interacting with the color slider ([#1414](https://github.com/Shopify/polaris-react/pull/1414))
 - Applied `font-family` to `button` elements which were being overridden by User Agent Stylesheet ([#1397](https://github.com/Shopify/polaris-react/pull/1397))
 - Allowed `Tooltip` content to wrap no nonbreaking strings [#1395](https://github.com/Shopify/polaris-react/pull/1395)
 - Fixed `Checkbox` being toggled when disabled ([#1369](https://github.com/Shopify/polaris-react/pull/1369))

--- a/src/components/ColorPicker/components/Slidable/Slidable.tsx
+++ b/src/components/ColorPicker/components/Slidable/Slidable.tsx
@@ -55,11 +55,19 @@ export default class Slidable extends React.PureComponent<Props, State> {
     };
 
     const moveListener = dragging ? (
-      <EventListener event="mousemove" handler={this.handleMove} />
+      <EventListener
+        event="mousemove"
+        handler={this.handleMove}
+        passive={false}
+      />
     ) : null;
 
     const touchMoveListener = dragging ? (
-      <EventListener event="touchmove" handler={this.handleMove} />
+      <EventListener
+        event="touchmove"
+        handler={this.handleMove}
+        passive={false}
+      />
     ) : null;
 
     const endDragListener = dragging ? (
@@ -121,7 +129,10 @@ export default class Slidable extends React.PureComponent<Props, State> {
   private handleMove = (event: MouseEvent | TouchEvent) => {
     event.stopImmediatePropagation();
     event.stopPropagation();
-    event.preventDefault();
+
+    if (event.cancelable) {
+      event.preventDefault();
+    }
 
     if (event.type === 'mousemove') {
       const mouseEvent = event as MouseEvent;

--- a/src/components/ColorPicker/components/Slidable/Slidable.tsx
+++ b/src/components/ColorPicker/components/Slidable/Slidable.tsx
@@ -18,6 +18,25 @@ export interface Props {
   onDraggerHeight?(height: number): void;
 }
 
+let isDragging = false;
+
+// Required to solve a bug causing the underlying page/container to scroll
+// while trying to drag the ColorPicker controls.
+// This must be called as soon as possible to properly prevent the event.
+// `passive: false` must also be set, as it seems webkit has changed the "default" behaviour
+// https://bugs.webkit.org/show_bug.cgi?id=182521
+window.addEventListener(
+  'touchmove',
+  (event) => {
+    if (!isDragging) {
+      return;
+    }
+
+    event.preventDefault();
+  },
+  {passive: false},
+);
+
 export default class Slidable extends React.PureComponent<Props, State> {
   state: State = {
     dragging: false,
@@ -119,10 +138,12 @@ export default class Slidable extends React.PureComponent<Props, State> {
       this.handleDraggerMove(mouseEvent.clientX, mouseEvent.clientY);
     }
 
+    isDragging = true;
     this.setState({dragging: true});
   };
 
   private handleDragEnd = () => {
+    isDragging = false;
     this.setState({dragging: false});
   };
 

--- a/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
+import EventListener from '../../EventListener';
 import {Slidable, AlphaPicker} from '../components';
 import ColorPicker from '../ColorPicker';
 
@@ -78,6 +79,44 @@ describe('<ColorPicker />', () => {
       );
 
       expect(colorPicker.find(AlphaPicker).prop('color')).toEqual(red);
+    });
+  });
+
+  describe('EventListener', () => {
+    it('passes false to passive prop for "mousemove" EventListener when dragging', () => {
+      const onChangeSpy = jest.fn();
+      const colorPicker = mountWithAppProvider(
+        <ColorPicker color={red} onChange={onChangeSpy} />,
+      );
+
+      colorPicker
+        .find(Slidable)
+        .at(SlidableType.BrightnessSaturation)
+        .simulate('mousedown');
+
+      const mouseMoveListener = colorPicker
+        .find(EventListener)
+        .filterWhere((listener) => listener.prop('event') === 'mousemove');
+
+      expect(mouseMoveListener.prop('passive')).toBe(false);
+    });
+
+    it('passes false to passive prop for "touchmove" EventListener when dragging', () => {
+      const onChangeSpy = jest.fn();
+      const colorPicker = mountWithAppProvider(
+        <ColorPicker color={red} onChange={onChangeSpy} />,
+      );
+
+      colorPicker
+        .find(Slidable)
+        .at(SlidableType.BrightnessSaturation)
+        .simulate('mousedown');
+
+      const touchMoveListener = colorPicker
+        .find(EventListener)
+        .filterWhere((listener) => listener.prop('event') === 'touchmove');
+
+      expect(touchMoveListener.prop('passive')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
While working with `ColorPicker` and testing on mobile, I noticed I was getting a ton of console logs:

<img width="816" alt="Screen Shot 2019-05-06 at 2 54 15 PM" src="https://user-images.githubusercontent.com/643944/57248435-52a76300-7010-11e9-9914-ea1d45b150f1.png">

Seemed pretty straight forward - we called `event.preventDefault()` within the `handleMove`, and the browser was defaulting to `passing: true`. In a nutshell, `passive=true` means you do not intend to call `preventDefault` within your handler, so the browser doesn't need to check for it. For those interested, you can read more here: https://developers.google.com/web/updates/2017/01/scrolling-intervention

But while I was at it, I also noticed the page was scrolling alongside touch interactions on the ColorPicker. This is an issue a few of us have already come across. The solution is to listen for `touchmove` on the `window` and `preventDefault` when we want to favour _some other_ interaction - in this case, dragging the color slider.

Please tophat this in Chrome + iOS. Run `yarn dev` and play around in the Storybook ColorPicker examples for both `master` and this branch.

cc/ @tsov 