### PR TITLE
Re-enable automated a11y testing in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,3 +54,4 @@ workflows:
     jobs:
       - check
       - percy
+      - a11y

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -30,6 +30,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Development workflow
 
+- Updated the a11y shitlist and re-enabled the pa11y job in CI. The job always passes for now, as a way for us to judge whether it is stable and can be made a required check. ([#1456](https://github.com/Shopify/polaris-react/pull/1456))
+
 ### Dependency upgrades
 
 ### Code quality

--- a/a11y_shitlist.json
+++ b/a11y_shitlist.json
@@ -1,341 +1,509 @@
 {
-  "http://localhost:3000/app-provider/0": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent",
-      "context": "<a aria-describedby=\"341\" class=\"Item-Link_2-raD\" href=\"customers/341\" data-polaris-unstyled=\"true\"></a>",
-      "message": "Anchor element found with a valid href attribute, but no link content has been supplied.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#app > div > div > div > div > ul > li:nth-child(1) > div > a"
-    },
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent",
-      "context": "<a aria-describedby=\"256\" class=\"Item-Link_2-raD\" href=\"customers/256\" data-polaris-unstyled=\"true\"></a>",
-      "message": "Anchor element found with a valid href attribute, but no link content has been supplied.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#app > div > div > div > div > ul > li:nth-child(2) > div > a"
-    }
-  ],
-  "http://localhost:3000/app-provider/1": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent",
-      "context": "<a aria-describedby=\"341\" class=\"Item-Link_2-raD\" href=\"customers/341\" data-polaris-unstyled=\"true\"></a>",
-      "message": "Anchor element found with a valid href attribute, but no link content has been supplied.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#app > div > div > div > div > ul > li:nth-child(1) > div > a"
-    },
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent",
-      "context": "<a aria-describedby=\"256\" class=\"Item-Link_2-raD\" href=\"customers/256\" data-polaris-unstyled=\"true\"></a>",
-      "message": "Anchor element found with a valid href attribute, but no link content has been supplied.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#app > div > div > div > div > ul > li:nth-child(2) > div > a"
-    }
-  ],
-  "http://localhost:3000/button-group/2": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This file input element does not have a name available to an accessibility API. Valid names are: label element, title attribute, aria-label attribute, aria-labelledby attribute.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    },
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    }
-  ],
-  "http://localhost:3000/drop-zone/0": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This file input element does not have a name available to an accessibility API. Valid names are: label element, title attribute, aria-label attribute, aria-labelledby attribute.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    },
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    }
-  ],
-  "http://localhost:3000/drop-zone/2": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
-      "context": "<input id=\"DropZone1\" accept=\"image/*\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This file input element does not have a name available to an accessibility API. Valid names are: label element, title attribute, aria-label attribute, aria-labelledby attribute.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    },
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
-      "context": "<input id=\"DropZone1\" accept=\"image/*\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    }
-  ],
-  "http://localhost:3000/drop-zone/3": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This file input element does not have a name available to an accessibility API. Valid names are: label element, title attribute, aria-label attribute, aria-labelledby attribute.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    },
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    }
-  ],
-  "http://localhost:3000/drop-zone/4": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
-      "context": "<input id=\"DropZone1\" accept=\"image/svg+xml\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This file input element does not have a name available to an accessibility API. Valid names are: label element, title attribute, aria-label attribute, aria-labelledby attribute.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    },
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
-      "context": "<input id=\"DropZone1\" accept=\"image/svg+xml\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    }
-  ],
-  "http://localhost:3000/drop-zone/5": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
-      "context": "<input id=\"DropZone2\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This file input element does not have a name available to an accessibility API. Valid names are: label element, title attribute, aria-label attribute, aria-labelledby attribute.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone2"
-    },
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
-      "context": "<input id=\"DropZone2\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone2"
-    },
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This file input element does not have a name available to an accessibility API. Valid names are: label element, title attribute, aria-label attribute, aria-labelledby attribute.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    },
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    }
-  ],
-  "http://localhost:3000/drop-zone/6": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This file input element does not have a name available to an accessibility API. Valid names are: label element, title attribute, aria-label attribute, aria-labelledby attribute.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    },
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    }
-  ],
-  "http://localhost:3000/drop-zone/7": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This file input element does not have a name available to an accessibility API. Valid names are: label element, title attribute, aria-label attribute, aria-labelledby attribute.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    },
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    }
-  ],
-  "http://localhost:3000/drop-zone/8": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This file input element does not have a name available to an accessibility API. Valid names are: label element, title attribute, aria-label attribute, aria-labelledby attribute.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    },
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
-      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
-      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#DropZone1"
-    }
-  ],
-  "http://localhost:3000/layout/2": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
-      "context": "<div class=\"Item-Container_16G76\" id=\"341\"><div class=\"Item-Owned_1lLjn\"><...</div>",
-      "message": "Duplicate id attribute value \"341\" found on the web page.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#341"
-    },
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
-      "context": "<div class=\"Item-Container_16G76\" id=\"256\"><div class=\"Item-Owned_1lLjn\"><...</div>",
-      "message": "Duplicate id attribute value \"256\" found on the web page.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#256"
-    }
-  ],
-  "http://localhost:3000/layout/3": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
-      "context": "<div class=\"Item-Container_16G76\" id=\"341\"><div class=\"Item-Owned_1lLjn\"><...</div>",
-      "message": "Duplicate id attribute value \"341\" found on the web page.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#341"
-    },
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
-      "context": "<div class=\"Item-Container_16G76\" id=\"256\"><div class=\"Item-Owned_1lLjn\"><...</div>",
-      "message": "Duplicate id attribute value \"256\" found on the web page.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#256"
-    },
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
-      "context": "<div class=\"Item-Container_16G76\" id=\"341\"><div class=\"Item-Owned_1lLjn\"><...</div>",
-      "message": "Duplicate id attribute value \"341\" found on the web page.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#341"
-    },
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
-      "context": "<div class=\"Item-Container_16G76\" id=\"256\"><div class=\"Item-Owned_1lLjn\"><...</div>",
-      "message": "Duplicate id attribute value \"256\" found on the web page.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#256"
-    }
-  ],
-  "http://localhost:3000/option-list/2": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
-      "context": "<ul class=\"OptionList-Options_3Df-D\" id=\"OptionList1\" aria-multiselectable=\"true\"><li class=\"Option-Option_nue26\"...</ul>",
-      "message": "Duplicate id attribute value \"OptionList1\" found on the web page.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#OptionList1"
-    },
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
-      "context": "<ul class=\"OptionList-Options_3Df-D\" id=\"OptionList1\" aria-multiselectable=\"true\"><li class=\"Option-Option_nue26\"...</ul>",
-      "message": "Duplicate id attribute value \"OptionList1\" found on the web page.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#OptionList1"
-    }
-  ],
-  "http://localhost:3000/range-slider/0": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputRange.Name",
-      "context": "<input type=\"range\" class=\"RangeSlider-Input_1VkvL\" id=\"RangeSlider1\" name=\"RangeSlider1\" min=\"0\" max=\"100\" aria-valuemin=\"0\" aria-valuemax=\"100\" aria-valuenow=\"32\" aria-invalid=\"false\" value=\"32\">",
-      "message": "This range input element does not have a name available to an accessibility API. Valid names are: element content.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#RangeSlider1"
-    }
-  ],
-  "http://localhost:3000/range-slider/1": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputRange.Name",
-      "context": "<input type=\"range\" class=\"RangeSlider-Input_1VkvL\" id=\"RangeSlider1\" name=\"RangeSlider1\" min=\"-10\" max=\"10\" step=\"5\" aria-valuemin=\"-10\" aria-valuemax=\"10\" aria-valuenow=\"5\" aria-invalid=\"false\" value=\"5\">",
-      "message": "This range input element does not have a name available to an accessibility API. Valid names are: element content.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#RangeSlider1"
-    }
-  ],
-  "http://localhost:3000/range-slider/2": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputRange.Name",
-      "context": "<input type=\"range\" class=\"RangeSlider-Input_1VkvL\" id=\"RangeSlider1\" name=\"RangeSlider1\" min=\"0\" max=\"360\" aria-valuemin=\"0\" aria-valuemax=\"360\" aria-valuenow=\"100\" aria-invalid=\"false\" value=\"100\">",
-      "message": "This range input element does not have a name available to an accessibility API. Valid names are: element content.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#RangeSlider1"
-    }
-  ],
-  "http://localhost:3000/resource-list/4": [
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent",
-      "context": "<a aria-describedby=\"341\" class=\"Item-Link_2-raD\" href=\"customers/341\" data-polaris-unstyled=\"true\"></a>",
-      "message": "Anchor element found with a valid href attribute, but no link content has been supplied.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#app > div > div > ul > li:nth-child(1) > div > a"
-    },
-    {
-      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent",
-      "context": "<a aria-describedby=\"256\" class=\"Item-Link_2-raD\" href=\"customers/256\" data-polaris-unstyled=\"true\"></a>",
-      "message": "Anchor element found with a valid href attribute, but no link content has been supplied.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#app > div > div > ul > li:nth-child(2) > div > a"
-    }
-  ],
-  "http://localhost:3000/resource-list/6": [
+  "all-components-app-provider--with-linkcomponent": [
     {
       "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
       "context": "<button type=\"button\" class=\"Button-Button_2pL_i Button-plain_RU0pa Button-iconOnly_2ZPSS\" tabindex=\"0\" aria-controls=\"Popover1\" aria-owns=\"Popover1\" aria-haspopup=\"true\" aria-expanded=\"false\"><span class=\"Button-Content_2iX...</button>",
-      "message": "This button element does not have a name available to an accessibility API. Valid names are: title attribute, element content, aria-label attribute, aria-labelledby attribute.",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#root > div > div > div > div > div:nth-child(1) > div:nth-child(1) > div > div > button"
+    }
+  ],
+  "all-components-app-provider--with-theme": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputSearch.Name",
+      "context": "<input class=\"SearchField-Input_EhctI\" placeholder=\"Search\" type=\"search\" autocapitalize=\"off\" autocomplete=\"off\" autocorrect=\"off\" value=\"\">",
+      "message": "This searchinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#AppFrameTopBar > div > div:nth-child(2) > div:nth-child(1) > div > input"
+    }
+  ],
+  "all-components-app-provider--with-i18n-object": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent",
+      "context": "<a aria-describedby=\"341\" class=\"Item-Link_2-raD\" tabindex=\"0\" id=\"ResourceListItemOverlay1\" href=\"customers/341\" data-polaris-unstyled=\"true\"></a>",
+      "message": "Anchor element found with a valid href attribute, but no link content has been supplied.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#ResourceListItemOverlay1"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent",
+      "context": "<a aria-describedby=\"256\" class=\"Item-Link_2-raD\" tabindex=\"0\" id=\"ResourceListItemOverlay2\" href=\"customers/256\" data-polaris-unstyled=\"true\"></a>",
+      "message": "Anchor element found with a valid href attribute, but no link content has been supplied.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#ResourceListItemOverlay2"
+    }
+  ],
+  "all-components-app-provider--default": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent",
+      "context": "<a aria-describedby=\"341\" class=\"Item-Link_2-raD\" tabindex=\"0\" id=\"ResourceListItemOverlay1\" href=\"customers/341\" data-polaris-unstyled=\"true\"></a>",
+      "message": "Anchor element found with a valid href attribute, but no link content has been supplied.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#ResourceListItemOverlay1"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent",
+      "context": "<a aria-describedby=\"256\" class=\"Item-Link_2-raD\" tabindex=\"0\" id=\"ResourceListItemOverlay2\" href=\"customers/256\" data-polaris-unstyled=\"true\"></a>",
+      "message": "Anchor element found with a valid href attribute, but no link content has been supplied.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#ResourceListItemOverlay2"
+    }
+  ],
+  "all-components-app-provider--with-theme-using-all-theme-keys": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputSearch.Name",
+      "context": "<input class=\"SearchField-Input_EhctI\" placeholder=\"Search\" type=\"search\" autocapitalize=\"off\" autocomplete=\"off\" autocorrect=\"off\" value=\"\">",
+      "message": "This searchinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#AppFrameTopBar > div > div:nth-child(2) > div:nth-child(1) > div > input"
+    }
+  ],
+  "all-components-drop-zone--drop-zone-accepts-only-svg-files": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
+      "context": "<input id=\"DropZone1\" accept=\"image/svg+xml\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This fileinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    },
+    {
+      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
+      "context": "<input id=\"DropZone1\" accept=\"image/svg+xml\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    }
+  ],
+  "all-components-drop-zone--drop-zone-with-file-upload": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
+      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This fileinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    },
+    {
+      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
+      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    }
+  ],
+  "all-components-drop-zone--drop-zone-with-image-file-upload": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
+      "context": "<input id=\"DropZone1\" accept=\"image/*\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This fileinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    },
+    {
+      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
+      "context": "<input id=\"DropZone1\" accept=\"image/*\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    }
+  ],
+  "all-components-drop-zone--drop-zone-with-drop-on-page": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button type=\"button\" class=\"Button-Button_2pL_i Button-plain_RU0pa Button-iconOnly_2ZPSS\" tabindex=\"0\" aria-controls=\"Popover1\" aria-owns=\"Popover1\" aria-haspopup=\"true\" aria-expanded=\"false\"><span class=\"Button-Content_2iX...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#root > div > div > div > div:nth-child(1) > div:nth-child(1) > div:nth-child(3) > div > button"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
+      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This fileinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    },
+    {
+      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
+      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    }
+  ],
+  "all-components-drop-zone--nested-drop-zone": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
+      "context": "<input id=\"DropZone2\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This fileinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone2"
+    },
+    {
+      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
+      "context": "<input id=\"DropZone2\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone2"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
+      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This fileinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    },
+    {
+      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
+      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    }
+  ],
+  "all-components-drop-zone--drop-zone-with-custom-file-dialog-trigger": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
+      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This fileinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    },
+    {
+      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
+      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    }
+  ],
+  "all-components-drop-zone--small-sized-drop-zone": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
+      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This fileinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    },
+    {
+      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
+      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    }
+  ],
+  "all-components-drop-zone--medium-sized-drop-zone": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
+      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This fileinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    },
+    {
+      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
+      "context": "<input id=\"DropZone1\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    }
+  ],
+  "all-components-frame--frame-in-a-stand-alone-application": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputSearch.Name",
+      "context": "<input class=\"SearchField-Input_EhctI\" placeholder=\"Search\" type=\"search\" autocapitalize=\"off\" autocomplete=\"off\" autocorrect=\"off\" value=\"\">",
+      "message": "This searchinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#AppFrameTopBar > div > div:nth-child(3) > div:nth-child(1) > div > input"
+    }
+  ],
+  "all-components-layout--two-columns-with-equal-width": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
+      "context": "<div class=\"Item-Container_16G76\" id=\"341\"><div class=\"Item-Owned_1lLjn\"><...</div>",
+      "message": "Duplicate id attribute value \"341\" found on the web page.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#341"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
+      "context": "<div class=\"Item-Container_16G76\" id=\"256\"><div class=\"Item-Owned_1lLjn\"><...</div>",
+      "message": "Duplicate id attribute value \"256\" found on the web page.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#256"
+    }
+  ],
+  "all-components-layout--three-columns-with-equal-width": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
+      "context": "<div class=\"Item-Container_16G76\" id=\"341\"><div class=\"Item-Owned_1lLjn\"><...</div>",
+      "message": "Duplicate id attribute value \"341\" found on the web page.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#341"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
+      "context": "<div class=\"Item-Container_16G76\" id=\"256\"><div class=\"Item-Owned_1lLjn\"><...</div>",
+      "message": "Duplicate id attribute value \"256\" found on the web page.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#256"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
+      "context": "<div class=\"Item-Container_16G76\" id=\"341\"><div class=\"Item-Owned_1lLjn\"><...</div>",
+      "message": "Duplicate id attribute value \"341\" found on the web page.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#341"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
+      "context": "<div class=\"Item-Container_16G76\" id=\"256\"><div class=\"Item-Owned_1lLjn\"><...</div>",
+      "message": "Duplicate id attribute value \"256\" found on the web page.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#256"
+    }
+  ],
+  "all-components-modal--modal-without-a-title": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button class=\"CloseButton-CloseButton_1J5w0 CloseButton-withoutTitle_3D5Ov\"><span class=\"Icon-Icon_mXAal Ic...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "html > body > div:nth-child(7) > div:nth-child(1) > div > div > div > button"
+    }
+  ],
+  "all-components-modal--basic-modal": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button class=\"CloseButton-CloseButton_1J5w0\"><span class=\"Icon-Icon_mXAal Ic...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "html > body > div:nth-child(7) > div:nth-child(1) > div > div > div > div:nth-child(1) > button"
+    }
+  ],
+  "all-components-modal--modal-with-primary-action": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button class=\"CloseButton-CloseButton_1J5w0\"><span class=\"Icon-Icon_mXAal Ic...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "html > body > div:nth-child(7) > div:nth-child(1) > div > div > div > div:nth-child(1) > button"
+    },
+    {
+      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
+      "context": "<input id=\"TextField1\" class=\"TextField-Input_2qkA6\" aria-label=\"\" aria-labelledby=\"TextField1Label\" aria-invalid=\"false\" value=\"https://polaris.shopify.com/\">",
+      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#TextField1"
+    }
+  ],
+  "all-components-modal--modal-with-primary-and-secondary-actions": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button class=\"CloseButton-CloseButton_1J5w0\"><span class=\"Icon-Icon_mXAal Ic...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "html > body > div:nth-child(7) > div:nth-child(1) > div > div > div > div:nth-child(1) > button"
+    }
+  ],
+  "all-components-modal--large-modal": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button class=\"CloseButton-CloseButton_1J5w0\"><span class=\"Icon-Icon_mXAal Ic...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "html > body > div:nth-child(7) > div:nth-child(1) > div > div > div > div:nth-child(1) > button"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputFile.Name",
+      "context": "<input id=\"DropZone1\" accept=\".csv\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This fileinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    },
+    {
+      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
+      "context": "<input id=\"DropZone1\" accept=\".csv\" type=\"file\" multiple=\"\" autocomplete=\"off\">",
+      "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#DropZone1"
+    }
+  ],
+  "all-components-modal--modal-with-scroll-listener": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button class=\"CloseButton-CloseButton_1J5w0\"><span class=\"Icon-Icon_mXAal Ic...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "html > body > div:nth-child(7) > div:nth-child(1) > div > div > div > div:nth-child(1) > button"
+    }
+  ],
+  "all-components-page--page-with-external-link": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button type=\"button\" class=\"Button-Button_2pL_i Button-plain_RU0pa Button-iconOnly_2ZPSS\" tabindex=\"0\" aria-controls=\"Popover1\" aria-owns=\"Popover1\" aria-haspopup=\"true\" aria-expanded=\"false\"><span class=\"Button-Content_2iX...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#root > div > div > div > div:nth-child(1) > div > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div > button"
+    }
+  ],
+  "all-components-page--page-with-all-header-elements": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button type=\"button\" class=\"Button-Button_2pL_i Button-plain_RU0pa Button-iconOnly_2ZPSS\" tabindex=\"0\" aria-controls=\"Popover1\" aria-owns=\"Popover1\" aria-haspopup=\"true\" aria-expanded=\"false\"><span class=\"Button-Content_2iX...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#root > div > div > div > div:nth-child(1) > div:nth-child(1) > div:nth-child(3) > div > button"
+    }
+  ],
+  "all-components-page--page-without-primary-action-in-header": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button type=\"button\" class=\"Button-Button_2pL_i Button-plain_RU0pa Button-iconOnly_2ZPSS\" tabindex=\"0\" aria-controls=\"Popover1\" aria-owns=\"Popover1\" aria-haspopup=\"true\" aria-expanded=\"false\"><span class=\"Button-Content_2iX...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#root > div > div > div > div:nth-child(1) > div:nth-child(1) > div:nth-child(3) > div > button"
+    }
+  ],
+  "all-components-option-list--option-list-with-sections": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
+      "context": "<ul class=\"OptionList-Options_3Df-D\" id=\"OptionList1\" aria-multiselectable=\"true\"><li class=\"Option-Option_nue26\"...</ul>",
+      "message": "Duplicate id attribute value \"OptionList1\" found on the web page.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#OptionList1"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_1.F77",
+      "context": "<ul class=\"OptionList-Options_3Df-D\" id=\"OptionList1\" aria-multiselectable=\"true\"><li class=\"Option-Option_nue26\"...</ul>",
+      "message": "Duplicate id attribute value \"OptionList1\" found on the web page.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#OptionList1"
+    }
+  ],
+  "all-components-page--full-width-page": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button type=\"button\" class=\"Button-Button_2pL_i Button-plain_RU0pa Button-iconOnly_2ZPSS\" tabindex=\"0\" aria-controls=\"Popover1\" aria-owns=\"Popover1\" aria-haspopup=\"true\" aria-expanded=\"false\"><span class=\"Button-Content_2iX...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#root > div > div > div > div:nth-child(1) > div:nth-child(2) > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div > button"
+    }
+  ],
+  "all-components-page--page-with-action-groups": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button type=\"button\" class=\"Button-Button_2pL_i Button-plain_RU0pa Button-iconOnly_2ZPSS\" tabindex=\"0\" aria-controls=\"Popover1\" aria-owns=\"Popover1\" aria-haspopup=\"true\" aria-expanded=\"false\"><span class=\"Button-Content_2iX...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#root > div > div > div > div:nth-child(1) > div:nth-child(1) > div:nth-child(2) > div > button"
+    }
+  ],
+  "all-components-page--page-with-content-after-title-title-metadata": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button type=\"button\" class=\"Button-Button_2pL_i Button-plain_RU0pa Button-iconOnly_2ZPSS\" tabindex=\"0\" aria-controls=\"Popover1\" aria-owns=\"Popover1\" aria-haspopup=\"true\" aria-expanded=\"false\"><span class=\"Button-Content_2iX...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#root > div > div > div > div:nth-child(1) > div:nth-child(1) > div:nth-child(3) > div > button"
+    }
+  ],
+  "all-components-popover--popover-with-lazy-loaded-list": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button class=\"Item-Button_30rEf\" tabindex=\"0\"></button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#Popover1 > div > div > ul > li:nth-child(1) > div > button"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button class=\"Item-Button_30rEf\" tabindex=\"0\"></button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#Popover1 > div > div > ul > li:nth-child(2) > div > button"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button class=\"Item-Button_30rEf\" tabindex=\"0\"></button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#Popover1 > div > div > ul > li:nth-child(3) > div > button"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button class=\"Item-Button_30rEf\" tabindex=\"0\"></button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#Popover1 > div > div > ul > li:nth-child(4) > div > button"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button class=\"Item-Button_30rEf\" tabindex=\"0\"></button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#Popover1 > div > div > ul > li:nth-child(5) > div > button"
+    }
+  ],
+  "all-components-resource-list--resource-list-with-persistent-item-shortcut-actions": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button type=\"button\" class=\"Button-Button_2pL_i Button-plain_RU0pa Button-iconOnly_2ZPSS\" tabindex=\"0\" aria-controls=\"Popover1\" aria-owns=\"Popover1\" aria-haspopup=\"true\" aria-expanded=\"false\"><span class=\"Button-Content_2iX...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
       "type": "error",
       "typeCode": 1,
       "selector": "#341 > div:nth-child(4) > div > button"
