### PR TITLE
Remove all usages of importing noop functions

### DIFF
--- a/src/components/AccountConnection/tests/AccountConnection.test.tsx
+++ b/src/components/AccountConnection/tests/AccountConnection.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import {Avatar, buttonFrom} from 'components';
 import AccountConnection from '../AccountConnection';
@@ -120,3 +119,5 @@ describe('<AccountConnection />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/ActionList/components/Section/tests/Section.test.tsx
+++ b/src/components/ActionList/components/Section/tests/Section.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import Item from '../../Item';
 import Section from '../Section';
@@ -120,3 +119,5 @@ describe('<Section />', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 });
+
+function noop() {}

--- a/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
+++ b/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
@@ -1,4 +1,3 @@
-import {noop} from '@shopify/javascript-utilities/other';
 import createApp, {
   getShopOrigin,
   LifecycleHook,
@@ -65,3 +64,5 @@ export const setClientInterfaceHook: DispatchActionHook = function(next) {
     return next(action);
   };
 };
+
+function noop() {}

--- a/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
+++ b/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as appBridge from '@shopify/app-bridge';
-import {noop} from '@shopify/javascript-utilities/other';
 import * as targets from '@shopify/react-utilities/target';
 import createAppProviderContext, {
   setClientInterfaceHook,
@@ -46,8 +45,8 @@ describe('createAppProviderContext()', () => {
         link: expect.any(Link),
         stickyManager: expect.any(StickyManager),
         scrollLockManager: expect.any(ScrollLockManager),
-        subscribe: noop,
-        unsubscribe: noop,
+        subscribe: expect.any(Function),
+        unsubscribe: expect.any(Function),
         appBridge: undefined,
       },
     });
@@ -91,8 +90,8 @@ describe('createAppProviderContext()', () => {
         link: expect.any(Link),
         stickyManager: expect.any(StickyManager),
         scrollLockManager: expect.any(ScrollLockManager),
-        subscribe: noop,
-        unsubscribe: noop,
+        subscribe: expect.any(Function),
+        unsubscribe: expect.any(Function),
         appBridge: {
           apiKey,
           forceRedirect: undefined,

--- a/src/components/AppProvider/utilities/createPolarisContext/tests/createPolarisContext.test.tsx
+++ b/src/components/AppProvider/utilities/createPolarisContext/tests/createPolarisContext.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {StickyManager} from '../../withSticky';
 import ScrollLockManager from '../../ScrollLockManager';
 import createPolarisContext from '../createPolarisContext';
@@ -31,14 +30,14 @@ describe('createPolarisContext()', () => {
         link: expect.any(Link),
         stickyManager: expect.any(StickyManager),
         scrollLockManager: expect.any(ScrollLockManager),
-        subscribe: noop,
-        unsubscribe: noop,
+        subscribe: expect.any(Function),
+        unsubscribe: expect.any(Function),
         appBridge: undefined,
       },
       polarisTheme: {
         logo: null,
-        subscribe: noop,
-        unsubscribe: noop,
+        subscribe: expect.any(Function),
+        unsubscribe: expect.any(Function),
       },
     });
   });
@@ -90,8 +89,8 @@ describe('createPolarisContext()', () => {
         link: new Link(CustomLinkComponent),
         stickyManager,
         scrollLockManager,
-        subscribe: noop,
-        unsubscribe: noop,
+        subscribe: expect.any(Function),
+        unsubscribe: expect.any(Function),
         appBridge: undefined,
       },
       polarisTheme: {
@@ -129,14 +128,14 @@ describe('createPolarisContext()', () => {
         link: new Link(CustomLinkComponent),
         stickyManager,
         scrollLockManager,
-        subscribe: noop,
-        unsubscribe: noop,
+        subscribe: expect.any(Function),
+        unsubscribe: expect.any(Function),
         appBridge: undefined,
       },
       polarisTheme: {
         logo: null,
-        subscribe: noop,
-        unsubscribe: noop,
+        subscribe: expect.any(Function),
+        unsubscribe: expect.any(Function),
       },
     };
 
@@ -160,8 +159,8 @@ describe('createPolarisContext()', () => {
         link: expect.any(Link),
         stickyManager: expect.any(StickyManager),
         scrollLockManager: expect.any(ScrollLockManager),
-        subscribe: noop,
-        unsubscribe: noop,
+        subscribe: expect.any(Function),
+        unsubscribe: expect.any(Function),
         appBridge: undefined,
       },
       polarisTheme: {

--- a/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
+++ b/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {shallow} from 'enzyme';
 import {OptionList, ActionList, Popover} from 'components';
 import {mountWithAppProvider, trigger} from 'test-utilities';
@@ -555,6 +554,8 @@ describe('<ComboBox/>', () => {
     });
   });
 });
