### PR TITLE
Fix contextual save bar typo

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -49,6 +49,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added accessibility documentation for `Card` and `CalloutCard` ([#1366](https://github.com/Shopify/polaris-react/pull/1366))
 - Added accessibility documentation for `Badge` ([#1364](https://github.com/Shopify/polaris-react/pull/1364))
 - Added accessibility documentation for `Icon` ([#1404](https://github.com/Shopify/polaris-react/pull/1404))
+- Fixed content example for `ContextualSaveBar` guidelines ([#1423](https://github.com/Shopify/polaris-react/pull/1423))
 
 ### Development workflow
 

--- a/src/components/ContextualSaveBar/README.md
+++ b/src/components/ContextualSaveBar/README.md
@@ -74,7 +74,7 @@ Actions in the contextual save bar component should consist of a strong verb tha
 
 #### Don’t
 
-- Don’t example
+- Save changes
 - Discard changes
 
 <!-- end -->


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1422

### WHAT is this pull request doing?

Adds the correct copy for a "Don't" example ("Save changes" instead of "Don't example").
