### PR TITLE
Removed section about running pa11y during CI

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Updated accessibility testing documentation ([#1449](https://github.com/Shopify/polaris-react/pull/1449))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/documentation/Accessibility testing.md
+++ b/documentation/Accessibility testing.md
@@ -6,13 +6,13 @@ We want Polaris and Shopify’s platform to be accessible for people with disabi
 
 ## Automated testing
 
-Pull requests to Polaris are reviewed using [Pa11y CI](https://github.com/pa11y/pa11y-ci) to identify simple-to-fix accessibility issues related to semantic markup, [Accessible Rich Internet Applications (ARIA)](https://www.w3.org/TR/wai-aria-1.1/), and styles. You can also run [Pa11y](https://github.com/pa11y/pa11y) locally before you submit your pull request.
+Running an automated tool like [Pa11y](https://github.com/pa11y/pa11y) locally before you submit your pull request is recommended.
 
 ## Manual testing
 
-Many accessibility tests can’t be automated, so you’ll want to do some manual testing on Playground and Storybook content as well. This checklist includes items that will likely not be caught by Pa11y, but doesn’t include items reliant on specific content or language.
+Many accessibility tests can’t be automated, so you’ll want to do some manual testing on Playground or Storybook content as well. This checklist includes items that will likely not be caught by Pa11y, but doesn’t include items reliant on specific content or language.
 
-Refer to the full [WCAG 2.1](https://www.w3.org/TR/WCAG21/) recommendation (and any other guidelines required) for all considerations that may impact your project.
+Refer to the full [WCAG 2.1](https://www.w3.org/TR/WCAG21/) recommendation (and any other guidelines required for your particular product) for all considerations that may impact your project.
 
 The [Polaris style guide](https://polaris.shopify.com/) also provides guidelines for usability and consistency that should be considered.
 


### PR DESCRIPTION
## WHY are these changes introduced?

Removes content about Pa11y running during CI. I was under the impression this was running, so this is an oversight on my part.

### WHAT is this pull request doing?

- [X] Edits `Accessibility testing.md`
- [X] Adds an entry for `UNRELEASED.md`