### PR TITLE
[Range slider] Dual range slider

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added support for dual values to `RangeSlider` component ([#784](https://github.com/Shopify/polaris-react/pull/784))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/RangeSlider/README.md
+++ b/src/components/RangeSlider/README.md
@@ -29,6 +29,7 @@ Range sliders should:
 - When a label is visible, it should clearly communicate the purpose of the range input and its values (min, max, step, value)
 - Be labeled as “Optional” when you need to request input that’s not required
 - Validate input as soon as merchants have finished interacting with a field (but not before)
+- Always be used with two text field components when range slider has dual thumbs, to provide accessible alternatives to both the lower and upper thumbs
 
 ---
 
@@ -219,6 +220,120 @@ class RangeSliderExample extends React.Component {
           prefix={<p>Hue</p>}
           suffix={<p style={suffixStyles}>{this.state.value}</p>}
         />
+      </Card>
+    );
+  }
+}
+```
+
+### Dual thumb range slider
+
+Use a dual thumb range slider when merchants need to select a range of values.
+
+```jsx
+const initialValue = [900, 1000];
+
+class RangeSliderExample extends React.Component {
+  state = {
+    intermediateTextFieldValue: initialValue,
+    value: initialValue,
+  };
+
+  handleRangeSliderChange = (value) => {
+    this.setState({value, intermediateTextFieldValue: value});
+  };
+
+  handleLowerTextFieldChange = (value) => {
+    const upperValue = this.state.value[1];
+    this.setState({intermediateTextFieldValue: [parseInt(value), upperValue]});
+  };
+
+  handleUpperTextFieldChange = (value) => {
+    const lowerValue = this.state.value[0];
+    this.setState({intermediateTextFieldValue: [lowerValue, parseInt(value)]});
+  };
+
+  handleLowerTextFieldBlur = () => {
+    const upperValue = this.state.value[1];
+    const value = this.state.intermediateTextFieldValue[0];
+
+    this.setState({value: [parseInt(value), upperValue]});
+  };
+
+  handleUpperTextFieldBlur = () => {
+    const lowerValue = this.state.value[0];
+    const value = this.state.intermediateTextFieldValue[1];
+
+    this.setState({value: [lowerValue, parseInt(value)]});
+  };
+
+  handleEnterKeyPress = (event) => {
+    const newValue = this.state.intermediateTextFieldValue;
+    const oldValue = this.state.value;
+
+    if (event.keyCode === Key.Enter && newValue !== oldValue) {
+      this.setState({value: newValue});
+    }
+  };
+
+  render() {
+    const {value, intermediateTextFieldValue} = this.state;
+    const prefix = '$';
+    const min = 0;
+    const max = 2000;
+    const step = 10;
+    const disabled = false;
+
+    const lowerTextFieldValue =
+      intermediateTextFieldValue[0] === value[0]
+        ? value[0]
+        : intermediateTextFieldValue[0];
+    const upperTextFieldValue =
+      intermediateTextFieldValue[1] === value[1]
+        ? value[1]
+        : intermediateTextFieldValue[1];
+
+    return (
+      <Card sectioned>
+        <div style={{marginTop: '20px'}} onKeyDown={this.handleEnterKeyPress}>
+          <RangeSlider
+            label="Money spent is between"
+            value={value}
+            prefix={prefix}
+            output
+            min={min}
+            max={max}
+            step={step}
+            disabled={disabled}
+            onChange={this.handleRangeSliderChange}
+          />
+          <Stack distribution="equalSpacing" spacing="extraLoose">
+            <TextField
+              label="Min money spent"
+              type="number"
+              value={`${lowerTextFieldValue}`}
+              prefix={prefix}
+              min={min}
+              max={max}
+              step={step}
+              disabled={disabled}
+              onChange={this.handleLowerTextFieldChange}
+              onBlur={this.handleLowerTextFieldBlur}
+            />
+            <TextField
+              label="Max money spent"
+              type="number"
+              value={`${upperTextFieldValue}`}
+              prefix={prefix}
+              min={min}
+              max={max}
+              step={step}
+              disabled={disabled}
+              onChange={this.handleUpperTextFieldChange}
+              onBlur={this.handleUpperTextFieldBlur}
+            />
+          </Stack>
+        </div>
       </Card>
     );
   }

--- a/src/components/RangeSlider/README.md
+++ b/src/components/RangeSlider/README.md
@@ -283,7 +283,6 @@ class RangeSliderExample extends React.Component {
     const min = 0;
     const max = 2000;
     const step = 10;
-    const disabled = false;
 
     const lowerTextFieldValue =
       intermediateTextFieldValue[0] === value[0]
@@ -305,7 +304,6 @@ class RangeSliderExample extends React.Component {
             min={min}
             max={max}
             step={step}
-            disabled={disabled}
             onChange={this.handleRangeSliderChange}
           />
           <Stack distribution="equalSpacing" spacing="extraLoose">
@@ -317,7 +315,6 @@ class RangeSliderExample extends React.Component {
               min={min}
               max={max}
               step={step}
-              disabled={disabled}
               onChange={this.handleLowerTextFieldChange}
               onBlur={this.handleLowerTextFieldBlur}
             />
@@ -329,7 +326,6 @@ class RangeSliderExample extends React.Component {
               min={min}
               max={max}
               step={step}
-              disabled={disabled}
               onChange={this.handleUpperTextFieldChange}
               onBlur={this.handleUpperTextFieldBlur}
             />

--- a/src/components/RangeSlider/README.md
+++ b/src/components/RangeSlider/README.md
@@ -135,6 +135,7 @@ class RangeSliderExample extends React.Component {
           label="Opacity percentage"
           value={this.state.value}
           onChange={this.handleChange}
+          output
         />
       </Card>
     );

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -10,29 +10,32 @@ type CombinedProps = Props & WithAppProviderProps;
 
 const getUniqueID = createUniqueIDFactory('RangeSlider');
 
-export function RangeSlider(props: CombinedProps) {
-  const {
-    id = getUniqueID(),
-    min = RangeSliderDefault.Min,
-    max = RangeSliderDefault.Max,
-    step = RangeSliderDefault.Step,
-    value,
-    ...rest
-  } = props;
+class RangeSlider extends React.Component<CombinedProps> {
+  private id = getUniqueID();
 
-  const sharedProps = {
-    id,
-    min,
-    max,
-    step,
-    ...rest,
-  };
+  render() {
+    const {
+      min = RangeSliderDefault.Min,
+      max = RangeSliderDefault.Max,
+      step = RangeSliderDefault.Step,
+      value,
+      ...rest
+    } = this.props;
 
-  return isDualThumb(value) ? (
-    <DualThumb value={value} {...sharedProps} />
-  ) : (
-    <SingleThumb value={value} {...sharedProps} />
-  );
+    const sharedProps = {
+      id: this.id,
+      min,
+      max,
+      step,
+      ...rest,
+    };
+
+    return isDualThumb(value) ? (
+      <DualThumb value={value} {...sharedProps} />
+    ) : (
+      <SingleThumb value={value} {...sharedProps} />
+    );
+  }
 }
 
 function isDualThumb(value: RangeSliderValue): value is DualValue {

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -1,203 +1,42 @@
 import * as React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
-import {classNames} from '@shopify/react-utilities/styles';
-
-import {Error} from '../../types';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
-import Labelled, {Action, helpTextID} from '../Labelled';
+import {Props, RangeSliderValue, DualValue} from './types';
+import {RangeSliderDefault} from './utilities';
 
-import styles from './RangeSlider.scss';
+import {SingleThumb, DualThumb} from './components';
 
-export interface State {
-  id: string;
-}
-
-export interface BaseProps {
-  /** Label for the range input */
-  label: string;
-  /** Adds an action to the label */
-  labelAction?: Action;
-  /** Visually hide the label */
-  labelHidden?: boolean;
-  /** ID for range input */
-  id?: string;
-  /** Initial value for range input */
-  value: number;
-  /** Minimum possible value for range input */
-  min?: number;
-  /** Maximum possible value for range input */
-  max?: number;
-  /** Increment value for range input changes */
-  step?: number;
-  /** Provide a tooltip while sliding, indicating the current value */
-  output?: boolean;
-  /** Additional text to aid in use */
-  helpText?: React.ReactNode;
-  /** Display an error message */
-  error?: Error;
-  /** Disable input */
-  disabled?: boolean;
-  /** Element to display before the input */
-  prefix?: React.ReactNode;
-  /** Element to display after the input */
-  suffix?: React.ReactNode;
-  /** Callback when the range input is changed */
-  onChange(value: number, id: string): void;
-  /** Callback when range input is focused */
-  onFocus?(): void;
-  /** Callback when focus is removed */
-  onBlur?(): void;
-}
-
-export interface Props extends BaseProps {}
-export type CombinedProps = Props & WithAppProviderProps;
+type CombinedProps = Props & WithAppProviderProps;
 
 const getUniqueID = createUniqueIDFactory('RangeSlider');
-const cssVarPrefix = '--Polaris-RangeSlider-';
 
-export class RangeSlider extends React.PureComponent<CombinedProps, State> {
-  static getDerivedStateFromProps(nextProps: CombinedProps, prevState: State) {
-    return nextProps.id != null && nextProps.id !== prevState.id
-      ? {
-          id: nextProps.id || prevState.id,
-        }
-      : null;
-  }
+export function RangeSlider(props: CombinedProps) {
+  const {
+    id = getUniqueID(),
+    min = RangeSliderDefault.Min,
+    max = RangeSliderDefault.Max,
+    step = RangeSliderDefault.Step,
+    value,
+    ...rest
+  } = props;
 
-  constructor(props: CombinedProps) {
-    super(props);
-
-    this.state = {
-      id: props.id || getUniqueID(),
-    };
-  }
-
-  render() {
-    const {id} = this.state;
-    const {min = 0, max = 100} = this.props;
-    const {
-      label,
-      labelAction,
-      labelHidden,
-      step,
-      value,
-      output,
-      helpText,
-      error,
-      disabled,
-      prefix,
-      suffix,
-      onFocus,
-      onBlur,
-    } = this.props;
-
-    const describedBy: string[] = [];
-
-    if (error) {
-      describedBy.push(`${id}Error`);
-    }
-
-    if (helpText) {
-      describedBy.push(helpTextID(id));
-    }
-
-    const ariaDescribedBy = describedBy.length
-      ? describedBy.join(' ')
-      : undefined;
-
-    const sliderProgress = ((value - min) * 100) / (max - min);
-
-    const cssVars = {
-      [`${cssVarPrefix}min`]: min,
-      [`${cssVarPrefix}max`]: max,
-      [`${cssVarPrefix}current`]: value,
-      [`${cssVarPrefix}progress`]: `${sliderProgress}%`,
-      [`${cssVarPrefix}output-factor`]: invertNumber(
-        (sliderProgress - 50) / 100,
-      ),
-    };
-
-    const outputMarkup = !disabled &&
-      output && (
-        <output htmlFor={id} className={styles.Output}>
-          <div className={styles.OutputBubble}>
-            <span className={styles.OutputText}>{value}</span>
-          </div>
-        </output>
-      );
-
-    const prefixMarkup = prefix && (
-      <div className={styles.Prefix}>{prefix}</div>
-    );
-
-    const suffixMarkup = suffix && (
-      <div className={styles.Suffix}>{suffix}</div>
-    );
-
-    const className = classNames(
-      styles.RangeSlider,
-      error && styles.error,
-      disabled && styles.disabled,
-    );
-
-    return (
-      <Labelled
-        id={id}
-        label={label}
-        error={error}
-        action={labelAction}
-        labelHidden={labelHidden}
-        helpText={helpText}
-      >
-        <div className={className} style={cssVars}>
-          {prefixMarkup}
-          <div className={styles.InputWrapper}>
-            <input
-              type="range"
-              className={styles.Input}
-              id={id}
-              name={id}
-              min={min}
-              max={max}
-              step={step}
-              value={value}
-              disabled={disabled}
-              onChange={this.handleChange}
-              onFocus={onFocus}
-              onBlur={onBlur}
-              aria-valuemin={min}
-              aria-valuemax={max}
-              aria-valuenow={value}
-              aria-invalid={Boolean(error)}
-              aria-describedby={ariaDescribedBy}
-            />
-            {outputMarkup}
-          </div>
-          {suffixMarkup}
-        </div>
-      </Labelled>
-    );
-  }
-
-  private handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const {onChange} = this.props;
-
-    if (onChange == null) {
-      return;
-    }
-
-    onChange(parseFloat(event.currentTarget.value), this.state.id);
+  const sharedProps = {
+    id,
+    min,
+    max,
+    step,
+    ...rest,
   };
+
+  return isDualThumb(value) ? (
+    <DualThumb value={value} {...sharedProps} />
+  ) : (
+    <SingleThumb value={value} {...sharedProps} />
+  );
 }
 
-export function invertNumber(number: number) {
-  if (Math.sign(number) === 1) {
-    return -Math.abs(number);
-  } else if (Math.sign(number) === -1) {
-    return Math.abs(number);
-  } else {
-    return 0;
-  }
+function isDualThumb(value: RangeSliderValue): value is DualValue {
+  return Array.isArray(value);
 }
 
 export default withAppProvider<Props>()(RangeSlider);

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -6,11 +6,12 @@ $stacking-order: (
 $range-wrapper: rem(28px);
 $range-track-height: rem(4px);
 $range-thumb-size: rem(24px);
-$range-thumb-border-size: rem(2px);
-$range-thumbs-border: rem(1px) solid color('sky', 'dark');
-$range-thumbs-border-error: rem(2px) solid color('red');
-$range-thumbs-shadow-hover: (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint));
-$range-thumbs-border-active: rem(2px) solid color('indigo');
+
+$range-thumb-border-error: rem(2px) solid color('red');
+
+$range-thumb-shadow: (0 0 0 rem(1px) rgba(black, 0.2), shadow(faint));
+$range-thumb-shadow-hover: (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint));
+$range-thumb-shadow-error: 0 0 0 rem(1px) color('red');
 
 .Wrapper {
   position: relative;
@@ -30,35 +31,6 @@ $range-thumbs-border-active: rem(2px) solid color('indigo');
   &.disabled {
     opacity: 0.8;
     cursor: not-allowed;
-  }
-
-  &.error {
-    &:active,
-    &:focus {
-      // stylelint-disable selector-max-specificity
-      // stylelint-disable selector-max-class
-      .Track {
-        --unselected-range: #{color('sky', 'dark')};
-        --selected-range: #{color('indigo')};
-        --gradient-colors: var(--unselected-range, transparent) 0%,
-          var(--unselected-range, transparent)
-            var(--Polaris-RangeSlider-progress-lower),
-          var(--selected-range, transparent)
-            var(--Polaris-RangeSlider-progress-lower),
-          var(--selected-range, transparent)
-            var(--Polaris-RangeSlider-progress-upper),
-          var(--unselected-range, transparent)
-            var(--Polaris-RangeSlider-progress-upper),
-          var(--unselected-range, transparent) 100%;
-        background-image: linear-gradient(to right, var(--gradient-colors));
-      }
-
-      .Thumbs {
-        border: $range-thumbs-border-active;
-      }
-      // stylelint-enable selector-max-specificity
-      // stylelint-enable selector-max-class
-    }
   }
 }
 
@@ -94,6 +66,11 @@ $range-thumbs-border-active: rem(2px) solid color('indigo');
       var(--unselected-range, transparent) 100%;
     background-image: linear-gradient(to right, var(--gradient-colors));
   }
+
+  .disabled & {
+    background-image: none;
+    background: color('sky', 'dark');
+  }
 }
 
 .Thumbs {
@@ -101,26 +78,33 @@ $range-thumbs-border-active: rem(2px) solid color('indigo');
   z-index: z-index('input', $stacking-order);
   width: $range-thumb-size;
   height: $range-thumb-size;
-  border: $range-thumbs-border;
   border-radius: 50%;
+  border: border-width() solid color('sky', 'lighter');
+  box-shadow: $range-thumb-shadow;
   background: linear-gradient(color('sky', 'lighter'), color('sky', 'light'));
 
   // stylelint-disable-next-line value-no-vendor-prefix
   cursor: -webkit-grab;
 
-  &:hover,
-  &:active,
-  &:focus {
-    border: $range-thumbs-border-active;
-  }
-
   &.disabled {
     cursor: not-allowed;
-    border: $range-thumbs-border;
+    border-color: color('sky', 'dark');
   }
 
   .error & {
-    border: $range-thumbs-border-error;
+    border-color: color('red');
+    box-shadow: $range-thumb-shadow-error;
+
+    &:hover,
+    &:focus {
+      border-color: color('red');
+      box-shadow: $range-thumb-shadow-error;
+    }
+  }
+
+  &:hover {
+    background: linear-gradient(color('sky', 'lighter'), color('sky', 'light'));
+    box-shadow: $range-thumb-shadow-hover;
   }
 }
 

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -1,0 +1,212 @@
+$stacking-order: (
+  output: 10,
+  input: 20,
+);
+
+$range-wrapper: rem(28px);
+$range-track-height: rem(4px);
+$range-thumb-size: rem(24px);
+$range-thumb-border-size: rem(2px);
+$range-thumbs-border: rem(1px) solid color('sky', 'dark');
+$range-thumbs-border-error: rem(2px) solid color('red');
+$range-thumbs-shadow-hover: (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint));
+$range-thumbs-border-active: rem(2px) solid color('indigo');
+
+.Wrapper {
+  position: relative;
+  width: 100%;
+  display: flex;
+  align-items: center;
+}
+
+.TrackWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: $range-wrapper;
+  cursor: pointer;
+
+  &.disabled {
+    opacity: 0.8;
+    cursor: not-allowed;
+  }
+
+  &.error {
+    &:active,
+    &:focus {
+      // stylelint-disable selector-max-specificity
+      // stylelint-disable selector-max-class
+      .Track {
+        --unselected-range: #{color('sky', 'dark')};
+        --selected-range: #{color('indigo')};
+        --gradient-colors: var(--unselected-range, transparent) 0%,
+          var(--unselected-range, transparent)
+            var(--Polaris-RangeSlider-progress-lower),
+          var(--selected-range, transparent)
+            var(--Polaris-RangeSlider-progress-lower),
+          var(--selected-range, transparent)
+            var(--Polaris-RangeSlider-progress-upper),
+          var(--unselected-range, transparent)
+            var(--Polaris-RangeSlider-progress-upper),
+          var(--unselected-range, transparent) 100%;
+        background-image: linear-gradient(to right, var(--gradient-colors));
+      }
+
+      .Thumbs {
+        border: $range-thumbs-border-active;
+      }
+      // stylelint-enable selector-max-specificity
+      // stylelint-enable selector-max-class
+    }
+  }
+}
+
+.Track {
+  position: absolute;
+  width: 100%;
+  height: $range-track-height;
+  border-radius: $range-thumb-size;
+
+  --unselected-range: #{color('sky', 'dark')};
+  --selected-range: #{color('indigo')};
+  --gradient-colors: var(--unselected-range, transparent) 0%,
+    var(--unselected-range, transparent)
+      var(--Polaris-RangeSlider-progress-lower),
+    var(--selected-range, transparent) var(--Polaris-RangeSlider-progress-lower),
+    var(--selected-range, transparent) var(--Polaris-RangeSlider-progress-upper),
+    var(--unselected-range, transparent)
+      var(--Polaris-RangeSlider-progress-upper),
+    var(--unselected-range, transparent) 100%;
+  background-image: linear-gradient(to right, var(--gradient-colors));
+
+  .error & {
+    --selected-range: #{color('red')};
+    --gradient-colors: var(--unselected-range, transparent) 0%,
+      var(--unselected-range, transparent)
+        var(--Polaris-RangeSlider-progress-lower),
+      var(--selected-range, transparent)
+        var(--Polaris-RangeSlider-progress-lower),
+      var(--selected-range, transparent)
+        var(--Polaris-RangeSlider-progress-upper),
+      var(--unselected-range, transparent)
+        var(--Polaris-RangeSlider-progress-upper),
+      var(--unselected-range, transparent) 100%;
+    background-image: linear-gradient(to right, var(--gradient-colors));
+  }
+}
+
+.Thumbs {
+  position: absolute;
+  z-index: z-index('input', $stacking-order);
+  width: $range-thumb-size;
+  height: $range-thumb-size;
+  border: $range-thumbs-border;
+  border-radius: 50%;
+  background: linear-gradient(color('sky', 'lighter'), color('sky', 'light'));
+
+  // stylelint-disable-next-line value-no-vendor-prefix
+  cursor: -webkit-grab;
+
+  &:hover,
+  &:active,
+  &:focus {
+    border: $range-thumbs-border-active;
+  }
+
+  &.disabled {
+    cursor: not-allowed;
+    border: $range-thumbs-border;
+  }
+
+  .error & {
+    border: $range-thumbs-border-error;
+  }
+
+  // stylelint-disable selector-max-specificity
+  &:hover + .Output &,
+  &:active + .Output &,
+  &:focus + .Output & {
+    transform: translateY(-$range-thumb-size);
+
+    @include page-content-when-not-partially-condensed {
+      transform: translateY(-($range-thumb-size / 2));
+    }
+  }
+  // stylelint-enable selector-max-specificity
+}
+
+$range-output-size: rem(32px);
+$range-output-tip-size: rem(8px);
+
+.Prefix {
+  flex: 0 0 auto;
+  margin-right: spacing(tight);
+}
+
+.Suffix {
+  flex: 0 0 auto;
+  margin-left: spacing(tight);
+}
+
+.Output {
+  position: absolute;
+  z-index: z-index('output', $stacking-order);
+  bottom: $range-output-size - $range-output-tip-size + $range-thumb-size;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition-property: opacity, visibility;
+  transition-duration: duration();
+  transition-timing-function: easing();
+
+  .ThumbLower:hover + &,
+  .ThumbLower:active + &,
+  .ThumbLower:focus + & {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .ThumbUpper:hover + &,
+  .ThumbUpper:active + &,
+  .ThumbUpper:focus + & {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+
+.OutputBubble {
+  position: relative;
+  display: flex;
+  padding: 0 spacing(tight);
+  min-width: $range-output-size;
+  height: $range-output-size;
+  background-color: color('ink');
+  border-radius: border-radius();
+  transition-property: transform;
+  transition-duration: duration();
+  transition-timing-function: easing();
+
+  &::before {
+    content: '';
+    position: absolute;
+    bottom: -($range-output-tip-size - rem(1px));
+    left: 50%;
+    margin-left: -$range-output-tip-size;
+    display: block;
+    width: 0;
+    height: 0;
+    border-left: $range-output-tip-size solid transparent;
+    border-right: $range-output-tip-size solid transparent;
+    border-top: $range-output-tip-size solid color('ink');
+  }
+}
+
+.OutputText {
+  @include text-style-subheading;
+  display: block;
+  flex: 1 1 auto;
+  margin: auto;
+  text-align: center;
+  color: color('white');
+}

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -122,22 +122,10 @@ $range-thumbs-border-active: rem(2px) solid color('indigo');
   .error & {
     border: $range-thumbs-border-error;
   }
-
-  // stylelint-disable selector-max-specificity
-  &:hover + .Output &,
-  &:active + .Output &,
-  &:focus + .Output & {
-    transform: translateY(-$range-thumb-size);
-
-    @include page-content-when-not-partially-condensed {
-      transform: translateY(-($range-thumb-size / 2));
-    }
-  }
-  // stylelint-enable selector-max-specificity
 }
 
 $range-output-size: rem(32px);
-$range-output-tip-size: rem(8px);
+$range-output-spacing: rem(16px);
 
 .Prefix {
   flex: 0 0 auto;
@@ -152,24 +140,18 @@ $range-output-tip-size: rem(8px);
 .Output {
   position: absolute;
   z-index: z-index('output', $stacking-order);
-  bottom: $range-output-size - $range-output-tip-size + $range-thumb-size;
+  bottom: $range-thumb-size;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
   transition-property: opacity, visibility;
   transition-duration: duration();
   transition-timing-function: easing();
+  transform: translateX(calc(-50% + #{$range-thumb-size / 2}));
 
-  .ThumbLower:hover + &,
-  .ThumbLower:active + &,
-  .ThumbLower:focus + & {
-    opacity: 1;
-    visibility: visible;
-  }
-
-  .ThumbUpper:hover + &,
-  .ThumbUpper:active + &,
-  .ThumbUpper:focus + & {
+  .Thumbs:hover + &,
+  .Thumbs:active + &,
+  .Thumbs:focus + & {
     opacity: 1;
     visibility: visible;
   }
@@ -187,19 +169,17 @@ $range-output-tip-size: rem(8px);
   transition-duration: duration();
   transition-timing-function: easing();
 
-  &::before {
-    content: '';
-    position: absolute;
-    bottom: -($range-output-tip-size - rem(1px));
-    left: 50%;
-    margin-left: -$range-output-tip-size;
-    display: block;
-    width: 0;
-    height: 0;
-    border-left: $range-output-tip-size solid transparent;
-    border-right: $range-output-tip-size solid transparent;
-    border-top: $range-output-tip-size solid color('ink');
+  // stylelint-disable selector-max-specificity
+  .Thumbs:hover + .Output &,
+  .Thumbs:active + .Output &,
+  .Thumbs:focus + .Output & {
+    transform: translateY(-$range-output-spacing);
+
+    @include page-content-when-not-partially-condensed {
+      transform: translateY(-($range-output-spacing / 2));
+    }
   }
+  // stylelint-enable selector-max-specificity
 }
 
 .OutputText {

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -82,6 +82,7 @@ $range-thumb-shadow-error: 0 0 0 rem(1px) color('red');
   border: border-width() solid color('sky', 'lighter');
   box-shadow: $range-thumb-shadow;
   background: linear-gradient(color('sky', 'lighter'), color('sky', 'light'));
+  -webkit-tap-highlight-color: transparent;
 
   // stylelint-disable-next-line value-no-vendor-prefix
   cursor: -webkit-grab;

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -73,6 +73,7 @@ export default class DualThumb extends React.Component<Props, State> {
   };
 
   private track = React.createRef<HTMLDivElement>();
+  private trackWrapper = React.createRef<HTMLDivElement>();
   private thumbLower = React.createRef<HTMLButtonElement>();
   private thumbUpper = React.createRef<HTMLButtonElement>();
 
@@ -94,6 +95,25 @@ export default class DualThumb extends React.Component<Props, State> {
 
   componentDidMount() {
     this.setTrackPosition();
+
+    if (this.trackWrapper.current != null) {
+      addEventListener(
+        this.trackWrapper.current,
+        'touchstart',
+        this.handleTouchStartTrack,
+        {passive: false},
+      );
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.trackWrapper.current != null) {
+      removeEventListener(
+        this.trackWrapper.current,
+        'touchstart',
+        this.handleTouchStartTrack,
+      );
+    }
   }
 
   render() {
@@ -211,8 +231,8 @@ export default class DualThumb extends React.Component<Props, State> {
             <div
               className={trackWrapperClassName}
               onMouseDown={this.handleMouseDownTrack}
-              onTouchStartCapture={this.handleTouchStartTrack}
               testID="trackWrapper"
+              ref={this.trackWrapper}
             >
               <div
                 className={styles.Track}
@@ -459,9 +479,9 @@ export default class DualThumb extends React.Component<Props, State> {
     }
   };
 
-  private handleTouchStartTrack = (event: React.TouchEvent) => {
+  private handleTouchStartTrack = (event: TouchEvent) => {
     if (this.props.disabled) return;
-    event.stopPropagation();
+    event.preventDefault();
     const clickXPosition = this.actualXPosition(event.touches[0].clientX);
     const {value} = this.state;
     const distanceFromLowerThumb = Math.abs(value[0] - clickXPosition);

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -1,0 +1,500 @@
+import * as React from 'react';
+import throttle from 'lodash-decorators/throttle';
+import isEqual from 'lodash/isEqual';
+import {autobind} from '@shopify/javascript-utilities/decorators';
+import {
+  addEventListener,
+  removeEventListener,
+} from '@shopify/javascript-utilities/events';
+import {classNames} from '@shopify/react-utilities/styles';
+import {CSS_VAR_PREFIX} from '../../utilities';
+import {Props as RangeSliderProps, DualValue} from '../../types';
+import Labelled from '../../../Labelled';
+import EventListener from '../../../EventListener';
+import {Key} from '../../../../types';
+
+import styles from './DualThumb.scss';
+
+export interface State {
+  value: DualValue;
+  trackWidth: number;
+  trackLeft: number;
+  prevValue?: DualValue;
+}
+
+export interface Props extends RangeSliderProps {
+  value: DualValue;
+  id: string;
+  min: number;
+  max: number;
+  step: number;
+}
+
+interface KeyHandlers {
+  [key: string]: () => void;
+}
+
+enum Control {
+  Lower,
+  Upper,
+}
+
+const THUMB_SIZE = 24;
+const OUTPUT_TIP_SIZE = 8;
+
+export default class DualThumb extends React.Component<Props, State> {
+  static getDerivedStateFromProps(props: Props, state: State) {
+    const {min, step, max, value, onChange, id} = props;
+    const {prevValue} = state;
+
+    if (isEqual(prevValue, value)) {
+      return null;
+    }
+
+    const sanitizedValue = sanitizeValue(value, min, max, step);
+
+    if (!isEqual(value, sanitizedValue)) {
+      onChange(sanitizedValue, id);
+    }
+
+    return {
+      prevValue: value,
+      value: sanitizedValue,
+    };
+  }
+
+  state: State = {
+    value: sanitizeValue(
+      this.props.value,
+      this.props.min,
+      this.props.max,
+      this.props.step,
+    ),
+    trackWidth: 0,
+    trackLeft: 0,
+  };
+
+  private track = React.createRef<HTMLDivElement>();
+  private thumbLower = React.createRef<HTMLButtonElement>();
+  private thumbUpper = React.createRef<HTMLButtonElement>();
+
+  componentDidMount() {
+    this.setTrackPosition();
+  }
+
+  render() {
+    const {
+      id,
+      min,
+      max,
+      prefix,
+      suffix,
+      disabled,
+      output,
+      error,
+      onFocus,
+      onBlur,
+      label,
+      labelAction,
+      labelHidden,
+      helpText,
+    } = this.props;
+    const {value} = this.state;
+
+    const idLower = `${id}Lower`;
+    const idUpper = `${id}Upper`;
+
+    const describedBy: string[] = [];
+
+    if (error) {
+      describedBy.push(`${id}Error`);
+    }
+
+    const ariaDescribedBy = describedBy.length
+      ? describedBy.join(' ')
+      : undefined;
+
+    const trackWrapperClassName = classNames(
+      styles.TrackWrapper,
+      error && styles.error,
+      disabled && styles.disabled,
+    );
+
+    const thumbLowerClassName = classNames(
+      styles.Thumbs,
+      styles.ThumbLower,
+      disabled && styles.disabled,
+    );
+    const thumbUpperClassName = classNames(
+      styles.Thumbs,
+      styles.ThumbUpper,
+      disabled && styles.disabled,
+    );
+
+    const trackWidth = this.state.trackWidth;
+    const range = max - min;
+
+    const leftPositionThumbLower = (value[0] / range) * trackWidth;
+    const leftPositionThumbUpper = (value[1] / range) * trackWidth;
+
+    const outputLowerClassName = classNames(styles.Output, styles.OutputLower);
+    const outputMarkupLower =
+      !disabled && output ? (
+        <output
+          htmlFor={idLower}
+          className={outputLowerClassName}
+          style={{
+            left: `calc(${leftPositionThumbLower}px - ${OUTPUT_TIP_SIZE}px)`,
+          }}
+        >
+          <div className={styles.OutputBubble}>
+            <span className={styles.OutputText}>{value[0]}</span>
+          </div>
+        </output>
+      ) : null;
+
+    const outputUpperClassName = classNames(styles.Output, styles.OutputUpper);
+    const outputMarkupUpper =
+      !disabled && output ? (
+        <output
+          htmlFor={idUpper}
+          className={outputUpperClassName}
+          style={{
+            left: `calc(${leftPositionThumbUpper}px - ${OUTPUT_TIP_SIZE}px)`,
+          }}
+        >
+          <div className={styles.OutputBubble}>
+            <span className={styles.OutputText}>{value[1]}</span>
+          </div>
+        </output>
+      ) : null;
+
+    const progressLower = leftPositionThumbLower + THUMB_SIZE / 2;
+    const progressUpper = leftPositionThumbUpper + THUMB_SIZE / 2;
+
+    const cssVars = {
+      [`${CSS_VAR_PREFIX}progress-lower`]: `${progressLower}px`,
+      [`${CSS_VAR_PREFIX}progress-upper`]: `${progressUpper}px`,
+    };
+
+    const prefixMarkup = prefix && (
+      <div className={styles.Prefix}>{prefix}</div>
+    );
+
+    const suffixMarkup = suffix && (
+      <div className={styles.Suffix}>{suffix}</div>
+    );
+
+    return (
+      <React.Fragment>
+        <Labelled
+          id={id}
+          label={label}
+          error={error}
+          action={labelAction}
+          labelHidden={labelHidden}
+          helpText={helpText}
+        >
+          <div className={styles.Wrapper} id={id}>
+            {prefixMarkup}
+            <div
+              className={trackWrapperClassName}
+              onMouseDown={this.handleMouseDownTrack}
+              testID="trackWrapper"
+            >
+              <div
+                className={styles.Track}
+                style={cssVars}
+                ref={this.track}
+                testID="track"
+              />
+              <button
+                id={idLower}
+                className={thumbLowerClassName}
+                ref={this.thumbLower}
+                style={{
+                  left: `${leftPositionThumbLower}px`,
+                }}
+                role="slider"
+                aria-disabled={disabled}
+                aria-valuemin={min}
+                aria-valuemax={max}
+                aria-valuenow={value[0]}
+                aria-invalid={Boolean(error)}
+                aria-describedby={ariaDescribedBy}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                onKeyDown={this.handleKeypressLower}
+                onMouseDown={this.handleMouseDownThumbLower}
+              />
+              {outputMarkupLower}
+              <button
+                id={idUpper}
+                className={thumbUpperClassName}
+                ref={this.thumbUpper}
+                style={{
+                  left: `${leftPositionThumbUpper}px`,
+                }}
+                role="slider"
+                aria-disabled={disabled}
+                aria-valuemin={min}
+                aria-valuemax={max}
+                aria-valuenow={value[1]}
+                aria-invalid={Boolean(error)}
+                aria-describedby={ariaDescribedBy}
+                onFocus={onFocus}
+                onBlur={onBlur}
+                onKeyDown={this.handleKeypressUpper}
+                onMouseDown={this.handleMouseDownThumbUpper}
+              />
+              {outputMarkupUpper}
+            </div>
+            {suffixMarkup}
+          </div>
+        </Labelled>
+        <EventListener event="resize" handler={this.setTrackPosition} />
+      </React.Fragment>
+    );
+  }
+
+  @throttle(40)
+  @autobind
+  private setTrackPosition() {
+    if (this.track.current) {
+      const {width, left} = this.track.current.getBoundingClientRect();
+      const adjustedTrackWidth = width - THUMB_SIZE;
+      this.setState({
+        trackWidth: adjustedTrackWidth,
+        trackLeft: left,
+      });
+    }
+  }
+
+  @autobind
+  private handleMouseDownThumbLower(
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) {
+    if (event.button !== 0) return;
+    registerMouseMoveHandler(this.handleMouseMoveThumbLower);
+    event.stopPropagation();
+  }
+
+  @autobind
+  private handleMouseMoveThumbLower(event: MouseEvent) {
+    const valueUpper = this.state.value[1];
+    this.setValue(
+      [this.actualXPosition(event.clientX), valueUpper],
+      Control.Upper,
+    );
+  }
+
+  @autobind
+  private handleMouseDownThumbUpper(
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) {
+    if (event.button !== 0) return;
+    registerMouseMoveHandler(this.handleMouseMoveThumbUpper);
+    event.stopPropagation();
+  }
+
+  @autobind
+  private handleMouseMoveThumbUpper(event: MouseEvent) {
+    const valueLower = this.state.value[0];
+    this.setValue(
+      [valueLower, this.actualXPosition(event.clientX)],
+      Control.Lower,
+    );
+  }
+
+  @autobind
+  private handleKeypressLower(event: React.KeyboardEvent<HTMLButtonElement>) {
+    const {incrementValueLower, decrementValueLower} = this;
+
+    const handlerMap: KeyHandlers = {
+      [Key.UpArrow]: incrementValueLower,
+      [Key.RightArrow]: incrementValueLower,
+      [Key.DownArrow]: decrementValueLower,
+      [Key.LeftArrow]: decrementValueLower,
+    };
+
+    const handler = handlerMap[event.keyCode];
+
+    if (handler != null) {
+      event.preventDefault();
+      event.stopPropagation();
+      handler();
+    }
+  }
+
+  @autobind
+  private handleKeypressUpper(event: React.KeyboardEvent<HTMLButtonElement>) {
+    const {incrementValueUpper, decrementValueUpper} = this;
+
+    const handlerMap: KeyHandlers = {
+      [Key.UpArrow]: incrementValueUpper,
+      [Key.RightArrow]: incrementValueUpper,
+      [Key.DownArrow]: decrementValueUpper,
+      [Key.LeftArrow]: decrementValueUpper,
+    };
+
+    const handler = handlerMap[event.keyCode];
+
+    if (handler != null) {
+      event.preventDefault();
+      event.stopPropagation();
+      handler();
+    }
+  }
+
+  @autobind
+  private incrementValueLower() {
+    this.setValue(
+      [this.state.value[0] + this.props.step, this.state.value[1]],
+      Control.Upper,
+    );
+  }
+
+  @autobind
+  private decrementValueLower() {
+    this.setValue(
+      [this.state.value[0] - this.props.step, this.state.value[1]],
+      Control.Upper,
+    );
+  }
+
+  @autobind
+  private incrementValueUpper() {
+    this.setValue(
+      [this.state.value[0], this.state.value[1] + this.props.step],
+      Control.Lower,
+    );
+  }
+
+  @autobind
+  private decrementValueUpper() {
+    this.setValue(
+      [this.state.value[0], this.state.value[1] - this.props.step],
+      Control.Lower,
+    );
+  }
+
+  @autobind
+  private dispatchValue() {
+    const {onChange, id} = this.props;
+    const {value} = this.state;
+
+    onChange(value, id);
+  }
+
+  @autobind
+  private setValue(dirtyValue: DualValue, control: Control) {
+    const {
+      props: {min, max, step},
+      state: {value},
+    } = this;
+
+    const sanitizedValue = sanitizeValue(dirtyValue, min, max, step, control);
+
+    if (isEqual(sanitizedValue, value) === false) {
+      this.setState(
+        {
+          value: sanitizedValue,
+        },
+        this.dispatchValue,
+      );
+    }
+  }
+
+  @autobind
+  private handleMouseDownTrack(event: React.MouseEvent) {
+    if (event.button !== 0) return;
+    const clickXPosition = this.actualXPosition(event.clientX);
+    const {value} = this.state;
+    const distanceFromLowerThumb = Math.abs(value[0] - clickXPosition);
+    const distanceFromUpperThumb = Math.abs(value[1] - clickXPosition);
+
+    if (distanceFromLowerThumb <= distanceFromUpperThumb) {
+      this.setValue([clickXPosition, value[1]], Control.Upper);
+      registerMouseMoveHandler(this.handleMouseMoveThumbLower);
+    } else {
+      this.setValue([value[0], clickXPosition], Control.Lower);
+      registerMouseMoveHandler(this.handleMouseMoveThumbUpper);
+    }
+  }
+
+  @autobind
+  private actualXPosition(dirtyXPosition: number): number {
+    if (this.track.current) {
+      const {min, max} = this.props;
+      const {trackLeft, trackWidth} = this.state;
+
+      const relativeX = dirtyXPosition - trackLeft;
+      const percentageOfTrack = relativeX / trackWidth;
+      return percentageOfTrack * (max - min);
+    } else {
+      return 0;
+    }
+  }
+}
+
+function registerMouseMoveHandler(handler: (event: MouseEvent) => void) {
+  addEventListener(document, 'mousemove', handler);
+  addEventListener(
+    document,
+    'mouseup',
+    () => {
+      removeEventListener(document, 'mousemove', handler);
+    },
+    {once: true},
+  );
+}
+
+function sanitizeValue(
+  value: DualValue,
+  min: number,
+  max: number,
+  step: number,
+  control = Control.Upper,
+): DualValue {
+  let upperValue = inBoundsUpper(roundedToStep(value[1]));
+  let lowerValue = inBoundsLower(roundedToStep(value[0]));
+
+  const maxLowerValue = upperValue - step;
+  const minUpperValue = lowerValue + step;
+
+  if (control === Control.Upper && lowerValue > maxLowerValue) {
+    lowerValue = maxLowerValue;
+  } else if (control === Control.Lower && upperValue < minUpperValue) {
+    upperValue = minUpperValue;
+  }
+
+  return [lowerValue, upperValue];
+
+  function inBoundsUpper(value: number): number {
+    const lowerMin = min + step;
+
+    if (value < lowerMin) {
+      return lowerMin;
+    } else if (value > max) {
+      return max;
+    } else {
+      return value;
+    }
+  }
+
+  function inBoundsLower(value: number): number {
+    const upperMax = max - step;
+
+    if (value < min) {
+      return min;
+    } else if (value > upperMax) {
+      return upperMax;
+    } else {
+      return value;
+    }
+  }
+
+  function roundedToStep(value: number) {
+    return Math.round(value / step) * step;
+  }
+}

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -8,7 +8,7 @@ import {
 import {classNames} from '@shopify/react-utilities/styles';
 import {CSS_VAR_PREFIX} from '../../utilities';
 import {Props as RangeSliderProps, DualValue} from '../../types';
-import Labelled from '../../../Labelled';
+import Labelled, {labelID} from '../../../Labelled';
 import EventListener from '../../../EventListener';
 import {Key} from '../../../../types';
 
@@ -135,7 +135,7 @@ export default class DualThumb extends React.Component<Props, State> {
     } = this.props;
     const {value} = this.state;
 
-    const idLower = `${id}Lower`;
+    const idLower = id;
     const idUpper = `${id}Upper`;
 
     const describedBy: string[] = [];
@@ -226,7 +226,7 @@ export default class DualThumb extends React.Component<Props, State> {
           labelHidden={labelHidden}
           helpText={helpText}
         >
-          <div className={styles.Wrapper} id={id}>
+          <div className={styles.Wrapper}>
             {prefixMarkup}
             <div
               className={trackWrapperClassName}
@@ -253,6 +253,7 @@ export default class DualThumb extends React.Component<Props, State> {
                 aria-valuenow={value[0]}
                 aria-invalid={Boolean(error)}
                 aria-describedby={ariaDescribedBy}
+                aria-labelledby={labelID(id)}
                 onFocus={onFocus}
                 onBlur={onBlur}
                 onKeyDown={this.handleKeypressLower}
@@ -274,6 +275,7 @@ export default class DualThumb extends React.Component<Props, State> {
                 aria-valuenow={value[1]}
                 aria-invalid={Boolean(error)}
                 aria-describedby={ariaDescribedBy}
+                aria-labelledby={labelID(id)}
                 onFocus={onFocus}
                 onBlur={onBlur}
                 onKeyDown={this.handleKeypressUpper}

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -74,8 +74,6 @@ export default class DualThumb extends React.Component<Props, State> {
   };
 
   private track = React.createRef<HTMLDivElement>();
-  private thumbLower = React.createRef<HTMLButtonElement>();
-  private thumbUpper = React.createRef<HTMLButtonElement>();
 
   componentDidMount() {
     this.setTrackPosition();
@@ -168,12 +166,9 @@ export default class DualThumb extends React.Component<Props, State> {
         </output>
       ) : null;
 
-    const progressLower = leftPositionThumbLower + THUMB_SIZE / 2;
-    const progressUpper = leftPositionThumbUpper + THUMB_SIZE / 2;
-
     const cssVars = {
-      [`${CSS_VAR_PREFIX}progress-lower`]: `${progressLower}px`,
-      [`${CSS_VAR_PREFIX}progress-upper`]: `${progressUpper}px`,
+      [`${CSS_VAR_PREFIX}progress-lower`]: `${leftPositionThumbLower}px`,
+      [`${CSS_VAR_PREFIX}progress-upper`]: `${leftPositionThumbUpper}px`,
     };
 
     const prefixMarkup = prefix && (
@@ -210,7 +205,6 @@ export default class DualThumb extends React.Component<Props, State> {
               <button
                 id={idLower}
                 className={thumbLowerClassName}
-                ref={this.thumbLower}
                 style={{
                   left: `${leftPositionThumbLower}px`,
                 }}
@@ -230,7 +224,6 @@ export default class DualThumb extends React.Component<Props, State> {
               <button
                 id={idUpper}
                 className={thumbUpperClassName}
-                ref={this.thumbUpper}
                 style={{
                   left: `${leftPositionThumbUpper}px`,
                 }}
@@ -262,9 +255,10 @@ export default class DualThumb extends React.Component<Props, State> {
     if (this.track.current) {
       const {width, left} = this.track.current.getBoundingClientRect();
       const adjustedTrackWidth = width - THUMB_SIZE;
+      const adjustedTrackLeft = left + THUMB_SIZE / 2;
       this.setState({
         trackWidth: adjustedTrackWidth,
-        trackLeft: left,
+        trackLeft: adjustedTrackLeft,
       });
     }
   }

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import throttle from 'lodash-decorators/throttle';
+import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
-import {autobind} from '@shopify/javascript-utilities/decorators';
 import {
   addEventListener,
   removeEventListener,
@@ -74,6 +73,22 @@ export default class DualThumb extends React.Component<Props, State> {
   };
 
   private track = React.createRef<HTMLDivElement>();
+
+  private setTrackPosition = debounce(
+    () => {
+      if (this.track.current) {
+        const {width, left} = this.track.current.getBoundingClientRect();
+        const adjustedTrackWidth = width - THUMB_SIZE;
+        const adjustedTrackLeft = left + THUMB_SIZE / 2;
+        this.setState({
+          trackWidth: adjustedTrackWidth,
+          trackLeft: adjustedTrackLeft,
+        });
+      }
+    },
+    40,
+    {leading: true, trailing: true, maxWait: 40},
+  );
 
   componentDidMount() {
     this.setTrackPosition();
@@ -249,58 +264,42 @@ export default class DualThumb extends React.Component<Props, State> {
     );
   }
 
-  @throttle(40)
-  @autobind
-  private setTrackPosition() {
-    if (this.track.current) {
-      const {width, left} = this.track.current.getBoundingClientRect();
-      const adjustedTrackWidth = width - THUMB_SIZE;
-      const adjustedTrackLeft = left + THUMB_SIZE / 2;
-      this.setState({
-        trackWidth: adjustedTrackWidth,
-        trackLeft: adjustedTrackLeft,
-      });
-    }
-  }
-
-  @autobind
-  private handleMouseDownThumbLower(
+  private handleMouseDownThumbLower = (
     event: React.MouseEvent<HTMLButtonElement>,
-  ) {
+  ) => {
     if (event.button !== 0 || this.props.disabled) return;
     registerMouseMoveHandler(this.handleMouseMoveThumbLower);
     event.stopPropagation();
-  }
+  };
 
-  @autobind
-  private handleMouseMoveThumbLower(event: MouseEvent) {
+  private handleMouseMoveThumbLower = (event: MouseEvent) => {
     const valueUpper = this.state.value[1];
     this.setValue(
       [this.actualXPosition(event.clientX), valueUpper],
       Control.Upper,
     );
-  }
+  };
 
-  @autobind
-  private handleMouseDownThumbUpper(
+  private handleMouseDownThumbUpper = (
     event: React.MouseEvent<HTMLButtonElement>,
-  ) {
+  ) => {
     if (event.button !== 0 || this.props.disabled) return;
     registerMouseMoveHandler(this.handleMouseMoveThumbUpper);
     event.stopPropagation();
-  }
+  };
 
-  @autobind
-  private handleMouseMoveThumbUpper(event: MouseEvent) {
+  private handleMouseMoveThumbUpper = (event: MouseEvent) => {
     const valueLower = this.state.value[0];
     this.setValue(
       [valueLower, this.actualXPosition(event.clientX)],
       Control.Lower,
     );
-  }
+  };
 
-  @autobind
-  private handleKeypressLower(event: React.KeyboardEvent<HTMLButtonElement>) {
+  private handleKeypressLower = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+  ) => {
+    if (this.props.disabled) return;
     const {incrementValueLower, decrementValueLower} = this;
 
     const handlerMap: KeyHandlers = {
@@ -317,10 +316,12 @@ export default class DualThumb extends React.Component<Props, State> {
       event.stopPropagation();
       handler();
     }
-  }
+  };
 
-  @autobind
-  private handleKeypressUpper(event: React.KeyboardEvent<HTMLButtonElement>) {
+  private handleKeypressUpper = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+  ) => {
+    if (this.props.disabled) return;
     const {incrementValueUpper, decrementValueUpper} = this;
 
     const handlerMap: KeyHandlers = {
@@ -337,50 +338,44 @@ export default class DualThumb extends React.Component<Props, State> {
       event.stopPropagation();
       handler();
     }
-  }
+  };
 
-  @autobind
-  private incrementValueLower() {
+  private incrementValueLower = () => {
     this.setValue(
       [this.state.value[0] + this.props.step, this.state.value[1]],
       Control.Upper,
     );
-  }
+  };
 
-  @autobind
-  private decrementValueLower() {
+  private decrementValueLower = () => {
     this.setValue(
       [this.state.value[0] - this.props.step, this.state.value[1]],
       Control.Upper,
     );
-  }
+  };
 
-  @autobind
-  private incrementValueUpper() {
+  private incrementValueUpper = () => {
     this.setValue(
       [this.state.value[0], this.state.value[1] + this.props.step],
       Control.Lower,
     );
-  }
+  };
 
-  @autobind
-  private decrementValueUpper() {
+  private decrementValueUpper = () => {
     this.setValue(
       [this.state.value[0], this.state.value[1] - this.props.step],
       Control.Lower,
     );
-  }
+  };
 
-  @autobind
-  private dispatchValue() {
+  private dispatchValue = () => {
     const {onChange, id} = this.props;
     const {value} = this.state;
 
     onChange(value, id);
-  }
+  };
 
-  @autobind
-  private setValue(dirtyValue: DualValue, control: Control) {
+  private setValue = (dirtyValue: DualValue, control: Control) => {
     const {
       props: {min, max, step},
       state: {value},
@@ -396,10 +391,9 @@ export default class DualThumb extends React.Component<Props, State> {
         this.dispatchValue,
       );
     }
-  }
+  };
 
-  @autobind
-  private handleMouseDownTrack(event: React.MouseEvent) {
+  private handleMouseDownTrack = (event: React.MouseEvent) => {
     if (event.button !== 0 || this.props.disabled) return;
     const clickXPosition = this.actualXPosition(event.clientX);
     const {value} = this.state;
@@ -413,10 +407,9 @@ export default class DualThumb extends React.Component<Props, State> {
       this.setValue([value[0], clickXPosition], Control.Lower);
       registerMouseMoveHandler(this.handleMouseMoveThumbUpper);
     }
-  }
+  };
 
-  @autobind
-  private actualXPosition(dirtyXPosition: number): number {
+  private actualXPosition = (dirtyXPosition: number): number => {
     if (this.track.current) {
       const {min, max} = this.props;
       const {trackLeft, trackWidth} = this.state;
@@ -427,7 +420,7 @@ export default class DualThumb extends React.Component<Props, State> {
     } else {
       return 0;
     }
-  }
+  };
 }
 
 function registerMouseMoveHandler(handler: (event: MouseEvent) => void) {

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -40,7 +40,6 @@ enum Control {
 }
 
 const THUMB_SIZE = 24;
-const OUTPUT_TIP_SIZE = 8;
 
 export default class DualThumb extends React.Component<Props, State> {
   static getDerivedStateFromProps(props: Props, state: State) {
@@ -144,7 +143,7 @@ export default class DualThumb extends React.Component<Props, State> {
           htmlFor={idLower}
           className={outputLowerClassName}
           style={{
-            left: `calc(${leftPositionThumbLower}px - ${OUTPUT_TIP_SIZE}px)`,
+            left: `${leftPositionThumbLower}px`,
           }}
         >
           <div className={styles.OutputBubble}>
@@ -160,7 +159,7 @@ export default class DualThumb extends React.Component<Props, State> {
           htmlFor={idUpper}
           className={outputUpperClassName}
           style={{
-            left: `calc(${leftPositionThumbUpper}px - ${OUTPUT_TIP_SIZE}px)`,
+            left: `${leftPositionThumbUpper}px`,
           }}
         >
           <div className={styles.OutputBubble}>

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -267,7 +267,7 @@ export default class DualThumb extends React.Component<Props, State> {
   private handleMouseDownThumbLower(
     event: React.MouseEvent<HTMLButtonElement>,
   ) {
-    if (event.button !== 0) return;
+    if (event.button !== 0 || this.props.disabled) return;
     registerMouseMoveHandler(this.handleMouseMoveThumbLower);
     event.stopPropagation();
   }
@@ -285,7 +285,7 @@ export default class DualThumb extends React.Component<Props, State> {
   private handleMouseDownThumbUpper(
     event: React.MouseEvent<HTMLButtonElement>,
   ) {
-    if (event.button !== 0) return;
+    if (event.button !== 0 || this.props.disabled) return;
     registerMouseMoveHandler(this.handleMouseMoveThumbUpper);
     event.stopPropagation();
   }
@@ -400,7 +400,7 @@ export default class DualThumb extends React.Component<Props, State> {
 
   @autobind
   private handleMouseDownTrack(event: React.MouseEvent) {
-    if (event.button !== 0) return;
+    if (event.button !== 0 || this.props.disabled) return;
     const clickXPosition = this.actualXPosition(event.clientX);
     const {value} = this.state;
     const distanceFromLowerThumb = Math.abs(value[0] - clickXPosition);

--- a/src/components/RangeSlider/components/DualThumb/index.ts
+++ b/src/components/RangeSlider/components/DualThumb/index.ts
@@ -1,0 +1,4 @@
+import DualThumb from './DualThumb';
+
+export {Props} from './DualThumb';
+export default DualThumb;

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -520,6 +520,23 @@ describe('<DualThumb />', () => {
       expect(onChangeSpy).not.toHaveBeenCalled();
     });
 
+    it('the lower and upper thumbs do not move when disabled', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb
+          {...mockProps}
+          value={[10, 40]}
+          onChange={onChangeSpy}
+          disabled
+        />,
+      );
+
+      moveUpperThumb(dualThumb, 0.5);
+      moveLowerThumb(dualThumb, 0.5);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
     it('moves the lower thumb when the track is clicked closer to it than the upper thumb', () => {
       const onChangeSpy = jest.fn();
       const dualThumb = mountWithAppProvider(
@@ -564,6 +581,38 @@ describe('<DualThumb />', () => {
       moveUpperThumb(dualThumb, 0.9);
 
       expect(onChangeSpy).toHaveBeenCalledWith([5, 45], mockProps.id);
+    });
+
+    it('does not move the lower thumb when the track is clicked and is disabled', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb
+          {...mockProps}
+          value={[5, 40]}
+          onChange={onChangeSpy}
+          disabled
+        />,
+      );
+
+      clickTrack(dualThumb, 0.2);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not move the upper thumb when the track is clicked and is disabled', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb
+          {...mockProps}
+          value={[5, 40]}
+          onChange={onChangeSpy}
+          disabled
+        />,
+      );
+
+      clickTrack(dualThumb, 0.6);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
     });
 
     function clickTrack(

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -1,0 +1,715 @@
+import * as React from 'react';
+import {noop} from '@shopify/javascript-utilities/other';
+import {ReactWrapper} from 'enzyme';
+import {mountWithAppProvider, findByTestID} from 'test-utilities';
+import {Key} from 'types';
+import DualThumb, {Props as DualThumbProps} from '../DualThumb';
+
+describe('<DualThumb />', () => {
+  const mockProps: DualThumbProps = {
+    id: 'RangeSlider',
+    value: [0, 1],
+    min: 0,
+    max: 50,
+    step: 1,
+    output: false,
+    disabled: false,
+    onChange: noop,
+    label: 'Dual thumb range slider',
+  };
+
+  describe('id', () => {
+    it('is used to set the id on the wrapper div', () => {
+      const id = 'MytestID';
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} id={id} />,
+      );
+      expect(dualThumb.find(`div#${id}`)).toHaveLength(1);
+    });
+
+    it('is used to set idLower on the lower thumb', () => {
+      const id = 'MyNewID';
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} id={id} />,
+      );
+      const thumbLower = findThumbLower(dualThumb);
+      expect(thumbLower.prop('id')).toBe(`${id}Lower`);
+    });
+
+    it('is used to set idUpper on the upper thumb', () => {
+      const id = 'MyNewID';
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} id={id} />,
+      );
+      const thumbUpper = findThumbUpper(dualThumb);
+      expect(thumbUpper.prop('id')).toBe(`${id}Upper`);
+    });
+  });
+
+  describe('min', () => {
+    it('is used to set the aria-valuemin on the lower thumb', () => {
+      const min = 0;
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} min={min} />,
+      );
+      const thumbLower = findThumbLower(dualThumb);
+      expect(thumbLower.prop('aria-valuemin')).toBe(min);
+    });
+
+    it('is used to set the aria-valuemin on the upper thumb', () => {
+      const min = 0;
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} min={min} />,
+      );
+      const thumbUpper = findThumbUpper(dualThumb);
+      expect(thumbUpper.prop('aria-valuemin')).toBe(min);
+    });
+  });
+
+  describe('max', () => {
+    it('is used to set the aria-valuemax on the lower thumb', () => {
+      const max = 100;
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} max={max} />,
+      );
+      const thumbLower = findThumbLower(dualThumb);
+      expect(thumbLower.prop('aria-valuemax')).toBe(max);
+    });
+
+    it('is used to set the aria-valuemax on the upper thumb', () => {
+      const max = 100;
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} max={max} />,
+      );
+      const thumbUpper = findThumbUpper(dualThumb);
+      expect(thumbUpper.prop('aria-valuemax')).toBe(max);
+    });
+  });
+
+  describe('disabled', () => {
+    it('sets aria-disabled to false by default on the lower thumb', () => {
+      const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
+
+      const thumbLower = findThumbLower(dualThumb);
+      expect(thumbLower.prop('aria-disabled')).toBe(false);
+    });
+
+    it('sets aria-disabled to false by default on the upper thumb', () => {
+      const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
+
+      const thumbUpper = findThumbUpper(dualThumb);
+      expect(thumbUpper.prop('aria-disabled')).toBe(false);
+    });
+
+    it('sets aria-disabled to true on the lower thumb', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} disabled />,
+      );
+
+      const thumbLower = findThumbLower(dualThumb);
+      expect(thumbLower.prop('aria-disabled')).toBe(true);
+    });
+
+    it('sets aria-disabled to true on the upper thumb', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} disabled />,
+      );
+
+      const thumbUpper = findThumbUpper(dualThumb);
+      expect(thumbUpper.prop('aria-disabled')).toBe(true);
+    });
+  });
+
+  describe('error', () => {
+    it('sets aria-invalid to true on the lower thumb', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} error="Error" />,
+      );
+
+      const thumbLower = findThumbLower(dualThumb);
+      expect(thumbLower.prop('aria-invalid')).toBe(true);
+    });
+
+    it('sets aria-invalid to true on the upper thumb', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} error="Error" />,
+      );
+
+      const thumbUpper = findThumbUpper(dualThumb);
+      expect(thumbUpper.prop('aria-invalid')).toBe(true);
+    });
+
+    describe('aria-describedby', () => {
+      it('gets set as RangeSliderError on the lower thumb', () => {
+        const dualThumb = mountWithAppProvider(
+          <DualThumb {...mockProps} error="Error" />,
+        );
+
+        const thumbLower = findThumbLower(dualThumb);
+        expect(thumbLower.prop('aria-describedby')).toBe('RangeSliderError');
+      });
+
+      it('gets set as RangeSliderError on the upper thumb', () => {
+        const dualThumb = mountWithAppProvider(
+          <DualThumb {...mockProps} error="Error" />,
+        );
+
+        const thumbUpper = findThumbUpper(dualThumb);
+        expect(thumbUpper.prop('aria-describedby')).toBe('RangeSliderError');
+      });
+    });
+  });
+
+  describe('output', () => {
+    it('does not render the lower output by default', () => {
+      const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
+
+      const outputLower = dualThumb.find('output').first();
+      expect(outputLower).toHaveLength(0);
+    });
+
+    it('does not render the upper output by default', () => {
+      const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
+
+      const outputUpper = dualThumb.find('output').last();
+      expect(outputUpper).toHaveLength(0);
+    });
+
+    it('renders the lower output', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} output />,
+      );
+
+      const outputLower = dualThumb.find('output').first();
+      expect(outputLower).toHaveLength(1);
+    });
+
+    it('renders the upper output', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} output />,
+      );
+
+      const outputUpper = dualThumb.find('output').last();
+      expect(outputUpper).toHaveLength(1);
+    });
+
+    it('renders the lower output value as text', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} output />,
+      );
+
+      const outputLower = dualThumb.find('output').first();
+      expect(outputLower.find('span').text()).toContain('0');
+    });
+
+    it('renders the upper output value as text', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} output />,
+      );
+
+      const outputUpper = dualThumb.find('output').last();
+      expect(outputUpper.find('span').text()).toContain('1');
+    });
+  });
+
+  describe('onFocus()', () => {
+    it('gets called when the lower thumb gets focus', () => {
+      const onFocusSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} onFocus={onFocusSpy} />,
+      );
+
+      const lowerThumb = findThumbLower(dualThumb);
+      lowerThumb.simulate('focus');
+      expect(onFocusSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('gets called when the upper thumb gets focus', () => {
+      const onFocusSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} onFocus={onFocusSpy} />,
+      );
+
+      const upperThumb = findThumbUpper(dualThumb);
+      upperThumb.simulate('focus');
+      expect(onFocusSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onBlur()', () => {
+    it('gets called when the lower thumb loses focus', () => {
+      const onBlurSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} onBlur={onBlurSpy} />,
+      );
+
+      const lowerThumb = findThumbLower(dualThumb);
+      lowerThumb.simulate('blur');
+      expect(onBlurSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('gets called when the upper thumb loses focus', () => {
+      const onBlurSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} onBlur={onBlurSpy} />,
+      );
+
+      const upperThumb = findThumbUpper(dualThumb);
+      upperThumb.simulate('blur');
+      expect(onBlurSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onChange()', () => {
+    it('is called when the value prop needs sanitization', () => {
+      const onChangeSpy = jest.fn();
+      const id = 'onChangeID';
+
+      mountWithAppProvider(
+        <DualThumb
+          {...mockProps}
+          value={[15, 10]}
+          onChange={onChangeSpy}
+          id={id}
+        />,
+      );
+
+      expect(onChangeSpy).toHaveBeenCalledWith([9, 10], id);
+    });
+
+    it('is not called when the value prop needs no sanitization', () => {
+      const onChangeSpy = jest.fn();
+
+      mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 15]} onChange={onChangeSpy} />,
+      );
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('CSS custom properties', () => {
+    it('gets set on the track', () => {
+      const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
+
+      const expected = {
+        '--Polaris-RangeSlider-progress-lower': '12px',
+        '--Polaris-RangeSlider-progress-upper': '11.52px',
+      };
+      const track = findByTestID(dualThumb, 'track');
+      const actual = track.find('[style]').prop('style');
+
+      expect(expected).toStrictEqual(actual);
+    });
+  });
+
+  describe('keyboard control', () => {
+    it('increments the lower value on right arrow press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.RightArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([11, 40], mockProps.id);
+    });
+
+    it('increments the upper value on right arrow press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbUpper(dualThumb), Key.RightArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([10, 41], mockProps.id);
+    });
+
+    it('decrement the upper value on left arrow press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbUpper(dualThumb), Key.LeftArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([10, 39], mockProps.id);
+    });
+
+    it('increments the lower value on up arrow press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.UpArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([11, 40], mockProps.id);
+    });
+
+    it('does not increment the lower value when it is a step below the upper value', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[39, 40]} onChange={onChangeSpy} />,
+      );
+      const lowerThumb = findThumbLower(dualThumb);
+      simulateKeyDown(lowerThumb, Key.RightArrow);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect([
+        lowerThumb.prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
+      ]).toStrictEqual([39, 40]);
+    });
+
+    it('does not decrement the lower value when it is equal to the min', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[0, 40]} onChange={onChangeSpy} />,
+      );
+      const lowerThumb = findThumbLower(dualThumb);
+      simulateKeyDown(lowerThumb, Key.LeftArrow);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect([
+        lowerThumb.prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
+      ]).toStrictEqual([0, 40]);
+    });
+
+    it('does not increment the upper value when it is equal to the max', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[0, 50]} onChange={onChangeSpy} />,
+      );
+      const upperThumb = findThumbUpper(dualThumb);
+      simulateKeyDown(upperThumb, Key.RightArrow);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect([
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        upperThumb.prop('aria-valuenow'),
+      ]).toStrictEqual([0, 50]);
+    });
+
+    it('does not decrement the upper value when it is a step above the lower value', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[49, 50]} onChange={onChangeSpy} />,
+      );
+      const upperThumb = findThumbUpper(dualThumb);
+      simulateKeyDown(upperThumb, Key.LeftArrow);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+      expect([
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        upperThumb.prop('aria-valuenow'),
+      ]).toStrictEqual([49, 50]);
+    });
+
+    it('decrements the lower value on left arrow press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.LeftArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([9, 40], mockProps.id);
+    });
+
+    it('decrements the lower value on down arrow press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.DownArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([9, 40], mockProps.id);
+    });
+
+    it('increment the lower value on up arrow press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.UpArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([11, 40], mockProps.id);
+    });
+
+    it('decrement the lower value on down arrow press', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.DownArrow);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([9, 40], mockProps.id);
+    });
+
+    function simulateKeyDown(component: ReactWrapper, keyCode: Key) {
+      component.simulate('keyDown', {
+        keyCode,
+        preventDefault: noop,
+        stopPropagation: noop,
+      });
+    }
+  });
+
+  describe('mouse interface', () => {
+    type EventCallback = (mockEventData?: {[key: string]: any}) => void;
+
+    const eventMap: {[eventType: string]: EventCallback} = {};
+    const origialAddEventListener = document.addEventListener;
+
+    beforeAll(() => {
+      jest
+        .spyOn(document, 'addEventListener')
+        .mockImplementation((eventType: string, callback: EventCallback) => {
+          eventMap[eventType] = callback;
+        });
+    });
+
+    afterAll(() => {
+      document.addEventListener = origialAddEventListener;
+    });
+
+    it('moving the lower thumb sets the lower value', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+
+      moveLowerThumb(dualThumb, 0.5);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([25, 40], mockProps.id);
+    });
+
+    it('moving the upper thumb sets the upper value', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+
+      moveUpperThumb(dualThumb, 0.5);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([10, 25], mockProps.id);
+    });
+
+    it('mouseup removes the mousemove event listener', () => {
+      const removeEventListenerSpy = jest.spyOn(
+        document,
+        'removeEventListener',
+      );
+      const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
+
+      moveUpperThumb(dualThumb, 0.5);
+      removeEventListenerSpy.mockClear();
+      eventMap.mouseup();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
+      expect(removeEventListenerSpy.mock.calls[0][0]).toBe('mousemove');
+    });
+
+    it('the lower and upper thumbs do not move when using a non-primary mouse button', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} onChange={onChangeSpy} />,
+      );
+
+      moveUpperThumb(dualThumb, 0.5, 1);
+      moveLowerThumb(dualThumb, 0.5, 1);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('moves the lower thumb when the track is clicked closer to it than the upper thumb', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[5, 40]} onChange={onChangeSpy} />,
+      );
+
+      clickTrack(dualThumb, 0.2);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([10, 40], mockProps.id);
+    });
+
+    it('moves the upper thumb when the track is clicked closer to it than the lower thumb', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[5, 40]} onChange={onChangeSpy} />,
+      );
+
+      clickTrack(dualThumb, 0.6);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([5, 30], mockProps.id);
+    });
+
+    it('moves the lower thumb when the track is clicked closer to it than the upper thumb and the mouse moves', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[5, 40]} onChange={onChangeSpy} />,
+      );
+
+      clickTrack(dualThumb, 0.2);
+      moveLowerThumb(dualThumb, 0.3);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([15, 40], mockProps.id);
+    });
+
+    it('moves the upper thumb when the track is clicked closer to it than the lower thumb and the mouse moves', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[5, 40]} onChange={onChangeSpy} />,
+      );
+
+      clickTrack(dualThumb, 0.6);
+      moveUpperThumb(dualThumb, 0.9);
+
+      expect(onChangeSpy).toHaveBeenCalledWith([5, 45], mockProps.id);
+    });
+
+    function clickTrack(
+      component: ReactWrapper,
+      percentageOfTrackX: number,
+      button = 0,
+    ) {
+      const trackWidth = 100;
+      const clientX = trackWidth * percentageOfTrackX;
+
+      component.setState({trackLeft: 0, trackWidth}, () => {
+        findTrack(component).simulate('mouseDown', {button, clientX});
+      });
+    }
+
+    function moveLowerThumb(
+      component: ReactWrapper,
+      percentageOfTrackX: number,
+      button = 0,
+    ) {
+      const trackWidth = 100;
+
+      component.setState({trackLeft: 0, trackWidth}, () => {
+        findThumbLower(component).simulate('mouseDown', {button});
+        eventMap.mousemove({clientX: trackWidth * percentageOfTrackX});
+      });
+    }
+
+    function moveUpperThumb(
+      component: ReactWrapper,
+      percentageOfTrackX: number,
+      button = 0,
+    ) {
+      const trackWidth = 100;
+
+      component.setState({trackLeft: 0, trackWidth}, () => {
+        findThumbUpper(component).simulate('mouseDown', {button});
+        eventMap.mousemove({clientX: trackWidth * percentageOfTrackX});
+      });
+    }
+  });
+
+  describe('value prop sanitization', () => {
+    it('sanitizes the lower value with respect to the step prop', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[4, 40]} step={5} />,
+      );
+      expect([
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
+      ]).toStrictEqual([5, 40]);
+    });
+
+    it('sanitizes the upper value with respect to the step prop', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[5, 41]} step={5} />,
+      );
+      expect([
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
+      ]).toStrictEqual([5, 40]);
+    });
+
+    it('sanitizes the lower value with respect to the max prop', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[110, 150]} max={100} />,
+      );
+      expect([
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
+      ]).toStrictEqual([99, 100]);
+    });
+
+    it('sanitizes the upper value with respect to the max prop', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[110, 150]} max={100} />,
+      );
+      expect([
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
+      ]).toStrictEqual([99, 100]);
+    });
+
+    it('sanitizes the lower value with respect to the min prop', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 40]} min={20} />,
+      );
+      expect([
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
+      ]).toStrictEqual([20, 40]);
+    });
+
+    it('sanitizes the upper value with respect to the min prop', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 15]} min={20} />,
+      );
+      expect([
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
+      ]).toStrictEqual([20, 21]);
+    });
+
+    it('sets the lower value to a step below the upper value if the lower value equals the upper value', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[10, 10]} />,
+      );
+
+      expect([
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
+      ]).toStrictEqual([9, 10]);
+    });
+
+    it('sets the lower value to a step below the upper value if the lower value is higher than the upper value', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[15, 10]} />,
+      );
+
+      expect([
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
+      ]).toStrictEqual([9, 10]);
+    });
+
+    it('sets the upper value to one step above the min and the lower value to the min when they are out of bounds and inversed', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[1500, -10]} />,
+      );
+
+      expect([
+        findThumbLower(dualThumb).prop('aria-valuenow'),
+        findThumbUpper(dualThumb).prop('aria-valuenow'),
+      ]).toStrictEqual([0, 1]);
+    });
+  });
+});
+
+function findThumbLower(containerComponent: ReactWrapper): ReactWrapper {
+  return containerComponent.find('button').first();
+}
+
+function findThumbUpper(containerComponent: ReactWrapper): ReactWrapper {
+  return containerComponent.find('button').last();
+}
+
+function findTrack(containerComponent: ReactWrapper): ReactWrapper {
+  return findByTestID(containerComponent, 'trackWrapper');
+}

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -444,6 +444,36 @@ describe('<DualThumb />', () => {
       expect(onChangeSpy).toHaveBeenCalledWith([9, 40], mockProps.id);
     });
 
