### PR TITLE
[Card] Add box-shadow in Windows high contrast mode

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -23,6 +23,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed an issue where the JavaScript breakpoints incorrectly set the navigation bar collapsed breakpoint ([#1475](https://github.com/Shopify/polaris-react/pull/1475))
 - Added a border to `Toast` messages to make them more visible in Windows high contrast mode ([#1469](https://github.com/Shopify/polaris-react/pull/1469))
 - Add `box-shadow` to the `Banner` to make it more visible in Windows high contrast mode ([#1481](https://github.com/Shopify/polaris-react/pull/1481))
+- Add `box-shadow` to the `Card` to make it more visible in Windows high contrast mode ([#1524](https://github.com/Shopify/polaris-react/pull/1524))
 
 ### Documentation
 

--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -10,6 +10,10 @@
   @include page-content-when-not-fully-condensed {
     border-radius: border-radius();
   }
+
+  @media (-ms-high-contrast: active) {
+    box-shadow: inset 0 0 0 border-width(base) ms-high-contrast-color('text');
+  }
 }
 
 .subdued {
@@ -42,6 +46,10 @@
 
 .Section-subdued {
   background-color: color('sky', 'lighter');
+
+  @media (-ms-high-contrast: active) {
+    background-color: transparent;
+  }
 
   .Header + & {
     border-top: border-width() solid color('sky');


### PR DESCRIPTION
### WHY are these changes introduced?

Partially fixes https://github.com/Shopify/polaris-ux/issues/255

### WHAT is this pull request doing?

This PR is adding `box-shadow` to the `Card` in Windows high contrast mode to make it more visible.

The `background-color` is also removed from subdued sections in Windows high contrast mode as it doesn't have any effect other than hiding the `box-shadow` used to highlight the border.

#### Before:

![https://screenshot.click/2019-05-17_11-42-27.png](https://screenshot.click/2019-05-17_11-42-27.png)

#### After:

![https://screenshot.click/2019-05-17_11-40-46.png](https://screenshot.click/2019-05-17_11-40-46.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

- Navigate to `Card` -> `All examples` on a Windows machine running in high contrast mode

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
