### PR TITLE
[Link] Improve accessibility of focus styles

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed `Popover` fade-in flutter on iOS by switching Transition component for CSSTransition [#1400](https://github.com/Shopify/polaris-react/pull/1400)
+- Improved the visibility of focus styles for the `Link` component. [#1425](https://github.com/Shopify/polaris-react/pull/1425)
 
 ### Documentation
 

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -5,16 +5,14 @@
   text-align: inherit;
   padding: 0;
   background: none;
-  border: none;
+  border: 0;
   font-size: inherit;
   color: color('blue');
   text-decoration: none;
   cursor: pointer;
 
   &:hover,
-  &:focus,
   &:active {
-    outline: none;
     color: color('blue', 'dark');
   }
 }

--- a/src/styles/shared/links.scss
+++ b/src/styles/shared/links.scss
@@ -23,11 +23,12 @@
     transition: opacity duration() easing();
   }
 
-  &:hover,
-  &:focus,
-  &:active {
-    &::after {
-      opacity: 0.4;
-    }
+  &:hover::after,
+  &:active::after {
+    opacity: 0.4;
+  }
+
+  &:focus::after {
+    display: none;
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/40 and https://github.com/Shopify/polaris-ux/issues/156

### Original design

In the original issues, we landed on some more accessible focus styles for links:

![56589956-33421c00-65b4-11e9-8215-6dcac9315bcc copy](https://user-images.githubusercontent.com/804014/57348851-a4cdae80-710c-11e9-8c86-b8f5247c246a.png)

### Implementation challenges

In implementing these, however, I ran into some problems. The main one is that if `Link` remains styled as an inline element, image links look bad out of the box:

<img width="119" alt="Image link issue" src="https://user-images.githubusercontent.com/804014/57348783-41438100-710c-11e9-9d41-fcc753e52a2c.png">

We could fix this by making all images in Polaris block-level by default. This is usually what you want, but may have knock-on effects in consuming apps. Another way would be to set links to be `inline-flex`, but has similar risks for existing apps.

### Current approach: go with browser defaults

To avoid breaking changes, I’ve opted to go a different route from the original designs and strip back to browser default styles instead.

Here’s how things look now in different browsers. I left out iOS Safari since I haven’t been able to get the external keyboard emulation working in order to visualize element focus.

#### Chrome (Android)
<img width="360" alt="Chrome Android" src="https://user-images.githubusercontent.com/804014/57348506-2290ba80-710b-11e9-8ce1-a23390f4faa0.png">

#### Chrome (Mac)
<img width="734" alt="Chrome Mac" src="https://user-images.githubusercontent.com/804014/57348361-a4ccaf00-710a-11e9-9d3f-8aa1134ec65d.png">

#### Safari (Mac)
<img width="732" alt="Safari Mac" src="https://user-images.githubusercontent.com/804014/57348364-a4ccaf00-710a-11e9-873e-005c7c0f04c9.png">

#### Edge (Windows)
<img width="551" alt="Edge Windows" src="https://user-images.githubusercontent.com/804014/57348362-a4ccaf00-710a-11e9-8a3a-0d60582ebf18.png">

#### Firefox (Mac)
<img width="663" alt="Firefox Mac" src="https://user-images.githubusercontent.com/804014/57348363-a4ccaf00-710a-11e9-89ef-53500fcb5aa6.png">

---

### How to review

My big question is: are we OK moving forward with this approach? It’s not ideal, but it’s also a big improvement on the inaccessible styles we have today.

Please give feedback based on either the screenshots attached, or 🎩using the playground below:

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Link} from '../src';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        <p style={{marginBottom: 16}}>
          Focus styles have to account for text wrapping.{' '}
          <Link url="#">Text links</Link> are intended for use within other
          text.
        </p>

        <p style={{marginBottom: 16}}>
          Focus styles have to account for text wrapping.{' '}
          <Link monochrome url="#">
            Monochrome links
          </Link>{' '}
          are also intended for use within other text.
        </p>

        <p style={{marginBottom: 16, maxWidth: 400}}>
          Focus styles have to account for text wrapping. Focus styles have to
          account for text wrapping.{' '}
          <Link url="#">Very long link that will wrap at some point</Link> are
          intended for use within other text.
        </p>

        <Link url="#">
          <img src="http://placekitten.com/80/80" alt="Kitten" />
        </Link>
      </Page>
    );
  }
}

```
</details>

### Next steps

If we’re OK with this experience, I’ll update documentation and changelog and ship. We can then consider what larger changes we’d want to make to Polaris’ foundations to support a better implementation/breaking change later.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [N/A] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
