### PR TITLE
[Range slider] Remove tip from output and fix styling

### DIFF
--- a/src/components/RangeSlider/README.md
+++ b/src/components/RangeSlider/README.md
@@ -135,6 +135,7 @@ class RangeSliderExample extends React.Component {
           label="Opacity percentage"
           value={this.state.value}
           onChange={this.handleChange}
+          output
         />
       </Card>
     );

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -122,22 +122,10 @@ $range-thumbs-border-active: rem(2px) solid color('indigo');
   .error & {
     border: $range-thumbs-border-error;
   }
-
-  // stylelint-disable selector-max-specificity
-  &:hover + .Output &,
-  &:active + .Output &,
-  &:focus + .Output & {
-    transform: translateY(-$range-thumb-size);
-
-    @include page-content-when-not-partially-condensed {
-      transform: translateY(-($range-thumb-size / 2));
-    }
-  }
-  // stylelint-enable selector-max-specificity
 }
 
 $range-output-size: rem(32px);
-$range-output-tip-size: rem(8px);
+$range-output-spacing: rem(16px);
 
 .Prefix {
   flex: 0 0 auto;
@@ -152,24 +140,18 @@ $range-output-tip-size: rem(8px);
 .Output {
   position: absolute;
   z-index: z-index('output', $stacking-order);
-  bottom: $range-output-size - $range-output-tip-size + $range-thumb-size;
+  bottom: $range-thumb-size;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
   transition-property: opacity, visibility;
   transition-duration: duration();
   transition-timing-function: easing();
+  transform: translateX(calc(-50% + #{$range-thumb-size / 2}));
 
-  .ThumbLower:hover + &,
-  .ThumbLower:active + &,
-  .ThumbLower:focus + & {
-    opacity: 1;
-    visibility: visible;
-  }
-
-  .ThumbUpper:hover + &,
-  .ThumbUpper:active + &,
-  .ThumbUpper:focus + & {
+  .Thumbs:hover + &,
+  .Thumbs:active + &,
+  .Thumbs:focus + & {
     opacity: 1;
     visibility: visible;
   }
@@ -187,19 +169,17 @@ $range-output-tip-size: rem(8px);
   transition-duration: duration();
   transition-timing-function: easing();
 
-  &::before {
-    content: '';
-    position: absolute;
-    bottom: -($range-output-tip-size - rem(1px));
-    left: 50%;
-    margin-left: -$range-output-tip-size;
-    display: block;
-    width: 0;
-    height: 0;
-    border-left: $range-output-tip-size solid transparent;
-    border-right: $range-output-tip-size solid transparent;
-    border-top: $range-output-tip-size solid color('ink');
+  // stylelint-disable selector-max-specificity
+  .Thumbs:hover + .Output &,
+  .Thumbs:active + .Output &,
+  .Thumbs:focus + .Output & {
+    transform: translateY(-$range-output-spacing);
+
+    @include page-content-when-not-partially-condensed {
+      transform: translateY(-($range-output-spacing / 2));
+    }
   }
+  // stylelint-enable selector-max-specificity
 }
 
 .OutputText {

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -40,7 +40,6 @@ enum Control {
 }
 
 const THUMB_SIZE = 24;
-const OUTPUT_TIP_SIZE = 8;
 
 export default class DualThumb extends React.Component<Props, State> {
   static getDerivedStateFromProps(props: Props, state: State) {
@@ -144,7 +143,7 @@ export default class DualThumb extends React.Component<Props, State> {
           htmlFor={idLower}
           className={outputLowerClassName}
           style={{
-            left: `calc(${leftPositionThumbLower}px - ${OUTPUT_TIP_SIZE}px)`,
+            left: `${leftPositionThumbLower}px`,
           }}
         >
           <div className={styles.OutputBubble}>
@@ -160,7 +159,7 @@ export default class DualThumb extends React.Component<Props, State> {
           htmlFor={idUpper}
           className={outputUpperClassName}
           style={{
-            left: `calc(${leftPositionThumbUpper}px - ${OUTPUT_TIP_SIZE}px)`,
+            left: `${leftPositionThumbUpper}px`,
           }}
         >
           <div className={styles.OutputBubble}>

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -158,15 +158,15 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
 ///
 /// Output value indicator
 $range-output-size: rem(32px);
-$range-output-tip-size: rem(8px);
 $range-output-translate-x: calc(
   -50% + var(--Polaris-RangeSlider-output-factor, 0) * #{$range-thumb-size}
 );
+$range-output-spacing: rem(16px);
 
 .Output {
   position: absolute;
   z-index: z-index('output', $stacking-order);
-  bottom: $range-output-size - $range-output-tip-size;
+  bottom: $range-thumb-size;
   left: var(--Polaris-RangeSlider-progress, 50%);
   transform: translateX($range-output-translate-x);
   opacity: 0;
@@ -196,28 +196,14 @@ $range-output-translate-x: calc(
   transition-duration: duration();
   transition-timing-function: easing();
 
-  &::before {
-    content: '';
-    position: absolute;
-    bottom: -($range-output-tip-size - rem(1px));
-    left: 50%;
-    margin-left: -$range-output-tip-size;
-    display: block;
-    width: 0;
-    height: 0;
-    border-left: $range-output-tip-size solid transparent;
-    border-right: $range-output-tip-size solid transparent;
-    border-top: $range-output-tip-size solid color('ink');
-  }
-
   // stylelint-disable selector-max-specificity
   .Input:hover + .Output &,
   .Input:active + .Output &,
   .Input:focus + .Output & {
-    transform: translateY(-$range-thumb-size);
+    transform: translateY(-$range-output-spacing);
 
     @include page-content-when-not-partially-condensed {
-      transform: translateY(-($range-thumb-size / 2));
+      transform: translateY(-($range-output-spacing / 2));
     }
   }
   // stylelint-enable selector-max-specificity


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #937

|Before|After|
|---|---|
|![single output before](https://user-images.githubusercontent.com/344839/57422744-203f6680-71c6-11e9-967e-0e2818800a64.gif)|![single output](https://user-images.githubusercontent.com/344839/57422794-3e0ccb80-71c6-11e9-9dea-2f48e3fab777.gif)|
|![dual output before](https://user-images.githubusercontent.com/344839/57422743-1fa6d000-71c6-11e9-96f0-494fd823c61b.gif)|![dual output](https://user-images.githubusercontent.com/344839/57422778-30574600-71c6-11e9-8859-f28af966adb5.gif)|

### WHAT is this pull request doing?

- Adds `output` to default example
- removes tip from output on single range slider and adjusts spacing
- removes tip from output on dual range slider, adjusts spacing, fixes broken animation, and fixes broken horizontal centering.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers) (doesn’t work in Safari, will defer fixing that)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] ~~Updated the component's `README.md` with documentation changes~~
* [ ] ~~[Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide~~

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
