### PR TITLE
Remove testID warning

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -25,6 +25,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Code quality
 
 - Upgraded the `Autocomplete` component from legacy context API to use createContext ([#1403](https://github.com/Shopify/polaris-react/pull/1403))
+- Removed testID warning in tests ([#1447](https://github.com/Shopify/polaris-react/pull/1447))
 - Updated `ThemeProvider` to use the new context api ([#1396](https://github.com/Shopify/polaris-react/pull/1396))
 - Updated `AppProvider` to no longer use `componentWillReceiveProps`([#1255](https://github.com/Shopify/polaris-react/pull/1255))
 - Upgraded the `Navigation` component from legacy context API to use createContext ([#1402](https://github.com/Shopify/polaris-react/pull/1402))

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -4,7 +4,7 @@ import Adapter from 'enzyme-adapter-react-16';
 configure({adapter: new Adapter()});
 
 const IGNORE_ERROR_REGEXES = [
-  /React does not recognize the `testID` prop on a DOM element/,
+  /React does not recognize the `%s` prop on a DOM element/,
   /Accessing PropTypes via the main React package is deprecated/,
   /ReactTestUtils has been moved to react-dom\/test-utils/,
   /Shallow renderer has been moved to react-test-renderer\/shallow/,


### PR DESCRIPTION
Fixes #1483

### WHY are these changes introduced?

We're getting spammed with testID warnings

![Screen Shot 2019-05-09 at 11 20 30 AM](https://user-images.githubusercontent.com/24610840/57465476-b0c08a00-724c-11e9-9b6e-17c64cb17b58.png)

### WHAT is this pull request doing?

Fixing the regex to match the output
