### PR TITLE
[Button] Remove tap-highlight-color for buttons

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -35,7 +35,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Add `onQueryFocus` callback prop to the `Filters` component ([#1948](https://github.com/Shopify/polaris-react/pull/1948))
 - Moved `ResourceItem` to its own component ([#1774](https://github.com/Shopify/polaris-react/pull/1774))
 - Updated `ResourceList` sort to show an inline label ([#1774](https://github.com/Shopify/polaris-react/pull/1774))
-- Removed the `tap-highlight-color` for `Buttons` ((#1545)[https://github.com/Shopify/polaris-react/pull/1545])
+- Removed the `tap-highlight-color` for `Buttons` ([#1545](https://github.com/Shopify/polaris-react/pull/1545))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -35,6 +35,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Add `onQueryFocus` callback prop to the `Filters` component ([#1948](https://github.com/Shopify/polaris-react/pull/1948))
 - Moved `ResourceItem` to its own component ([#1774](https://github.com/Shopify/polaris-react/pull/1774))
 - Updated `ResourceList` sort to show an inline label ([#1774](https://github.com/Shopify/polaris-react/pull/1774))
+- Removed the `tap-highlight-color` for `Buttons` ((#1545)[https://github.com/Shopify/polaris-react/pull/1545])
 
 ### Bug fixes
 

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -34,6 +34,7 @@
   transition-property: background, border, box-shadow;
   transition-duration: duration();
   transition-timing-function: easing();
+  -webkit-tap-highlight-color: transparent;
 
   &:hover {
     background: linear-gradient(


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #1541

Removes `tap-highlight-color` for buttons. This looks nice for our default button, but I think our other buttons need some work.

|😄|😐|😞|
|---|---|---|
|![default button active](https://user-images.githubusercontent.com/344839/58121550-8cee3400-7bbc-11e9-8606-1ac8465998e6.gif)|![primary button active](https://user-images.githubusercontent.com/344839/58121554-8d86ca80-7bbc-11e9-9b4f-eea5b76180b9.gif)|![plain button active](https://user-images.githubusercontent.com/344839/58121553-8d86ca80-7bbc-11e9-9132-a0a9088c090a.gif)|

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
