### PR TITLE
[v4] Pull hooks up

### DIFF
--- a/src/hooks/tests/use-app-bridge.test.tsx
+++ b/src/hooks/tests/use-app-bridge.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import isEqual from 'lodash/isEqual';
-import {createPolarisContext} from '../../../components';
-import {mountWithAppProvider} from '../../../test-utilities/enzyme';
-
+import {createPolarisContext} from '../../components';
+import {mountWithAppProvider} from '../../test-utilities/enzyme';
 import useAppBridge from '../use-app-bridge';
 
 describe('useApp', () => {

--- a/src/hooks/tests/use-polaris.test.tsx
+++ b/src/hooks/tests/use-polaris.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {mount} from 'enzyme';
-import {AppProviderContext, createPolarisContext} from '../../../components';
-import {mountWithAppProvider} from '../../../test-utilities/enzyme';
+import {AppProviderContext, createPolarisContext} from '../../components';
+import {mountWithAppProvider} from '../../test-utilities/enzyme';
 import usePolaris from '../use-polaris';
 
 describe('usePolaris', () => {

--- a/src/hooks/use-app-bridge.tsx
+++ b/src/hooks/use-app-bridge.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {AppProviderContext} from '../../components';
+import {AppProviderContext} from '../components';
 
 function useAppBridge() {
   const {appBridge} = React.useContext(AppProviderContext);

--- a/src/hooks/use-app-bridge/index.ts
+++ b/src/hooks/use-app-bridge/index.ts
@@ -1,3 +1,0 @@
-import useAppBridge from './use-app-bridge';
-
-export default useAppBridge;

--- a/src/hooks/use-polaris.tsx
+++ b/src/hooks/use-polaris.tsx
@@ -3,7 +3,7 @@ import {
   AppProviderContext,
   ThemeProviderContext,
   PolarisContext,
-} from '../../components';
+} from '../components';
 
 function usePolaris() {
   const polaris = React.useContext(AppProviderContext);

--- a/src/hooks/use-polaris/index.ts
+++ b/src/hooks/use-polaris/index.ts
@@ -1,3 +1,0 @@
-import usePolaris from './use-polaris';
-
-export default usePolaris;


### PR DESCRIPTION
Per my slightly late comment on #1482, there's no need for sub folders as each hook will always be a single file so having a nested directory structure doesn't offer any value

- Move `src/hooks/use-polaris/use-polaris.ts` to `src/hooks/use-polaris.ts`
- Move `src/hooks/use-polaris/tests/use-polaris.ts` to `src/hooks/tests/use-polaris.ts`
- Same for `use-app-bridge`