### PR TITLE
[Range slider] Store ID as an instance property

### DIFF
--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -10,29 +10,32 @@ type CombinedProps = Props & WithAppProviderProps;
 
 const getUniqueID = createUniqueIDFactory('RangeSlider');
 
-export function RangeSlider(props: CombinedProps) {
-  const {
-    id = getUniqueID(),
-    min = RangeSliderDefault.Min,
-    max = RangeSliderDefault.Max,
-    step = RangeSliderDefault.Step,
-    value,
-    ...rest
-  } = props;
+class RangeSlider extends React.Component<CombinedProps> {
+  private id = getUniqueID();
 
-  const sharedProps = {
-    id,
-    min,
-    max,
-    step,
-    ...rest,
-  };
+  render() {
+    const {
+      min = RangeSliderDefault.Min,
+      max = RangeSliderDefault.Max,
+      step = RangeSliderDefault.Step,
+      value,
+      ...rest
+    } = this.props;
 
-  return isDualThumb(value) ? (
-    <DualThumb value={value} {...sharedProps} />
-  ) : (
-    <SingleThumb value={value} {...sharedProps} />
-  );
+    const sharedProps = {
+      id: this.id,
+      min,
+      max,
+      step,
+      ...rest,
+    };
+
+    return isDualThumb(value) ? (
+      <DualThumb value={value} {...sharedProps} />
+    ) : (
+      <SingleThumb value={value} {...sharedProps} />
+    );
+  }
 }
 
 function isDualThumb(value: RangeSliderValue): value is DualValue {


### PR DESCRIPTION
### WHY are these changes introduced?

This was causing a new ID to be generated and updated on every render.

### WHAT is this pull request doing?

Converts the top-level `RangeSlider` component to a class and stores the ID as an instance property.

### 🎩 checklist

* [x] 🎩 
* [ ] ~~Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)~~
* [ ] ~~Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)~~
* [ ] ~~Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)~~
* [ ] ~~Updated the component's `README.md` with documentation changes~~
* [ ] ~~[Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide~~

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
