### PR TITLE
[RangeSlider] Add border for high contrast mode

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed an issue where the JavaScript breakpoints incorrectly set the navigation bar collapsed breakpoint ([#1475](https://github.com/Shopify/polaris-react/pull/1475))
+- Added border to the `RangeSlider` track for Windows high contrast mode. [#1468](https://github.com/Shopify/polaris-react/pull/1468)
 
 ### Documentation
 

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -75,7 +75,7 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
   flex: 1 1 auto;
 
   @media (-ms-high-contrast: active) {
-    border: 1px solid ms-high-contrast-color('text');
+    border: border-width(base) solid ms-high-contrast-color('text');
   }
 
   @include range-track-selectors {

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -74,6 +74,10 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
   z-index: z-index('input', $stacking-order);
   flex: 1 1 auto;
 
+  @media (-ms-high-contrast: active) {
+    border: 1px solid ms-high-contrast-color('text');
+  }
+
   @include range-track-selectors {
     cursor: pointer;
     width: 100%;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/796

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR adds a border to the `RangeSlider` for Windows high contrast mode.

It addresses an issue where the `RangeSlider`'s track was not visible in Windows high contrast mode.

However, subsequent changes may already have addressed this & if so, this PR can be closed.

#### Before:

![https://screenshot.click/2019-05-14_12-53-14.png](https://screenshot.click/2019-05-14_12-53-14.png)

#### After:

![https://screenshot.click/2019-05-14_12-57-39.png](https://screenshot.click/2019-05-14_12-57-39.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

- Navigate to `RangeSlider` -> `Default range slider` in the storybook oon a Windows machine running in high contrast mode.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