@@ -343,20 +511,74 @@
     {
       "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
       "context": "<button type=\"button\" class=\"Button-Button_2pL_i Button-plain_RU0pa Button-iconOnly_2ZPSS\" tabindex=\"0\" aria-controls=\"Popover2\" aria-owns=\"Popover2\" aria-haspopup=\"true\" aria-expanded=\"false\"><span class=\"Button-Content_2iX...</button>",
-      "message": "This button element does not have a name available to an accessibility API. Valid names are: title attribute, element content, aria-label attribute, aria-labelledby attribute.",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
       "type": "error",
       "typeCode": 1,
       "selector": "#256 > div:nth-child(4) > div > button"
     }
   ],
-  "http://localhost:3000/tabs/0": [
+  "all-components-resource-list--resource-list-with-filtering": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent",
+      "context": "<a aria-describedby=\"341\" class=\"Item-Link_2-raD\" tabindex=\"0\" id=\"ResourceListItemOverlay1\" href=\"customers/341\" data-polaris-unstyled=\"true\"></a>",
+      "message": "Anchor element found with a valid href attribute, but no link content has been supplied.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#ResourceListItemOverlay1"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.A.NoContent",
+      "context": "<a aria-describedby=\"256\" class=\"Item-Link_2-raD\" tabindex=\"0\" id=\"ResourceListItemOverlay2\" href=\"customers/256\" data-polaris-unstyled=\"true\"></a>",
+      "message": "Anchor element found with a valid href attribute, but no link content has been supplied.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#ResourceListItemOverlay2"
+    }
+  ],
+  "all-components-resource-list--resource-list-with-all-of-its-elements": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button type=\"button\" class=\"Button-Button_2pL_i Button-plain_RU0pa Button-iconOnly_2ZPSS\" tabindex=\"0\" aria-controls=\"Popover2\" aria-owns=\"Popover2\" aria-haspopup=\"true\" aria-expanded=\"false\"><span class=\"Button-Content_2iX...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#341 > div:nth-child(4) > div > button"
+    },
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
+      "context": "<button type=\"button\" class=\"Button-Button_2pL_i Button-plain_RU0pa Button-iconOnly_2ZPSS\" tabindex=\"0\" aria-controls=\"Popover3\" aria-owns=\"Popover3\" aria-haspopup=\"true\" aria-expanded=\"false\"><span class=\"Button-Content_2iX...</button>",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#256 > div:nth-child(4) > div > button"
+    }
+  ],
+  "all-components-sheet--basic-sheet": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Fieldset.Name",
+      "context": "<fieldset class=\"ChoiceList-ChoiceList_1SSgm\" id=\"salesChannelsList[]\" aria-invalid=\"false\" aria-describedby=\"salesChannelsList[]Error\"><ul class=\"ChoiceList-Choices_a...</fieldset>",
+      "message": "This fieldset element does not have a name available to an accessibility API. Valid names are: legend element, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#salesChannelsList[]"
+    },
+    {
+      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.H71.NoLegend",
+      "context": "<fieldset class=\"ChoiceList-ChoiceList_1SSgm\" id=\"salesChannelsList[]\" aria-invalid=\"false\" aria-describedby=\"salesChannelsList[]Error\"><ul class=\"ChoiceList-Choices_a...</fieldset>",
+      "message": "Fieldset does not contain a legend element. All fieldsets should contain a legend element that describes a description of the field group.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#salesChannelsList[]"
+    }
+  ],
+  "all-components-tabs--fitted-tabs": [
     {
       "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
       "context": "<button tabindex=\"-1\" class=\"Tabs-DisclosureActivator_1avNu\"><span class=\"Icon-Icon_mXAal\"><...</button>",
-      "message": "This button element does not have a name available to an accessibility API. Valid names are: title attribute, element content, aria-label attribute, aria-labelledby attribute.",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
       "type": "error",
       "typeCode": 1,
-      "selector": "#app > div > div:nth-child(1) > div > button"
+      "selector": "#root > div > div > div > div > div:nth-child(2) > button"
     },
     {
       "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F92,ARIA4",
@@ -364,17 +586,17 @@
       "message": "This element's role is \"presentation\" but contains child elements with semantic meaning.",
       "type": "error",
       "typeCode": 1,
-      "selector": "#app > div > div:nth-child(1) > ul > li:nth-child(5)"
+      "selector": "#root > div > div > div > div > ul > li:nth-child(3)"
     }
   ],
