### PR TITLE
Update to use default import for react and prop-types

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,7 +38,7 @@ Fixes #0000 <!-- link to issue if one exists -->
 <summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>
 
 ```jsx
-import * as React from 'react';
+import React from 'react';
 import {Page} from '@shopify/polaris';
 
 interface State {}

--- a/.storybook/stories-from-readme.js
+++ b/.storybook/stories-from-readme.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import * as Polaris from '../src';
 import {withA11y} from '@storybook/addon-a11y';
 import {storiesOf} from '@storybook/react';

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -24,6 +24,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Development workflow
 
+- Import react using the default import `import React` instead of namespace imports `import * as React` ([#1515](https://github.com/Shopify/polaris-react/pull/1515))
+
 ### Dependency upgrades
 
 - Removed runtime dependency on `@shopify/images` as we never needed it at runtime ([#1474](https://github.com/Shopify/polaris-react/pull/1474))

--- a/config/typescript/react.d.ts
+++ b/config/typescript/react.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 declare module 'react' {
   interface Attributes {

--- a/playground/Playground.tsx
+++ b/playground/Playground.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Page} from '../src';
 
 interface State {}

--- a/src/components/AccountConnection/AccountConnection.tsx
+++ b/src/components/AccountConnection/AccountConnection.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {Action} from '../../types';
 import Avatar from '../Avatar';

--- a/src/components/AccountConnection/tests/AccountConnection.test.tsx
+++ b/src/components/AccountConnection/tests/AccountConnection.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {Avatar, buttonFrom} from 'components';
 import AccountConnection from '../AccountConnection';

--- a/src/components/ActionList/ActionList.tsx
+++ b/src/components/ActionList/ActionList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ActionListItemDescriptor, ActionListSection} from '../../types';
 import {Section} from './components';
 

--- a/src/components/ActionList/components/Item/Item.tsx
+++ b/src/components/ActionList/components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities';
 
 import {ActionListItemDescriptor} from '../../../../types';

--- a/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {UnstyledLink} from 'components';
 import Item from '../Item';

--- a/src/components/ActionList/components/Section/Section.tsx
+++ b/src/components/ActionList/components/Section/Section.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import Item from '../Item';
 import {ActionListItemDescriptor, ActionListSection} from '../../../../types';
 

--- a/src/components/ActionList/components/Section/tests/Section.test.tsx
+++ b/src/components/ActionList/components/Section/tests/Section.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Item from '../../Item';
 import Section from '../Section';

--- a/src/components/ActionList/tests/ActionList.test.tsx
+++ b/src/components/ActionList/tests/ActionList.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import ActionList from '../ActionList';
 import {Item, Section} from '../components';

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import ThemeProvider from '../ThemeProvider';
 import {
   StickyManager,

--- a/src/components/AppProvider/README.md
+++ b/src/components/AppProvider/README.md
@@ -398,7 +398,7 @@ To provide access to your initialized Shopify App Bridge instance, we make it av
 ```js
 import React from 'react';
 import {render} from 'react-dom';
-import * as PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import {AppProvider} from '@shopify/polaris';
 import {Redirect} from '@shopify/app-bridge/actions';
 

--- a/src/components/AppProvider/tests/AppProvider.test.tsx
+++ b/src/components/AppProvider/tests/AppProvider.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import {createThemeContext} from '../../ThemeProvider';
 import {StickyManager, createAppProviderContext} from '../utilities';

--- a/src/components/AppProvider/types.ts
+++ b/src/components/AppProvider/types.ts
@@ -1,6 +1,6 @@
 import {ClientApplication} from '@shopify/app-bridge';
 import {ValidationMap} from 'react';