+
+function noop() {}
 
 function renderTextField() {
   return <TextField label="" onChange={noop} />;

--- a/src/components/Autocomplete/tests/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/tests/Autocomplete.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {CirclePlusMinor} from '@shopify/polaris-icons';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {Spinner} from 'components';
 import Autocomplete from '..';
@@ -128,6 +127,8 @@ describe('<Autocomplete/>', () => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });
+
+  function noop() {}
 
   function renderTextField() {
     return <Autocomplete.TextField label="" onChange={noop} />;

--- a/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import {CallbackAction, LinkAction} from '../../../types';
 import Breadcrumbs from '../Breadcrumbs';
@@ -57,3 +56,5 @@ describe('<Breadcrumbs />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {MinusMinor, TickSmallMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
-import {createUniqueIDFactory, noop} from '@shopify/javascript-utilities/other';
+import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import Choice, {helpTextID} from '../Choice';
@@ -145,6 +145,8 @@ class Checkbox extends React.PureComponent<CombinedProps, never> {
     );
   }
 }
+
+function noop() {}
 
 function stopPropagation<E>(event: React.MouseEvent<E>) {
   event.stopPropagation();

--- a/src/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/Checkbox/tests/Checkbox.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import {Key} from '../../../types';
 import Checkbox from '../Checkbox';
@@ -253,3 +252,5 @@ describe('<Checkbox />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/ChoiceList/ChoiceList.tsx
+++ b/src/components/ChoiceList/ChoiceList.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
-import {noop, createUniqueIDFactory} from '@shopify/javascript-utilities/other';
+import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import Checkbox from '../Checkbox';
@@ -127,6 +127,8 @@ function ChoiceList({
     </fieldset>
   );
 }
+
+function noop() {}
 
 function choiceIsSelected({value}: Choice, selected: string[]) {
   return selected.indexOf(value) >= 0;

--- a/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
+++ b/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {calculateDraggerY, alphaForDraggerY} from '../utilities';
 import Slidable from '../../Slidable';
@@ -74,3 +73,5 @@ describe('<AlphaPicker />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
+++ b/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {calculateDraggerY, hueForDraggerY} from '../utilities';
 import Slidable from '../../Slidable';
@@ -66,3 +65,5 @@ describe('<HuePicker />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import EventListener from '../../EventListener';
 import {Slidable, AlphaPicker} from '../components';
@@ -193,3 +192,5 @@ describe('<ColorPicker />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import {mountWithAppProvider} from 'test-utilities';
-import {noop} from '../../../utilities/other';
 import ContextualSaveBar from '../ContextualSaveBar';
 
 describe('<ContextualSaveBar />', () => {
@@ -54,6 +53,8 @@ describe('<ContextualSaveBar />', () => {
     expect(frame.setContextualSaveBar).toHaveBeenCalledTimes(1);
   });
 });
+
+function noop() {}
 
 function mountWithContext(element: React.ReactElement<any>) {
   const frame = {

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {ArrowLeftMinor, ArrowRightMinor} from '@shopify/polaris-icons';
-import {noop} from '@shopify/javascript-utilities/other';
 import {
   Range,
   Months,
@@ -280,6 +279,8 @@ export class DatePicker extends React.PureComponent<CombinedProps, State> {
     });
   };
 }
+
+function noop() {}
 
 function handleKeyDown(event: React.KeyboardEvent<HTMLElement>) {
   const {key} = event;

--- a/src/components/DatePicker/components/Day/Day.tsx
+++ b/src/components/DatePicker/components/Day/Day.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
-import {noop} from '@shopify/javascript-utilities/other';
 import {Months, isSameDay} from '@shopify/javascript-utilities/dates';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 
@@ -91,3 +90,5 @@ export class Day extends React.PureComponent<CombinedProps, never> {
 }
 
 export default withAppProvider<Props>()(Day);
+
+function noop() {}

--- a/src/components/DatePicker/components/Month/Month.tsx
+++ b/src/components/DatePicker/components/Month/Month.tsx
@@ -12,7 +12,6 @@ import {
   dateIsSelected,
   getNewRange,
 } from '@shopify/javascript-utilities/dates';
-import {noop} from '@shopify/javascript-utilities/other';
 import {classNames} from '@shopify/react-utilities/styles';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 import styles from '../../DatePicker.scss';
@@ -139,6 +138,8 @@ function Month({
 }
 
 export default withAppProvider<Props>()(Month);
+
+function noop() {}
 
 function hoveringDateIsInRange(
   day: Date | null,

--- a/src/components/DatePicker/tests/DatePicker.test.tsx
+++ b/src/components/DatePicker/tests/DatePicker.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {Weekdays} from '@shopify/javascript-utilities/dates';
 import {mountWithAppProvider} from 'test-utilities';
 import {Day, Month, Weekday} from '../components';
@@ -180,3 +179,5 @@ describe('<DatePicker />', () => {
     ).toBe(false);
   });
 });
+
+function noop() {}

--- a/src/components/EventListener/tests/EventListener.test.tsx
+++ b/src/components/EventListener/tests/EventListener.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import EventListener from '../EventListener';
 
@@ -37,3 +36,5 @@ describe('<EventListener />', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 });
+
+function noop() {}

--- a/src/components/Form/tests/Form.test.tsx
+++ b/src/components/Form/tests/Form.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import Form from '../Form';
 
@@ -159,3 +158,5 @@ describe('<Form />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/FormLayout/components/Group/tests/Group.test.tsx
+++ b/src/components/FormLayout/components/Group/tests/Group.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import {TextField} from 'components';
 import Group from '../Group';
@@ -33,3 +32,5 @@ describe('<Group />', () => {
     expect(item.contains(helpText)).toBe(true);
   });
 });
+
+function noop() {}

--- a/src/components/FormLayout/components/Item/tests/Item.test.tsx
+++ b/src/components/FormLayout/components/Item/tests/Item.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import {TextField} from 'components';
 import Item from '../Item';
@@ -11,3 +10,5 @@ describe('<Item />', () => {
     expect(item.contains(children)).toBe(true);
   });
 });
+
+function noop() {}

--- a/src/components/FormLayout/tests/FormLayout.test.tsx
+++ b/src/components/FormLayout/tests/FormLayout.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import {TextField} from 'components';
 import FormLayout from '../FormLayout';
@@ -13,3 +12,5 @@ describe('<FormLayout />', () => {
     expect(formLayout.contains(children)).toBe(true);
   });
 });
