### PR TITLE
[Range slider] Fix types and styles

### DIFF
--- a/src/components/RangeSlider/RangeSlider.scss
+++ b/src/components/RangeSlider/RangeSlider.scss
@@ -1,2 +1,6 @@
+// Having no SCSS at the root of a component will prevent
+// sub component SCSS from being built
+
+// stylelint-disable-next-line block-no-empty
 .RangeSliderContainer {
 }

--- a/src/components/RangeSlider/RangeSlider.scss
+++ b/src/components/RangeSlider/RangeSlider.scss
@@ -1,0 +1,2 @@
+.RangeSliderContainer {
+}

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
-import {Props, RangeSliderValue, DualValue} from './types';
+import {RangeSliderProps, RangeSliderValue, DualValue} from './types';
 import {RangeSliderDefault} from './utilities';
 
 import {SingleThumb, DualThumb} from './components';
+import styles from './RangeSlider.scss';
 
+// The script in the styleguide that generates the Props Explorer data expects
+// a component's props to be found in the Props interface. This silly workaround
+// ensures that the Props Explorer table is generated correctly, instead of
+// crashing if we write `RangeSlider extends React.Component<RangeSliderProps>`
+interface Props extends RangeSliderProps {}
 type CombinedProps = Props & WithAppProviderProps;
 
 const getUniqueID = createUniqueIDFactory('RangeSlider');
@@ -30,11 +36,13 @@ class RangeSlider extends React.Component<CombinedProps> {
       ...rest,
     };
 
-    return isDualThumb(value) ? (
+    const sliderType = isDualThumb(value) ? (
       <DualThumb value={value} {...sharedProps} />
     ) : (
       <SingleThumb value={value} {...sharedProps} />
     );
+
+    return <div className={styles.RangeSliderContainer}>{sliderType}</div>;
   }
 }
 

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -7,7 +7,7 @@ import {
 } from '@shopify/javascript-utilities/events';
 import {classNames} from '@shopify/css-utilities';
 import {CSS_VAR_PREFIX} from '../../utilities';
-import {Props as RangeSliderProps, DualValue} from '../../types';
+import {RangeSliderProps, DualValue} from '../../types';
 import Labelled, {labelID} from '../../../Labelled';
 import EventListener from '../../../EventListener';
 import {Key} from '../../../../types';

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
@@ -4,7 +4,7 @@ import clamp from '../../../../utilities/clamp';
 import Labelled, {helpTextID} from '../../../Labelled';
 
 import {invertNumber, CSS_VAR_PREFIX} from '../../utilities';
-import {Props as RangeSliderProps} from '../../types';
+import {RangeSliderProps} from '../../types';
 
 import styles from './SingleThumb.scss';
 

--- a/src/components/RangeSlider/index.ts
+++ b/src/components/RangeSlider/index.ts
@@ -1,4 +1,4 @@
 import RangeSlider from './RangeSlider';
 
-export {Props, RangeSliderValue} from './types';
+export {RangeSliderProps, RangeSliderValue, DualValue} from './types';
 export default RangeSlider;

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -5,7 +5,7 @@ import {Error} from '../../types';
 export type DualValue = [number, number];
 export type RangeSliderValue = number | DualValue;
 
-export interface Props {
+export interface RangeSliderProps {
   /** Label for the range input */
   label: string;
   /** Adds an action to the label */

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -197,7 +197,7 @@ export {default as Portal, Props as PortalProps} from './Portal';
 
 export {default as RadioButton, Props as RadioButtonProps} from './RadioButton';
 
-export {default as RangeSlider, Props as RangeSliderProps} from './RangeSlider';
+export {default as RangeSlider, RangeSliderProps} from './RangeSlider';
 
 export {
   default as ResourceList,


### PR DESCRIPTION
### WHY are these changes introduced?

Props table was not rendering in the style guide AND the styles were not getting built

### WHAT is this pull request doing?

- Defines `Props` in the component. This is what the style guide parses.
- Adds an empty-ish top-level SCSS file so the styles get built

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide