### PR TITLE
[Range slider] Support touch

### DIFF
--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -82,6 +82,7 @@ $range-thumb-shadow-error: 0 0 0 rem(1px) color('red');
   border: border-width() solid color('sky', 'lighter');
   box-shadow: $range-thumb-shadow;
   background: linear-gradient(color('sky', 'lighter'), color('sky', 'light'));
+  -webkit-tap-highlight-color: transparent;
 
   // stylelint-disable-next-line value-no-vendor-prefix
   cursor: -webkit-grab;

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -73,6 +73,7 @@ export default class DualThumb extends React.Component<Props, State> {
   };
 
   private track = React.createRef<HTMLDivElement>();
+  private trackWrapper = React.createRef<HTMLDivElement>();
   private thumbLower = React.createRef<HTMLButtonElement>();
   private thumbUpper = React.createRef<HTMLButtonElement>();
 
@@ -94,6 +95,25 @@ export default class DualThumb extends React.Component<Props, State> {
 
   componentDidMount() {
     this.setTrackPosition();
+
+    if (this.trackWrapper.current != null) {
+      addEventListener(
+        this.trackWrapper.current,
+        'touchstart',
+        this.handleTouchStartTrack,
+        {passive: false},
+      );
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.trackWrapper.current != null) {
+      removeEventListener(
+        this.trackWrapper.current,
+        'touchstart',
+        this.handleTouchStartTrack,
+      );
+    }
   }
 
   render() {
@@ -211,8 +231,8 @@ export default class DualThumb extends React.Component<Props, State> {
             <div
               className={trackWrapperClassName}
               onMouseDown={this.handleMouseDownTrack}
-              onTouchStartCapture={this.handleTouchStartTrack}
               testID="trackWrapper"
+              ref={this.trackWrapper}
             >
               <div
                 className={styles.Track}
@@ -459,9 +479,9 @@ export default class DualThumb extends React.Component<Props, State> {
     }
   };
 
-  private handleTouchStartTrack = (event: React.TouchEvent) => {
+  private handleTouchStartTrack = (event: TouchEvent) => {
     if (this.props.disabled) return;
-    event.stopPropagation();
+    event.preventDefault();
     const clickXPosition = this.actualXPosition(event.touches[0].clientX);
     const {value} = this.state;
     const distanceFromLowerThumb = Math.abs(value[0] - clickXPosition);

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -444,6 +444,36 @@ describe('<DualThumb />', () => {
       expect(onChangeSpy).toHaveBeenCalledWith([9, 40], mockProps.id);
     });
 
+    it('does not change the lower value if disabled', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb
+          {...mockProps}
+          value={[10, 40]}
+          onChange={onChangeSpy}
+          disabled
+        />,
+      );
+      simulateKeyDown(findThumbLower(dualThumb), Key.RightArrow);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not change the upper value if disabled', () => {
+      const onChangeSpy = jest.fn();
+      const dualThumb = mountWithAppProvider(
+        <DualThumb
+          {...mockProps}
+          value={[10, 40]}
+          onChange={onChangeSpy}
+          disabled
+        />,
+      );
+      simulateKeyDown(findThumbUpper(dualThumb), Key.RightArrow);
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
     function simulateKeyDown(component: ReactWrapper, keyCode: Key) {
       component.simulate('keyDown', {
         keyCode,
@@ -822,6 +852,21 @@ describe('<DualThumb />', () => {
       touchTrack(dualThumb, 0.6);
 
       expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('removes touchstart listener on track', () => {
+      const dualThumb = mountWithAppProvider(
+        <DualThumb {...mockProps} value={[5, 40]} onChange={noop} />,
+      );
+
+      const track = findTrack(dualThumb).getDOMNode();
+
+      const removeEventListenerSpy = jest.spyOn(track, 'removeEventListener');
+      removeEventListenerSpy.mockClear();
+
+      dualThumb.unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalled();
     });
 
     function touchTrack(component: ReactWrapper, percentageOfTrackX: number) {


### PR DESCRIPTION
### WHY are these changes introduced?

Supports touch

![touch](https://user-images.githubusercontent.com/344839/57491525-183d0080-7272-11e9-9fd0-4175d0d51a08.gif)

#### Capture focus when clicking on track

![capture focus](https://user-images.githubusercontent.com/344839/57489828-1f611000-726c-11e9-946f-af2447a12393.gif)


### WHAT is this pull request doing?

- Adds touch events
- removes the semi-transparent tap styles
- focuses thumbs after clicking on track
- prevents page scrolling on `touchmove`.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] ~~Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)~~
* [ ] ~~Updated the component's `README.md` with documentation changes~~
* [ ] ~~[Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide~~