### PR TITLE
[v4][Scrollable.ScrollTo] Remove withContext

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -29,6 +29,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed testID warning in tests ([#1447](https://github.com/Shopify/polaris-react/pull/1447))
 - Updated `ThemeProvider` to use the new context api ([#1396](https://github.com/Shopify/polaris-react/pull/1396))
 - Updated `AppProvider` to no longer use `componentWillReceiveProps`([#1255](https://github.com/Shopify/polaris-react/pull/1255))
+- Removed `withContext` from `Scrollable.ScrollTo` and added a test to boost coverage ([#1499](https://github.com/Shopify/polaris-react/pull/1499))
 - Upgraded the `Navigation` component from legacy context API to use createContext ([#1402](https://github.com/Shopify/polaris-react/pull/1402))
 - Updated `ThemeProvider` to no longer use `componentWillReceiveProps`([#1254](https://github.com/Shopify/polaris-react/pull/1254))
 - Removed unused context from `Scrollable` ([#1253](https://github.com/Shopify/polaris-react/pull/1253))

--- a/src/components/Scrollable/components/ScrollTo/ScrollTo.tsx
+++ b/src/components/Scrollable/components/ScrollTo/ScrollTo.tsx
@@ -1,31 +1,20 @@
 import * as React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
-import withContext from '../../../WithContext';
-import ScrollableContext, {ScrollableContextType} from '../../context';
-import {WithContextTypes} from '../../../../types';
+import ScrollableContext from '../../context';
 
-type ComposedProps = WithContextTypes<ScrollableContextType>;
+export default function ScrollTo() {
+  const anchorNode = React.useRef<HTMLAnchorElement>(null);
+  const {scrollToPosition} = React.useContext(ScrollableContext);
 
-class ScrollTo extends React.Component<ComposedProps, never> {
-  private ref: React.RefObject<HTMLAnchorElement> = React.createRef();
-
-  componentDidMount() {
-    const {scrollToPosition} = this.props.context;
-
-    if (!scrollToPosition || !this.ref.current) {
+  React.useEffect(() => {
+    if (!scrollToPosition || !anchorNode.current) {
       return;
     }
 
-    scrollToPosition(this.ref.current.offsetTop);
-  }
+    scrollToPosition(anchorNode.current.offsetTop);
+  }, []);
 
-  render() {
-    const getUniqueId = createUniqueIDFactory(`ScrollTo`);
-    // eslint-disable-next-line jsx-a11y/anchor-is-valid
-    return <a id={getUniqueId()} ref={this.ref} />;
-  }
+  const getUniqueId = createUniqueIDFactory(`ScrollTo`);
+  // eslint-disable-next-line jsx-a11y/anchor-is-valid
+  return <a id={getUniqueId()} ref={anchorNode} />;
 }
-
-export default withContext<{}, {}, ScrollableContextType>(
-  ScrollableContext.Consumer,
-)(ScrollTo);

--- a/src/components/Scrollable/components/ScrollTo/tests/ScrollTo.test.tsx
+++ b/src/components/Scrollable/components/ScrollTo/tests/ScrollTo.test.tsx
@@ -18,4 +18,20 @@ describe('<Scrollable.ScrollTo />', () => {
 
     expect(spy).toHaveBeenCalled();
   });
+
+  it("does not call scrollToPosition when it's undefined", () => {
+    const mockContext = {
+      scrollToPosition: undefined,
+    };
+
+    function fn() {
+      mountWithAppProvider(
+        <ScrollableContext.Provider value={mockContext}>
+          <ScrollTo />
+        </ScrollableContext.Provider>,
+      );
+    }
+
+    expect(fn).not.toThrowError();
+  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Part of #1484

### WHAT is this pull request doing?

I'm converting Scrollable.ScrollTo to a functional component and removing `withContext`

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
Tests / percy / development server