+
+function noop() {}

--- a/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/tests/DiscardConfirmationModal.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/tests/DiscardConfirmationModal.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import {noop} from '@shopify/javascript-utilities/other';
 import {shallowWithAppProvider, trigger} from 'test-utilities';
 
 import {Modal} from 'components';
@@ -31,3 +30,5 @@ describe('<DiscardConfirmationModal />', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 });
+
+function noop() {}

--- a/src/components/Frame/components/Toast/tests/Toast.test.tsx
+++ b/src/components/Frame/components/Toast/tests/Toast.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {timer} from '@shopify/jest-dom-mocks';
 import {mountWithAppProvider, trigger, findByTestID} from 'test-utilities';
-import {noop} from 'utilities/other';
 import Button from '../../../../Button';
 import {ToastProps as Props} from '../../../types';
 import Toast from '../Toast';
@@ -185,3 +184,5 @@ describe('<Toast />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
+++ b/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {timer} from '@shopify/jest-dom-mocks';
 import {mountWithAppProvider} from 'test-utilities';
-import {noop} from 'utilities/other';
 import Toast from '../../Toast';
 import Frame from '../../../Frame';
 import ToastManager from '..';
@@ -78,3 +77,5 @@ describe('onDismiss()', () => {
     expect(spy2).toHaveBeenCalledTimes(1);
   });
 });
