### PR TITLE
[ColorPicker] Do not call `window` if "undefined"

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fix `window` call on `server` executed code [#1427](https://github.com/Shopify/polaris-react/pull/1427)
 - Fixed onClick from firing three times when using the enter key on a `ResourceList` item ([#1188](https://github.com/Shopify/polaris-react/pull/1188))
 - Resolve console `[Intervention]` errors for touch interactions on `ColorPicker`, along with preventing page scrolling while interacting with the color slider ([#1414](https://github.com/Shopify/polaris-react/pull/1414))
 - Applied `font-family` to `button` elements which were being overridden by User Agent Stylesheet ([#1397](https://github.com/Shopify/polaris-react/pull/1397))

--- a/src/components/ColorPicker/components/Slidable/Slidable.tsx
+++ b/src/components/ColorPicker/components/Slidable/Slidable.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import {isServer} from '@shopify/react-utilities/target';
 import EventListener from '../../../EventListener';
+
 import styles from '../../ColorPicker.scss';
 
 export interface Position {
@@ -25,17 +27,19 @@ let isDragging = false;
 // This must be called as soon as possible to properly prevent the event.
 // `passive: false` must also be set, as it seems webkit has changed the "default" behaviour
 // https://bugs.webkit.org/show_bug.cgi?id=182521
-window.addEventListener(
-  'touchmove',
-  (event) => {
-    if (!isDragging) {
-      return;
-    }
+if (!isServer) {
+  window.addEventListener(
+    'touchmove',
+    (event) => {
+      if (!isDragging) {
+        return;
+      }
 
-    event.preventDefault();
-  },
-  {passive: false},
-);
+      event.preventDefault();
+    },
+    {passive: false},
+  );
+}
 
 export default class Slidable extends React.PureComponent<Props, State> {
   state: State = {

--- a/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -157,5 +157,39 @@ describe('<ColorPicker />', () => {
 
       expect(event.preventDefault).not.toHaveBeenCalled();
     });
+
+    describe('isServer', () => {
+      jest.resetModules();
+      jest.mock('@shopify/react-utilities/target', () => ({
+        ...require.requireActual('@shopify/react-utilities/target'),
+        isServer: () => {
+          return true;
+        },
+      }));
+      const ColorPicker = require('../ColorPicker').default;
+      const Slidable = require('../components/Slidable').default;
+
+      it('does not attach the touchmove handler to the window when server side rendered', () => {
+        const colorPicker = mountWithAppProvider(
+          <ColorPicker color={red} onChange={noop} />,
+        );
+
+        colorPicker
+          .find(Slidable)
+          .first()
+          .simulate('mousedown');
+
+        const touch = {clientX: 0, clientY: 0};
+        const event = new TouchEvent('touchmove', {
+          touches: [touch],
+          cancelable: true,
+        } as TouchEventInit);
+        Object.assign(event, {preventDefault: jest.fn()});
+
+        window.dispatchEvent(event);
+
+        expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });


### PR DESCRIPTION
I shipped some code recently that solved a issue with ColorPicker `touchmove` behaviour: https://github.com/Shopify/polaris-react/pull/1414

I made a silly mistake - one that I had already resolved in my own app but forget to transfer over to my `polaris-react` PR.

We need to call `window.addEventListener`, but depending on how your app is configured, that code _could_ get executed on the `server`, where `window` does not exist.

```
[server] Error in server execution, check the console for more info.
window.addEventListener('touchmove', function (event) {
^
ReferenceError: window is not defined
```

All I need to do is wrap that event listener in a conditional to check if `window` is not `undefined`. I've tophatted in my app it everything is working.