### PR TITLE
[Color system] deprecated orange, purple, and all shades of blue as options for the Icon component's color property

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Deprecations
 
+- Deprecated passing `purple`, `orange`, `blueLighter`, `blueLight`, `blue`, `blueDark`, and `blueDarker` to the `color` property of the `Icon` component ([#1537](https://github.com/Shopify/polaris-react/pull/1537))
+
 ### New components
 
 ### Enhancements

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -194,6 +194,16 @@ export interface Props {
 
 export type CombinedProps = Props & WithAppProviderProps;
 
+export const DEPRECATED_COLORS: Color[] = [
+  'purple',
+  'orange',
+  'blueLighter',
+  'blueLight',
+  'blue',
+  'blueDark',
+  'blueDarker',
+];
+
 function Icon({
   source,
   color,
@@ -208,6 +218,15 @@ function Icon({
       intl.translate('Polaris.Icon.backdropWarning', {
         color,
         colorsWithBackDrops: COLORS_WITH_BACKDROPS.join(', '),
+      }),
+    );
+  }
+
+  if (color && DEPRECATED_COLORS.includes(color)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      intl.translate('Polaris.Icon.deprecatedColorWarning', {
+        color,
       }),
     );
   }

--- a/src/components/Icon/tests/Icon.test.tsx
+++ b/src/components/Icon/tests/Icon.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {PlusMinor} from '@shopify/polaris-icons';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
-import Icon from '../Icon';
+import Icon, {DEPRECATED_COLORS} from '../Icon';
 import Button from '../../Button';
 
 describe('<Icon />', () => {
@@ -69,6 +69,21 @@ describe('<Icon />', () => {
       const svg = "<svg><path d='M10 10'/></svg>";
       shallowWithAppProvider(<Icon source={svg} untrusted />);
       expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('console.warn', () => {
+    it('warns when a warning status is passed to badge', () => {
+      const warnSpy = jest.spyOn(console, 'warn');
+      const svg = "<svg><path d='M10 10'/></svg>";
+
+      DEPRECATED_COLORS.forEach((color) => {
+        mountWithAppProvider(<Icon source={svg} color={color} />);
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          `Deprecation: The ${color} option for the \`color\` property on Icon has been deprecated. Use another \`color\` instead.`,
+        );
+      });
     });
   });
 });

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -95,7 +95,8 @@
       }
     },
     "Icon": {
-      "backdropWarning": "Das {color}-Symbol akzeptiert keine Hintergründe. Die Symbolfarben, die Hintergründe haben, sind: {colorsWithBackDrops}"
+      "backdropWarning": "Das {color}-Symbol akzeptiert keine Hintergründe. Die Symbolfarben, die Hintergründe haben, sind: {colorsWithBackDrops}",
+      "deprecatedColorWarning": "Eingestellt: Die {color}-Option für die Farbeigenschaft des Symbols wurde eingestellt Verwenden Sie stattdessen eine andere Farbe."
     },
     "Modal": {
       "iFrameTitle": "Text-Markup",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -108,7 +108,8 @@
     },
 
     "Icon": {
-      "backdropWarning": "The {color} icon doesn’t accept backdrops. The icon colors that have backdrops are: {colorsWithBackDrops}"
+      "backdropWarning": "The {color} icon doesn’t accept backdrops. The icon colors that have backdrops are: {colorsWithBackDrops}",
+      "deprecatedColorWarning": "Deprecation: The {color} option for the `color` property on Icon has been deprecated. Use another `color` instead."
     },
 
     "Modal": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -95,7 +95,8 @@
       }
     },
     "Icon": {
-      "backdropWarning": "El ícono {color} no acepta fondos. Los colores de los íconos que tienen fondos son: {colorsWithBackDrops}"
+      "backdropWarning": "El ícono {color} no acepta fondos. Los colores de los íconos que tienen fondos son: {colorsWithBackDrops}",
+      "deprecatedColorWarning": "Obsoleto: la opción {color} para la propiedad del color en el Icono ha quedado en desuso. Usa otro color en su lugar "
     },
     "Modal": {
       "iFrameTitle": "etiqueta body",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -95,7 +95,8 @@
       }
     },
     "Icon": {
-      "backdropWarning": "L'icône {color} n'accepte pas les fonds. Les couleurs des icônes qui possèdent un fond sont : {colorsWithBackDrops}"
+      "backdropWarning": "L'icône {color} n'accepte pas les fonds. Les couleurs des icônes qui possèdent un fond sont : {colorsWithBackDrops}",
+      "deprecatedColorWarning": "Obsolète : l'option {color} pour la propriété `de couleur` sur Icône est obsolète. Utilisez une autre `couleur` à la place."
     },
     "Modal": {
       "iFrameTitle": "balisage du corps",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -95,7 +95,8 @@
       }
     },
     "Icon": {
-      "backdropWarning": "{color} आइकन बैकड्रॉप स्वीकार नहीं करता है. आइकन के वे रंग जिनमें बैकड्रॉप होते हैं: {colorsWithBackDrops}"
+      "backdropWarning": "{color} आइकन बैकड्रॉप स्वीकार नहीं करता है. आइकन के वे रंग जिनमें बैकड्रॉप होते हैं: {colorsWithBackDrops}",
+      "deprecatedColorWarning": "पदावनति: आइकन पर रंग गुण के लिए {color} विकल्प को हटा दिया गया है. इसके बजाय किसी दूसरे रंग का उपयोग करें."
     },
     "Modal": {
       "iFrameTitle": "बॉडी मार्कअप",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -95,7 +95,8 @@
       }
     },
     "Icon": {
-      "backdropWarning": "L'icona {color} non accetta gli sfondi. I colori dell'icona con sfondi sono i seguenti: {colorsWithBackDrops}"
+      "backdropWarning": "L'icona {color} non accetta gli sfondi. I colori dell'icona con sfondi sono i seguenti: {colorsWithBackDrops}",
+      "deprecatedColorWarning": "Elemento deprecato: l'opzione {color} per la proprietà colore su Icona è stata deprecata. Usa un altro colore."
     },
     "Modal": {
       "iFrameTitle": "markup del testo",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -95,7 +95,8 @@
       }
     },
     "Icon": {
-      "backdropWarning": "{color}のアイコンは、背景を受け付けません。背景を持つアイコンの色は次のとおりです: {colorsWithBackDrops}"
+      "backdropWarning": "{color}のアイコンは、背景を受け付けません。背景を持つアイコンの色は次のとおりです: {colorsWithBackDrops}",
+      "deprecatedColorWarning": "廃止: アイコンの色プロパティに関する{color}オプションは、廃止されました。代わりに別の色を使用してください。"
     },
     "Modal": {
       "iFrameTitle": "ボディのマークアップ",

--- a/src/locales/ms.json
+++ b/src/locales/ms.json
@@ -95,7 +95,8 @@
       }
     },
     "Icon": {
-      "backdropWarning": "Ikon {color} tidak menerima latar belakang. Warna ikon yang mempunyai latar belakang adalah: {colorsWithBackDrops}"
+      "backdropWarning": "Ikon {color} tidak menerima latar belakang. Warna ikon yang mempunyai latar belakang adalah: {colorsWithBackDrops}",
+      "deprecatedColorWarning": "Penamatan: Opsyen {color} untuk sifat `warna` di Ikon telah ditamatkan. Sebaliknya, gunakan `warna` yang lain"
     },
     "Modal": {
       "iFrameTitle": "penanda badan",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -95,7 +95,8 @@
       }
     },
     "Icon": {
-      "backdropWarning": "Het pictogram {color} accepteert geen achtergronden. De pictogramkleuren met achtergronden zijn: {colorsWithBackDrops}"
+      "backdropWarning": "Het pictogram {color} accepteert geen achtergronden. De pictogramkleuren met achtergronden zijn: {colorsWithBackDrops}",
+      "deprecatedColorWarning": "Veroudering: De optie {color} voor de eigenschap `kleur` op Pictogram is verouderd. Gebruik een andere `kleur`."
     },
     "Modal": {
       "iFrameTitle": "opmaak platte tekst",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -95,7 +95,8 @@
       }
     },
     "Icon": {
-      "backdropWarning": "O ícone {color} não aceita fundo. As cores dos ícones que têm fundos são: {colorsWithBackDrops}"
+      "backdropWarning": "O ícone {color} não aceita fundo. As cores dos ícones que têm fundos são: {colorsWithBackDrops}",
+      "deprecatedColorWarning": "Elemento em desuso: a opção {color} da propriedade \"cor\" no ícone se tornou obsoleta. Use outra \"cor\"."
     },
     "Modal": {
       "iFrameTitle": "marcação de corpo",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -95,7 +95,8 @@
       }
     },
     "Icon": {
-      "backdropWarning": "{color} 图标不能用于背景。可用于背景的图标颜色：{colorsWithBackDrops}"
+      "backdropWarning": "{color} 图标不能用于背景。可用于背景的图标颜色：{colorsWithBackDrops}",
+      "deprecatedColorWarning": "弃用通知：图标上颜色属性的{color}选项已被弃用。请改用另一种颜色。"
     },
     "Modal": {
       "iFrameTitle": "正文标记",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -95,7 +95,8 @@
       }
     },
     "Icon": {
-      "backdropWarning": "{color} 圖示不適用背景。有背景的圖示顏色為：{colorsWithBackDrops}"
+      "backdropWarning": "{color} 圖示不適用背景。有背景的圖示顏色為：{colorsWithBackDrops}",
+      "deprecatedColorWarning": "停用：圖示的「顏色」屬性之「{color}」選項已停用。請改用其他顏色。"
     },
     "Modal": {
       "iFrameTitle": "本文標記",


### PR DESCRIPTION
Partially addresses https://github.com/Shopify/polaris-react/issues/1433, https://github.com/Shopify/polaris-react/issues/1420, and https://github.com/Shopify/polaris-react/issues/1421