+
+function noop() {}

--- a/src/components/KeypressListener/tests/KeypressListener.test.tsx
+++ b/src/components/KeypressListener/tests/KeypressListener.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import {Key} from '../../../types';
 import KeypressListener from '../KeypressListener';
@@ -49,3 +48,5 @@ describe('<KeypressListener />', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 });
+
+function noop() {}

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {Modal as AppBridgeModal} from '@shopify/app-bridge/actions';
-import {noop} from '@shopify/javascript-utilities/other';
 import {animationFrame} from '@shopify/jest-dom-mocks';
 import {findByTestID, trigger, mountWithAppProvider} from 'test-utilities';
 import {Badge, Spinner, Portal, Scrollable} from 'components';
@@ -495,3 +494,5 @@ function mountWithAppBridge(element: React.ReactElement<any>) {
 
   return {modal, polaris};
 }
+
+function noop() {}

--- a/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {PlusMinor} from '@shopify/polaris-icons';
-import {noop} from '@shopify/javascript-utilities/other';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {Icon, UnstyledLink, Indicator, Badge} from 'components';
 import {trigger, mountWithAppProvider} from 'test-utilities';
@@ -452,6 +451,8 @@ describe('<Nav.Item />', () => {
     });
   });
 });
+
+function noop() {}
 
 function itemForLocation(location: string, overrides: Partial<ItemProps> = {}) {
   return mountWithAppProvider(

--- a/src/components/Navigation/components/Message/tests/Message.test.tsx
+++ b/src/components/Navigation/components/Message/tests/Message.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import Message from '../Message';
 import Badge from '../../../../Badge';
@@ -38,3 +37,5 @@ describe('<Message />', () => {
     expect(message.find(Badge)).toHaveLength(1);
   });
 });
+
+function noop() {}

--- a/src/components/Navigation/components/Section/tests/Section.test.tsx
+++ b/src/components/Navigation/components/Section/tests/Section.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-import {noop} from '@shopify/javascript-utilities/other';
 
 import {matchMedia, animationFrame} from '@shopify/jest-dom-mocks';
 import {findByTestID, trigger, mountWithAppProvider} from 'test-utilities';
@@ -248,3 +247,5 @@ describe('<Navigation.Section />', () => {
     expect(onClickSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+function noop() {}

--- a/src/components/OptionList/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/OptionList/components/Checkbox/tests/Checkbox.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import Checkbox, {Props} from '../Checkbox';
 
@@ -36,3 +35,5 @@ describe('<Checkbox />', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 });
+
+function noop() {}

--- a/src/components/OptionList/components/Option/tests/Option.test.tsx
+++ b/src/components/OptionList/components/Option/tests/Option.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import Checkbox from '../../Checkbox';
 import Option, {Props} from '../Option';
@@ -88,3 +87,5 @@ describe('<Option />', () => {
     expect(checkbox.prop('disabled')).toBe(disabled);
   });
 });
+
+function noop() {}

--- a/src/components/OptionList/tests/OptionList.test.tsx
+++ b/src/components/OptionList/tests/OptionList.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import {Option} from '../components';
 import OptionList, {
@@ -527,6 +526,8 @@ describe('<OptionList />', () => {
     });
   });
 });
