### PR TITLE
[Navigation] Fix hover and active states

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -24,6 +24,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added a border to `Toast` messages to make them more visible in Windows high contrast mode ([#1469](https://github.com/Shopify/polaris-react/pull/1469))
 - Add `box-shadow` to the `Banner` to make it more visible in Windows high contrast mode ([#1481](https://github.com/Shopify/polaris-react/pull/1481))
 - Add `box-shadow` to the `Card` to make it more visible in Windows high contrast mode ([#1524](https://github.com/Shopify/polaris-react/pull/1524))
+- Fixed UI regressions in `Navigation` component hover and active states ([#1551](https://github.com/Shopify/polaris-react/pull/1551))
 
 ### Documentation
 

--- a/src/components/Navigation/Navigation.scss
+++ b/src/components/Navigation/Navigation.scss
@@ -54,7 +54,7 @@ $disabled-fade: 0.6;
 }
 
 .Item-selected {
-  font-weight: 700;
+  font-weight: 600;
   color: color('indigo', 'dark');
   background-color: $item-selected-background;
 
@@ -165,7 +165,7 @@ $secondary-item-font-size: rem(15px);
     }
   }
   .Item-selected {
-    font-weight: 700;
+    font-weight: 600;
     color: color('indigo', 'dark');
   }
   .Item-disabled {

--- a/src/components/Navigation/variables.scss
+++ b/src/components/Navigation/variables.scss
@@ -43,6 +43,7 @@ $nav-animation-variables: (
 
   &:hover {
     @include state(hover);
+    color: color('ink');
     text-decoration: none;
 
     .Icon {


### PR DESCRIPTION
Closes https://github.com/Shopify/polaris-react/issues/1487

I was unable to reproduce the cursor inconsistency described in the issue.

|:tophat: before|:tophat: after |
|-|-|
|![navigation-before](https://user-images.githubusercontent.com/1403188/58178029-6d661280-7c73-11e9-803d-19aa4175d743.gif)|![navigation-after](https://user-images.githubusercontent.com/1403188/58178062-75be4d80-7c73-11e9-88b8-9dc533e93723.gif)|

## :tophat:

- `dev up` in `shopify/web`
- pull this branch down
- `dev up` in `shopify/polaris-react`
- `yarn build-consumer web` in `shopify/polaris-react`
- `dev server` in `shopify/web`
- :tophat: `Customers/index` (a rails route), hovering over other navigation items