### PR TITLE
[v4][ContextualSaveBar] Remove withContext

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -41,6 +41,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed `withContext` from `ResourceList.FilterControl` ([#1500](https://github.com/Shopify/polaris-react/pull/1500))
 - Upgraded the `Navigation` component from legacy context API to use createContext ([#1402](https://github.com/Shopify/polaris-react/pull/1402))
 - Updated `ThemeProvider` to no longer use `componentWillReceiveProps`([#1254](https://github.com/Shopify/polaris-react/pull/1254))
+- Removed `withContext` and `withAppProvider` from `ContextualSaveBar` ([#1498](https://github.com/Shopify/polaris-react/pull/1498))
 - Removed unused context from `Scrollable` ([#1253](https://github.com/Shopify/polaris-react/pull/1253))
 - Removed `withContext` from `Loading` ([#1497](https://github.com/Shopify/polaris-react/pull/1497))
 - Removed `withRef` from `UnstyledLink` ([#1501](https://github.com/Shopify/polaris-react/pull/1501))

--- a/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -1,64 +1,43 @@
-import React from 'react';
-import compose from '@shopify/react-compose';
-import isEqual from 'lodash/isEqual';
-import {ContextualSaveBarProps, FrameContextType, FrameContext} from '../Frame';
-import withContext from '../WithContext';
-import {WithContextTypes} from '../../types';
-import {withAppProvider, WithAppProviderProps} from '../AppProvider';
+import * as React from 'react';
+import {ContextualSaveBarProps, FrameContext} from '../Frame';
 
 // The script in the styleguide that generates the Props Explorer data expects
 // a component's props to be found in the Props interface. This silly workaround
 // ensures that the Props Explorer table is generated correctly, instead of
 // crashing if we write `ContextualSaveBar extends React.Component<ContextualSaveBarProps>`
 interface Props extends ContextualSaveBarProps {}
-export type ComposedProps = Props &
-  WithAppProviderProps &
-  WithContextTypes<FrameContextType>;
 
-class ContextualSaveBar extends React.PureComponent<ComposedProps, never> {
-  componentDidMount() {
-    const {
-      props: {polaris, context, ...rest},
-    } = this;
-    context.setContextualSaveBar(rest);
-  }
+export default function ContextualSaveBar({
+  message,
+  saveAction,
+  discardAction,
+  alignContentFlush,
+}: Props) {
+  const frame = React.useContext(FrameContext);
 
-  componentWillUnmount() {
-    this.props.context.removeContextualSaveBar();
-  }
+  React.useEffect(
+    () => {
+      if (!frame) return;
 
-  componentDidUpdate(oldProps: ComposedProps) {
-    const {
-      props: {polaris, context, ...rest},
-    } = this;
-    if (contextualSaveBarHasChanged(rest, oldProps)) {
-      context.setContextualSaveBar(rest);
-    }
-  }
-
-  render() {
-    return null;
-  }
-}
-
-function contextualSaveBarHasChanged(
-  {message, saveAction, discardAction}: Props,
-  {
-    message: oldMessage,
-    saveAction: oldsaveAction,
-    discardAction: oldDiscardAction,
-  }: Props,
-) {
-  return Boolean(
-    message !== oldMessage ||
-      !isEqual(saveAction, oldsaveAction) ||
-      !isEqual(discardAction, oldDiscardAction),
+      frame.setContextualSaveBar({
+        message,
+        saveAction,
+        discardAction,
+        alignContentFlush,
+      });
+    },
+    [message, saveAction, discardAction, alignContentFlush, frame],
   );
-}
 
-export default compose<Props>(
-  withContext<Props, WithAppProviderProps, FrameContextType>(
-    FrameContext.Consumer,
-  ),
-  withAppProvider(),
-)(ContextualSaveBar);
+  React.useEffect(
+    () => {
+      return () => {
+        if (!frame) return;
+        frame.removeContextualSaveBar();
+      };
+    },
+    [frame],
+  );
+
+  return null;
+}

--- a/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -7,7 +7,7 @@ import {ContextualSaveBarProps, FrameContext} from '../Frame';
 // crashing if we write `ContextualSaveBar extends React.Component<ContextualSaveBarProps>`
 interface Props extends ContextualSaveBarProps {}
 
-export default function ContextualSaveBar({
+export default React.memo(function ContextualSaveBar({
   message,
   saveAction,
   discardAction,
@@ -26,7 +26,8 @@ export default function ContextualSaveBar({
         alignContentFlush,
       });
     },
-    [message, saveAction, discardAction, alignContentFlush, frame],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [message, saveAction, discardAction, alignContentFlush],
   );
 
   React.useEffect(
@@ -36,8 +37,9 @@ export default function ContextualSaveBar({
         frame.removeContextualSaveBar();
       };
     },
-    [frame],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
   );
 
   return null;
-}
+});

--- a/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {mount} from 'enzyme';
 import {mountWithAppProvider} from 'test-utilities';
 import ContextualSaveBar from '../ContextualSaveBar';
 import {FrameContext, createFrameContext} from '../../Frame';
@@ -85,6 +86,23 @@ describe('<ContextualSaveBar />', () => {
       children: <ContextualSaveBar {...newProps} />,
     });
     expect(mockFrameContext.setContextualSaveBar).toHaveBeenCalledTimes(1);
+  });
+
+  it("doesn't call setContextualSave when frame is not defined", () => {
+    function fn() {
+      mount(<ContextualSaveBar {...props} />);
+    }
+
+    expect(fn).not.toThrow();
+  });
+
+  it("doesn't call removeContextualSave when frame is not defined", () => {
+    function fn() {
+      const contextualSavebar = mount(<ContextualSaveBar {...props} />);
+      contextualSavebar.unmount();
+    }
+
+    expect(fn).not.toThrow();
   });
 });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Part of #1484

### WHAT is this pull request doing?

I'm converting ContextualSaveBar to a functional component and removing `withContext`

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
Tests / percy / development server