### PR TITLE
PR generator script: remove ping to non-existent team

### DIFF
--- a/scripts/new-version-pr-generator.js
+++ b/scripts/new-version-pr-generator.js
@@ -44,8 +44,6 @@ function pullRequestTemplate(repository, version) {
 
 See what’s new: https://github.com/Shopify/polaris-react/releases/tag/${version}
 
-cc @Shopify/polaris-reviewers
-
 ---
 
 <details>


### PR DESCRIPTION
The @Shopify/polaris-reviewers team doesn't exist, should we remove it from the PR that gets opened when polaris-react is deployed?