### PR TITLE
[Navigation.Section] Prevent rollup from collapsing when sub nav and on mobile

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -34,6 +34,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed styling issue for Pagination component previous/next buttons when tooltips present ([#1277](https://github.com/Shopify/polaris-react/pull/1277))
 - Fixed a regression introduced in Polaris v3 where certain children of a `TextContainer` would have no top margin ([#1357](https://github.com/Shopify/polaris-react/pull/1357))
 - Added border to `Tooltip` in Windows high contrast mode ([#1405](https://github.com/Shopify/polaris-react/pull/1405))
+- Fixed `Navigation.Section` rollup to prevent collapsing when a sub navigation was expanding ([#1417](https://github.com/Shopify/polaris-react/pull/1417))
 
 ### Documentation
 

--- a/src/components/Navigation/components/Section/Section.tsx
+++ b/src/components/Navigation/components/Section/Section.tsx
@@ -3,6 +3,7 @@ import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 
+import {navigationBarCollapsed} from '../../../../utilities/breakpoints';
 import Collapsible from '../../../Collapsible';
 import Icon, {Props as IconProps} from '../../../Icon';
 import {contextTypes} from '../../types';
@@ -80,14 +81,17 @@ export default class Section extends React.Component<Props, State> {
     );
 
     const itemsMarkup = items.map((item) => {
-      const {onClick, label, ...rest} = item;
+      const {onClick, label, subNavigationItems, ...rest} = item;
+      const hasSubNavItems =
+        subNavigationItems != null && subNavigationItems.length > 0;
 
       return (
         <Item
           {...rest}
           key={label}
           label={label}
-          onClick={this.handleClick(onClick)}
+          subNavigationItems={subNavigationItems}
+          onClick={this.handleClick(onClick, hasSubNavItems)}
         />
       );
     });
@@ -166,7 +170,7 @@ export default class Section extends React.Component<Props, State> {
     );
   }
 
-  private handleClick(onClick: ItemProps['onClick']) {
+  private handleClick(onClick: ItemProps['onClick'], hasSubNavItems: boolean) {
     return () => {
       if (onClick) {
         onClick();
@@ -176,9 +180,11 @@ export default class Section extends React.Component<Props, State> {
         cancelAnimationFrame(this.animationFrame);
       }
 
-      this.animationFrame = requestAnimationFrame(() =>
-        this.setState({expanded: false}),
-      );
+      if (!hasSubNavItems || !navigationBarCollapsed().matches) {
+        this.animationFrame = requestAnimationFrame(() =>
+          this.setState({expanded: false}),
+        );
+      }
     };
   }
 

--- a/src/components/Navigation/components/Section/tests/Section.test.tsx
+++ b/src/components/Navigation/components/Section/tests/Section.test.tsx
@@ -129,6 +129,51 @@ describe('<Navigation.Section />', () => {
     expect(channels.state('expanded')).toBe(false);
   });
 
+  it('does not set expanded to false on item click when it has a sub nav and on the mobile breakpoint', () => {
+    matchMedia.setMedia(() => ({matches: true}));
+    const withSubNav = mountWithAppProvider(
+      <Section
+        rollup={{
+          after: 1,
+          view: 'view',
+          hide: 'hide',
+          activePath: '/',
+        }}
+        items={[
+          {
+            label: 'some label',
+            url: '/admin',
+          },
+          {
+            label: 'other label',
+            url: '/other',
+            subNavigationItems: [
+              {
+                label: 'sub label',
+                url: '/other',
+              },
+            ],
+          },
+        ]}
+      />,
+      {
+        context,
+        childContextTypes,
+      },
+    );
+
+    withSubNav.setState({expanded: true});
+
+    withSubNav
+      .find('a[href="/other"]')
+      .first()
+      .simulate('click');
+
+    animationFrame.runFrame();
+
+    expect(withSubNav.state('expanded')).toBe(true);
+  });
+
   it('adds a toggle button if rollupAfter has a value', () => {
     const channels = mountWithAppProvider(
       <Section


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1004

### WHAT is this pull request doing?

Prevents the rollup from collapsing when an item clicked has sub nav and at the mobile breakpoint 

|Before|After|
|---|---|
|![rollup bug](https://user-images.githubusercontent.com/344839/57260400-44f5db80-7018-11e9-87bd-7e5b64c8f2cb.gif)|![prevent rollup](https://user-images.githubusercontent.com/344839/57260410-4cb58000-7018-11e9-8b05-420d6e86d805.gif)|

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Navigation} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <Navigation location="/">
          <Navigation.Section
            rollup={{
              after: 1,
              view: 'view',
              hide: 'hide',
              activePath: '/',
            }}
            items={[
              {
                url: '/path/to/place',
                label: 'Home',
                icon: 'home',
              },
              {
                url: '/path/to/place',
                label: 'Orders',
                icon: 'orders',
                badge: '15',
              },
              {
                url: '/path/to/place',
                label: 'Products',
                icon: 'products',
                subNavigationItems: [
                  {
                    url: '/path/to/place',
                    label: 'Foo',
                  },
                  {
                    url: '/path/to/place',
                    label: 'Bar',
                  },
                  {
                    url: '/path/to/place',
                    label: 'Baz',
                  },
                ],
              },
            ]}
          />
        </Navigation>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] ~~Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)~~
* [ ] ~~Updated the component's `README.md` with documentation changes~~
* [ ] ~~[Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide~~

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
