### PR TITLE
[v4] Add usePolaris/AppBridge 

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ export {
   default as AppProvider,
   Props as AppProviderProps,
   createAppProviderContext,
+  AppProviderContext,
   createPolarisContext,
   withAppProvider,
   WithAppProviderProps,
@@ -257,6 +258,7 @@ export {
   default as ThemeProvider,
   Props as ThemeProviderProps,
   ThemeProviderContextType,
+  ThemeProviderContext,
   createThemeContext,
 } from './ThemeProvider';
 
@@ -306,3 +308,5 @@ export {default as Indicator, Props as IndicatorProps} from './Indicator';
 export {default as withContext} from './WithContext';
 
 export {default as withRef, WithRef} from './WithRef';
+
+export {PolarisContext} from './types';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,3 @@
+export {default as usePolaris} from './use-polaris';
+
+export {default as useAppBridge} from './use-app-bridge';

--- a/src/hooks/use-app-bridge/index.ts
+++ b/src/hooks/use-app-bridge/index.ts
@@ -1,0 +1,3 @@
+import useAppBridge from './use-app-bridge';
+
+export default useAppBridge;

--- a/src/hooks/use-app-bridge/tests/use-app-bridge.test.tsx
+++ b/src/hooks/use-app-bridge/tests/use-app-bridge.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import isEqual from 'lodash/isEqual';
+import {createPolarisContext} from '../../../components';
+import {mountWithAppProvider} from '../../../test-utilities/enzyme';
+
+import useAppBridge from '../use-app-bridge';
+
+describe('useApp', () => {
+  it('returns context', () => {
+    function Component() {
+      return isEqual(useAppBridge(), createPolarisContext().appBridge) ? (
+        <div />
+      ) : null;
+    }
+
+    const component = mountWithAppProvider(<Component />);
+    expect(component.find('div')).toHaveLength(1);
+  });
+});

--- a/src/hooks/use-app-bridge/use-app-bridge.tsx
+++ b/src/hooks/use-app-bridge/use-app-bridge.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import {AppProviderContext} from '../../components';
+
+function useAppBridge() {
+  const {appBridge} = React.useContext(AppProviderContext);
+
+  return appBridge;
+}
+
+export default useAppBridge;

--- a/src/hooks/use-polaris/index.ts
+++ b/src/hooks/use-polaris/index.ts
@@ -1,0 +1,3 @@
+import usePolaris from './use-polaris';
+
+export default usePolaris;

--- a/src/hooks/use-polaris/tests/use-polaris.test.tsx
+++ b/src/hooks/use-polaris/tests/use-polaris.test.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import {mount} from 'enzyme';
+import {AppProviderContext, createPolarisContext} from '../../../components';
+import {mountWithAppProvider} from '../../../test-utilities/enzyme';
+import usePolaris from '../use-polaris';
+
+describe('usePolaris', () => {
+  it('throws when polaris is not defined', () => {
+    function Component() {
+      usePolaris();
+      return null;
+    }
+
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const fn = () => {
+      mount(
+        <AppProviderContext.Provider value={{} as any}>
+          <Component />
+        </AppProviderContext.Provider>,
+      );
+      consoleSpy.mockRestore();
+    };
+    expect(fn).toThrowError();
+  });
+
+  it('returns context', () => {
+    let context;
+    function Component() {
+      context = usePolaris();
+      return null;
+    }
+
+    mountWithAppProvider(<Component />);
+    expect(JSON.stringify(context)).toEqual(
+      JSON.stringify(createPolarisContext()),
+    );
+  });
+});

--- a/src/hooks/use-polaris/use-polaris.tsx
+++ b/src/hooks/use-polaris/use-polaris.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import {
+  AppProviderContext,
+  ThemeProviderContext,
+  PolarisContext,
+} from '../../components';
+
+function usePolaris() {
+  const polaris = React.useContext(AppProviderContext);
+
+  if (Object.keys(polaris).length < 1) {
+    throw new Error(
+      `The <AppProvider> component is required as of v2.0 of Polaris React. See
+                  https://polaris.shopify.com/components/structure/app-provider for implementation
+                  instructions.`,
+    );
+  }
+
+  const polarisTheme = React.useContext(ThemeProviderContext);
+
+  const polarisContext: PolarisContext = {
+    ...polaris,
+    theme: polarisTheme,
+  };
+
+  return polarisContext;
+}
+
+export default usePolaris;


### PR DESCRIPTION
### WHY are these changes introduced?

Preparing for hooks

### WHAT is this pull request doing?

* create a new directory for hooks `src/hooks`
* create `usePolaris` hook for internal use
* create `useAppBridge` hook for external use
* 🎉 tests 🎉 


### 🎩 

Trust in the powers of tests or try the playground - you'll need credentials for testing `useAppBridge`

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, AppProvider, Card} from '../src';
import {usePolaris, useAppBridge} from '../src/hooks';

interface State {}

const credentials = {
  apiKey: undefined,
  shopOrigin: undefined,
}

export default function() {
  const {apiKey, shopOrigin} = credentials;
  return (
    <AppProvider apiKey={apiKey} shopOrigin={shopOrigin}>
      <Page title="Playground">
        <Card title="usePolaris">
          {JSON.stringify(usePolaris(), null, 2)}
        </Card>

        <Card title="useAppBridge">
          {!apiKey && !shopOrigin ? "You'll need real credentials or this is undefined :shocked:" : '' }
          {JSON.stringify(useAppBridge())}
        </Card>
      </Page>
    </AppProvider>
  );
}
```

</details>
