### PR TITLE
[Resource Picker] Fix reference to old callback function

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -28,6 +28,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed text and other elements from being selected in Safari when dragging the color picker ([#1562](https://github.com/Shopify/polaris-react/pull/1562))
 - Fixed `Banner` `title` overflowing when set to a single long word ([#1553](https://github.com/Shopify/polaris-react/pull/1553))
 - Fixed improper spacing and coloring on a `TextField` prefix ([#1132](https://github.com/Shopify/polaris-react/issues/1132))
+- Fixed `ResourcePicker` not updating function references for `onSelection` and `onCancel` callbacks [#1451](https://github.com/Shopify/polaris-react/pull/1451)
 
 ### Documentation
 

--- a/src/components/ResourcePicker/ResourcePicker.tsx
+++ b/src/components/ResourcePicker/ResourcePicker.tsx
@@ -113,6 +113,8 @@ export class ResourcePicker extends React.PureComponent<CombinedProps, never> {
       showHidden = false,
       allowMultiple = true,
       showVariants = true,
+      onSelection,
+      onCancel,
     } = this.props;
     const wasOpen = prevProps.open;
 
@@ -123,6 +125,24 @@ export class ResourcePicker extends React.PureComponent<CombinedProps, never> {
         selectMultiple: allowMultiple,
         showVariants,
       });
+    }
+
+    this.appBridgeResourcePicker.unsubscribe();
+
+    if (onSelection != null) {
+      this.appBridgeResourcePicker.subscribe(
+        AppBridgeResourcePicker.Action.SELECT,
+        ({selection}) => {
+          onSelection({selection});
+        },
+      );
+    }
+
+    if (onCancel != null) {
+      this.appBridgeResourcePicker.subscribe(
+        AppBridgeResourcePicker.Action.CANCEL,
+        onCancel,
+      );
     }
 
     if (wasOpen !== open) {

--- a/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
+++ b/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
@@ -68,6 +68,28 @@ describe('<ResourcePicker />', () => {
       expect(onSelection).toHaveBeenCalledWith(selectionPayload);
     });
 
+    it('calls the new selection callback when changed', () => {
+      const onSelection = jest.fn();
+      const selectionPayload = {selection: []};
+      const {resourcePicker} = mountWithAppBridge(
+        <ResourcePicker resourceType="Product" open />,
+      );
+
+      resourcePicker.setProps({onSelection});
+
+      expect(appBridgeResourcePickerMock.unsubscribe).toHaveBeenCalledTimes(1);
+      expect(appBridgeResourcePickerMock.subscribe).toHaveBeenCalledTimes(1);
+
+      const [
+        firstArg,
+        secondArg,
+      ] = appBridgeResourcePickerMock.subscribe.mock.calls[0];
+      expect(firstArg).toBe(AppBridgeResourcePicker.Action.SELECT);
+      secondArg(selectionPayload);
+      expect(onSelection).toHaveBeenCalledTimes(1);
+      expect(onSelection).toHaveBeenCalledWith(selectionPayload);
+    });
+
     it('subscribes the cancel callback', () => {
       mountWithAppBridge(
         <ResourcePicker resourceType="Product" open onCancel={noop} />,
@@ -78,6 +100,26 @@ describe('<ResourcePicker />', () => {
         'CANCEL',
         noop,
       );
+    });
+
+    it('calls the new cancel callback when changed', () => {
+      const onCancel = jest.fn();
+      const {resourcePicker} = mountWithAppBridge(
+        <ResourcePicker resourceType="Product" open />,
+      );
+
+      resourcePicker.setProps({onCancel});
+
+      expect(appBridgeResourcePickerMock.unsubscribe).toHaveBeenCalledTimes(1);
+      expect(appBridgeResourcePickerMock.subscribe).toHaveBeenCalledTimes(1);
+
+      const [
+        firstArg,
+        secondArg,
+      ] = appBridgeResourcePickerMock.subscribe.mock.calls[0];
+      expect(firstArg).toBe(AppBridgeResourcePicker.Action.CANCEL);
+      secondArg();
+      expect(onCancel).toHaveBeenCalledTimes(1);
     });
 
     it('dispatches an open action on mount', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

When developing an app that adds line items to a draft order, I noticed that my ResourcePicker kept resetting my line items to the initial state. Since this component requires being inside of an embedded app and I am working on a private project, I put together an example app that demonstrates the issue: https://github.com/katzenbar/shopify-resource-picker-bug

This example app takes the products selected in the ResourcePicker, and adds them to the end of the list in the card. https://github.com/katzenbar/shopify-resource-picker-bug/blob/master/app/javascript/components/ProductPage.tsx#L24-L28

But when `handleSelection` is run, the `products` array is empty. This results in the old selection being replaced.

![bug-demo](https://user-images.githubusercontent.com/1699388/57495712-6c110f00-729d-11e9-98b7-1e18fb7f2d26.gif)

The expected behavior should be that the newly selected products are added to the end of the list.

![fix-demo](https://user-images.githubusercontent.com/1699388/57496099-2c4b2700-729f-11e9-860b-354be85f394e.gif)

I believe part of reproducing this issue is using React Hooks instead of `setState`, but I have not tested to verify that is the case.

### WHAT is this pull request doing?

When pulling out `onSelection` and `onCancel` in `componentDidMount` through destructuring, you will keep a reference to the version of that function when the component was mounted. If data these functions reference is updated, these function references become stale and are not updated. In theory, if you were to initially have these callbacks be null and then change them to a real function they would never get called.

To fix this, I changed the code to always register a subscriber for `onSelection` and `onCancel` and get the current reference of these from `this.props` when the callback fires. This seems more efficient that trying to track subscribe/unsubscribe inside of `componentDidUpdate` in the general case. I've tested this on my sample application in Chrome, and it works as I expect now.

If anyone else is experiencing this issue, a workaround is to treat the `ResourcePicker` like the `Toast` example in the documentation and only render it when you are about to open the modal.

```
{showResourcePicker && (
        <ResourcePicker
          resourceType="Product"
          initialQuery={productSearchQuery}
          open={showResourcePicker}
          onSelection={handleResourcePickerSelection}
          onCancel={closeResourcePicker}
        />
      )}
```