### PR TITLE
[Navigation] Remove deprecated UserMenu option for styleguide

### DIFF
--- a/src/components/Navigation/README.md
+++ b/src/components/Navigation/README.md
@@ -171,17 +171,6 @@ Action allows a complementary icon-only action to render next to the section tit
 
 The user menu component displays the current user’s avatar and name, and actions that are related to the current logged in user. The menu is displayed at the top of the navigation sidebar at small screen sizes. The user menu can display any messages that the current user has available to read.
 
-### User menu properties
-
-| Prop           | Type                    | Description                                                                                             |
-| -------------- | ----------------------- | ------------------------------------------------------------------------------------------------------- |
-| name           | string                  | A string detailing the merchant’s full name to be displayed in the user menu                            |
-| detail         | string                  | A string allowing further details on the merchant’s name displayed in the user menu                     |
-| actions        | UserActionSection[]     | An array of action objects that are rendered inside of a dropdown triggered by this menu                |
-| message        | MessageProps            | Accepts a message that facilitates direct, urgent communication with the merchant through the user menu |
-| avatarInitials | AvatarProps['initials'] | The merchant’s initials, rendered in place of an avatar image when not provided                         |
-| avatarSource   | AvatarProps['source']   | An avatar image representing the merchant                                                               |
-
 ### Deprecation rationale
 
 As of release 3.6.0 `Navigation.UserMenu` is deprecated in favor of [`TopBar.UserMenu`](https://polaris.shopify.com/components/structure/top-bar#top-bar-menu) which will stay visible on mobile.
@@ -208,55 +197,6 @@ Use to present a navigation menu in the [frame](/components/structure/frame).
         label: 'Orders',
         icon: 'orders',
         badge: '15',
-      },
-      {
-        url: '/path/to/place',
-        label: 'Products',
-        icon: 'products',
-      },
-    ]}
-  />
-</Navigation>
-```
-
-### Navigation with user menu
-
-Use to present a navigation menu and a user menu in the [frame](/components/structure/frame).
-
-```jsx
-<Navigation
-  location="/"
-  userMenu={
-    <Navigation.UserMenu
-      name="Ellen Ochoa"
-      detail="Ochoa Crafts"
-      actions={[
-        {
-          id: '123',
-          items: [{content: 'Perform action'}],
-        },
-      ]}
-      message={{
-        title: 'Message title',
-        description: 'Message description',
-        action: {content: 'Perform action'},
-        link: {to: 'path/to/place', content: 'Link content'},
-      }}
-      avatarInitials="EO"
-    />
-  }
->
-  <Navigation.Section
-    items={[
-      {
-        url: '/path/to/place',
-        label: 'Home',
-        icon: 'home',
-      },
-      {
-        url: '/path/to/place',
-        label: 'Orders',
-        icon: 'orders',
       },
       {
         url: '/path/to/place',


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #1470  <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Removes `UserMenu` option and shortens description now that this sub-component has been deprecated.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
