### PR TITLE
[v4][OptionList] Remove componentWillReceiveProps

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -28,6 +28,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Code quality
 
 - Remove `withRef` and `withContext` from `DropZone.FileUpload` ([#1491](https://github.com/Shopify/polaris-react/pull/1491))
+- Updated `OptionList` to no longer use `componentWillReceiveProps`([#1557](https://github.com/Shopify/polaris-react/pull/1557))
 - Updated all our context files to export react context rather than a provider and consumer ([#1459](https://github.com/Shopify/polaris-react/pull/1459))
 - Upgraded the `Autocomplete` component from legacy context API to use createContext ([#1403](https://github.com/Shopify/polaris-react/pull/1403))
 - Removed testID warning in tests ([#1447](https://github.com/Shopify/polaris-react/pull/1447))

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, {useState, useRef, useCallback} from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 
 import {arraysAreEqual} from '../../utilities/arrays';
@@ -75,17 +75,14 @@ export default function OptionList({
   onChange,
   id: propId,
 }: Props) {
-  const [normalizedOptions, setNormalizedOptions] = React.useState(
+  const [normalizedOptions, setNormalizedOptions] = useState(
     createNormalizedOptions(options, sections, title),
   );
-  const id = React.useRef(propId || getUniqueId());
+  const id = useRef(propId || getUniqueId());
 
-  React.useEffect(
-    () => {
-      id.current = propId || id.current;
-    },
-    [propId],
-  );
+  if (id.current !== propId) {
+    id.current = propId || id.current;
+  }
 
   useDeepCompare(
     () => {
@@ -97,7 +94,7 @@ export default function OptionList({
     optionArraysAreEqual,
   );
 
-  const handleClick = React.useCallback(
+  const handleClick = useCallback(
     (sectionIndex: number, optionIndex: number) => {
       const selectedValue =
         normalizedOptions[sectionIndex].options[optionIndex].value;

--- a/src/components/OptionList/tests/OptionList.test.tsx
+++ b/src/components/OptionList/tests/OptionList.test.tsx
@@ -106,7 +106,7 @@ describe('<OptionList />', () => {
     ];
 
     optionList.setProps({options: newOptions});
-
+    optionList.update();
     const optionWrappers = optionList.find(Option);
     expect(optionWrappers).toHaveLength(totalOptions(newOptions, sections));
   });
@@ -134,7 +134,7 @@ describe('<OptionList />', () => {
     ];
 
     optionList.setProps({sections: newSections});
-
+    optionList.update();
     const optionWrappers = optionList.find(Option);
     expect(optionWrappers).toHaveLength(totalOptions(options, newSections));
   });
@@ -173,7 +173,7 @@ describe('<OptionList />', () => {
     ];
 
     optionList.setProps({options: newOptions, sections: newSections});
-
+    optionList.update();
     const optionWrappers = optionList.find(Option);
     expect(optionWrappers).toHaveLength(totalOptions(newOptions, newSections));
   });
@@ -185,7 +185,7 @@ describe('<OptionList />', () => {
     );
 
     optionList.setProps({options: undefined});
-
+    optionList.update();
     const optionWrappers = optionList.find(Option);
     expect(optionWrappers).toHaveLength(totalOptions([], sections));
   });
@@ -197,7 +197,7 @@ describe('<OptionList />', () => {
     );
 
     optionList.setProps({sections: undefined});
-
+    optionList.update();
     const optionWrappers = optionList.find(Option);
     expect(optionWrappers).toHaveLength(totalOptions(options, []));
   });
@@ -224,7 +224,7 @@ describe('<OptionList />', () => {
     ];
 
     optionList.setProps({options: undefined, sections: newSections});
-
+    optionList.update();
     const optionWrappers = optionList.find(Option);
     expect(optionWrappers).toHaveLength(totalOptions(undefined, newSections));
   });
@@ -247,7 +247,7 @@ describe('<OptionList />', () => {
     ];
 
     optionList.setProps({options: newOptions, sections: undefined});
-
+    optionList.update();
     const optionWrappers = optionList.find(Option);
     expect(optionWrappers).toHaveLength(totalOptions(newOptions, undefined));
   });
@@ -315,7 +315,7 @@ describe('<OptionList />', () => {
       ];
 
       optionList.setProps({options: newOptions});
-
+      optionList.update();
       const optionWrappers = optionList.find(Option);
       expect(optionWrappers).toHaveLength(totalOptions(newOptions, sections));
     });
@@ -343,7 +343,7 @@ describe('<OptionList />', () => {
       ];
 
       optionList.setProps({sections: newSections});
-
+      optionList.update();
       const optionWrappers = optionList.find(Option);
       expect(optionWrappers).toHaveLength(totalOptions(options, newSections));
     });
@@ -382,7 +382,7 @@ describe('<OptionList />', () => {
       ];
 
       optionList.setProps({options: newOptions, sections: newSections});
-
+      optionList.update();
       const optionWrappers = optionList.find(Option);
       expect(optionWrappers).toHaveLength(
         totalOptions(newOptions, newSections),
@@ -396,7 +396,7 @@ describe('<OptionList />', () => {
       );
 
       optionList.setProps({options: undefined});
-
+      optionList.update();
       const optionWrappers = optionList.find(Option);
       expect(optionWrappers).toHaveLength(totalOptions(undefined, sections));
     });
@@ -408,7 +408,7 @@ describe('<OptionList />', () => {
       );
 
       optionList.setProps({sections: undefined});
-
+      optionList.update();
       const optionWrappers = optionList.find(Option);
       expect(optionWrappers).toHaveLength(totalOptions(options, undefined));
     });
@@ -435,7 +435,7 @@ describe('<OptionList />', () => {
       ];
 
       optionList.setProps({options: undefined, sections: newSections});
-
+      optionList.update();
       const optionWrappers = optionList.find(Option);
       expect(optionWrappers).toHaveLength(totalOptions(undefined, newSections));
     });
@@ -458,7 +458,7 @@ describe('<OptionList />', () => {
       ];
 
       optionList.setProps({options: newOptions, sections: undefined});
-
+      optionList.update();
       const optionWrappers = optionList.find(Option);
       expect(optionWrappers).toHaveLength(totalOptions(newOptions, undefined));
     });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,5 @@
 export {default as usePolaris} from './use-polaris';
 
 export {default as useAppBridge} from './use-app-bridge';
+
+export {default as useDeepCompare} from './use-deep-compare';

--- a/src/hooks/use-deep-compare/index.ts
+++ b/src/hooks/use-deep-compare/index.ts
@@ -1,0 +1,3 @@
+import useDeepCompare from './use-deep-compare';
+
+export default useDeepCompare;

--- a/src/hooks/use-deep-compare/use-deep-compare.tsx
+++ b/src/hooks/use-deep-compare/use-deep-compare.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import isEqual from 'lodash/isEqual';
+
+type EffectCallback = () => void | (() => void | undefined);
+type DependencyList = ReadonlyArray<unknown>;
+type Comparator = (a: DependencyList, b: DependencyList) => boolean;
+
+function useDeepCompareRef(
+  dependencies: DependencyList,
+  comparator: Comparator = isEqual,
+) {
+  const dependencyList = React.useRef<DependencyList>(dependencies);
+
+  if (!comparator(dependencyList.current, dependencies)) {
+    dependencyList.current = dependencies;
+  }
+
+  return dependencyList.current;
+}
+
+function useDeepCompare(
+  callback: EffectCallback,
+  dependencies: DependencyList,
+  customCompare?: Comparator,
+) {
+  React.useEffect(callback, useDeepCompareRef(dependencies, customCompare));
+}
+
+export default useDeepCompare;


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-react/issues/519

### WHAT is this pull request doing?

* Removing `componentWillReceiveProps` from option list
* Fix tests
* Create a hook to address deep comparison
* Add changelog

### How to 🎩

Tests / Percy / Heroku deployment playground


### Notes

The reason for a deep comparison hook is that react doesn't do very much work comparing your dependencies. They only use [Object.is](https://github.com/facebook/react/blob/101901dc2d09509fa0b667196e1ac63ec17bc656/packages/react-reconciler/src/ReactFiberHooks.js#L300)(link to source code) and offer suggestions like [`JSON.stringify`](https://github.com/facebook/react/issues/14476#issuecomment-471199055). We often have complex types that we need to compare so this hook will be very useful in the future as well.