+
+function noop() {}
 
 function firstOption(
   options?: OptionDescriptor[],

--- a/src/components/Page/components/Header/components/ActionGroup/tests/ActionGroup.test.tsx
+++ b/src/components/Page/components/Header/components/ActionGroup/tests/ActionGroup.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {SaveMinor} from '@shopify/polaris-icons';
-import {noop} from '@shopify/javascript-utilities/other';
 import {Popover, ActionList} from 'components';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import Action from '../../Action';
@@ -114,3 +113,5 @@ describe('<ActionGroup />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -6,7 +6,6 @@ import {
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import {Page, Card} from 'components';
 import {LinkAction} from '../../../types';
-import {noop} from '../../../utilities/other';
 import {Header} from '../components';
 // eslint-disable-next-line shopify/strict-component-boundaries
 import {SecondaryAction, PrimaryActionProps} from '../components/Header/Header';
@@ -385,6 +384,8 @@ describe('<Page />', () => {
     });
   });
 });
+
+function noop() {}
 
 function mountWithAppBridge(element: React.ReactElement<any>) {
   const appBridge = {};

--- a/src/components/Pagination/tests/Pagination.test.tsx
+++ b/src/components/Pagination/tests/Pagination.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider, findByTestID} from 'test-utilities';
 import {Tooltip, TextField} from 'components';
@@ -161,6 +160,8 @@ describe('<Pagination />', () => {
     });
   });
 });
+
+function noop() {}
 
 function focusElement(
   wrapper: ReactWrapper<any, any>,

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import {TextContainer} from 'components';
 import {Key} from '../../../../../types';
@@ -156,3 +155,5 @@ describe('<PopoverOverlay />', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 });
+
+function noop() {}

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {createPortal} from 'react-dom';
-import {createUniqueIDFactory, noop} from '@shopify/javascript-utilities/other';
+import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 
 export interface Props {
   children?: React.ReactNode;
@@ -50,3 +50,5 @@ export default class Portal extends React.PureComponent<Props, State> {
       : null;
   }
 }
+
+function noop() {}

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider, findByTestID} from 'test-utilities';
 import {Key} from 'types';
@@ -1008,6 +1007,8 @@ describe('<DualThumb />', () => {
     });
   });
 });
+
+function noop() {}
 
 function findThumbLower(containerComponent: ReactWrapper): ReactWrapper {
   return containerComponent.find('button').first();

--- a/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import {SingleThumb} from '../..';
 
@@ -252,3 +251,5 @@ describe('<SingleThumb />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/RangeSlider/tests/RangeSlider.test.tsx
+++ b/src/components/RangeSlider/tests/RangeSlider.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import RangeSlider from '../RangeSlider';
 import {DualThumb, SingleThumb} from '../components';
@@ -130,3 +129,5 @@ describe('<RangeSlider />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {DatePicker, Select, TextField} from 'components';
 import {trigger, mountWithAppProvider} from 'test-utilities';
 import DateSelector, {Props, DateFilterOption} from '../DateSelector';
@@ -578,3 +577,5 @@ describe('<DateSelector />', () => {
     });
   }
 });
+
+function noop() {}

--- a/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/tests/FilterValueSelector.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/tests/FilterValueSelector.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {trigger, shallowWithAppProvider} from 'test-utilities';
 import {Select, TextField} from 'components';
 import FilterValueSelector from '../FilterValueSelector';
@@ -443,3 +442,5 @@ describe('<FilterValueSelector />', () => {
     });
   }
 });
+
+function noop() {}

--- a/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {trigger, mountWithAppProvider} from 'test-utilities';
 import {TextField, Tag, Button} from 'components';
 import {Provider} from '../../Context';
@@ -776,3 +775,5 @@ describe('<FilterControl />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/ResourceList/components/Item/Item.tsx
+++ b/src/components/ResourceList/components/Item/Item.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
-import {createUniqueIDFactory, noop} from '@shopify/javascript-utilities/other';
+import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import compose from '@shopify/react-compose';
 import isEqual from 'lodash/isEqual';
 import {DisableableAction, WithContextTypes} from '../../../../types';
@@ -398,6 +398,8 @@ export class Item extends React.Component<CombinedProps, State> {
     this.setState({actionsMenuVisible: false});
   };
 }
