### PR TITLE
Storybook: Don't generate All Examples page for modal

### DIFF
--- a/.storybook/stories-from-readme.js
+++ b/.storybook/stories-from-readme.js
@@ -5,7 +5,7 @@ import {storiesOf} from '@storybook/react';
 import Playground from '../playground/Playground';
 
 /**
- * In most cases we want to test the "All Examples" page as fewer snapshots
+ * In most cases we want to test an "All Examples" page as fewer snapshots
  * means cheaper pricing. However some examples we need to test individually,
  * usually because they use position:fixed and we don't want examples to
  * overlay each other as it stops the test being useful.
@@ -22,13 +22,16 @@ export function generateStories(readme, readmeModule) {
 
   const testIndividualExamples = percyShouldTestIndividualExamples(readme.name);
 
-  storiesOf(`All Components|${readme.name}`, readmeModule)
-    .addDecorator(AppProviderDecorator)
-    .addDecorator(withA11y)
-    .addParameters({
-      percy: {skip: testIndividualExamples},
-    })
-    .add('All Examples', () => AllExamplesStoryForReadme(readme));
+  // Only add "All Examples" pages for components that use them for percy testing
+  if (!testIndividualExamples) {
+    storiesOf(`All Components|${readme.name}`, readmeModule)
+      .addDecorator(AppProviderDecorator)
+      .addDecorator(withA11y)
+      .addParameters({
+        percy: {skip: false},
+      })
+      .add('All Examples', () => AllExamplesStoryForReadme(readme));
+  }
 
   readme.examples.forEach((example) => {
     storiesOf(`All Components|${readme.name}`, readmeModule)


### PR DESCRIPTION
Modals use fixed positioning so the All Examples page looks like a mess
of modals overlaid one atop the other. That's not useful so stop
generating it.

Fixes #1307

### To test

Look at storybook and see that the Modal "All Examples" story is no longer generated.