### PR TITLE
[TabMeasure] Prevents reflow when measuring tabs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Improves performance of `TabMeasure` component ([#1544](https://github.com/Shopify/polaris-react/pull/1544))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
+++ b/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
@@ -24,6 +24,7 @@ export interface Props {
 
 export default class TabMeasurer extends React.PureComponent<Props, never> {
   private containerNode: HTMLElement | null = null;
+  private animationFrame: number | null = null;
 
   componentDidMount() {
     this.handleMeasurement();
@@ -83,25 +84,31 @@ export default class TabMeasurer extends React.PureComponent<Props, never> {
   };
 
   private handleMeasurement = () => {
-    if (this.containerNode == null) {
-      return;
+    if (this.animationFrame) {
+      cancelAnimationFrame(this.animationFrame);
     }
 
-    const {handleMeasurement} = this.props;
-    const containerWidth = this.containerNode.offsetWidth;
-    const tabMeasurerNode = findDOMNode(this);
-    const hiddenTabNodes =
-      tabMeasurerNode instanceof Element && tabMeasurerNode.children;
-    const hiddenTabNodesArray: HTMLElement[] = [].slice.call(hiddenTabNodes);
-    const hiddenTabWidths = hiddenTabNodesArray.map((node) => {
-      return node.getBoundingClientRect().width;
-    });
-    const disclosureWidth = hiddenTabWidths.pop() as number;
+    this.animationFrame = requestAnimationFrame(() => {
+      if (this.containerNode == null) {
+        return;
+      }
 
-    handleMeasurement({
-      containerWidth,
-      disclosureWidth,
-      hiddenTabWidths,
+      const {handleMeasurement} = this.props;
+      const containerWidth = this.containerNode.offsetWidth;
+      const tabMeasurerNode = findDOMNode(this);
+      const hiddenTabNodes =
+        tabMeasurerNode instanceof Element && tabMeasurerNode.children;
+      const hiddenTabNodesArray: HTMLElement[] = [].slice.call(hiddenTabNodes);
+      const hiddenTabWidths = hiddenTabNodesArray.map((node) => {
+        return node.getBoundingClientRect().width;
+      });
+      const disclosureWidth = hiddenTabWidths.pop() as number;
+
+      handleMeasurement({
+        containerWidth,
+        disclosureWidth,
+        hiddenTabWidths,
+      });
     });
   };
 }

--- a/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
+++ b/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
@@ -5,6 +5,17 @@ import Tab from '../../Tab';
 import Item from '../../Item';
 
 describe('<TabMeasurer />', () => {
+  let requestAnimationFrameSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    requestAnimationFrameSpy = jest.spyOn(window, 'requestAnimationFrame');
+    requestAnimationFrameSpy.mockImplementation((cb) => cb());
+  });
+
+  afterEach(() => {
+    requestAnimationFrameSpy.mockRestore();
+  });
+
   const mockProps = {
     tabToFocus: 0,
     activator: <Item id="id" focused />,


### PR DESCRIPTION
### WHY are these changes introduced?
This PR prevents the reflow that happens when we initialize the `Tabs` component. We need to measure the width of the tabs to determine how many we can fit in to a row and how many we need to hide.

### WHAT is this pull request doing?
This PR uses `requestAnimationFrame` in the `handleMeasurement` method to defer the actions that cause the reflow.

Here's what the reflow looked like on a slow device. `handleMeasurement` took about ~500ms.
<img width="964" alt="Screen Shot 2019-05-21 at 11 01 53 AM" src="https://user-images.githubusercontent.com/4441303/58121819-41488400-7bd6-11e9-86b3-c534518810fd.png">


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Check that the tab component still behaves as expected. This should only be a performance improvement.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

export default class Playground extends React.Component {
  state = {
    selected: 0,
  };

  handleTabChange = (selectedTabIndex) => {
    this.setState({selected: selectedTabIndex});
  };

  render() {
    const {selected} = this.state;
    const tabs = [
      {
        id: 'all-customers',
        content: 'All',
        accessibilityLabel: 'All customers',
        panelID: 'all-customers-content',
      },
      {
        id: 'accepts-marketing',
        content: 'Accepts marketing',
        panelID: 'accepts-marketing-content',
      },
      {
        id: 'repeat-customers',
        content: 'Repeat customers',
        panelID: 'repeat-customers-content',
      },
      {
        id: 'prospects',
        content: 'Prospects',
        panelID: 'prospects-content',
      },
    ];

    return (
      <Card>
        <Tabs tabs={tabs} selected={selected} onSelect={this.handleTabChange}>
          <Card.Section title={tabs[selected].content}>
            <p>Tab {selected} selected</p>
          </Card.Section>
        </Tabs>
      </Card>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