+
+function noop() {}
 
 function stopPropagation(event: React.MouseEvent<any>) {
   event.stopPropagation();

--- a/src/components/ResourceList/components/Item/tests/Item.test.tsx
+++ b/src/components/ResourceList/components/Item/tests/Item.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {findByTestID, mountWithAppProvider, trigger} from 'test-utilities';
 import {
   Avatar,
@@ -480,3 +479,5 @@ describe('<Item />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
+++ b/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {ResourcePicker as AppBridgeResourcePicker} from '@shopify/app-bridge/actions';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import ResourcePicker from '../ResourcePicker';
 
@@ -179,6 +178,8 @@ describe('<ResourcePicker />', () => {
     });
   });
 });
+
+function noop() {}
 
 function mountWithAppBridge(element: React.ReactElement<any>) {
   const appBridge = {};

--- a/src/components/Select/tests/Select.test.tsx
+++ b/src/components/Select/tests/Select.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {ShallowWrapper} from 'enzyme';
-import {noop} from '@shopify/javascript-utilities/other';
 import {InlineError} from 'components';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import Select from '../Select';
@@ -339,3 +338,5 @@ describe('<Select />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/SettingToggle/tests/SettingToggle.test.tsx
+++ b/src/components/SettingToggle/tests/SettingToggle.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import SettingAction from 'components/SettingAction';
 import SettingToggle from '../SettingToggle';
@@ -61,3 +60,5 @@ describe('<SettingToggle />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/Sheet/tests/Sheet.test.tsx
+++ b/src/components/Sheet/tests/Sheet.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 
 import {CSSTransition} from 'react-transition-group';
-import {noop} from '@shopify/javascript-utilities/other';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {mountWithAppProvider} from 'test-utilities';
 
@@ -79,6 +78,8 @@ describe('<Sheet />', () => {
     );
   });
 });
+
+function noop() {}
 
 function mountWithContext(element: React.ReactElement<any>) {
   const frame = {};

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
-import {noop} from '@shopify/javascript-utilities/other';
 
 import Icon from '../Icon';
 import Popover from '../Popover';
@@ -309,6 +308,8 @@ export default class Tabs extends React.PureComponent<Props, State> {
     onSelect(selectedIndex);
   };
 }
+
+function noop() {}
 
 function handleKeyDown(event: React.KeyboardEvent<HTMLElement>) {
   const {key} = event;

--- a/src/components/Tabs/components/Item/Item.tsx
+++ b/src/components/Tabs/components/Item/Item.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 
 import styles from '../../Tabs.scss';
 import UnstyledLink from '../../../UnstyledLink';
@@ -72,3 +71,5 @@ export default class Item extends React.PureComponent<Props, never> {
     this.focusedNode = node;
   };
 }
+
+function noop() {}

--- a/src/components/Tabs/components/List/List.tsx
+++ b/src/components/Tabs/components/List/List.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 
 import Item from '../Item';
 import {TabDescriptor} from '../../types';
@@ -45,6 +44,8 @@ export default class List extends React.PureComponent<Props, never> {
     onKeyPress(event);
   };
 }
+
+function noop() {}
 
 function handleKeyDown(event: React.KeyboardEvent<HTMLElement>) {
   const {key} = event;

--- a/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
+++ b/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {findDOMNode} from 'react-dom';
-import {noop} from '@shopify/javascript-utilities/other';
 import {classNames} from '@shopify/react-utilities/styles';
 
 import EventListener from '../../../EventListener';
@@ -107,3 +106,5 @@ export default class TabMeasurer extends React.PureComponent<Props, never> {
     });
   };
 }
+
+function noop() {}

--- a/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
+++ b/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import TabMeasurer from '../TabMeasurer';
 import Tab from '../../Tab';
