### PR TITLE
[Color system] update the info variant of the badge component to use teal instead of blue for greater system consistency

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,8 +15,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added support for dual values to `RangeSlider` component ([#784](https://github.com/Shopify/polaris-react/pull/784))
-
 - Updated type restrictions for `AnnotatedSection` to allow its `title` prop to accept `React.ReactNode` instead of `string` ([#1431](https://github.com/Shopify/polaris-react/pull/1431))
+- Updated the `informational` variant of the `Badge` component to use teal as a base color instead of blue ([#1538](https://github.com/Shopify/polaris-react/pull/1538))
 
 ### Bug fixes
 

--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -36,9 +36,9 @@ $pip-spacing: ($height - $pip-size) / 2;
 }
 
 .statusInfo {
-  @include pip-color(color('blue', 'dark'));
-  background-color: color('blue', 'light');
-  color: color('blue', 'text');
+  @include pip-color(color('teal', 'dark'));
+  background-color: color('teal', 'light');
+  color: color('teal', 'text');
 }
 
 .statusAttention {


### PR DESCRIPTION
|Blue|Teal|
|-|-|
|<img width="99" alt="Screen Shot 2019-05-20 at 11 49 46 AM" src="https://user-images.githubusercontent.com/1403188/58034896-93fe3f00-7af5-11e9-83a2-a205e131ecd2.png">|<img width="99" alt="Screen Shot 2019-05-20 at 11 49 27 AM" src="https://user-images.githubusercontent.com/1403188/58034907-9bbde380-7af5-11e9-8e49-41693e380f05.png">|

Partially addresses https://github.com/Shopify/polaris-react/issues/1486, https://github.com/Shopify/polaris-react/issues/1421, and https://github.com/Shopify/polaris-react/issues/1430

Closes https://github.com/Shopify/polaris-ux/issues/110