### PR TITLE
[TextField] Set alignment values in a logical order

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -26,7 +26,7 @@ export type Type =
   | 'week'
   | 'currency';
 
-export type Alignment = 'left' | 'right' | 'center';
+export type Alignment = 'left' | 'center' | 'right';
 
 export interface State {
   height?: number | null;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

In the styleguide, possible values for the prop "Alignment" are shown as (in a dropdown):

- left
- right
- center

In a left-to-right world, it's more logical to have those as:

- left
- center
- right

### WHAT is this pull request doing?

Reorders props in a more logical order.