### PR TITLE
[Banner] Break word in title instead of overflowing line

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed text and other elements from being selected in Safari when dragging the color picker ([#1562](https://github.com/Shopify/polaris-react/pull/1562))
+- Fixed `Banner` `title` overflowing when set to a single long word ([#1553](https://github.com/Shopify/polaris-react/pull/1553))
 
 ### Documentation
 

--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -142,6 +142,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 
 .Heading {
   padding-top: $heading-offset;
+  word-break: break-word;
 }
 
 .Content {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #737 

Currently, long single word titles overflow the `Banner`'s boundary instead of wrapping to the next line. This PR ensures the line will wrap instead of overflowing.

### WHAT is this pull request doing?

Adds handling of `word-wrap` to the `Banner-Heading` class.

|  Before | After  |
|---|---|
|<img width="811" alt="Screen Shot 2019-05-22 at 1 48 15 PM" src="https://user-images.githubusercontent.com/18447883/58196433-4cfc7f00-7c98-11e9-9b06-c557e5d0066b.png">|<img width="796" alt="Screen Shot 2019-05-22 at 1 34 12 PM" src="https://user-images.githubusercontent.com/18447883/58196448-54238d00-7c98-11e9-9632-717b41f47c1e.png">|

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Banner} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <Banner
          title="W6R47WCFJNSXW6R47WCFJNSXW6R47WCFJNSXW6R47WCFJNSXW6R47WCFJNSXW6R47WCFJNSXW6R47WCFJNSXW6R47WCFJNSX"
          onDismiss={() => {}}
        >
          <p>This order was archived on March 7, 2017 at 3:12pm EDT.</p>
        </Banner>

        <Banner
          title="W6R47WCFJNSXW6R47WCFJNSXW6R47WCFJNSXW6R47WCFJNSXW6R47WCFJNSXW6R47WCFJNSXW6R47WCFJNSXW6R47WCFJNSX other words that might go here too maybe"
          onDismiss={() => {}}
        >
          <p>This order was archived on March 7, 2017 at 3:12pm EDT.</p>
        </Banner>
        <Banner
          title="Some banner title that is the normal use case but way longer than necessary to double triple check that this doesn't break stuff"
          onDismiss={() => {}}
        >
          <p>This order was archived on March 7, 2017 at 3:12pm EDT.</p>
        </Banner>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested in [supported browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
~* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)~
~* [ ] Updated the component's `README.md` with documentation changes~
~* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide~

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
