### PR TITLE
[Checkbox] Fix regression when disabled

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed `Checkbox` from improperly toggling when disabled ([#1467](https://github.com/Shopify/polaris-react/pull/1467))
 - Fixed `Popover` fade-in flutter on iOS by switching Transition component for CSSTransition [#1400](https://github.com/Shopify/polaris-react/pull/1400)
 - Improved the visibility of focus styles for the `Link` component. [#1425](https://github.com/Shopify/polaris-react/pull/1425)
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -45,27 +45,10 @@ const getUniqueID = createUniqueIDFactory('Checkbox');
 class Checkbox extends React.PureComponent<CombinedProps, never> {
   private inputNode = React.createRef<HTMLInputElement>();
 
-  componentDidMount() {
-    const {checked, disabled} = this.props;
-
-    if (checked && disabled) this.handleInput();
-  }
-
-  componentDidUpdate({disabled: prevDisabled}: Props) {
-    if (
-      prevDisabled === true &&
-      this.props.disabled &&
-      this.inputNode.current &&
-      this.inputNode.current.checked
-    ) {
-      this.handleInput();
-    }
-  }
-
   handleInput = () => {
-    const {onChange, id} = this.props;
+    const {onChange, id, disabled} = this.props;
 
-    if (onChange == null || this.inputNode.current == null) {
+    if (onChange == null || this.inputNode.current == null || disabled) {
       return;
     }
 

--- a/src/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/Checkbox/tests/Checkbox.test.tsx
@@ -79,31 +79,24 @@ describe('<Checkbox />', () => {
       expect(checkbox.find('input').instance()).toBe(document.activeElement);
     });
 
-    it('is not called when disabled', () => {
+    it('is not called from keyboard events when disabled', () => {
+      const spy = jest.fn();
+      const checkbox = mountWithAppProvider(
+        <Checkbox label="label" disabled onChange={spy} />,
+      );
+      checkbox.find('input').simulate('keyup', {
+        keyCode: Key.Enter,
+      });
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('is not called from click events when disabled', () => {
       const spy = jest.fn();
       const checkbox = mountWithAppProvider(
         <Checkbox label="label" disabled onChange={spy} />,
       );
       checkbox.find('input').simulate('click');
       expect(spy).not.toHaveBeenCalled();
-    });
-
-    it('is called when disabled and checked are both true on load', () => {
-      const spy = jest.fn();
-      mountWithAppProvider(
-        <Checkbox label="label" id="id" disabled onChange={spy} checked />,
-      );
-      expect(spy).toHaveBeenCalledWith(false, 'id');
-    });
-
-    it('it is called when disabled and checked are both true after initial load', () => {
-      const spy = jest.fn();
-      const checkbox = mountWithAppProvider(
-        <Checkbox label="label" disabled onChange={spy} id="id" />,
-      );
-
-      checkbox.setProps({checked: true});
-      expect(spy).toHaveBeenCalledWith(false, 'id');
     });
   });
 
@@ -164,6 +157,18 @@ describe('<Checkbox />', () => {
         <Checkbox label="Checkbox" disabled={false} />,
       );
       expect(element.find('input').prop('disabled')).toBeFalsy();
+    });
+
+    it('can change values when disabled', () => {
+      const spy = jest.fn();
+      const checkbox = mountWithAppProvider(
+        <Checkbox label="label" disabled onChange={spy} />,
+      );
+      checkbox.find('input').simulate('keyup', {
+        keyCode: Key.Enter,
+      });
+      checkbox.setProps({checked: true});
+      expect(checkbox.find('input').prop('checked')).toBe(true);
     });
   });
 

--- a/src/components/Choice/Choice.tsx
+++ b/src/components/Choice/Choice.tsx
@@ -35,12 +35,6 @@ export default function Choice({
   helpText,
   onClick,
 }: Props) {
-  function handleClick() {
-    if (disabled || !onClick) return;
-
-    onClick();
-  }
-
   const className = classNames(
     styles.Choice,
     labelHidden && styles.labelHidden,
@@ -48,7 +42,7 @@ export default function Choice({
   );
 
   const labelMarkup = (
-    <label className={className} htmlFor={id} onClick={handleClick}>
+    <label className={className} htmlFor={id} onClick={onClick}>
       <span className={styles.Control}>{children}</span>
       <span className={styles.Label}>{label}</span>
     </label>

--- a/src/components/Choice/tests/Choice.test.tsx
+++ b/src/components/Choice/tests/Choice.test.tsx
@@ -86,13 +86,4 @@ describe('<Choice />', () => {
       expect(label.find(blockLevelElements[i])).toHaveLength(0);
     }
   });
-
-  it('does not fire an onClick event when disabled is true', () => {
-    const spy = jest.fn();
-    const choice = mountWithAppProvider(
-      <Choice id="id" label="Label" onClick={spy} disabled />,
-    );
-    choice.find('label').simulate('click');
-    expect(spy).not.toHaveBeenCalled();
-  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

It’s unfortunate that we missed this in the `build-consumer` test. This seems to be a regression caused by not fully understanding #1363. In #1369 I made it so Checkbox cannot be disabled and checked. however, it seems we wanted to remove the ability to fire click events while disabled and keep the ability to change `Checkbox` checked state.

### WHAT is this pull request doing?

* removing unnecessary code
* moving logic from `Choice` to `Checkbox`
* updating tests 

### How to 🎩

* Simple playground to toggle `checked` and `disabled` states  ⬇️&
* Build-consumer and check the failing test in web

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Checkbox, Button} from '@shopify/polaris';

interface State {
  checked: boolean;
  disabled: boolean;
}

export default class Playground extends React.Component {
  state = {
    checked: true,
    disabled: false,
  };

  render() {
    const {checked, disabled} = this.state;

    return (
      <div>
        <Checkbox
          checked={checked}
          disabled={disabled}
          label="Basic checkbox"
          onChange={this.handleChange}
        />
        <Button
          onClick={() => this.setState(({disabled}) => ({disabled: !disabled}))}
        >
          toggle disabled
        </Button>
        <Button
          onClick={() => this.setState(({checked}) => ({checked: !checked}))}
        >
          toggle checked
        </Button>
      </div>
    );
  }

  handleChange = (value) => {
    this.setState({checked: value});
  };
}

```

</details>
