### PR TITLE
Remove dependency on @shopify/images

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -4,9 +4,6 @@
 
 const path = require('path');
 
-const {
-  svgOptions: svgOptimizationOptions,
-} = require('@shopify/images/optimize');
 const postcssShopify = require('postcss-shopify');
 
 // Use the version of webpack-bundle-analyzer (and other plugins/loaders) from

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Dependency upgrades
 
+- Removed runtime dependency on `@shopify/images` as we never needed it at runtime ([#1474](https://github.com/Shopify/polaris-react/pull/1474))
+
 ### Code quality
 
 ### Deprecations

--- a/package.json
+++ b/package.json
@@ -178,7 +178,6 @@
   "dependencies": {
     "@babel/runtime": "^7.1.6",
     "@shopify/app-bridge": "^1.3.0",
-    "@shopify/images": "^1.1.0",
     "@shopify/javascript-utilities": "^2.2.1",
     "@shopify/polaris-icons": "^3.3.0",
     "@shopify/polaris-tokens": "^2.5.0",

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {SVGSource} from '@shopify/images';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 import {
   PlusMinor,
@@ -162,6 +161,11 @@ const COLORS_WITH_BACKDROPS = [
   'ink',
   'inkLighter',
 ];
+
+interface SVGSource {
+  body: string;
+  viewBox: string;
+}
 
 export type BundledIcon = keyof typeof BUNDLED_ICONS;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1244,7 +1244,7 @@
   resolved "https://registry.yarnpkg.com/@shopify/fail-on-unexpected-module-shaking-plugin/-/fail-on-unexpected-module-shaking-plugin-1.0.4.tgz#56cf7e7724d1347d2c66a2c4c0ac51ce8b974136"
   integrity sha512-NmP0/ag0xj+K3K6XGHnwfondzqLPxs4ASDXHBVmfnf9svsYUOuPm4smJ7n7tkZq+/9RaC4dsFI40AAR7Khp6XA==
 
-"@shopify/images@^1.1.0", "@shopify/images@^1.1.4":
+"@shopify/images@^1.1.4":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@shopify/images/-/images-1.1.5.tgz#f7ae5d5801b4550085480825ceda66420d9ff700"
   integrity sha512-DIPOT6ACpmsqYwvh0TQ48PgmZFceuoV8imrxfmCK6HD+zWcE6TWfunKaGEo0DkkdsS+6guGd/aJXe9m+dyBvdQ==


### PR DESCRIPTION
This was never needed at runtime, we only used it for a trivial type
that we can easily duplicate (and we'll remove the need for that type in
v4)

We don't need it at build time as sk handles our svg optimization

To test:

- Icon unit tests
- Search for `@shopify/images` and see the only mentions are in the yarn.lock files of our examples.