### PR TITLE
[Navigation] fix hover regression on navigation items on rails views

### DIFF
--- a/src/components/Navigation/variables.scss
+++ b/src/components/Navigation/variables.scss
@@ -43,6 +43,7 @@ $nav-animation-variables: (
 
   &:hover {
     @include state(hover);
+    text-decoration: none;
 
     .Icon {
       @include recolor-icon(


### PR DESCRIPTION
https://github.com/Shopify/polaris-react/pull/1304 introduced a regression that caused a widely applicable style (a style on all `a` tags coming from Polaris rails) on rails views to have underlines when hovered. React views did not have the same hover underline.

|:tophat: React before|:tophat: Rails before|:tophat: React after|:tophat: Rails after|
|-|-|-|-|
|<img width="1532" alt="Screen Shot 2019-05-14 at 10 45 00 AM" src="https://user-images.githubusercontent.com/1403188/57708599-9cf39a00-7637-11e9-9f16-845362a701c8.png">|<img width="1440" alt="Screen Shot 2019-05-14 at 10 43 19 AM" src="https://user-images.githubusercontent.com/1403188/57708623-a846c580-7637-11e9-841a-45dab1c0e1c5.png">|<img width="1532" alt="Screen Shot 2019-05-14 at 10 57 48 AM" src="https://user-images.githubusercontent.com/1403188/57708652-bb599580-7637-11e9-8cf5-884e4b9874df.png">|<img width="1532" alt="Screen Shot 2019-05-14 at 10 57 35 AM" src="https://user-images.githubusercontent.com/1403188/57708694-c90f1b00-7637-11e9-8f41-6af32ceb0d43.png">|

cc: @yourpalsonja 