@@ -104,3 +103,5 @@ describe('<TabMeasurer />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {Tab, Panel, TabMeasurer, List} from '../components';
@@ -424,3 +423,5 @@ describe('<Tabs />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
+++ b/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider, findByTestID, trigger} from 'test-utilities';
 import Resizer from '../Resizer';
 import EventListener from '../../../../EventListener';
@@ -203,3 +202,5 @@ describe('<Resizer />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/TextField/components/Spinner/tests/Spinner.test.tsx
+++ b/src/components/TextField/components/Spinner/tests/Spinner.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {shallow} from 'enzyme';
-import {noop} from '@shopify/javascript-utilities/other';
 import Spinner from '../Spinner';
 
 describe('<Spinner />', () => {
@@ -91,3 +90,5 @@ describe('<Spinner />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {
   shallowWithAppProvider,
   mountWithAppProvider,
@@ -905,3 +904,5 @@ describe('<TextField />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/ThemeProvider/utils/index.ts
+++ b/src/components/ThemeProvider/utils/index.ts
@@ -1,5 +1,4 @@
 import tokens from '@shopify/polaris-tokens';
-import {noop} from '@shopify/javascript-utilities/other';
 import {needsVariantList} from '../config';
 import {HSLColor} from '../../../utilities/color-types';
 import {
@@ -134,3 +133,5 @@ export function createThemeContext(theme?: ThemeContext): ThemeProviderContext {
   const {logo = null, subscribe = noop, unsubscribe = noop} = theme;
   return {polarisTheme: {logo, subscribe, unsubscribe}};
 }
+
+function noop() {}

--- a/src/components/Toast/tests/Toast.test.tsx
+++ b/src/components/Toast/tests/Toast.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import {Toast as AppBridgeToast} from '@shopify/app-bridge/actions';
 import {mountWithAppProvider} from 'test-utilities';
-import {noop} from '../../../utilities/other';
 import Toast from '../Toast';
 
 describe('<Toast />', () => {
@@ -94,6 +93,8 @@ describe('<Toast />', () => {
     });
   });
 });
+
+function noop() {}
 
 function mountWithContext(element: React.ReactElement<any>) {
   const frame = {showToast: jest.fn(), hideToast: jest.fn()};

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {noop, createUniqueIDFactory} from '@shopify/javascript-utilities/other';
+import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {findFirstFocusableNode} from '@shopify/javascript-utilities/focus';
 
 import {PreferredPosition} from '../PositionedOverlay';
@@ -137,3 +137,5 @@ export default class Tooltip extends React.PureComponent<Props, State> {
     accessibilityNode.setAttribute('aria-describedby', id);
   }
 }
+
+function noop() {}

--- a/src/components/TopBar/components/Menu/components/Message/tests/Message.test.tsx
+++ b/src/components/TopBar/components/Menu/components/Message/tests/Message.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import Message from '../Message';
 import Badge from '../../../../../../Badge';
@@ -38,3 +37,5 @@ describe('<Message />', () => {
     expect(message.find(Badge)).toHaveLength(1);
   });
 });
+
+function noop() {}

--- a/src/components/TopBar/components/Menu/tests/Menu.test.tsx
+++ b/src/components/TopBar/components/Menu/tests/Menu.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 
 import {ActionList, Popover} from 'components';
@@ -131,3 +130,5 @@ describe('<Menu />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/TopBar/components/SearchField/SearchField.tsx
+++ b/src/components/TopBar/components/SearchField/SearchField.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {CircleCancelMinor, SearchMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 
-import {noop} from '../../../../utilities/other';
 import Icon from '../../../Icon';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 
@@ -153,6 +152,8 @@ export class SearchField extends React.Component<ComposedProps, never> {
     onChange(currentTarget.value);
   };
 }
+
+function noop() {}
 
 function preventDefault(event: React.KeyboardEvent<HTMLInputElement>) {
   if (event.key === 'Enter') {

--- a/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
+++ b/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {CircleCancelMinor} from '@shopify/polaris-icons';
-import {noop} from '@shopify/javascript-utilities/other';
 import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider} from 'test-utilities';
 import SearchField from '../SearchField';
@@ -130,6 +129,8 @@ describe('<TextField />', () => {
     });
   });
 });
+
+function noop() {}
 
 function findInput(wrapper: ReactWrapper) {
   return wrapper.find('input');

--- a/src/components/TopBar/components/UserMenu/components/UserMenu/tests/UserMenu.test.tsx
+++ b/src/components/TopBar/components/UserMenu/components/UserMenu/tests/UserMenu.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {NotificationMajorMonotone} from '@shopify/polaris-icons';
 
 import {ReactWrapper} from 'enzyme';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import Menu from '../../../../Menu';
 import UserMenu from '../UserMenu';
@@ -69,6 +68,8 @@ describe('<UserMenu />', () => {
     });
   });
 });
