### PR TITLE
[TextField] Adding an alignRight prop on TextField

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 – Enhanced `NavigationItem`s colour accessibility for `active`, `focus`, `hover` and `Selected` states([1304](https://github.com/Shopify/polaris-react/pull/1304))
 
+- Added `align` prop to `TextField` ([#1428](https://github.com/Shopify/polaris-react/pull/1428))
+
 ### Bug fixes
 
 - Fixed `Popover` fade-in flutter on iOS by switching Transition component for CSSTransition [#1400](https://github.com/Shopify/polaris-react/pull/1400)

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -414,6 +414,37 @@ class LabelActionExample extends React.Component {
 }
 ```
 
+### TextField with right aligned text
+
+Use when input text should be aligned right.
+
+```jsx
+class RightAlignExample extends React.Component {
+  state = {
+    value: '1',
+  };
+
+  handleChange = (value) => {
+    this.setState({value});
+  };
+
+  render() {
+    return (
+      <Stack>
+        <Stack.Item fill>Price</Stack.Item>
+        <TextField
+          label="Price"
+          labelHidden
+          value={this.state.value}
+          onChange={this.handleChange}
+          align="right"
+        />
+      </Stack>
+    );
+  }
+}
+```
+
 ### Text field with placeholder text
 
 Use to provide a short, non-essential hint about the expected input. Placeholder text is low-contrast, so don’t rely on it for important information.

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -133,6 +133,18 @@ $stacking-order: (
   padding-right: 0;
 }
 
+.Input-alignRight {
+  text-align: right;
+}
+
+.Input-alignLeft {
+  text-align: left;
+}
+
+.Input-alignCenter {
+  text-align: center;
+}
+
 .Backdrop {
   position: absolute;
   z-index: z-index(backdrop, $stacking-order);

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {addEventListener} from '@shopify/javascript-utilities/events';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
-import {classNames} from '@shopify/react-utilities/styles';
+import {classNames, variationName} from '@shopify/react-utilities/styles';
 
 import Labelled, {Action, helpTextID, labelID} from '../Labelled';
 import Connected from '../Connected';
@@ -25,6 +25,8 @@ export type Type =
   | 'time'
   | 'week'
   | 'currency';
+
+export type Alignment = 'left' | 'right' | 'center';
 
 export interface State {
   height?: number | null;
@@ -99,6 +101,8 @@ export interface BaseProps {
   ariaAutocomplete?: string;
   /** Indicates whether or not the character count should be displayed */
   showCharacterCount?: boolean;
+  /** Determines the alignment of the text in the input */
+  align?: Alignment;
   /** Callback when value is changed */
   onChange?(value: string, id: string): void;
   /** Callback when input is focused */
@@ -157,41 +161,42 @@ class TextField extends React.PureComponent<CombinedProps, State> {
 
   render() {
     const {
-      id = this.state.id,
-      value,
-      placeholder,
-      disabled,
-      readOnly,
-      role,
-      autoFocus,
-      type,
-      name,
-      error,
-      multiline,
-      connectedRight,
-      connectedLeft,
-      label,
-      labelAction,
-      labelHidden,
-      helpText,
-      prefix,
-      suffix,
-      onFocus,
-      onBlur,
-      autoComplete,
-      min,
-      max,
-      step,
-      minLength,
-      maxLength,
-      spellCheck,
-      pattern,
-      ariaOwns,
+      align,
       ariaActiveDescendant,
       ariaAutocomplete,
       ariaControls,
-      showCharacterCount,
+      ariaOwns,
+      autoComplete,
+      autoFocus,
+      connectedLeft,
+      connectedRight,
+      disabled,
+      error,
+      helpText,
+      id = this.state.id,
+      label,
+      labelAction,
+      labelHidden,
+      max,
+      maxLength,
+      min,
+      minLength,
+      multiline,
+      name,
+      onBlur,
+      onFocus,
+      pattern,
+      placeholder,
       polaris: {intl},
+      prefix,
+      readOnly,
+      role,
+      showCharacterCount,
+      spellCheck,
+      step,
+      suffix,
+      type,
+      value,
     } = this.props;
 
     const normalizedValue = value != null ? value : '';
@@ -292,6 +297,7 @@ class TextField extends React.PureComponent<CombinedProps, State> {
 
     const inputClassName = classNames(
       styles.Input,
+      align && styles[variationName('Input-align', align)],
       suffix && styles['Input-suffixed'],
     );
 

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -24,6 +24,7 @@ describe('<TextField />', () => {
         maxLength={2}
         spellCheck={false}
         pattern={pattern}
+        align="left"
       />,
     ).find('input');
 


### PR DESCRIPTION
There are a few instances in the admin where the `TextField` is right aligned. Usually in a modal where multiple rows of numbers need to line up.

To achieve this I added an align="left | right | center" prop to Textfield.


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Card, TextField, Stack} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Sales by product">
        <Card sectioned>
          <Stack vertical>
            <TextField onChange={() => null} value="default" label="default" />
            <TextField
              onChange={() => null}
              value="right"
              label="right"
              align="right"
            />
            <TextField
              onChange={() => null}
              value="left"
              label="left"
              align="left"
            />
            <TextField
              onChange={() => null}
              value="center"
              label="center"
              align="center"
            />
          </Stack>
        </Card>
      </Page>
    );
  }
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
