### PR TITLE
[Range slider] Fix disabled state

### DIFF
--- a/src/components/RangeSlider/README.md
+++ b/src/components/RangeSlider/README.md
@@ -282,7 +282,6 @@ class RangeSliderExample extends React.Component {
     const min = 0;
     const max = 2000;
     const step = 10;
-    const disabled = false;
 
     const lowerTextFieldValue =
       intermediateTextFieldValue[0] === value[0]
@@ -304,7 +303,6 @@ class RangeSliderExample extends React.Component {
             min={min}
             max={max}
             step={step}
-            disabled={disabled}
             onChange={this.handleRangeSliderChange}
           />
           <Stack distribution="equalSpacing" spacing="extraLoose">
@@ -316,7 +314,6 @@ class RangeSliderExample extends React.Component {
               min={min}
               max={max}
               step={step}
-              disabled={disabled}
               onChange={this.handleLowerTextFieldChange}
               onBlur={this.handleLowerTextFieldBlur}
             />
@@ -328,7 +325,6 @@ class RangeSliderExample extends React.Component {
               min={min}
               max={max}
               step={step}
-              disabled={disabled}
               onChange={this.handleUpperTextFieldChange}
               onBlur={this.handleUpperTextFieldBlur}
             />

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -274,7 +274,7 @@ export default class DualThumb extends React.Component<Props, State> {
   private handleMouseDownThumbLower(
     event: React.MouseEvent<HTMLButtonElement>,
   ) {
-    if (event.button !== 0) return;
+    if (event.button !== 0 || this.props.disabled) return;
     registerMouseMoveHandler(this.handleMouseMoveThumbLower);
     event.stopPropagation();
   }
@@ -292,7 +292,7 @@ export default class DualThumb extends React.Component<Props, State> {
   private handleMouseDownThumbUpper(
     event: React.MouseEvent<HTMLButtonElement>,
   ) {
-    if (event.button !== 0) return;
+    if (event.button !== 0 || this.props.disabled) return;
     registerMouseMoveHandler(this.handleMouseMoveThumbUpper);
     event.stopPropagation();
   }
@@ -407,7 +407,7 @@ export default class DualThumb extends React.Component<Props, State> {
 
   @autobind
   private handleMouseDownTrack(event: React.MouseEvent) {
-    if (event.button !== 0) return;
+    if (event.button !== 0 || this.props.disabled) return;
     const clickXPosition = this.actualXPosition(event.clientX);
     const {value} = this.state;
     const distanceFromLowerThumb = Math.abs(value[0] - clickXPosition);

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -520,6 +520,23 @@ describe('<DualThumb />', () => {
       expect(onChangeSpy).not.toHaveBeenCalled();
     });
 
+    it('the lower and upper thumbs do not move when disabled', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb
+          {...mockProps}
+          value={[10, 40]}
+          onChange={onChangeSpy}
+          disabled
+        />,
+      );
+
+      moveUpperThumb(dualThumb, 0.5);
+      moveLowerThumb(dualThumb, 0.5);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
     it('moves the lower thumb when the track is clicked closer to it than the upper thumb', () => {
       const onChangeSpy = jest.fn();
       const dualThumb = mountWithAppProvider(
@@ -564,6 +581,38 @@ describe('<DualThumb />', () => {
       moveUpperThumb(dualThumb, 0.9);
 
       expect(onChangeSpy).toHaveBeenCalledWith([5, 45], mockProps.id);
+    });
+
+    it('does not move the lower thumb when the track is clicked and is disabled', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb
+          {...mockProps}
+          value={[5, 40]}
+          onChange={onChangeSpy}
+          disabled
+        />,
+      );
+
+      clickTrack(dualThumb, 0.2);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not move the upper thumb when the track is clicked and is disabled', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb
+          {...mockProps}
+          value={[5, 40]}
+          onChange={onChangeSpy}
+          disabled
+        />,
+      );
+
+      clickTrack(dualThumb, 0.6);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
     });
 
     function clickTrack(


### PR DESCRIPTION
### WHY are these changes introduced?

Disabling the dual range slider did not disable it.

### WHAT is this pull request doing?

Early return if `disabled` is set to true