+
+function noop() {}
 
 function returnMenuProp(wrapper: ReactWrapper, prop: string) {
   return wrapper.find(Menu).prop(prop);

--- a/src/components/TopBar/components/UserMenu/context/tests/Modifier.test.tsx
+++ b/src/components/TopBar/components/UserMenu/context/tests/Modifier.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {ViewMinor} from '@shopify/polaris-icons';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import {UserMenuProps} from '../../components';
 import UserMenuContext from '../context';
@@ -31,3 +30,5 @@ describe('<Modifier />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
+++ b/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {ViewMinor} from '@shopify/polaris-icons';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import {UserMenuContext} from '../context';
 import {UserMenu as UserMenuComponent, UserMenuProps} from '../components';
@@ -83,3 +82,5 @@ describe('<UserMenu />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/components/TopBar/tests/TopBar.test.tsx
+++ b/src/components/TopBar/tests/TopBar.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {
   mountWithAppProvider,
   shallowWithAppProvider,
@@ -274,6 +273,8 @@ describe('<TopBar />', () => {
     });
   });
 });
+
+function noop() {}
 
 function addPolarisContext(logo: ThemeContext) {
   const context = {

--- a/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {noop} from '@shopify/javascript-utilities/other';
 import {mountWithAppProvider} from 'test-utilities';
 import {EventListener, Focus, TextContainer, TextField} from 'components';
 import TrapFocus from '../TrapFocus';
@@ -89,3 +88,5 @@ describe('<TrapFocus />', () => {
     expect(document.activeElement).toBe(focusedElement);
   });
 });
+
+function noop() {}

--- a/src/utilities/breakpoints.ts
+++ b/src/utilities/breakpoints.ts
@@ -1,5 +1,3 @@
-import {noop} from '@shopify/javascript-utilities/other';
-
 const Breakpoints = {
   navigationBarCollapsed: '768px',
   stackedContent: '1043px',
@@ -15,6 +13,8 @@ const noWindowMatches: MediaQueryList = {
   removeEventListener: noop,
   dispatchEvent: (_: Event) => true,
 };
+
+function noop() {}
 
 export function navigationBarCollapsed() {
   return typeof window === 'undefined'

--- a/src/utilities/other.ts
+++ b/src/utilities/other.ts
@@ -1,1 +1,0 @@
-export function noop() {}

--- a/src/utilities/tests/app-bridge-transformers.test.ts
+++ b/src/utilities/tests/app-bridge-transformers.test.ts
@@ -1,7 +1,8 @@
 import {ClientApplication} from '@shopify/app-bridge';
 import {Button, ButtonGroup, Redirect} from '@shopify/app-bridge/actions';
-import {noop} from '../other';
 import {generateRedirect, transformActions} from '../app-bridge-transformers';
+
+function noop() {}
 
 describe('app bridge transformers', () => {
   const appBridge = {} as ClientApplication<{}>;


### PR DESCRIPTION
Define them inline to move us towards removing our dependency on
`@shopify/javascript-utilities`, which is going to be deprecated eventually
