### PR TITLE
[Breakpoints] fix breakpoint off by 1

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed an issue where the JavaScript breakpoints incorrectly set the navigation bar collapsed breakpoint ([#1475](https://github.com/Shopify/polaris-react/pull/1475))
+
 ### Documentation
 
 ### Development workflow

--- a/src/utilities/breakpoints.ts
+++ b/src/utilities/breakpoints.ts
@@ -1,7 +1,7 @@
 import {noop} from '@shopify/javascript-utilities/other';
 
 const Breakpoints = {
-  navigationBarCollapsed: '769px',
+  navigationBarCollapsed: '768px',
   stackedContent: '1043px',
 };
 


### PR DESCRIPTION
While tophatting a change in web to replace the web implementation of `Sheet` with the Polaris implementation, I saw that the breakpoint in the JavaScript is wrong, as navigation should be displayed inclusive of 768px, but not 769px. This results in a sheet which, for one pixel at `769px` wide appears as the desktop sheet but functions as the mobile sheet (closing towards the bottom). This fixes that issue.