+    it('does not change the lower value if disabled', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb
+          {...mockProps}
+          value={[10, 40]}
+          onChange={onChangeSpy}
+          disabled
+        />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.RightArrow);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not change the upper value if disabled', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb
+          {...mockProps}
+          value={[10, 40]}
+          onChange={onChangeSpy}
+          disabled
+        />,
+      );
+      simulateKeyDown(findThumbUpper(dualThumb), Key.RightArrow);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
     function simulateKeyDown(component: ReactWrapper, keyCode: Key) {
       component.simulate('keyDown', {
         keyCode,
@@ -822,6 +852,21 @@ describe('<DualThumb />', () => {
       touchTrack(dualThumb, 0.6);
 
       expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('removes touchstart listener on track', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[5, 40]} onChange={noop} />,
+      );
+
+      const track = findTrack(dualThumb).getDOMNode();
+
+      const removeEventListenerSpy = jest.spyOn(track, 'removeEventListener');
+      removeEventListenerSpy.mockClear();
+
+      dualThumb.unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalled();
     });
 
     function touchTrack(component: ReactWrapper, percentageOfTrackX: number) {

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -19,21 +19,13 @@ describe('<DualThumb />', () => {
   };
 
   describe('id', () => {
-    it('is used to set the id on the wrapper div', () => {
-      const id = 'MytestID';
-      const dualThumb = mountWithAppProvider(
-        <DualThumb {...mockProps} id={id} />,
-      );
-      expect(dualThumb.find(`div#${id}`)).toHaveLength(1);
-    });
-
-    it('is used to set idLower on the lower thumb', () => {
+    it('is used on the lower thumb', () => {
       const id = 'MyNewID';
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} id={id} />,
       );
       const thumbLower = findThumbLower(dualThumb);
-      expect(thumbLower.prop('id')).toBe(`${id}Lower`);
+      expect(thumbLower.prop('id')).toBe(id);
     });
 
     it('is used to set idUpper on the upper thumb', () => {

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -293,13 +293,13 @@ describe('<DualThumb />', () => {
       const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
 
       const expected = {
-        '--Polaris-RangeSlider-progress-lower': '12px',
-        '--Polaris-RangeSlider-progress-upper': '11.52px',
+        '--Polaris-RangeSlider-progress-lower': '0px',
+        '--Polaris-RangeSlider-progress-upper': '-0.48px',
       };
       const track = findByTestID(dualThumb, 'track');
       const actual = track.find('[style]').prop('style');
 
-      expect(expected).toStrictEqual(actual);
+      expect(actual).toStrictEqual(expected);
     });
   });
 

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -33,6 +33,12 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
   }
 }
 
+.disabled {
+  input {
+    cursor: not-allowed;
+  }
+}
+
 .Prefix {
   flex: 0 0 auto;
   margin-right: spacing(tight);

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -10,13 +10,9 @@ $range-thumb-shadow-hover: (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint));
 $range-thumb-shadow-error: 0 0 0 rem(1px) color('red');
 $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
 
-.RangeSlider {
+.SingleThumb {
   display: flex;
   align-items: center;
-
-  &:not(:first-child) {
-    margin-top: spacing(tight);
-  }
 
   &.disabled {
     opacity: 0.8;
@@ -29,6 +25,12 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
   align-items: center;
   flex: 1 1 auto;
   height: $range-thumb-size;
+
+  input {
+    padding: spacing(base-tight) 0;
+    background-color: transparent;
+    cursor: pointer;
+  }
 }
 
 .Prefix {

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -158,15 +158,15 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
 ///
 /// Output value indicator
 $range-output-size: rem(32px);
-$range-output-tip-size: rem(8px);
 $range-output-translate-x: calc(
   -50% + var(--Polaris-RangeSlider-output-factor, 0) * #{$range-thumb-size}
 );
+$range-output-spacing: rem(16px);
 
 .Output {
   position: absolute;
   z-index: z-index('output', $stacking-order);
-  bottom: $range-output-size - $range-output-tip-size;
+  bottom: $range-thumb-size;
   left: var(--Polaris-RangeSlider-progress, 50%);
   transform: translateX($range-output-translate-x);
   opacity: 0;
@@ -196,28 +196,14 @@ $range-output-translate-x: calc(
   transition-duration: duration();
   transition-timing-function: easing();
 
-  &::before {
-    content: '';
-    position: absolute;
-    bottom: -($range-output-tip-size - rem(1px));
-    left: 50%;
-    margin-left: -$range-output-tip-size;
-    display: block;
-    width: 0;
-    height: 0;
-    border-left: $range-output-tip-size solid transparent;
-    border-right: $range-output-tip-size solid transparent;
-    border-top: $range-output-tip-size solid color('ink');
-  }
-
   // stylelint-disable selector-max-specificity
   .Input:hover + .Output &,
   .Input:active + .Output &,
   .Input:focus + .Output & {
-    transform: translateY(-$range-thumb-size);
+    transform: translateY(-$range-output-spacing);
 
     @include page-content-when-not-partially-condensed {
-      transform: translateY(-($range-thumb-size / 2));
+      transform: translateY(-($range-output-spacing / 2));
     }
   }
   // stylelint-enable selector-max-specificity

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import {classNames} from '@shopify/react-utilities/styles';
+import clamp from '../../../../utilities/clamp';
+import Labelled, {helpTextID} from '../../../Labelled';
+
+import {invertNumber, CSS_VAR_PREFIX} from '../../utilities';
+import {Props as RangeSliderProps} from '../../types';
+
+import styles from './SingleThumb.scss';
+
+export interface Props extends RangeSliderProps {
+  value: number;
+  id: string;
+  min: number;
+  max: number;
+  step: number;
+}
+
+export default function SingleThumb(props: Props) {
+  const {
+    id,
+    error,
+    helpText,
+    value,
+    min,
+    max,
+    disabled,
+    output,
+    prefix,
+    suffix,
+    label,
+    labelAction,
+    labelHidden,
+    step,
+    onBlur,
+    onFocus,
+  } = props;
+  const clampedValue = clamp(value, min, max);
+  const describedBy: string[] = [];
+
+  if (error) {
+    describedBy.push(`${id}Error`);
+  }
+
+  if (helpText) {
+    describedBy.push(helpTextID(id));
+  }
+
+  const ariaDescribedBy = describedBy.length
+    ? describedBy.join(' ')
+    : undefined;
+
+  const sliderProgress = ((clampedValue - min) * 100) / (max - min);
+  const outputFactor = invertNumber((sliderProgress - 50) / 100);
+
+  const cssVars = {
+    [`${CSS_VAR_PREFIX}min`]: min,
+    [`${CSS_VAR_PREFIX}max`]: max,
+    [`${CSS_VAR_PREFIX}current`]: clampedValue,
+    [`${CSS_VAR_PREFIX}progress`]: `${sliderProgress}%`,
+    [`${CSS_VAR_PREFIX}output-factor`]: `${outputFactor}`,
+  };
+
+  const outputMarkup = !disabled &&
+    output && (
+      <output htmlFor={id} className={styles.Output}>
+        <div className={styles.OutputBubble}>
+          <span className={styles.OutputText}>{clampedValue}</span>
+        </div>
+      </output>
+    );
+
+  const prefixMarkup = prefix && <div className={styles.Prefix}>{prefix}</div>;
+
+  const suffixMarkup = suffix && <div className={styles.Suffix}>{suffix}</div>;
+
+  const className = classNames(
+    styles.SingleThumb,
+    error && styles.error,
+    disabled && styles.disabled,
+  );
+
+  return (
+    <Labelled
+      id={id}
+      label={label}
+      error={error}
+      action={labelAction}
+      labelHidden={labelHidden}
+      helpText={helpText}
+    >
+      <div className={className} style={cssVars}>
+        {prefixMarkup}
+        <div className={styles.InputWrapper}>
+          <input
+            type="range"
+            className={styles.Input}
+            id={id}
+            name={id}
+            min={min}
+            max={max}
+            step={step}
+            value={clampedValue}
+            disabled={disabled}
+            onChange={handleChange}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            aria-valuemin={min}
+            aria-valuemax={max}
+            aria-valuenow={clampedValue}
+            aria-invalid={Boolean(error)}
+            aria-describedby={ariaDescribedBy}
+          />
+          {outputMarkup}
+        </div>
+        {suffixMarkup}
+      </div>
+    </Labelled>
+  );
+
+  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const {onChange} = props;
+
+    if (onChange == null) {
+      return;
+    }
+
+    onChange(parseFloat(event.currentTarget.value), id);
+  }
+}

--- a/src/components/RangeSlider/components/SingleThumb/index.ts
+++ b/src/components/RangeSlider/components/SingleThumb/index.ts
@@ -1,0 +1,4 @@
+import SingleThumb from './SingleThumb';
+
+export {Props} from './SingleThumb';
+export default SingleThumb;

--- a/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
@@ -1,0 +1,254 @@
+import * as React from 'react';
+import {noop} from '@shopify/javascript-utilities/other';
+import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
+import {SingleThumb} from '../..';
+
+const mockProps = {
+  id: 'MyRangeSlider',
+  label: 'RangeSlider',
+  min: 10,
+  max: 20,
+  step: 0.5,
+  onChange: noop,
+  value: 15,
+};
+
+describe('<SingleThumb />', () => {
+  it('allows specific props to pass through properties on the input', () => {
+    const input = shallowWithAppProvider(
+      <SingleThumb disabled {...mockProps} />,
+    ).find('input');
+
+    expect(input.prop('value')).toBe(15);
+    expect(input.prop('min')).toBe(10);
+    expect(input.prop('max')).toBe(20);
+    expect(input.prop('step')).toBe(0.5);
+    expect(input.prop('disabled')).toBe(true);
+  });
+
+  describe('onChange()', () => {
+    it('is called when the input changes', () => {
+      const onChangeSpy = jest.fn();
+      const {onChange, ...rest} = mockProps;
+      const element = mountWithAppProvider(
+        <SingleThumb onChange={onChangeSpy} {...rest} />,
+      );
+
+      const singleThumb = element.find(SingleThumb);
+      singleThumb.find('input').simulate('change');
+      expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called with a new value', () => {
+      const onChangeSpy = jest.fn();
+      const {onChange, ...rest} = mockProps;
+      const element = mountWithAppProvider(
+        <SingleThumb onChange={onChangeSpy} {...rest} />,
+      );
+
+      const singleThumb = element.find(SingleThumb);
+      (element.find('input') as any).instance().value = 40;
+      singleThumb.find('input').simulate('change');
+      expect(onChangeSpy).toHaveBeenCalledWith(40, 'MyRangeSlider');
+    });
+  });
+
+  describe('onFocus()', () => {
+    it('is called when the input is focused', () => {
+      const onFocusSpy = jest.fn();
+      shallowWithAppProvider(
+        <SingleThumb {...mockProps} onFocus={onFocusSpy} />,
+      )
+        .find('input')
+        .simulate('focus');
+      expect(onFocusSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onBlur()', () => {
+    it('is called when the input is blurred', () => {
+      const onBlurSpy = jest.fn();
+      const element = shallowWithAppProvider(
+        <SingleThumb {...mockProps} onBlur={onBlurSpy} />,
+      );
+
+      element.find('input').simulate('focus');
+      element.find('input').simulate('blur');
+
+      expect(onBlurSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('id', () => {
+    it('sets the id on the input', () => {
+      const id = shallowWithAppProvider(<SingleThumb {...mockProps} />)
+        .find('input')
+        .prop('id');
+
+      expect(id).toBe('MyRangeSlider');
+    });
+  });
+
+  describe('output', () => {
+    it('connects the input to the output', () => {
+      const element = mountWithAppProvider(
+        <SingleThumb {...mockProps} output />,
+      );
+      const inputId = element.find('input').prop('id');
+
+      expect(typeof inputId).toBe('string');
+      expect(element.find('output').prop('htmlFor')).toBe(inputId);
+    });
+
+    it('contains the value as text', () => {
+      const element = mountWithAppProvider(
+        <SingleThumb {...mockProps} output />,
+      );
+      const outputText = element.find('output').find('span');
+
+      expect(outputText.text()).toBe('15');
+    });
+  });
+
+  describe('helpText', () => {
+    it('connects the input to the help text', () => {
+      const element = mountWithAppProvider(
+        <SingleThumb {...mockProps} helpText="Some help" />,
+      );
+      const helpTextID = element.find('input').prop<string>('aria-describedby');
+
+      expect(typeof helpTextID).toBe('string');
+      expect(element.find(`#${helpTextID}`).text()).toBe('Some help');
+    });
+  });
+
+  describe('error', () => {
+    it('marks the input as invalid', () => {
+      const element = shallowWithAppProvider(
+        <SingleThumb error={<span>Invalid</span>} {...mockProps} />,
+      );
+      expect(element.find('input').prop<string>('aria-invalid')).toBe(true);
+
+      element.setProps({error: 'Some error'});
+      expect(element.find('input').prop<string>('aria-invalid')).toBe(true);
+    });
+
+    it('connects the input to the error', () => {
+      const element = mountWithAppProvider(
+        <SingleThumb {...mockProps} error="Some error" />,
+      );
+      const errorID = element.find('input').prop<string>('aria-describedby');
+
+      expect(typeof errorID).toBe('string');
+      expect(element.find(`#${errorID}`).text()).toBe('Some error');
+    });
+
+    it('connects the input to both an error and help text', () => {
+      const element = mountWithAppProvider(
+        <SingleThumb {...mockProps} helpText="Some help" error="Some error" />,
+      );
+      const descriptions = element
+        .find('input')
+        .prop<string>('aria-describedby')
+        .split(' ');
+
+      expect(descriptions).toHaveLength(2);
+      expect(element.find(`#${descriptions[1]}`).text()).toBe('Some help');
+      expect(element.find(`#${descriptions[0]}`).text()).toBe('Some error');
+    });
+
+    describe('prefix', () => {
+      const text = 'prefix text';
+
+      it('outputs the provided prefix element', () => {
+        const element = mountWithAppProvider(
+          <SingleThumb {...mockProps} prefix={<p>{text}</p>} />,
+        );
+        const prefixElement = element.find('p');
+
+        expect(prefixElement.text()).toBe(text);
+      });
+    });
+  });
+
+  describe('suffix', () => {
+    const text = 'suffix text';
+    it('outputs the provided suffix element', () => {
+      const element = mountWithAppProvider(
+        <SingleThumb {...mockProps} suffix={<p>{text}</p>} />,
+      );
+      const suffixElement = element.find('p');
+
+      expect(suffixElement.text()).toBe(text);
+    });
+  });
+
+  describe('CSS custom properties', () => {
+    it('gets set on the parent element', () => {
+      const element = mountWithAppProvider(<SingleThumb {...mockProps} />);
+      const expected = {
+        '--Polaris-RangeSlider-min': 10,
+        '--Polaris-RangeSlider-max': 20,
+        '--Polaris-RangeSlider-current': 15,
+        '--Polaris-RangeSlider-progress': '50%',
+        '--Polaris-RangeSlider-output-factor': '0',
+      };
+      const actual = element.find('[style]').prop('style');
+
+      expect(expected).toStrictEqual(actual || {});
+    });
+  });
+
+  describe('value', () => {
+    it('gets adjusted to be at least the min', () => {
+      const value = 9;
+      const min = 10;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} min={min} />,
+      );
+
+      expect(singleThumb.find('input').prop('value')).toBe(min);
+    });
+
+    it('gets adjusted to be no more than the max', () => {
+      const value = 101;
+      const max = 100;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} max={max} />,
+      );
+
+      expect(singleThumb.find('input').prop('value')).toBe(max);
+    });
+  });
+
+  describe('aria-valuenow', () => {
+    it('gets passed the value', () => {
+      const value = 15;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} />,
+      );
+
+      expect(singleThumb.find('input').prop('aria-valuenow')).toBe(value);
+    });
+
+    it('gets adjusted to be at least the min', () => {
+      const value = 9;
+      const min = 10;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} min={min} />,
+      );
+
+      expect(singleThumb.find('input').prop('aria-valuenow')).toBe(min);
+    });
+
+    it('gets adjusted to be no more than the max', () => {
+      const value = 101;
+      const max = 100;
+      const singleThumb = mountWithAppProvider(
+        <SingleThumb {...mockProps} value={value} max={max} />,
+      );
+
+      expect(singleThumb.find('input').prop('aria-valuenow')).toBe(max);
+    });
+  });
+});

--- a/src/components/RangeSlider/components/index.ts
+++ b/src/components/RangeSlider/components/index.ts
@@ -1,0 +1,2 @@
+export {default as DualThumb} from './DualThumb';
+export {default as SingleThumb} from './SingleThumb';

--- a/src/components/RangeSlider/index.ts
+++ b/src/components/RangeSlider/index.ts
@@ -1,4 +1,4 @@
 import RangeSlider from './RangeSlider';
 
-export {Props, invertNumber} from './RangeSlider';
+export {Props, RangeSliderValue} from './types';
 export default RangeSlider;

--- a/src/components/RangeSlider/tests/RangeSlider.test.tsx
+++ b/src/components/RangeSlider/tests/RangeSlider.test.tsx
@@ -1,281 +1,132 @@
 import * as React from 'react';
 import {noop} from '@shopify/javascript-utilities/other';
-import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
-import RangeSlider, {invertNumber} from '../RangeSlider';
+import {mountWithAppProvider} from 'test-utilities';
+import RangeSlider from '../RangeSlider';
+import {DualThumb, SingleThumb} from '../components';
+import {RangeSliderDefault} from '../utilities';
+
+const mockRangeSliderProps = {
+  label: 'RangeSlider',
+  onChange: noop,
+};
 
 describe('<RangeSlider />', () => {
-  it('allows specific props to pass through properties on the input', () => {
-    const input = shallowWithAppProvider(
-      <RangeSlider
-        label="RangeSlider"
-        value={15}
-        min={10}
-        max={20}
-        step={0.5}
-        disabled
-        onChange={noop}
-      />,
-    ).find('input');
-
-    expect(input.prop('value')).toBe(15);
-    expect(input.prop('min')).toBe(10);
-    expect(input.prop('max')).toBe(20);
-    expect(input.prop('step')).toBe(0.5);
-    expect(input.prop('disabled')).toBe(true);
-  });
-
-  describe('onChange()', () => {
-    it('is called with the new value', () => {
-      const spy = jest.fn();
+  describe('<DualThumb />', () => {
+    it('renders a dual thumb if value is a tuple', () => {
       const element = mountWithAppProvider(
-        <RangeSlider
-          id="MyRangeSlider"
-          label="RangeSlider"
-          value={50}
-          onChange={spy}
-        />,
+        <RangeSlider value={[0, 25]} {...mockRangeSliderProps} />,
       );
 
-      (element.find('input') as any).instance().value = 40;
-      element.find('input').simulate('change');
-
-      expect(spy).toHaveBeenCalledWith(40, 'MyRangeSlider');
-    });
-  });
-
-  describe('onFocus()', () => {
-    it('is called when the input is focused', () => {
-      const spy = jest.fn();
-      shallowWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          onChange={noop}
-          onFocus={spy}
-        />,
-      )
-        .find('input')
-        .simulate('focus');
-      expect(spy).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('onBlur()', () => {
-    it('is called when the input is blurred', () => {
-      const spy = jest.fn();
-      const element = shallowWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          onChange={noop}
-          onBlur={spy}
-        />,
-      );
-
-      element.find('input').simulate('focus');
-      element.find('input').simulate('blur');
-
-      expect(spy).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('id', () => {
-    it('sets the id on the input', () => {
-      const id = shallowWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          id="MyRangeSlider"
-          value={50}
-          onChange={noop}
-        />,
-      )
-        .find('input')
-        .prop('id');
-
-      expect(id).toBe('MyRangeSlider');
+      expect(element.find(DualThumb)).toHaveLength(1);
     });
 
-    it('sets a random id on the input when none is passed', () => {
-      const id = shallowWithAppProvider(
-        <RangeSlider label="RangeSlider" value={50} onChange={noop} />,
-      )
-        .find('input')
-        .prop('id');
-
-      expect(typeof id).toBe('string');
-      expect(id).toBeTruthy();
-    });
-  });
-
-  describe('output', () => {
-    it('connects the input to the output', () => {
+    it('passes default props to dual thumb', () => {
       const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          id="MyRangeSlider"
-          value={50}
-          output
-          onChange={noop}
-        />,
+        <RangeSlider value={[0, 25]} {...mockRangeSliderProps} />,
       );
-      const inputId = element.find('input').prop<string>('id');
 
-      expect(typeof inputId).toBe('string');
-      expect(element.find('output').prop<string>('htmlFor')).toBe(inputId);
+      const {min, max, step} = element.find(DualThumb).props();
+
+      expect({
+        min,
+        max,
+        step,
+      }).toStrictEqual({
+        min: RangeSliderDefault.Min,
+        max: RangeSliderDefault.Max,
+        step: RangeSliderDefault.Step,
+      });
     });
 
-    it('contains the provided value text', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider label="RangeSlider" value={50} output onChange={noop} />,
-      );
-      const outputText = element.find('output').find('span');
-
-      expect(outputText.text()).toBe('50');
-    });
-  });
-
-  describe('helpText', () => {
-    it('connects the input to the help text', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          helpText="Some help"
-          onChange={noop}
-        />,
-      );
-      const helpTextID = element.find('input').prop<string>('aria-describedby');
-
-      expect(typeof helpTextID).toBe('string');
-      expect(element.find(`#${helpTextID}`).text()).toBe('Some help');
-    });
-  });
-
-  describe('error', () => {
-    it('marks the input as invalid', () => {
-      const element = shallowWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          error={<span>Invalid</span>}
-          onChange={noop}
-        />,
-      );
-      expect(element.find('input').prop<string>('aria-invalid')).toBe(true);
-
-      element.setProps({error: 'Some error'});
-      expect(element.find('input').prop<string>('aria-invalid')).toBe(true);
-    });
-
-    it('connects the input to the error', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          error="Some error"
-          onChange={noop}
-        />,
-      );
-      const errorID = element.find('input').prop<string>('aria-describedby');
-
-      expect(typeof errorID).toBe('string');
-      expect(element.find(`#${errorID}`).text()).toBe('Some error');
-    });
-
-    it('connects the input to both an error and help text', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          helpText="Some help"
-          error="Some error"
-          onChange={noop}
-        />,
-      );
-      const descriptions = element
-        .find('input')
-        .prop<string>('aria-describedby')
-        .split(' ');
-
-      expect(descriptions).toHaveLength(2);
-      expect(element.find(`#${descriptions[1]}`).text()).toBe('Some help');
-      expect(element.find(`#${descriptions[0]}`).text()).toBe('Some error');
-    });
-  });
-
-  describe('prefix', () => {
-    const text = 'prefix text';
-
-    it('outputs the provided prefix element', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          prefix={<p>{text}</p>}
-          onChange={noop}
-        />,
-      );
-      const prefixElement = element.find('p');
-
-      expect(prefixElement.text()).toBe(text);
-    });
-  });
-
-  describe('suffix', () => {
-    const text = 'suffix text';
-
-    it('outputs the provided suffix element', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          value={50}
-          suffix={<p>{text}</p>}
-          onChange={noop}
-        />,
-      );
-      const suffixElement = element.find('p');
-
-      expect(suffixElement.text()).toBe(text);
-    });
-  });
-
-  describe('invertNumber', () => {
-    it('returns a negative number when the argument is positive', () => {
-      const negative = invertNumber(10);
-      expect(negative).toBe(-10);
-    });
-
-    it('returns a positive number when the argument is negative', () => {
-      const negative = invertNumber(-10);
-      expect(negative).toBe(10);
-    });
-
-    it('returns 0 when the argument is 0', () => {
-      const negative = invertNumber(0);
-      expect(negative).toBe(0);
-    });
-  });
-
-  describe('CSS custom properties', () => {
-    it('sets the css custom properties', () => {
-      const element = mountWithAppProvider(
-        <RangeSlider
-          label="RangeSlider"
-          id="MyRangeSlider"
-          value={25}
-          onChange={noop}
-        />,
-      );
-      const expected = {
-        '--Polaris-RangeSlider-min': 0,
-        '--Polaris-RangeSlider-max': 100,
-        '--Polaris-RangeSlider-current': 25,
-        '--Polaris-RangeSlider-progress': '25%',
-        '--Polaris-RangeSlider-output-factor': 0.25,
+    it('passes overrides to default props to dual thumb', () => {
+      const overrideProps = {
+        id: 'MyRangeSlider',
+        min: 99,
+        max: 999,
+        step: 9,
       };
-      const actual = element.find('[style]').prop('style') as {};
 
-      expect(expected).toStrictEqual(actual);
+      const element = mountWithAppProvider(
+        <RangeSlider
+          value={[0, 25]}
+          {...mockRangeSliderProps}
+          {...overrideProps}
+        />,
+      );
+
+      const {min, max, id, step} = element.find(DualThumb).props();
+
+      expect({
+        min,
+        max,
+        step,
+        id,
+      }).toStrictEqual(overrideProps);
+    });
+
+    it('passes an id to dual thumb', () => {
+      const element = mountWithAppProvider(
+        <RangeSlider value={[0, 25]} {...mockRangeSliderProps} />,
+      );
+
+      expect(element.find(DualThumb).props().id).not.toBeNull();
+    });
+  });
+
+  describe('<SingleThumb />', () => {
+    it('renders a single thumb if value is a single number', () => {
+      const element = mountWithAppProvider(
+        <RangeSlider value={25} {...mockRangeSliderProps} />,
+      );
+      expect(element.find(SingleThumb)).toHaveLength(1);
+    });
+
+    it('passes default props to single thumb', () => {
+      const element = mountWithAppProvider(
+        <RangeSlider value={25} {...mockRangeSliderProps} />,
+      );
+
+      const {min, max, step} = element.find(SingleThumb).props();
+
+      expect({
+        min,
+        max,
+        step,
+      }).toStrictEqual({
+        min: RangeSliderDefault.Min,
+        max: RangeSliderDefault.Max,
+        step: RangeSliderDefault.Step,
+      });
+    });
+
+    it('passes an id to single thumb', () => {
+      const element = mountWithAppProvider(
+        <RangeSlider value={25} {...mockRangeSliderProps} />,
+      );
+
+      expect(element.find(SingleThumb).props().id).not.toBeNull();
+    });
+
+    it('passes overrides to default props to single thumb', () => {
+      const overrideProps = {
+        id: 'MyRangeSlider',
+        min: 99,
+        max: 999,
+        step: 9,
+      };
+
+      const element = mountWithAppProvider(
+        <RangeSlider value={25} {...mockRangeSliderProps} {...overrideProps} />,
+      );
+
+      const {min, max, id, step} = element.find(SingleThumb).props();
+
+      expect({
+        min,
+        max,
+        step,
+        id,
+      }).toStrictEqual(overrideProps);
     });
   });
 });

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -1,0 +1,43 @@
+import {Action} from '../Labelled';
+
+import {Error} from '../../types';
+
+export type DualValue = [number, number];
+export type RangeSliderValue = number | DualValue;
+
+export interface Props {
+  /** Label for the range input */
+  label: string;
+  /** Adds an action to the label */
+  labelAction?: Action;
+  /** Visually hide the label */
+  labelHidden?: boolean;
+  /** ID for range input */
+  id?: string;
+  /** Initial value for range input */
+  value: RangeSliderValue;
+  /** Minimum possible value for range input */
+  min?: number;
+  /** Maximum possible value for range input */
+  max?: number;
+  /** Increment value for range input changes */
+  step?: number;
+  /** Provide a tooltip while sliding, indicating the current value */
+  output?: boolean;
+  /** Additional text to aid in use */
+  helpText?: React.ReactNode;
+  /** Display an error message */
+  error?: Error;
+  /** Disable input */
+  disabled?: boolean;
+  /** Element to display before the input */
+  prefix?: React.ReactNode;
+  /** Element to display after the input */
+  suffix?: React.ReactNode;
+  /** Callback when the range input is changed */
+  onChange(value: RangeSliderValue, id: string): void;
+  /** Callback when range input is focused */
+  onFocus?(): void;
+  /** Callback when focus is removed */
+  onBlur?(): void;
+}

--- a/src/components/RangeSlider/utilities/index.ts
+++ b/src/components/RangeSlider/utilities/index.ts
@@ -1,0 +1,7 @@
+export const CSS_VAR_PREFIX = '--Polaris-RangeSlider-';
+export enum RangeSliderDefault {
+  Min = 0,
+  Max = 100,
+  Step = 1,
+}
+export {default as invertNumber} from './invertNumber';

--- a/src/components/RangeSlider/utilities/invertNumber.ts
+++ b/src/components/RangeSlider/utilities/invertNumber.ts
@@ -1,0 +1,9 @@
+export default function invertNumber(number: number) {
+  if (Math.sign(number) === 1) {
+    return -Math.abs(number);
+  } else if (Math.sign(number) === -1) {
+    return Math.abs(number);
+  } else {
+    return 0;
+  }
+}

--- a/src/components/RangeSlider/utilities/tests/invertNumber.test.ts
+++ b/src/components/RangeSlider/utilities/tests/invertNumber.test.ts
@@ -1,0 +1,18 @@
+import {invertNumber} from '../index';
+
+describe('invertNumber', () => {
+  it('returns a negative number when the argument is positive', () => {
+    const negative = invertNumber(10);
+    expect(negative).toBe(-10);
+  });
+
+  it('returns a positive number when the argument is negative', () => {
+    const negative = invertNumber(-10);
+    expect(negative).toBe(10);
+  });
+
+  it('returns 0 when the argument is 0', () => {
+    const negative = invertNumber(0);
+    expect(negative).toBe(0);
+  });
+});

--- a/src/utilities/clamp.ts
+++ b/src/utilities/clamp.ts
@@ -1,0 +1,5 @@
+export default function clamp(number: number, min: number, max: number) {
+  if (number < min) return min;
+  if (number > max) return max;
+  return number;
+}

--- a/src/utilities/tests/clamp.test.ts
+++ b/src/utilities/tests/clamp.test.ts
@@ -1,0 +1,23 @@
+import clamp from '../clamp';
+
+describe('clamp', () => {
+  it('adjusts the given number to be at least the min', () => {
+    const min = 10;
+    const number = clamp(9, min, 50);
+    expect(number).toBe(min);
+  });
+
+  it('adjusts the given number to be no more than the max', () => {
+    const max = 100;
+    const number = clamp(101, 0, max);
+    expect(number).toBe(max);
+  });
+
+  it('does not change the given number if it is between the min and max', () => {
+    const value = 50;
+    const min = 0;
+    const max = 100;
+    const number = clamp(value, min, max);
+    expect(number).toBe(value);
+  });
+});


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #595. Adds support for a dual range slider.
<img width="743" alt="Screen Shot 2019-05-08 at 6 55 45 PM" src="https://user-images.githubusercontent.com/344839/57421967-ede03a00-71c2-11e9-8818-3e5929a05859.png">

### WHAT is this pull request doing?

Extends the `value` prop of `RangeSlider` to accept a tuple and splits the internals of `RangeSlider` into two subcomponents, `SingleThumb` (current `RangeSlider`) and `DualThumb` (new component to support a dual range slider)

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
