### PR TITLE
Fix issue where tsx would copy the package.json file where it shouldn't

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yarn add @shopify/polaris
 ```html
 <link
   rel="stylesheet"
-  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.2/polaris.min.css"
+  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.3/polaris.min.css"
 />
 ```
 
@@ -81,7 +81,7 @@ If React doesn’t make sense for your application, you can use a CSS-only versi
 ```html
 <link
   rel="stylesheet"
-  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.2/polaris.min.css"
+  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.3/polaris.min.css"
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yarn add @shopify/polaris
 ```html
 <link
   rel="stylesheet"
-  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.1/polaris.min.css"
+  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.2/polaris.min.css"
 />
 ```
 
@@ -81,7 +81,7 @@ If React doesn’t make sense for your application, you can use a CSS-only versi
 ```html
 <link
   rel="stylesheet"
-  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.1/polaris.min.css"
+  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.2/polaris.min.css"
 />
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/polaris",
   "description": "Shopify’s product component library",
-  "version": "3.14.1-rc.1",
+  "version": "3.14.1-rc.2",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify <dev@shopify.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/polaris",
   "description": "Shopify’s product component library",
-  "version": "3.14.1-rc.2",
+  "version": "3.14.1-rc.3",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify <dev@shopify.com>",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,12 +2,7 @@
 
 const {execSync} = require('child_process');
 const {join, resolve: resolvePath} = require('path');
-const {
-  ensureDirSync,
-  writeFileSync,
-  readFileSync,
-  removeSync,
-} = require('fs-extra');
+const {ensureDirSync, writeFileSync, readFileSync} = require('fs-extra');
 const {rollup} = require('rollup');
 const {cp, mv, rm} = require('shelljs');
 const copyfiles = require('copyfiles');
@@ -62,11 +57,6 @@ copy(['./src/**/*.{scss,svg,png,jpg,jpeg,json}', intermediateBuild], {up: 1})
       );
     });
   })
-  // tsc includes the root directory's package.json file in the output by default
-  // and the "files" key ends up filtering which files get included in the
-  // build output. Ideally the package.json file wouldn't be copied,
-  // but deleting it is a good workaround.
-  .then(() => removeSync(resolvePath(intermediateBuild, 'package.json')))
   // Custom build consumed by Sewing Kit: it preserves all ESNext features
   // including imports/ exports for better tree shaking.
   .then(() => ensureDirSync(finalEsnext))

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -2,7 +2,12 @@
 
 const {execSync} = require('child_process');
 const {join, resolve: resolvePath} = require('path');
-const {ensureDirSync, writeFileSync, readFileSync} = require('fs-extra');
+const {
+  ensureDirSync,
+  writeFileSync,
+  readFileSync,
+  removeSync,
+} = require('fs-extra');
 const {rollup} = require('rollup');
 const {cp, mv, rm} = require('shelljs');
 const copyfiles = require('copyfiles');
@@ -57,6 +62,11 @@ copy(['./src/**/*.{scss,svg,png,jpg,jpeg,json}', intermediateBuild], {up: 1})
       );
     });
   })
+  // tsc includes the root directory's package.json file in the output by default
+  // and the "files" key ends up filtering which files get included in the
+  // build output. Ideally the package.json file wouldn't be copied,
+  // but deleting it is a good workaround.
+  .then(() => removeSync(resolvePath(intermediateBuild, 'package.json')))
   // Custom build consumed by Sewing Kit: it preserves all ESNext features
   // including imports/ exports for better tree shaking.
   .then(() => ensureDirSync(finalEsnext))

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -52,7 +52,7 @@ Use React components in most cases, especially if you’re building a highly int
 ```html
 <link
   rel="stylesheet"
-  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.1/polaris.min.css"
+  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.2/polaris.min.css"
 />
 ```
 
@@ -73,7 +73,7 @@ Include the CSS in your HTML:
 ```html
 <link
   rel="stylesheet"
-  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.1/polaris.min.css"
+  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.2/polaris.min.css"
 />
 ```
 
@@ -106,7 +106,7 @@ Include the CSS stylesheet in your HTML:
 ```html
 <link
   rel="stylesheet"
-  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.1/polaris.min.css"
+  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.2/polaris.min.css"
 />
 ```
 

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -52,7 +52,7 @@ Use React components in most cases, especially if you’re building a highly int
 ```html
 <link
   rel="stylesheet"
-  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.2/polaris.min.css"
+  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.3/polaris.min.css"
 />
 ```
 
@@ -73,7 +73,7 @@ Include the CSS in your HTML:
 ```html
 <link
   rel="stylesheet"
-  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.2/polaris.min.css"
+  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.3/polaris.min.css"
 />
 ```
 
@@ -106,7 +106,7 @@ Include the CSS stylesheet in your HTML:
 ```html
 <link
   rel="stylesheet"
-  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.2/polaris.min.css"
+  href="https://sdks.shopifycdn.com/polaris/3.14.1-rc.3/polaris.min.css"
 />
 ```
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
       "scripthost"
     ]
   },
-  "include": ["./config/typescript/**/*", "./src/**/*", "./package.json"]
+  "include": ["./config/typescript/**/*", "./src/**/*"]
 }


### PR DESCRIPTION
### WHY are these changes introduced?

We can't update `polaris-react` in `web` because of this bug.

This issue was introduced when we updated Typescript from 3.1.6 to 3.2.4.

### WHAT is this pull request doing?

In 3.2.4, `tsc` includes the root directory's `package.json` file in the output build by default
This is a problem because the "files" key in the root `package.json` ends up filtering which files get included in the build output. Ideally the package.json file wouldn't be copied, but I couldn't easily figure out how to configure that, so I delete the `package.json` file before copying the `tsc` output to its proper folder.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Run a build, and run the following command:
```
npm pack 2>&1 | tee packoutput.txt
```

And then inspect `packoutput.txt`. Check that the files included in the `/esnext/` folder look like this: https://unpkg.com/@shopify/polaris@3.13.0/esnext/