### PR TITLE
[AnnotatedSection] Update type definition for title prop to accept React.ReactNode

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Added support for dual values to `RangeSlider` component ([#784](https://github.com/Shopify/polaris-react/pull/784))
 
+- Updated type restrictions for `AnnotatedSection` to allow its `title` prop to accept `React.ReactNode` instead of `string` ([#1431](https://github.com/Shopify/polaris-react/pull/1431))
+
 ### Bug fixes
 
 - Fixed an issue where the JavaScript breakpoints incorrectly set the navigation bar collapsed breakpoint ([#1475](https://github.com/Shopify/polaris-react/pull/1475))

--- a/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
+++ b/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
@@ -5,7 +5,7 @@ import styles from '../../Layout.scss';
 
 export interface Props {
   children?: React.ReactNode;
-  title?: string;
+  title?: React.ReactNode;
   description?: React.ReactNode;
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?
We came across a use case where we wanted to render another component, such as a `Badge` alongside the heading for an `AnnotatedSection`:

![image](https://user-images.githubusercontent.com/8534230/57400460-8ebdfd80-71a1-11e9-90a3-1eb66e2b30e5.png)

We considered passing a React component to the `title` prop that rendered both a `Heading` and a `Badge` component:

```jsx
<Layout.AnnotatedSection
    title={
        <Stack>
            <Heading />
            <Badge />
        </Stack>
    }
>
``` 

While this renders successfuly in the browser, it raises a TypeScript error in the text editor because, at the moment, the `title` prop only supports strings.

![image](https://user-images.githubusercontent.com/8534230/57400740-2ae80480-71a2-11e9-8ef1-af4232090153.png)

After consulting @BPScott, we felt it seemed reasonable to change the type restriction for the `title` prop in this scenario: https://shopify.slack.com/archives/C8H54T86Q/p1557331031274400

### WHAT is this pull request doing?
This PR updates the type definition for the `title` prop of the `AnnotatedSection` component to accept `React.ReactNode` instead of `string`.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        {/* Add the code you want to test here */}
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