-  "http://localhost:3000/tabs/1": [
+  "all-components-tabs--default-tabs": [
     {
       "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
       "context": "<button tabindex=\"-1\" class=\"Tabs-DisclosureActivator_1avNu\"><span class=\"Icon-Icon_mXAal\"><...</button>",
-      "message": "This button element does not have a name available to an accessibility API. Valid names are: title attribute, element content, aria-label attribute, aria-labelledby attribute.",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
       "type": "error",
       "typeCode": 1,
-      "selector": "#app > div > div:nth-child(1) > div > button"
+      "selector": "#root > div > div > div > div > div:nth-child(2) > button"
     },
     {
       "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F92,ARIA4",
@@ -382,17 +604,37 @@
       "message": "This element's role is \"presentation\" but contains child elements with semantic meaning.",
       "type": "error",
       "typeCode": 1,
-      "selector": "#app > div > div:nth-child(1) > ul > li:nth-child(3)"
+      "selector": "#root > div > div > div > div > ul > li:nth-child(5)"
     }
   ],
-  "http://localhost:3000/text-field/11": [
+  "all-components-text-field--text-field-with-separate-validation-error": [
     {
       "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Button.Name",
       "context": "<button type=\"button\" class=\"Button-Button_2pL_i Button-iconOnly_2ZPSS\"><span class=\"Button-Content_2iX...</button>",
-      "message": "This button element does not have a name available to an accessibility API. Valid names are: title attribute, element content, aria-label attribute, aria-labelledby attribute.",
+      "message": "This button element does not have a name available to an accessibility API. Valid names are: title undefined, element content, aria-label undefined, aria-labelledby undefined.",
       "type": "error",
       "typeCode": 1,
-      "selector": "#app > div > div > div > div > div > div:nth-child(2) > button"
+      "selector": "#root > div > div > div > div > div > div > div > div:nth-child(2) > button"
+    }
+  ],
+  "all-components-top-bar--top-bar-with-all-of-its-elements": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputSearch.Name",
+      "context": "<input class=\"SearchField-Input_EhctI\" placeholder=\"Search\" type=\"search\" autocapitalize=\"off\" autocomplete=\"off\" autocorrect=\"off\" value=\"\">",
+      "message": "This searchinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#AppFrameTopBar > div > div:nth-child(3) > div:nth-child(1) > div > input"
+    }
+  ],
+  "all-components-top-bar--top-bar-themed-with-keys": [
+    {
+      "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputSearch.Name",
+      "context": "<input class=\"SearchField-Input_EhctI\" placeholder=\"Search\" type=\"search\" autocapitalize=\"off\" autocomplete=\"off\" autocorrect=\"off\" value=\"\">",
+      "message": "This searchinput element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
+      "type": "error",
+      "typeCode": 1,
+      "selector": "#AppFrameTopBar > div > div:nth-child(3) > div:nth-child(1) > div > input"
     }
   ]
 }

