### PR TITLE
[DataTable] Fix for iOS fixed column issue

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixed an issue where the JavaScript breakpoints incorrectly set the navigation bar collapsed breakpoint ([#1475](https://github.com/Shopify/polaris-react/pull/1475))
 - Added a border to `Toast` messages to make them more visible in Windows high contrast mode ([#1469](https://github.com/Shopify/polaris-react/pull/1469))
+- Fixed iOS bug on `DataTable` where fixed column was not visible [#1426](https://github.com/Shopify/polaris-react/pull/1426)
 
 ### Documentation
 

--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -1,5 +1,9 @@
 $fixed-column-width: rem(145px);
 $breakpoint: 768px;
+$stacking-order: (
+  fixed-cell: 2,
+  icon: 1,
+);
 
 .DataTable {
   position: relative;
@@ -26,7 +30,7 @@ $breakpoint: 768px;
   }
 
   .ScrollContainer {
-    margin-left: rem($fixed-column-width);
+    padding-left: rem($fixed-column-width);
   }
 }
 
@@ -58,7 +62,7 @@ $breakpoint: 768px;
 .ScrollContainer {
   overflow-x: auto;
   // account for a mysterious gap in Safari when not collapsed
-  margin-left: rem(140px);
+  padding-left: rem($fixed-column-width);
   -webkit-overflow-scrolling: touch;
 }
 
@@ -95,12 +99,14 @@ $breakpoint: 768px;
 }
 
 .Cell {
+  position: relative;
+  vertical-align: top;
   padding: spacing();
   border-bottom: border-width() solid color('sky', 'light');
+  background-color: color('white');
   white-space: nowrap;
   text-align: left;
   transition: background-color 0.2s ease-in-out;
-  vertical-align: top;
 }
 
 .Cell-numeric {
@@ -111,6 +117,7 @@ $breakpoint: 768px;
   @include text-emphasis-normal;
   @include text-breakword;
   position: absolute;
+  z-index: z-index(fixed-cell, $stacking-order);
   top: auto;
   left: 0;
   width: $fixed-column-width;
@@ -136,6 +143,7 @@ $breakpoint: 768px;
 }
 
 .Icon {
+  z-index: z-index(icon, $stacking-order);
   display: flex;
   align-self: flex-end;
   opacity: 0;

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -75,7 +75,12 @@ export class DataTable extends React.PureComponent<
     } = this;
     let collapsed = false;
     if (table && scrollContainer) {
-      collapsed = table.scrollWidth > scrollContainer.clientWidth;
+      const headerCells = table.querySelectorAll(
+        headerCell.selector,
+      ) as NodeListOf<HTMLElement>;
+      const fixedColumnWidth = headerCells[0].offsetWidth;
+      collapsed =
+        table.scrollWidth + fixedColumnWidth > scrollContainer.clientWidth;
       scrollContainer.scrollLeft = 0;
     }
     this.setState(

--- a/src/components/DataTable/utilities.ts
+++ b/src/components/DataTable/utilities.ts
@@ -13,10 +13,9 @@ export function measureColumn(tableData: TableMeasurements) {
       firstVisibleColumnIndex,
       tableLeftVisibleEdge: tableStart,
       tableRightVisibleEdge: tableEnd,
-      fixedColumnWidth,
     } = tableData;
 
-    const leftEdge = column.offsetLeft + fixedColumnWidth;
+    const leftEdge = column.offsetLeft;
     const rightEdge = leftEdge + column.offsetWidth;
     const isVisibleLeft = isEdgeVisible(leftEdge, tableStart, tableEnd);
     const isVisibleRight = isEdgeVisible(rightEdge, tableStart, tableEnd);


### PR DESCRIPTION
resolves: https://github.com/Shopify/polaris-react/issues/489

On iOS, the overflow-x auto on ios doesn't allow the position absolute column to be visible.

In trying to solve this I changed the margin-left to padding-left. The result is that scrolls bar appears across the entire bottom, which IMO, is a decent compromise:

![datatable](https://user-images.githubusercontent.com/1229901/57374303-93b28b00-7168-11e9-8447-b1daccd22e25.gif)

As a result though, on iOS, the first columns scrolls with the content so this still needs some work but might be easier to solve than the current issue?



### WHY are these changes introduced?

Fixes: https://github.com/Shopify/polaris-react/issues/489


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, DataTable, Card} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  state = {
    sortedRows: null,
  };

  sortCurrency = (rows, index, direction) => {
    return [...rows].sort((rowA, rowB) => {
      const amountA = parseFloat(rowA[index].substring(1));
      const amountB = parseFloat(rowB[index].substring(1));

      return direction === 'descending' ? amountB - amountA : amountA - amountB;
    });
  };

  handleSort = (rows) => (index, direction) => {
    this.setState({sortedRows: this.sortCurrency(rows, index, direction)});
  };

  render() {
    const {sortedRows} = this.state;
    const initiallySortedRows = [
      ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
      ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
      [
        'Navy Merino Wool Blazer with khaki chinos and yellow belt',
        '$445.00',
        124518,
        32,
        '$14,240.00',
      ],
    ];
    const rows = sortedRows ? sortedRows : initiallySortedRows;

    return (
      <Page title="Sales by product">
        <Card>
          <DataTable
            columnContentTypes={[
              'text',
              'numeric',
              'numeric',
              'numeric',
              'numeric',
            ]}
            headings={[
              'Product',
              'Price',
              'SKU Number',
              'Net quantity',
              'Net sales',
            ]}
            rows={rows}
            totals={['', '', '', 255, '$155,830.00']}
            sortable={[false, true, false, false, true]}
            defaultSortDirection="descending"
            initialSortColumnIndex={4}
            onSort={this.handleSort(rows)}
          />
        </Card>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
