### PR TITLE
Deprecate passing a stringy name of a bundled icon into <Icon source>

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Deprecations
 
+- Deprecated passing a string representing a "bundled icon" into `<Icon source>` Pass in an svg component imported from `@shopify/polaris-icons` instead ([#1534](https://github.com/Shopify/polaris-react/pull/1534)).
+
 ### New components
 
 ### Enhancements

--- a/src/components/ActionList/tests/ActionList.test.tsx
+++ b/src/components/ActionList/tests/ActionList.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {ImportMinor, ExportMinor} from '@shopify/polaris-icons';
 import {mountWithAppProvider} from 'test-utilities';
 import ActionList from '../ActionList';
 import Badge from '../../Badge';
@@ -87,8 +88,8 @@ describe('<ActionList />', () => {
           {
             title: 'File options',
             items: [
-              {content: 'Import file', icon: 'import'},
-              {content: 'Export file', icon: 'export'},
+              {content: 'Import file', icon: ImportMinor},
+              {content: 'Export file', icon: ExportMinor},
             ],
           },
         ]}
@@ -111,8 +112,8 @@ describe('<ActionList />', () => {
           {
             title: 'File options',
             items: [
-              {content: 'Import file', icon: 'import'},
-              {content: 'Export file', icon: 'export'},
+              {content: 'Import file', icon: ImportMinor},
+              {content: 'Export file', icon: ExportMinor},
             ],
           },
         ]}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -50,7 +50,7 @@ export interface Props {
   /** Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value. */
   download?: string | boolean;
   /** Icon to display to the left of the button content */
-  icon?: React.ReactNode | IconSource;
+  icon?: React.ReactElement | IconSource;
   /** Visually hidden text for screen readers */
   accessibilityLabel?: string;
   /** Id of the element the button controls */

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -238,6 +238,11 @@ function Icon({
     contentMarkup = <div className={styles.Placeholder} />;
   } else if (isBundledIcon(source)) {
     SourceComponent = BUNDLED_ICONS[source];
+    const componentImportName = importForStringIcon(source);
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Deprecation: passing the string "${source}" into <Icon source> is deprecated and will be removed in the next major version. Pass in the "${componentImportName}" React Component from the @shopify/polaris-icons package instead.`,
+    );
     contentMarkup = <SourceComponent {...defaultIconProps} />;
   } else if (typeof source === 'function') {
     const sourceElement = <SourceComponent {...defaultIconProps} />;
@@ -296,6 +301,63 @@ function isSVGSource(source: IconSource): source is SVGSource {
 
 function isUntrustedSVG(source: IconSource): source is UntrustedSVG {
   return typeof source === 'string';
+}
+
+function importForStringIcon(string: BundledIcon) {
+  return {
+    add: 'PlusMinor',
+    alert: 'AlertMinor',
+    arrowDown: 'ArrowDownMinor',
+    arrowLeft: 'ArrowLeftMinor',
+    arrowRight: 'ArrowRightMinor',
+    arrowUp: 'ArrowUpMinor',
+    arrowUpDown: 'ArrowUpDownMinor',
+    calendar: 'CalendarMinor',
+    cancel: 'MobileCancelMajorMonotone',
+    cancelSmall: 'CancelSmallMinor',
+    caretDown: 'CaretDownMinor',
+    caretUp: 'CaretUpMinor',
+    checkmark: 'TickSmallMinor',
+    chevronDown: 'ChevronDownMinor',
+    chevronLeft: 'ChevronLeftMinor',
+    chevronRight: 'ChevronRightMinor',
+    chevronUp: 'ChevronUpMinor',
+    circleCancel: 'CircleCancelMinor',
+    circleChevronDown: 'CircleChevronDownMinor',
+    circleChevronLeft: 'CircleChevronLeftMinor',
+    circleChevronRight: 'CircleChevronRightMinor',
+    circleChevronUp: 'CircleChevronUpMinor',
+    circleInformation: 'CircleInformationMajorTwotone',
+    circlePlus: 'CirclePlusMinor',
+    circlePlusOutline: 'CirclePlusOutlineMinor',
+    conversation: 'ConversationMinor',
+    delete: 'DeleteMinor',
+    disable: 'CircleDisableMinor',
+    dispute: 'DisputeMinor',
+    duplicate: 'DuplicateMinor',
+    embed: 'EmbedMinor',
+    export: 'ExportMinor',
+    external: 'ExternalMinor',
+    help: 'QuestionMarkMajorTwotone',
+    home: 'HomeMajorMonotone',
+    horizontalDots: 'HorizontalDotsMinor',
+    import: 'ImportMinor',
+    logOut: 'LogOutMinor',
+    menu: 'MobileHamburgerMajorMonotone',
+    notes: 'NoteMinor',
+    notification: 'NotificationMajorMonotone',
+    onlineStore: 'OnlineStoreMajorTwotone',
+    orders: 'OrdersMajorTwotone',
+    print: 'PrintMinor',
+    products: 'ProductsMajorTwotone',
+    profile: 'ProfileMinor',
+    refresh: 'RefreshMinor',
+    risk: 'RiskMinor',
+    save: 'SaveMinor',
+    search: 'SearchMinor',
+    subtract: 'MinusMinor',
+    view: 'ViewMinor',
+  }[string];
 }
 
 export default withAppProvider<Props>()(Icon);

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {addEventListener} from '@shopify/javascript-utilities/events';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {classNames, variationName} from '@shopify/css-utilities';
+import {CircleCancelMinor} from '@shopify/polaris-icons';
 
 import Labelled, {Action, helpTextID, labelID} from '../Labelled';
 import Connected from '../Connected';
@@ -270,7 +271,7 @@ class TextField extends React.PureComponent<CombinedProps, State> {
           onClick={this.handleClearButtonPress}
           disabled={disabled}
         >
-          <Icon source="circleCancel" color="inkLightest" />
+          <Icon source={CircleCancelMinor} color="inkLightest" />
         </button>
       ) : null;
 


### PR DESCRIPTION
### WHY are these changes introduced?

To shrink polaris-react we should stop bundling icons, and instead make people explicitly reference the icon they need.

### WHAT is this pull request doing?

This PR deprecates passing a string into `<Icon source />` and instead tells people to import an icon from polaris-icons instead. e.g. instead of 

```jsx
const x = <Icon source="add" />
```

do:

```jsx
import {PlusMinor} from '@shopify/polaris-icons';
const x = <Icon source={PlusMinor} />
```

The groundwork to enable this - updating our own code to import from polaris-icons was done in #1196 and #1297.

This PR also tightens the type for `<Button icon>` from `ReactNode|IconSource` to `ReactElement|IconSource` as ReactNode is far too broad - we only want people passing in some kind of html element, we don't want to handle strings or anything else that a ReactNode could be. I consider this a bug fix change as this would have never resulted in a useable output in the first place and makes typescript point out when you're about to do something undesired.

### How to 🎩

Check that deprecation notices are triggered when you do `<Icon source="add" />`.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Icon, Page, TextField} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    function handleChange() {}

    return (
      <Page title="Playground">
        HELLO
        <Icon source="add" />
        <TextField label="hi" value="FOO" onChange={handleChange} clearButton />
        {/* Add the code you want to test in here */}
      </Page>
    );
  }
}
```

</details>