--- a/scripts/pa11y-utilities.js
+++ b/scripts/pa11y-utilities.js
@@ -8,16 +8,16 @@ function shitlistCheck(results, immutableShitlist) {
   });
 
   const filteredResults = results.map((result) => {
-    if (mutableShitlist[result.pageUrl]) {
+    if (mutableShitlist[result.exampleID]) {
       result.issues = result.issues.filter((issue) => {
         const issueHash = hash(issue);
-        const matchIndex = mutableShitlist[result.pageUrl].findIndex(
+        const matchIndex = mutableShitlist[result.exampleID].findIndex(
           (shitlistedResult) => {
             return hash(shitlistedResult) === issueHash;
           },
         );
         if (matchIndex >= 0) {
-          mutableShitlist[result.pageUrl].splice(matchIndex, 1);
+          mutableShitlist[result.exampleID].splice(matchIndex, 1);
         }
         return matchIndex === -1;
       });
@@ -28,7 +28,7 @@ function shitlistCheck(results, immutableShitlist) {
   Object.keys(mutableShitlist).forEach((key) => {
     if (mutableShitlist[key].length) {
       remainingIssues.push({
-        pageUrl: key,
+        exampleID: key,
         issues: mutableShitlist[key],
       });
     }

--- a/scripts/pa11y.js
+++ b/scripts/pa11y.js
@@ -58,34 +58,35 @@ async function runPa11y() {
     .goto(iframePath)
     .then(() => page.evaluate(() => window.__STORYBOOK_CLIENT_API__.raw()));
 
-  const queryStrings = stories.reduce((memo, story) => {
+  const storyIDs = stories.reduce((memo, story) => {
     // There is no need to test the Playground, or the "All Examples" stories
     const isSkippedStory =
       story.kind === 'Playground|Playground' || story.name === 'All Examples';
 
     if (!isSkippedStory) {
-      memo.push(`id=${encodeURIComponent(story.id)}`);
+      memo.push(`${encodeURIComponent(story.id)}`);
     }
     return memo;
   }, []);
 
-  queryStrings.forEach((queryString) => {
+  storyIDs.forEach((queryString) => {
     const currentBrowser = browsers[browserIndex % NUMBER_OF_BROWSERS];
     browserIndex++;
     currentBrowser.taken = currentBrowser.taken.then(async () => {
       console.log('Testing ', queryString);
-      results.push(
-        await pa11y(`${iframePath}?${queryString}`, {
-          browser: currentBrowser.browser,
-          ignore: [
-            // Missing lang attribute on <html> tag
-            // Storybook does not include this property so ignore it
-            'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
-            // Color contrast failures
-            'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail',
-          ],
-        }),
-      );
+      const result = await pa11y(`${iframePath}?id=${queryString}`, {
+        browser: currentBrowser.browser,
+        ignore: [
+          // Missing lang attribute on <html> tag
+          // Storybook does not include this property so ignore it
+          'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
+          // Color contrast failures
+          'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail',
+        ],
+      });
+      result.exampleID = queryString;
+      delete result.pageUrl;
+      results.push(result);
     });
   });
 
@@ -122,7 +123,7 @@ Please edit the file a11y_shitlist.json to remove them and run these tests again
       console.log(
         '------------------------------------------------------------------------',
       );
-      console.log(issue.pageUrl);
+      console.log(issue.exampleID);
       console.log(
         '------------------------------------------------------------------------',
       );
@@ -144,7 +145,7 @@ The following issues were discovered and need to be fixed before this code can b
       console.log(
         '------------------------------------------------------------------------',
       );
-      console.log(result.pageUrl);
+      console.log(result.exampleID);
       console.log(
         '------------------------------------------------------------------------',
       );

--- a/src/components/Sheet/README.md
+++ b/src/components/Sheet/README.md
@@ -207,6 +207,7 @@ class SheetExample extends React.Component {
                   </div>
                   <Scrollable style={{padding: '1.6rem', height: '100%'}}>
                     <ChoiceList
+                      name="salesChannelsList"
                       choices={salesChannels}
                       selected={selected}
                       allowMultiple

--- a/tests/pa11y-utilities.test.js
+++ b/tests/pa11y-utilities.test.js
@@ -17,7 +17,7 @@ describe('shitlistCheck', () => {
   it('filters errors on the shitlist', () => {
     const issueList = [
       {
-        pageUrl: '伊藤美来',
+        exampleID: '伊藤美来',
         issues: [{code: 'ショッキングブルー'}, {code: '風の戦士'}],
       },
     ];
@@ -36,7 +36,7 @@ describe('shitlistCheck', () => {
   it('leaves errors not on the shitlist', () => {
     const issueList = [
       {
-        pageUrl: '伊藤美来',
+        exampleID: '伊藤美来',
         issues: [{code: '美来の色探し'}, {code: '風の戦士'}],
       },
     ];
@@ -49,7 +49,7 @@ describe('shitlistCheck', () => {
   it('removes entries with no issues from the list', () => {
     const issueList = [
       {
-        pageUrl: '虹香',
+        exampleID: '虹香',
         issues: [],
       },
     ];
@@ -62,7 +62,7 @@ describe('shitlistCheck', () => {
   it('returns a list with errors that werent found', () => {
     const issueList = [
       {
-        pageUrl: '伊藤美来',
+        exampleID: '伊藤美来',
         issues: [{code: 'ショッキングブルー'}],
       },
     ];


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

We experimented with automated a11y testing with pa11y previously, but it was breaking way too often so we decided to disable it. Since then we've made changes to the codebase that I believe should make pa11y more stable:
- Named examples can be checked against more reliably than an array of examples
- Component renames/refactors don't happen as often


### WHAT is this pull request doing?

Re-enables automated a11y testing in CI.

I re-generated the shitlist to be up to date, and updated the script to deal with example names properly.

Also made the CI job always pass. We can keep it running in master for a week to evaluate whether it would help, or whether it's still failing too often to be useful. After a week we'll decide on the best way forward. The main two options are either fixing all errors and getting rid of the shitlist before enabling the CI job, or just enabling the CI job if we have confidence in the shitlist approach.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Just run the command locally and make sure it passes.