### PR TITLE
Increase react and react-dom peer dependencies to 16.8.6

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -6,7 +6,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Breaking changes
 
-- Increase peer-dependencies on `react` and `react-dom` to 16.8.6 to enable the use of hooks ([#1525](https://github.com/Shopify/polaris-react/pull/1525))
+- Increased peer-dependencies on `react` and `react-dom` to 16.8.6 to enable the use of hooks ([#1525](https://github.com/Shopify/polaris-react/pull/1525))
 
 ### New components
 

--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Breaking changes
 
+- Increase peer-dependencies on `react` and `react-dom` to 16.8.6 to enable the use of hooks ([#1525](https://github.com/Shopify/polaris-react/pull/1525))
+
 ### New components
 
 ### Enhancements

--- a/package.json
+++ b/package.json
@@ -157,8 +157,8 @@
     "yargs": "^12.0.1"
   },
   "peerDependencies": {
-    "react": "^16.3.1",
-    "react-dom": "^16.3.1"
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
   },
   "resolutions": {
     "typescript-eslint-parser": "20.0.0"


### PR DESCRIPTION
We updated the devDependencies, but forgot the peer deps