-import * as PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import {LinkLikeComponent} from '../UnstyledLink';
 import {Theme, THEME_CONTEXT_TYPES as polarisTheme} from '../ThemeProvider';
 import {

--- a/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
+++ b/src/components/AppProvider/utilities/createAppProviderContext/tests/createAppProviderContext.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import * as appBridge from '@shopify/app-bridge';
 import * as targets from '@shopify/react-utilities/target';
 import createAppProviderContext, {

--- a/src/components/AppProvider/utilities/createPolarisContext/tests/createPolarisContext.test.tsx
+++ b/src/components/AppProvider/utilities/createPolarisContext/tests/createPolarisContext.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {StickyManager} from '../../withSticky';
 import ScrollLockManager from '../../ScrollLockManager';
 import createPolarisContext from '../createPolarisContext';

--- a/src/components/AppProvider/utilities/withAppProvider/withAppProvider.tsx
+++ b/src/components/AppProvider/utilities/withAppProvider/withAppProvider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 import {ClientApplication} from '@shopify/app-bridge';
 import merge from '../../../../utilities/merge';

--- a/src/components/AppProvider/utilities/withSticky/withSticky.tsx
+++ b/src/components/AppProvider/utilities/withSticky/withSticky.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 import merge from '../../../../utilities/merge';
 import {WithAppProviderProps} from '../withAppProvider';

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {ActionListItemDescriptor} from '../../types';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import OptionList, {OptionDescriptor} from '../../../OptionList';
 import ActionList from '../../../ActionList';

--- a/src/components/Autocomplete/components/ComboBox/components/TextField/TextField.tsx
+++ b/src/components/Autocomplete/components/ComboBox/components/TextField/TextField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {contextTypes} from '../../../types';
 import BaseTextField, {Props as TextFieldProps} from '../../../../../TextField';

--- a/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
+++ b/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {shallow} from 'enzyme';
 import {OptionList, ActionList, Popover} from 'components';
 import {mountWithAppProvider, trigger} from 'test-utilities';

--- a/src/components/Autocomplete/components/types.ts
+++ b/src/components/Autocomplete/components/types.ts
@@ -1,4 +1,4 @@
-import * as PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import {ValidationMap} from 'react';
 
 export const contextTypes: ValidationMap<any> = {

--- a/src/components/Autocomplete/tests/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/tests/Autocomplete.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {CirclePlusMinor} from '@shopify/polaris-icons';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {Spinner} from 'components';

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {isServer} from '@shopify/react-utilities/target';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 

--- a/src/components/Avatar/tests/Avatar.test.tsx
+++ b/src/components/Avatar/tests/Avatar.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import * as targets from '@shopify/react-utilities/target';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {Image} from 'components';

--- a/src/components/Backdrop/Backdrop.tsx
+++ b/src/components/Backdrop/Backdrop.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities';
 
 import ScrollLock from '../ScrollLock';

--- a/src/components/Backdrop/tests/Backdrop.test.tsx
+++ b/src/components/Backdrop/tests/Backdrop.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider, findByTestID} from 'test-utilities';
 import BackDrop from '..';
 

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import VisuallyHidden from '../VisuallyHidden';

--- a/src/components/Badge/tests/Badge.test.tsx
+++ b/src/components/Badge/tests/Badge.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {VisuallyHidden} from 'components';
 import Badge, {Status, Progress, PROGRESS_LABELS, STATUS_LABELS} from '..';

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 import {
   CancelSmallMinor,

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider} from 'test-utilities';
 import {

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ChevronLeftMinor} from '@shopify/polaris-icons';
 
 import Icon from '../Icon';

--- a/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {CallbackAction, LinkAction} from '../../../types';
 import Breadcrumbs from '../Breadcrumbs';

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {CaretDownMinor} from '@shopify/polaris-icons';
 import {classNames, variationName} from '@shopify/react-utilities';
 

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   shallowWithAppProvider,
   mountWithAppProvider,

--- a/src/components/Button/utils.tsx
+++ b/src/components/Button/utils.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ComplexAction} from '../../types';
 import Button, {Props} from './Button';
 

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import {elementChildren} from '@shopify/react-utilities';
 import {Item} from './components';

--- a/src/components/ButtonGroup/components/Item/Item.tsx
+++ b/src/components/ButtonGroup/components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 
 import {Props as ButtonProps} from '../../../Button';

--- a/src/components/ButtonGroup/components/Item/tests/Item.test.tsx
+++ b/src/components/ButtonGroup/components/Item/tests/Item.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {Button} from 'components';
 import Item from '../Item';

--- a/src/components/ButtonGroup/tests/ButtonGroup.test.tsx
+++ b/src/components/ButtonGroup/tests/ButtonGroup.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {Button} from 'components';
 import {Item} from '../components';

--- a/src/components/CalloutCard/CalloutCard.tsx
+++ b/src/components/CalloutCard/CalloutCard.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {CancelSmallMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities';
 

--- a/src/components/CalloutCard/tests/CalloutCard.test.tsx
+++ b/src/components/CalloutCard/tests/CalloutCard.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {Button} from 'components';
 import CalloutCard from '../CalloutCard';

--- a/src/components/Caption/Caption.tsx
+++ b/src/components/Caption/Caption.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styles from './Caption.scss';
 
 export interface Props {

--- a/src/components/Caption/tests/Caption.test.tsx
+++ b/src/components/Caption/tests/Caption.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Caption from '../Caption';
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 
 import {Action, DisableableAction, contentContextTypes} from '../../types';

--- a/src/components/Card/components/Header/Header.tsx
+++ b/src/components/Card/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {DisableableAction} from '../../../../types';
 import {buttonsFrom} from '../../../Button';

--- a/src/components/Card/components/Header/tests/Header.test.tsx
+++ b/src/components/Card/components/Header/tests/Header.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {ButtonGroup, Heading, buttonsFrom} from 'components';
 import Header from '../Header';

--- a/src/components/Card/components/Section/Section.tsx
+++ b/src/components/Card/components/Section/Section.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 
 import Subheading from '../../../Subheading';

--- a/src/components/Card/components/Section/tests/Section.test.tsx
+++ b/src/components/Card/components/Section/tests/Section.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {Badge, Subheading} from 'components';
 import Section from '../Section';

--- a/src/components/Card/tests/Card.test.tsx
+++ b/src/components/Card/tests/Card.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {Card, Badge, Button} from 'components';
 import {contentContextTypes} from '../../../types';

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {MinusMinor, TickSmallMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';

--- a/src/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/Checkbox/tests/Checkbox.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import {Key} from '../../../types';
 import Checkbox from '../Checkbox';

--- a/src/components/Choice/Choice.tsx
+++ b/src/components/Choice/Choice.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 
 import {Error} from '../../types';

--- a/src/components/Choice/tests/Choice.test.tsx
+++ b/src/components/Choice/tests/Choice.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {InlineError} from 'components';
 import Choice from '../Choice';

--- a/src/components/ChoiceList/ChoiceList.tsx
+++ b/src/components/ChoiceList/ChoiceList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 

--- a/src/components/ChoiceList/tests/ChoiceList.test.tsx
+++ b/src/components/ChoiceList/tests/ChoiceList.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import {RadioButton, Checkbox, InlineError} from 'components';

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import * as PropTypes from 'prop-types';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {classNames} from '@shopify/react-utilities/styles';
 import {
   addEventListener,

--- a/src/components/Collapsible/tests/Collapsible.test.tsx
+++ b/src/components/Collapsible/tests/Collapsible.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {shallowWithAppProvider} from 'test-utilities';
 import Collapsible from '../Collapsible';
 

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {clamp} from '@shopify/javascript-utilities/math';
 
 import {hsbToRgb} from '../../utilities/color-transformers';

--- a/src/components/ColorPicker/components/AlphaPicker/AlphaPicker.tsx
+++ b/src/components/ColorPicker/components/AlphaPicker/AlphaPicker.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import Slidable, {Position} from '../Slidable';
 import {HSBColor} from '../../../../utilities/color-types';
 import {hsbToRgb} from '../../../../utilities/color-transformers';

--- a/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
+++ b/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {calculateDraggerY, alphaForDraggerY} from '../utilities';
 import Slidable from '../../Slidable';

--- a/src/components/ColorPicker/components/HuePicker/HuePicker.tsx
+++ b/src/components/ColorPicker/components/HuePicker/HuePicker.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import Slidable, {Position} from '../Slidable';
 import styles from '../../ColorPicker.scss';
 import {calculateDraggerY, hueForDraggerY} from './utilities';

--- a/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
+++ b/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {calculateDraggerY, hueForDraggerY} from '../utilities';
 import Slidable from '../../Slidable';

--- a/src/components/ColorPicker/components/Slidable/Slidable.tsx
+++ b/src/components/ColorPicker/components/Slidable/Slidable.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {isServer} from '@shopify/react-utilities/target';
 import EventListener from '../../../EventListener';
 

--- a/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import EventListener from '../../EventListener';
 import {Slidable, AlphaPicker} from '../components';

--- a/src/components/Connected/Connected.tsx
+++ b/src/components/Connected/Connected.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {Item, ItemPosition} from './components';
 import styles from './Connected.scss';

--- a/src/components/Connected/components/Item/Item.tsx
+++ b/src/components/Connected/components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import styles from '../../Connected.scss';
 

--- a/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import isEqual from 'lodash/isEqual';
 import {
   ContextualSaveBarProps,

--- a/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import * as PropTypes from 'prop-types';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {mountWithAppProvider} from 'test-utilities';
 import ContextualSaveBar from '../ContextualSaveBar';
 

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import isEqual from 'lodash/isEqual';
 import debounce from 'lodash/debounce';

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {CaretUpMinor, CaretDownMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 

--- a/src/components/DataTable/components/Navigation/Navigation.tsx
+++ b/src/components/DataTable/components/Navigation/Navigation.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ChevronLeftMinor, ChevronRightMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 

--- a/src/components/DataTable/components/Navigation/tests/Navigation.test.tsx
+++ b/src/components/DataTable/components/Navigation/tests/Navigation.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {Button} from 'components';
 import Navigation from '../Navigation';

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider, findByTestID} from 'test-utilities';
 import {isEdgeVisible, getPrevAndCurrentColumns} from '../utilities';
 import {Cell, Navigation} from '../components';

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ArrowLeftMinor, ArrowRightMinor} from '@shopify/polaris-icons';
 import {
   Range,

--- a/src/components/DatePicker/components/Day/Day.tsx
+++ b/src/components/DatePicker/components/Day/Day.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import {Months, isSameDay} from '@shopify/javascript-utilities/dates';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';

--- a/src/components/DatePicker/components/Day/tests/Day.test.tsx
+++ b/src/components/DatePicker/components/Day/tests/Day.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Day from '../Day';
 

--- a/src/components/DatePicker/components/Month/Month.tsx
+++ b/src/components/DatePicker/components/Month/Month.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   Range,
   Weekdays,

--- a/src/components/DatePicker/components/Month/tests/Month.test.tsx
+++ b/src/components/DatePicker/components/Month/tests/Month.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Weekdays} from '@shopify/javascript-utilities/dates';
 import {mountWithAppProvider} from 'test-utilities';
 import {Weekday} from '../..';

--- a/src/components/DatePicker/components/Weekday/Weekday.tsx
+++ b/src/components/DatePicker/components/Weekday/Weekday.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Weekdays} from '@shopify/javascript-utilities/dates';
 import {classNames} from '@shopify/react-utilities/styles';
 import styles from '../../DatePicker.scss';

--- a/src/components/DatePicker/components/Weekday/tests/Weekday.test.tsx
+++ b/src/components/DatePicker/components/Weekday/tests/Weekday.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Weekdays} from '@shopify/javascript-utilities/dates';
 import {mountWithAppProvider} from 'test-utilities';
 import Weekday from '../Weekday';

--- a/src/components/DatePicker/tests/DatePicker.test.tsx
+++ b/src/components/DatePicker/tests/DatePicker.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Weekdays} from '@shopify/javascript-utilities/dates';
 import {mountWithAppProvider} from 'test-utilities';
 import {Day, Month, Weekday} from '../components';

--- a/src/components/DescriptionList/DescriptionList.tsx
+++ b/src/components/DescriptionList/DescriptionList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import styles from './DescriptionList.scss';
 

--- a/src/components/DescriptionList/tests/DescriptionList.test.tsx
+++ b/src/components/DescriptionList/tests/DescriptionList.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 
 import DescriptionList from '../DescriptionList';

--- a/src/components/DisplayText/DisplayText.tsx
+++ b/src/components/DisplayText/DisplayText.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 import {HeadingTagName} from '../../types';
 import styles from './DisplayText.scss';

--- a/src/components/DisplayText/tests/DisplayText.test.tsx
+++ b/src/components/DisplayText/tests/DisplayText.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 
 import DisplayText from '../DisplayText';

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {classNames} from '@shopify/react-utilities/styles';
 import debounce from 'lodash/debounce';

--- a/src/components/DropZone/components/Context/Context.tsx
+++ b/src/components/DropZone/components/Context/Context.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {DropZoneContext} from '../../types';
 
 const {Provider, Consumer} = React.createContext<DropZoneContext>({

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import {DragDropMajorMonotone} from '@shopify/polaris-icons';
 

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Link, Icon, Button, Caption, TextStyle} from 'components';
 import {mountWithAppProvider} from 'test-utilities';
 import {Provider} from '../../Context';

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {clock} from '@shopify/jest-dom-mocks';
 import {Label, Labelled, DisplayText, Caption} from 'components';

--- a/src/components/EmptySearchResult/EmptySearchResult.tsx
+++ b/src/components/EmptySearchResult/EmptySearchResult.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import DisplayText from '../DisplayText';

--- a/src/components/EmptySearchResult/tests/EmptySearchResult.test.tsx
+++ b/src/components/EmptySearchResult/tests/EmptySearchResult.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {DisplayText, TextStyle} from 'components';
 import EmptySearchResult from '../EmptySearchResult';

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 
 import {Action} from '../../types';

--- a/src/components/EmptyState/tests/EmptyState.test.tsx
+++ b/src/components/EmptyState/tests/EmptyState.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {Image, DisplayText, TextContainer, Link} from 'components';
 import EmptyState from '../EmptyState';

--- a/src/components/EventListener/EventListener.tsx
+++ b/src/components/EventListener/EventListener.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   addEventListener,
   removeEventListener,

--- a/src/components/EventListener/tests/EventListener.test.tsx
+++ b/src/components/EventListener/tests/EventListener.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import EventListener from '../EventListener';
 

--- a/src/components/ExceptionList/ExceptionList.tsx
+++ b/src/components/ExceptionList/ExceptionList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 
 import Icon, {Props as IconProps} from '../Icon';

--- a/src/components/ExceptionList/tests/ExceptionList.test.tsx
+++ b/src/components/ExceptionList/tests/ExceptionList.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {CirclePlusMinor, NoteMinor} from '@shopify/polaris-icons';
 import {mountWithAppProvider} from 'test-utilities';
 import {Icon} from 'components';

--- a/src/components/Focus/Focus.tsx
+++ b/src/components/Focus/Focus.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import React from 'react';
+import {findDOMNode} from 'react-dom';
 import isEqual from 'lodash/isEqual';
 import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
 
@@ -28,7 +28,7 @@ export default class Focus extends React.PureComponent<Props, never> {
       return;
     }
 
-    const root = ReactDOM.findDOMNode(this) as HTMLElement | null;
+    const root = findDOMNode(this) as HTMLElement | null;
     if (root) {
       if (!root.querySelector('[autofocus]')) {
         focusFirstFocusableNode(root, false);

--- a/src/components/Focus/tests/Focus.test.tsx
+++ b/src/components/Focus/tests/Focus.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Focus from '../Focus';
 

--- a/src/components/FooterHelp/FooterHelp.tsx
+++ b/src/components/FooterHelp/FooterHelp.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {QuestionMarkMajorTwotone} from '@shopify/polaris-icons';
 import Icon from '../Icon';
 import styles from './FooterHelp.scss';

--- a/src/components/FooterHelp/tests/FooterHelp.test.tsx
+++ b/src/components/FooterHelp/tests/FooterHelp.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {QuestionMarkMajorTwotone} from '@shopify/polaris-icons';
 import {mountWithAppProvider} from 'test-utilities';
 import {Icon} from 'components';

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import VisuallyHidden from '../VisuallyHidden';
 

--- a/src/components/Form/tests/Form.test.tsx
+++ b/src/components/Form/tests/Form.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Form from '../Form';
 

--- a/src/components/FormLayout/FormLayout.tsx
+++ b/src/components/FormLayout/FormLayout.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {wrapWithComponent, isElementOfType} from '@shopify/react-utilities';
 
 import {Group, Item, ItemProps} from './components';

--- a/src/components/FormLayout/components/Group/Group.tsx
+++ b/src/components/FormLayout/components/Group/Group.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {classNames} from '@shopify/react-utilities/styles';
 import {wrapWithComponent} from '@shopify/react-utilities';

--- a/src/components/FormLayout/components/Group/tests/Group.test.tsx
+++ b/src/components/FormLayout/components/Group/tests/Group.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {TextField} from 'components';
 import Group from '../Group';

--- a/src/components/FormLayout/components/Item/Item.tsx
+++ b/src/components/FormLayout/components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styles from '../../FormLayout.scss';
 
 export interface Props {

--- a/src/components/FormLayout/components/Item/tests/Item.test.tsx
+++ b/src/components/FormLayout/components/Item/tests/Item.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {TextField} from 'components';
 import Item from '../Item';

--- a/src/components/FormLayout/tests/FormLayout.test.tsx
+++ b/src/components/FormLayout/tests/FormLayout.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {TextField} from 'components';
 import FormLayout from '../FormLayout';

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {MobileCancelMajorMonotone} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {durationSlow} from '@shopify/polaris-tokens';

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {getWidth} from '../../../../utilities/getWidth';
 

--- a/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/DiscardConfirmationModal.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/DiscardConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {
   withAppProvider,

--- a/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/tests/DiscardConfirmationModal.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/tests/DiscardConfirmationModal.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {shallowWithAppProvider, trigger} from 'test-utilities';
 

--- a/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {polarisAppProviderContextTypes} from 'components/AppProvider';
 import {createThemeContext, ThemeContext} from 'components/ThemeProvider';

--- a/src/components/Frame/components/Loading/Loading.tsx
+++ b/src/components/Frame/components/Loading/Loading.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import debounce from 'lodash/debounce';
 import styles from './Loading.scss';
 

--- a/src/components/Frame/components/Loading/tests/Loading.test.tsx
+++ b/src/components/Frame/components/Loading/tests/Loading.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Loading from '../Loading';
 

--- a/src/components/Frame/components/Toast/Toast.tsx
+++ b/src/components/Frame/components/Toast/Toast.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {MobileCancelMajorMonotone} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities';
 

--- a/src/components/Frame/components/Toast/tests/Toast.test.tsx
+++ b/src/components/Frame/components/Toast/tests/Toast.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {timer} from '@shopify/jest-dom-mocks';
 import {mountWithAppProvider, trigger, findByTestID} from 'test-utilities';
 import Button from '../../../../Button';

--- a/src/components/Frame/components/ToastManager/ToastManager.tsx
+++ b/src/components/Frame/components/ToastManager/ToastManager.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {TransitionGroup, CSSTransition} from 'react-transition-group';
 import {classNames} from '@shopify/react-utilities/styles';
 import EventListener from '../../../EventListener';

--- a/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
+++ b/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {timer} from '@shopify/jest-dom-mocks';
 import {mountWithAppProvider} from 'test-utilities';
 import Toast from '../../Toast';

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {CSSTransition} from 'react-transition-group';
 import {animationFrame} from '@shopify/jest-dom-mocks';
 import {mountWithAppProvider, documentHasStyle} from 'test-utilities';

--- a/src/components/Frame/types.ts
+++ b/src/components/Frame/types.ts
@@ -1,4 +1,4 @@
-import * as PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import {Action} from '../../types';
 
 export interface FrameManager {

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {HeadingTagName} from '../../types';
 import styles from './Heading.scss';
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 import {
   PlusMinor,

--- a/src/components/Icon/tests/Icon.test.tsx
+++ b/src/components/Icon/tests/Icon.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {PlusMinor} from '@shopify/polaris-icons';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import Icon from '../Icon';

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 export interface SourceSet {
   source: string;

--- a/src/components/Image/tests/Image.test.tsx
+++ b/src/components/Image/tests/Image.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import Image from '../Image';
 

--- a/src/components/Indicator/Indicator.tsx
+++ b/src/components/Indicator/Indicator.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import styles from './Indicator.scss';
 

--- a/src/components/Indicator/tests/Indicator.test.tsx
+++ b/src/components/Indicator/tests/Indicator.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Indicator from '../Indicator';
 

--- a/src/components/InlineError/InlineError.tsx
+++ b/src/components/InlineError/InlineError.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {AlertMinor} from '@shopify/polaris-icons';
 
 import Icon from '../Icon';

--- a/src/components/InlineError/tests/InlineError.test.tsx
+++ b/src/components/InlineError/tests/InlineError.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import InlineError from '../InlineError';
 

--- a/src/components/KeyboardKey/KeyboardKey.tsx
+++ b/src/components/KeyboardKey/KeyboardKey.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styles from './KeyboardKey.scss';
 
 export interface Props {

--- a/src/components/KeyboardKey/tests/KeyboardKey.test.tsx
+++ b/src/components/KeyboardKey/tests/KeyboardKey.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import KeyboardKey from '../KeyboardKey';
 

--- a/src/components/KeypressListener/KeypressListener.tsx
+++ b/src/components/KeypressListener/KeypressListener.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   addEventListener,
   removeEventListener,

--- a/src/components/KeypressListener/tests/KeypressListener.test.tsx
+++ b/src/components/KeypressListener/tests/KeypressListener.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {Key} from '../../../types';
 import KeypressListener from '../KeypressListener';

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 
 import styles from './Label.scss';

--- a/src/components/Label/tests/Label.test.tsx
+++ b/src/components/Label/tests/Label.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Label, {labelID} from '../Label';
 

--- a/src/components/Labelled/Labelled.tsx
+++ b/src/components/Labelled/Labelled.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 
 import {Action, Error} from '../../types';

--- a/src/components/Labelled/tests/Labelled.test.tsx
+++ b/src/components/Labelled/tests/Labelled.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {InlineError, Label, buttonFrom, Labelled} from 'components';
 import {mountWithAppProvider} from 'test-utilities';
 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {AnnotatedSection, Section} from './components';
 import styles from './Layout.scss';
 

--- a/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
+++ b/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import Heading from '../../../Heading';
 import TextContainer from '../../../TextContainer';
 import styles from '../../Layout.scss';

--- a/src/components/Layout/components/Section/Section.tsx
+++ b/src/components/Layout/components/Section/Section.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import styles from '../../Layout.scss';
 

--- a/src/components/Layout/tests/Layout.test.tsx
+++ b/src/components/Layout/tests/Layout.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   findByTestID,
   matchByTestID,

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {classNames} from '@shopify/react-utilities';
 import {ExternalSmallMinor} from '@shopify/polaris-icons';

--- a/src/components/Link/tests/Link.test.tsx
+++ b/src/components/Link/tests/Link.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {UnstyledLink, Icon} from 'components';
 import en from '../../../locales/en.json';

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 import {Item} from './components';
 import styles from './List.scss';

--- a/src/components/List/components/Item/Item.tsx
+++ b/src/components/List/components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styles from '../../List.scss';
 
 export interface Props {

--- a/src/components/List/components/Item/tests/Item.test.tsx
+++ b/src/components/List/components/Item/tests/Item.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Item from '../Item';
 

--- a/src/components/List/tests/List.test.tsx
+++ b/src/components/List/tests/List.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import List from '../List';
 

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Loading as AppBridgeLoading} from '@shopify/app-bridge/actions';
 import {FrameContext, frameContextTypes} from '../Frame';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';

--- a/src/components/Loading/tests/Loading.test.tsx
+++ b/src/components/Loading/tests/Loading.test.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 import {Loading as AppBridgeLoading} from '@shopify/app-bridge/actions';
-import * as PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import {mountWithAppProvider} from 'test-utilities';
 
 import Loading from '../Loading';

--- a/src/components/MessageIndicator/MessageIndicator.tsx
+++ b/src/components/MessageIndicator/MessageIndicator.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import styles from './MessageIndicator.scss';
 

--- a/src/components/MessageIndicator/tests/MessageIndicator.test.tsx
+++ b/src/components/MessageIndicator/tests/MessageIndicator.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider, findByTestID} from 'test-utilities';
 import MessageIndicator from '../MessageIndicator';
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import isEqual from 'lodash/isEqual';
 import {TransitionGroup} from 'react-transition-group';
 import {write} from '@shopify/javascript-utilities/fastdom';

--- a/src/components/Modal/components/CloseButton/CloseButton.tsx
+++ b/src/components/Modal/components/CloseButton/CloseButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {MobileCancelMajorMonotone} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities';
 

--- a/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/src/components/Modal/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Transition, CSSTransition} from 'react-transition-group';
 import {classNames} from '@shopify/react-utilities/styles';
 import {durationBase} from '@shopify/polaris-tokens';

--- a/src/components/Modal/components/Dialog/tests/Dialog.test.tsx
+++ b/src/components/Modal/components/Dialog/tests/Dialog.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {animationFrame} from '@shopify/jest-dom-mocks';
 import {trigger, mountWithAppProvider} from 'test-utilities';
 import {KeypressListener} from 'components';

--- a/src/components/Modal/components/Footer/Footer.tsx
+++ b/src/components/Modal/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {ComplexAction, AppBridgeAction} from '../../../../types';
 import {buttonsFrom} from '../../../Button';

--- a/src/components/Modal/components/Header/Header.tsx
+++ b/src/components/Modal/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import DisplayText from '../../../DisplayText';
 import CloseButton from '../CloseButton';

--- a/src/components/Modal/components/Section/Section.tsx
+++ b/src/components/Modal/components/Section/Section.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import styles from './Section.scss';
 

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Modal as AppBridgeModal} from '@shopify/app-bridge/actions';
 import {animationFrame} from '@shopify/jest-dom-mocks';
 import {findByTestID, trigger, mountWithAppProvider} from 'test-utilities';

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import Scrollable from '../Scrollable';
 

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {classNames} from '@shopify/react-utilities/styles';
 import {navigationBarCollapsed} from '../../../../utilities/breakpoints';

--- a/src/components/Navigation/components/Item/components/Secondary/Secondary.tsx
+++ b/src/components/Navigation/components/Item/components/Secondary/Secondary.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 
 import Collapsible from '../../../../../Collapsible';

--- a/src/components/Navigation/components/Item/components/Secondary/tests/Secondary.test.tsx
+++ b/src/components/Navigation/components/Item/components/Secondary/tests/Secondary.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 
 import Secondary from '../Secondary';

--- a/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {PlusMinor} from '@shopify/polaris-icons';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {Icon, UnstyledLink, Indicator, Badge} from 'components';

--- a/src/components/Navigation/components/Message/Message.tsx
+++ b/src/components/Navigation/components/Message/Message.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import Badge, {Props as BadgeProps} from '../../../Badge';
 import Button from '../../../Button';

--- a/src/components/Navigation/components/Message/tests/Message.test.tsx
+++ b/src/components/Navigation/components/Message/tests/Message.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Message from '../Message';
 import Badge from '../../../../Badge';

--- a/src/components/Navigation/components/Section/Section.tsx
+++ b/src/components/Navigation/components/Section/Section.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';

--- a/src/components/Navigation/components/Section/tests/Section.test.tsx
+++ b/src/components/Navigation/components/Section/tests/Section.test.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import * as PropTypes from 'prop-types';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import {matchMedia, animationFrame} from '@shopify/jest-dom-mocks';
 import {findByTestID, trigger, mountWithAppProvider} from 'test-utilities';

--- a/src/components/Navigation/components/UserMenu/UserMenu.tsx
+++ b/src/components/Navigation/components/UserMenu/UserMenu.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {UserMenuModifier} from '../../../TopBar';
 import {IconableAction} from '../../../../types';
 import {Props as MessageProps} from '../Message';

--- a/src/components/Navigation/components/UserMenu/tests/User.test.tsx
+++ b/src/components/Navigation/components/UserMenu/tests/User.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {UserMenuModifier} from '../../../../TopBar';
 import UserMenu, {Props as UserMenuProps} from '../UserMenu';

--- a/src/components/Navigation/tests/Navigation.test.tsx
+++ b/src/components/Navigation/tests/Navigation.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Navigation from '../Navigation';
 import {UserMenu} from '../components';

--- a/src/components/Navigation/types.ts
+++ b/src/components/Navigation/types.ts
@@ -1,4 +1,4 @@
-import * as PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import {Props as IconProps} from '../Icon';
 import {contentContextTypes} from '../../types';
 

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 
 import {arraysAreEqual} from '../../utilities/arrays';

--- a/src/components/OptionList/components/Checkbox/Checkbox.tsx
+++ b/src/components/OptionList/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {TickSmallMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';

--- a/src/components/OptionList/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/OptionList/components/Checkbox/tests/Checkbox.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Checkbox, {Props} from '../Checkbox';
 

--- a/src/components/OptionList/components/Option/Option.tsx
+++ b/src/components/OptionList/components/Option/Option.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 
 import {Props as IconProps} from '../../../Icon';

--- a/src/components/OptionList/components/Option/tests/Option.test.tsx
+++ b/src/components/OptionList/components/Option/tests/Option.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Checkbox from '../../Checkbox';
 import Option, {Props} from '../Option';

--- a/src/components/OptionList/tests/OptionList.test.tsx
+++ b/src/components/OptionList/tests/OptionList.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import {Option} from '../components';
 import OptionList, {

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import isEqual from 'lodash/isEqual';
 import {classNames} from '@shopify/react-utilities/styles';
 import {

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {

--- a/src/components/Page/components/Header/components/Action/Action.tsx
+++ b/src/components/Page/components/Header/components/Action/Action.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {CaretDownMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities';
 import {IconableAction, DisableableAction} from '../../../../../../types';

--- a/src/components/Page/components/Header/components/Action/tests/Action.test.tsx
+++ b/src/components/Page/components/Header/components/Action/tests/Action.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {SaveMinor} from '@shopify/polaris-icons';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import Icon from '../../../../../../Icon';

--- a/src/components/Page/components/Header/components/ActionGroup/ActionGroup.tsx
+++ b/src/components/Page/components/Header/components/ActionGroup/ActionGroup.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import ActionList from '../../../../../ActionList';
 import Popover from '../../../../../Popover';
 import Action from '../Action';

--- a/src/components/Page/components/Header/components/ActionGroup/tests/ActionGroup.test.tsx
+++ b/src/components/Page/components/Header/components/ActionGroup/tests/ActionGroup.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {SaveMinor} from '@shopify/polaris-icons';
 import {Popover, ActionList} from 'components';

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {SaveMinor} from '@shopify/polaris-icons';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {Breadcrumbs, buttonsFrom, Pagination} from 'components';

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   Button as AppBridgeButton,
   TitleBar as AppBridgeTitleBar,

--- a/src/components/PageActions/PageActions.tsx
+++ b/src/components/PageActions/PageActions.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {ComplexAction, DisableableAction, LoadableAction} from '../../types';
 import Stack from '../Stack';

--- a/src/components/PageActions/tests/PageActions.test.tsx
+++ b/src/components/PageActions/tests/PageActions.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import PageActions from '..';
 import ButtonGroup from '../../ButtonGroup';

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ArrowLeftMinor, ArrowRightMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities';
 import isInputFocused from '../../utilities/isInputFocused';

--- a/src/components/Pagination/tests/Pagination.test.tsx
+++ b/src/components/Pagination/tests/Pagination.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider, findByTestID} from 'test-utilities';
 import {Tooltip, TextField} from 'components';

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {
   focusFirstFocusableNode,

--- a/src/components/Popover/components/Pane/Pane.tsx
+++ b/src/components/Popover/components/Pane/Pane.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import {wrapWithComponent} from '@shopify/react-utilities';
 

--- a/src/components/Popover/components/Pane/tests/Pane.test.tsx
+++ b/src/components/Popover/components/Pane/tests/Pane.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {TextContainer, Scrollable} from 'components';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import Pane from '../Pane';

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {nodeContainsDescendant} from '@shopify/javascript-utilities/dom';
 import {write} from '@shopify/javascript-utilities/fastdom';
 import {classNames} from '@shopify/react-utilities/styles';

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {TextContainer} from 'components';
 import {Key} from '../../../../../types';

--- a/src/components/Popover/components/Section/Section.tsx
+++ b/src/components/Popover/components/Section/Section.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styles from '../../Popover.scss';
 
 export interface Props {

--- a/src/components/Popover/components/Section/tests/Section.test.tsx
+++ b/src/components/Popover/components/Section/tests/Section.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {TextContainer} from 'components';
 import Section from '../Section';

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider, findByTestID} from 'test-utilities';
 import Popover from '../Popover';
 

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createPortal} from 'react-dom';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 

--- a/src/components/Portal/tests/Portal.test.tsx
+++ b/src/components/Portal/tests/Portal.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import * as targets from '@shopify/react-utilities/target';
 import {mountWithAppProvider} from 'test-utilities';
 import Portal from '../Portal';

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import {getRectForNode, Rect} from '@shopify/javascript-utilities/geometry';
 import {closest} from '@shopify/javascript-utilities/dom';

--- a/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Rect} from '@shopify/javascript-utilities/geometry';
 import {mountWithAppProvider} from 'test-utilities';
 import EventListener from '../../EventListener';

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import styles from './ProgressBar.scss';

--- a/src/components/ProgressBar/tests/ProgressBar.test.tsx
+++ b/src/components/ProgressBar/tests/ProgressBar.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import ProgressBar from '../ProgressBar';
 

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import Choice, {helpTextID} from '../Choice';
 import styles from './RadioButton.scss';

--- a/src/components/RadioButton/tests/RadioButton.test.tsx
+++ b/src/components/RadioButton/tests/RadioButton.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import RadioButton from '../RadioButton';
 

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import {Props, RangeSliderValue, DualValue} from './types';

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 import {

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider, findByTestID} from 'test-utilities';
 import {Key} from 'types';

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import clamp from '../../../../utilities/clamp';
 import Labelled, {helpTextID} from '../../../Labelled';

--- a/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import {SingleThumb} from '../..';
 

--- a/src/components/RangeSlider/tests/RangeSlider.test.tsx
+++ b/src/components/RangeSlider/tests/RangeSlider.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import RangeSlider from '../RangeSlider';
 import {DualThumb, SingleThumb} from '../components';

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import debounce from 'lodash/debounce';
 import {classNames} from '@shopify/react-utilities/styles';

--- a/src/components/ResourceList/components/BulkActions/BulkActions.tsx
+++ b/src/components/ResourceList/components/BulkActions/BulkActions.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {CSSTransition, Transition} from 'react-transition-group';
 import debounce from 'lodash/debounce';
 import {classNames} from '@shopify/react-utilities/styles';

--- a/src/components/ResourceList/components/BulkActions/components/BulkActionButton/BulkActionButton.tsx
+++ b/src/components/ResourceList/components/BulkActions/components/BulkActionButton/BulkActionButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {findDOMNode} from 'react-dom';
 import {CaretDownMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities';

--- a/src/components/ResourceList/components/BulkActions/tests/BulkActions.test.tsx
+++ b/src/components/ResourceList/components/BulkActions/tests/BulkActions.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Transition, CSSTransition} from 'react-transition-group';
 import {mountWithAppProvider, findByTestID} from 'test-utilities';
 import {Popover} from 'components';

--- a/src/components/ResourceList/components/CheckableButton/CheckableButton.tsx
+++ b/src/components/ResourceList/components/CheckableButton/CheckableButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import Checkbox from '../../../Checkbox';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';

--- a/src/components/ResourceList/components/CheckableButton/tests/CheckableButton.test.tsx
+++ b/src/components/ResourceList/components/CheckableButton/tests/CheckableButton.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import {Checkbox} from 'components';
 import CheckableButton from '../CheckableButton';

--- a/src/components/ResourceList/components/Context/Context.tsx
+++ b/src/components/ResourceList/components/Context/Context.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {Intl} from '../../../AppProvider';
 import {ResourceListContext} from '../../types';
 

--- a/src/components/ResourceList/components/FilterControl/FilterControl.tsx
+++ b/src/components/ResourceList/components/FilterControl/FilterControl.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {SearchMinor} from '@shopify/polaris-icons';
 import compose from '@shopify/react-compose';
 import {ComplexAction, WithContextTypes} from '../../../../types';

--- a/src/components/ResourceList/components/FilterControl/components/DateSelector/DateSelector.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/DateSelector/DateSelector.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {CalendarMinor} from '@shopify/polaris-icons';
 import DatePicker, {Months, Year, Range} from '../../../../../DatePicker';
 import Select from '../../../../../Select';

--- a/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {DatePicker, Select, TextField} from 'components';
 import {trigger, mountWithAppProvider} from 'test-utilities';
 import DateSelector, {Props, DateFilterOption} from '../DateSelector';

--- a/src/components/ResourceList/components/FilterControl/components/FilterCreator/FilterCreator.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterCreator/FilterCreator.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import Button from '../../../../../Button';
 import Popover from '../../../../../Popover';
 import Select from '../../../../../Select';

--- a/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {
   trigger,

--- a/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/FilterValueSelector.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/FilterValueSelector.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import Select from '../../../../../Select';
 import Stack from '../../../../../Stack';
 import TextField from '../../../../../TextField';

--- a/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/tests/FilterValueSelector.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/tests/FilterValueSelector.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {trigger, shallowWithAppProvider} from 'test-utilities';
 import {Select, TextField} from 'components';
 import FilterValueSelector from '../FilterValueSelector';

--- a/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {trigger, mountWithAppProvider} from 'test-utilities';
 import {TextField, Tag, Button} from 'components';
 import {Provider} from '../../Context';

--- a/src/components/ResourceList/components/Item/Item.tsx
+++ b/src/components/ResourceList/components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';

--- a/src/components/ResourceList/components/Item/tests/Item.test.tsx
+++ b/src/components/ResourceList/components/Item/tests/Item.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {findByTestID, mountWithAppProvider, trigger} from 'test-utilities';
 import {
   Avatar,

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ResourceList, Select, Spinner, EmptySearchResult} from 'components';
 import {
   findByTestID,

--- a/src/components/ResourcePicker/ResourcePicker.tsx
+++ b/src/components/ResourcePicker/ResourcePicker.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import isEqual from 'lodash/isEqual';
 import {ResourcePicker as AppBridgeResourcePicker} from '@shopify/app-bridge/actions';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';

--- a/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
+++ b/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ResourcePicker as AppBridgeResourcePicker} from '@shopify/app-bridge/actions';
 import {mountWithAppProvider} from 'test-utilities';
 import ResourcePicker from '../ResourcePicker';

--- a/src/components/ScrollLock/ScrollLock.tsx
+++ b/src/components/ScrollLock/ScrollLock.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import './ScrollLock.scss';
 import {polarisAppProviderContextTypes} from '../AppProvider';
 

--- a/src/components/ScrollLock/tests/ScrollLock.test.tsx
+++ b/src/components/ScrollLock/tests/ScrollLock.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {SCROLL_LOCKING_ATTRIBUTE} from '../../AppProvider';
 import ScrollLock from '../ScrollLock';

--- a/src/components/Scrollable/Scrollable.tsx
+++ b/src/components/Scrollable/Scrollable.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import debounce from 'lodash/debounce';
 import {
   addEventListener,

--- a/src/components/Scrollable/components/ScrollTo/ScrollTo.tsx
+++ b/src/components/Scrollable/components/ScrollTo/ScrollTo.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {contextTypes} from '../../types';
 

--- a/src/components/Scrollable/components/ScrollTo/tests/ScrollTo.test.tsx
+++ b/src/components/Scrollable/components/ScrollTo/tests/ScrollTo.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import ScrollTo from '../ScrollTo';
 

--- a/src/components/Scrollable/tests/Scrollable.test.tsx
+++ b/src/components/Scrollable/tests/Scrollable.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {contextTypes} from '../types';
 import Scrollable from '../Scrollable';

--- a/src/components/Scrollable/types.ts
+++ b/src/components/Scrollable/types.ts
@@ -1,4 +1,4 @@
-import * as PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import {ValidationMap} from 'react';
 
 export const contextTypes: ValidationMap<any> = {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ArrowUpDownMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';

--- a/src/components/Select/tests/Select.test.tsx
+++ b/src/components/Select/tests/Select.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ShallowWrapper} from 'enzyme';
 import {InlineError} from 'components';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';

--- a/src/components/SettingAction/SettingAction.tsx
+++ b/src/components/SettingAction/SettingAction.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styles from './SettingAction.scss';
 
 export interface Props {

--- a/src/components/SettingToggle/SettingToggle.tsx
+++ b/src/components/SettingToggle/SettingToggle.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {ComplexAction} from '../../types';
 import SettingAction from '../SettingAction';

--- a/src/components/SettingToggle/tests/SettingToggle.test.tsx
+++ b/src/components/SettingToggle/tests/SettingToggle.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import SettingAction from 'components/SettingAction';
 import SettingToggle from '../SettingToggle';

--- a/src/components/Sheet/Sheet.tsx
+++ b/src/components/Sheet/Sheet.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {CSSTransition} from 'react-transition-group';
 import debounce from 'lodash/debounce';

--- a/src/components/Sheet/tests/Sheet.test.tsx
+++ b/src/components/Sheet/tests/Sheet.test.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import * as PropTypes from 'prop-types';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import {CSSTransition} from 'react-transition-group';
 import {matchMedia} from '@shopify/jest-dom-mocks';

--- a/src/components/SkeletonBodyText/SkeletonBodyText.tsx
+++ b/src/components/SkeletonBodyText/SkeletonBodyText.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styles from './SkeletonBodyText.scss';
 
 export interface Props {

--- a/src/components/SkeletonBodyText/tests/SkeletonBodyText.test.tsx
+++ b/src/components/SkeletonBodyText/tests/SkeletonBodyText.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import SkeletonBodyText from '../SkeletonBodyText';
 

--- a/src/components/SkeletonDisplayText/SkeletonDisplayText.tsx
+++ b/src/components/SkeletonDisplayText/SkeletonDisplayText.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 import styles from './SkeletonDisplayText.scss';
 

--- a/src/components/SkeletonDisplayText/tests/SkeletonDisplayText.test.tsx
+++ b/src/components/SkeletonDisplayText/tests/SkeletonDisplayText.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import SkeletonDisplayText from '../SkeletonDisplayText';
 

--- a/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/src/components/SkeletonPage/SkeletonPage.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import DisplayText from '../DisplayText';
 import SkeletonDisplayText from '../SkeletonDisplayText';

--- a/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
+++ b/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {
   Layout,

--- a/src/components/SkeletonThumbnail/SkeletonThumbnail.tsx
+++ b/src/components/SkeletonThumbnail/SkeletonThumbnail.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 import styles from './SkeletonThumbnail.scss';
 

--- a/src/components/SkeletonThumbnail/tests/SkeletonThumbnail.test.tsx
+++ b/src/components/SkeletonThumbnail/tests/SkeletonThumbnail.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import SkeletonThumbnail from '../SkeletonThumbnail';
 

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import Image from '../Image';

--- a/src/components/Spinner/tests/Spinner.test.tsx
+++ b/src/components/Spinner/tests/Spinner.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 import Spinner from '../Spinner';
 import Image from '../../Image';

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 import {elementChildren, wrapWithComponent} from '@shopify/react-utilities';
 

--- a/src/components/Stack/components/Item/Item.tsx
+++ b/src/components/Stack/components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import styles from '../../Stack.scss';
 

--- a/src/components/Sticky/Sticky.tsx
+++ b/src/components/Sticky/Sticky.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {getRectForNode} from '@shopify/javascript-utilities/geometry';
 import {polarisAppProviderContextTypes} from '../AppProvider';
 

--- a/src/components/Sticky/tests/Sticky.test.tsx
+++ b/src/components/Sticky/tests/Sticky.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Sticky from '../Sticky';
 

--- a/src/components/Subheading/Subheading.tsx
+++ b/src/components/Subheading/Subheading.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {HeadingTagName} from '../../types';
 import styles from './Subheading.scss';
 

--- a/src/components/Subheading/tests/Subheading.test.tsx
+++ b/src/components/Subheading/tests/Subheading.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {Button} from 'components';
 import Subheading from '../Subheading';

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 

--- a/src/components/Tabs/components/Item/Item.tsx
+++ b/src/components/Tabs/components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import styles from '../../Tabs.scss';
 import UnstyledLink from '../../../UnstyledLink';

--- a/src/components/Tabs/components/Item/tests/Item.test.tsx
+++ b/src/components/Tabs/components/Item/tests/Item.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {UnstyledLink} from 'components';
 import Item from '../Item';

--- a/src/components/Tabs/components/List/List.tsx
+++ b/src/components/Tabs/components/List/List.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import Item from '../Item';
 import {TabDescriptor} from '../../types';

--- a/src/components/Tabs/components/List/tests/List.test.tsx
+++ b/src/components/Tabs/components/List/tests/List.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import List from '../List';
 import Item from '../../Item';

--- a/src/components/Tabs/components/Panel/Panel.tsx
+++ b/src/components/Tabs/components/Panel/Panel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styles from '../../Tabs.scss';
 
 export interface Props {

--- a/src/components/Tabs/components/Panel/tests/Panel.test.tsx
+++ b/src/components/Tabs/components/Panel/tests/Panel.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Panel from '../Panel';
 

--- a/src/components/Tabs/components/Tab/Tab.tsx
+++ b/src/components/Tabs/components/Tab/Tab.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
 

--- a/src/components/Tabs/components/Tab/tests/Tab.test.tsx
+++ b/src/components/Tabs/components/Tab/tests/Tab.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Tab from '../Tab';
 

--- a/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
+++ b/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {findDOMNode} from 'react-dom';
 import {classNames} from '@shopify/react-utilities/styles';
 

--- a/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
+++ b/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import TabMeasurer from '../TabMeasurer';
 import Tab from '../../Tab';

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {Tab, Panel, TabMeasurer, List} from '../components';

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {CancelSmallMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';

--- a/src/components/Tag/tests/Tag.test.tsx
+++ b/src/components/Tag/tests/Tag.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Tag from '../Tag';
 

--- a/src/components/TextContainer/TextContainer.tsx
+++ b/src/components/TextContainer/TextContainer.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 
 import styles from './TextContainer.scss';

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {addEventListener} from '@shopify/javascript-utilities/events';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {classNames, variationName} from '@shopify/react-utilities/styles';

--- a/src/components/TextField/components/Resizer/Resizer.tsx
+++ b/src/components/TextField/components/Resizer/Resizer.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import EventListener from '../../../EventListener';
 import styles from '../../TextField.scss';
 

--- a/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
+++ b/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider, findByTestID, trigger} from 'test-utilities';
 import Resizer from '../Resizer';
 import EventListener from '../../../../EventListener';

--- a/src/components/TextField/components/Spinner/Spinner.tsx
+++ b/src/components/TextField/components/Spinner/Spinner.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {CaretDownMinor, CaretUpMinor} from '@shopify/polaris-icons';
 import Icon from '../../../Icon';
 

--- a/src/components/TextField/components/Spinner/tests/Spinner.test.tsx
+++ b/src/components/TextField/components/Spinner/tests/Spinner.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {shallow} from 'enzyme';
 import Spinner from '../Spinner';
 

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   shallowWithAppProvider,
   mountWithAppProvider,

--- a/src/components/TextStyle/TextStyle.tsx
+++ b/src/components/TextStyle/TextStyle.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 import styles from './TextStyle.scss';
 

--- a/src/components/TextStyle/tests/TextStyle.test.tsx
+++ b/src/components/TextStyle/tests/TextStyle.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import TextStyle from '../TextStyle';
 

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import isEqual from 'lodash/isEqual';
 import {setColors} from './utils';
 import {Theme, ThemeProviderContext, THEME_CONTEXT_TYPES} from './types';

--- a/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import {mountWithAppProvider} from 'test-utilities';
 import ThemeProvider from '../ThemeProvider';

--- a/src/components/ThemeProvider/types.ts
+++ b/src/components/ThemeProvider/types.ts
@@ -1,4 +1,4 @@
-import * as PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 
 export type ColorsToParse = ThemeColor;
 

--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames, variationName} from '@shopify/react-utilities/styles';
 import Image from '../Image';
 import styles from './Thumbnail.scss';

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {Toast as AppBridgeToast} from '@shopify/app-bridge/actions';
 

--- a/src/components/Toast/tests/Toast.test.tsx
+++ b/src/components/Toast/tests/Toast.test.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import * as PropTypes from 'prop-types';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {Toast as AppBridgeToast} from '@shopify/app-bridge/actions';
 import {mountWithAppProvider} from 'test-utilities';
 import Toast from '../Toast';

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {findFirstFocusableNode} from '@shopify/javascript-utilities/focus';
 

--- a/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 
 import {layer} from '../../../shared';

--- a/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {findByTestID, mountWithAppProvider} from 'test-utilities';
 import {Link} from 'components';
 import Tooltip from '../Tooltip';

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {MobileHamburgerMajorMonotone} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 

--- a/src/components/TopBar/components/Menu/Menu.tsx
+++ b/src/components/TopBar/components/Menu/Menu.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import ActionList, {Props as ActionListProps} from '../../../ActionList';
 import Popover from '../../../Popover';

--- a/src/components/TopBar/components/Menu/components/Message/Message.tsx
+++ b/src/components/TopBar/components/Menu/components/Message/Message.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import Badge, {Props as BadgeProps} from '../../../../../Badge';
 import Button from '../../../../../Button';

--- a/src/components/TopBar/components/Menu/components/Message/tests/Message.test.tsx
+++ b/src/components/TopBar/components/Menu/components/Message/tests/Message.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Message from '../Message';
 import Badge from '../../../../../../Badge';

--- a/src/components/TopBar/components/Menu/tests/Menu.test.tsx
+++ b/src/components/TopBar/components/Menu/tests/Menu.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 
 import {ActionList, Popover} from 'components';

--- a/src/components/TopBar/components/Search/Search.tsx
+++ b/src/components/TopBar/components/Search/Search.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {classNames} from '@shopify/react-utilities/styles';
 import styles from './Search.scss';
 

--- a/src/components/TopBar/components/Search/tests/Search.test.tsx
+++ b/src/components/TopBar/components/Search/tests/Search.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Search from '../Search';
 

--- a/src/components/TopBar/components/SearchField/SearchField.tsx
+++ b/src/components/TopBar/components/SearchField/SearchField.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {CircleCancelMinor, SearchMinor} from '@shopify/polaris-icons';
 import {classNames} from '@shopify/react-utilities/styles';
 

--- a/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
+++ b/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {CircleCancelMinor} from '@shopify/polaris-icons';
 import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider} from 'test-utilities';

--- a/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import withContext from '../../../WithContext';
 import {WithContextTypes} from '../../../../types';
 import {Consumer as UserMenuConsumer, UserMenuContextTypes} from './context';

--- a/src/components/TopBar/components/UserMenu/components/UserMenu/UserMenu.tsx
+++ b/src/components/TopBar/components/UserMenu/components/UserMenu/UserMenu.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {IconableAction} from '../../../../../../types';
 import Avatar, {Props as AvatarProps} from '../../../../../Avatar';
 import MessageIndicator from '../../../../../MessageIndicator';

--- a/src/components/TopBar/components/UserMenu/components/UserMenu/tests/UserMenu.test.tsx
+++ b/src/components/TopBar/components/UserMenu/components/UserMenu/tests/UserMenu.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {NotificationMajorMonotone} from '@shopify/polaris-icons';
 
 import {ReactWrapper} from 'enzyme';

--- a/src/components/TopBar/components/UserMenu/context/Modifier.tsx
+++ b/src/components/TopBar/components/UserMenu/context/Modifier.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import withContext from '../../../../WithContext';
 import {WithContextTypes} from '../../../../../types';
 import {UserMenuProps} from '../components';

--- a/src/components/TopBar/components/UserMenu/context/Provider.tsx
+++ b/src/components/TopBar/components/UserMenu/context/Provider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import isEqual from 'lodash/isEqual';
 import {UserMenuProps} from '../components';
 import UserMenuContext, {UserMenuContextTypes} from './context';

--- a/src/components/TopBar/components/UserMenu/context/context.ts
+++ b/src/components/TopBar/components/UserMenu/context/context.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {UserMenuProps} from '../components';
 
 export interface UserMenuContextTypes {

--- a/src/components/TopBar/components/UserMenu/context/tests/Modifier.test.tsx
+++ b/src/components/TopBar/components/UserMenu/context/tests/Modifier.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ViewMinor} from '@shopify/polaris-icons';
 import {mountWithAppProvider} from 'test-utilities';
 import {UserMenuProps} from '../../components';

--- a/src/components/TopBar/components/UserMenu/context/tests/Provider.test.tsx
+++ b/src/components/TopBar/components/UserMenu/context/tests/Provider.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import UserMenuContext from '../context';
 import Provider from '../Provider';

--- a/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
+++ b/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ViewMinor} from '@shopify/polaris-icons';
 import {mountWithAppProvider} from 'test-utilities';
 import {UserMenuContext} from '../context';

--- a/src/components/TopBar/tests/TopBar.test.tsx
+++ b/src/components/TopBar/tests/TopBar.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {
   mountWithAppProvider,
   shallowWithAppProvider,

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {closest} from '@shopify/javascript-utilities/dom';
 import {
   focusFirstFocusableNode,

--- a/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {EventListener, Focus, TextContainer, TextField} from 'components';
 import TrapFocus from '../TrapFocus';

--- a/src/components/Truncate/Truncate.tsx
+++ b/src/components/Truncate/Truncate.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styles from './Truncate.scss';
 
 export interface Props {

--- a/src/components/Truncate/tests/Truncate.test.tsx
+++ b/src/components/Truncate/tests/Truncate.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import Truncate from '../Truncate';
 

--- a/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/src/components/UnstyledLink/UnstyledLink.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ReactComponent} from '@shopify/react-utilities/types';
 import {unstyled} from '../shared';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider/utilities';

--- a/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
+++ b/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import Link from 'components/AppProvider/utilities/Link';
 import {mountWithAppProvider} from 'test-utilities';
 import UnstyledLink from '../UnstyledLink';

--- a/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styles from './VisuallyHidden.scss';
 
 export interface Props {

--- a/src/components/WithContext/WithContext.tsx
+++ b/src/components/WithContext/WithContext.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 import {WithContextTypes} from '../../types';
 

--- a/src/components/WithContext/tests/WithContext.test.tsx
+++ b/src/components/WithContext/tests/WithContext.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
 import {WithContextTypes} from '../../../types';
 import withContext from '../WithContext';

--- a/src/components/WithRef/WithRef.tsx
+++ b/src/components/WithRef/WithRef.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 import {ReactComponent} from '@shopify/react-utilities/types';
 import {NonReactStatics} from '@shopify/useful-types';

--- a/src/components/WithRef/components/Context/Context.tsx
+++ b/src/components/WithRef/components/Context/Context.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 export interface WithRef<T = any> {
   forwardedRef: React.RefObject<T> | null;

--- a/src/test-utilities/enzyme.tsx
+++ b/src/test-utilities/enzyme.tsx
@@ -7,7 +7,7 @@ import {
   MountRendererProps,
   ShallowRendererProps,
 } from 'enzyme';
-import * as React from 'react';
+import React from 'react';
 import {get} from '../utilities/get';
 import merge from '../utilities/merge';
 import {PolarisContext} from '../components/types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import * as PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import {ValidationMap} from 'react';
 // eslint-disable-next-line shopify/strict-component-boundaries
 import {Props as IconProps} from './components/Icon';

--- a/src/utilities/react-compose.tsx
+++ b/src/utilities/react-compose.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {ReactComponent} from '@shopify/react-utilities/types';
 import reactCompose from '@shopify/react-compose';
 import {NonReactStatics} from '@shopify/useful-types';

--- a/src/utilities/tests/isInputFocused.test.tsx
+++ b/src/utilities/tests/isInputFocused.test.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {mount} from 'enzyme';
 import isInputFocused from '../isInputFocused';
 


### PR DESCRIPTION
`import * from React` and `import React` are functionally identical and
the latter is about to become the new recommendation (see https://github.com/Shopify/eslint-plugin-shopify/pull/262 and https://github.com/Shopify/web/pull/13571).

This will also allow us to import hooks without needing prefixes in v4, e.g.:
`import React, {useState} from 'react';`

- Replace `import * as React from 'react';` with `import React from 'react';`
- Replace `import * as PropTypes from 'prop-types';` with `import PropTypes from 'prop-types';`

---

We don't need to explicitly enable `esModuleInterop` just yet (which is used to handle libraries without a default export) as these two libraries both have a default export already. Which is just as well because currently explodes due to react-utilities doing something silly.

We can safely enable esModuleInterop once https://github.com/Shopify/polaris-react/pull/1473 removes the dependency on react-utilities.