### PR TITLE
Check that v4 changes are listed in the correct UNRELEASED file

### DIFF
--- a/.github/changelog.yml
+++ b/.github/changelog.yml
@@ -1,4 +1,4 @@
-filename: UNRELEASED.md
+filename: UNRELEASED-V4.md
 include:
   - /^config\//
   - /^documentation\//
@@ -12,6 +12,6 @@ include:
   - /^LICENSE.md$/
   - /^package.json$/
   - /^tsconfig.json$/
-inProgressMessage: missing an entry in UNRELEASED.md
+inProgressMessage: missing an entry in UNRELEASED-V4.md
 skipLabel: skip changelog
-detailsUrl: https://github.com/Shopify/polaris-react/blob/master/UNRELEASED.md
+detailsUrl: https://github.com/Shopify/polaris-react/blob/version-4.0.0/UNRELEASED-V4.md


### PR DESCRIPTION
This should tell the changelog bot that v4-related changes are to be made in the v4 branch.

@tmlayton Not sure this will work, as the bot may be getting its config from the `master` branch. What do you think?