### PR TITLE
[ColorPicker] Fix errant text selection

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed text and other elements from being selected in Safari when dragging the color picker. ([#1562](https://github.com/Shopify/polaris-react/pull/1562))
+
 ### Documentation
 
 ### Development workflow

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,7 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
-- Fixed text and other elements from being selected in Safari when dragging the color picker. ([#1562](https://github.com/Shopify/polaris-react/pull/1562))
+- Fixed text and other elements from being selected in Safari when dragging the color picker ([#1562](https://github.com/Shopify/polaris-react/pull/1562))
 
 ### Documentation
 

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -70,7 +70,12 @@ export default class ColorPicker extends React.PureComponent<Props, State> {
     ) : null;
 
     return (
-      <div className={styles.ColorPicker} id={id}>
+      <div
+        className={styles.ColorPicker}
+        id={id}
+        onMouseDown={this.handlePickerDrag}
+        onMouseMove={this.handlePickerDrag}
+      >
         <div ref={this.setColorNode} className={styles.MainColor}>
           <div
             className={styles.ColorLayer}
@@ -119,5 +124,11 @@ export default class ColorPicker extends React.PureComponent<Props, State> {
     const brightness = clamp(1 - y / pickerSize, 0, 1);
 
     onChange({hue, saturation, brightness, alpha});
+  };
+
+  private handlePickerDrag = (
+    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ) => {
+    e.preventDefault();
   };
 }

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -74,7 +74,6 @@ export default class ColorPicker extends React.PureComponent<Props, State> {
         className={styles.ColorPicker}
         id={id}
         onMouseDown={this.handlePickerDrag}
-        onMouseMove={this.handlePickerDrag}
       >
         <div ref={this.setColorNode} className={styles.MainColor}>
           <div
@@ -127,9 +126,9 @@ export default class ColorPicker extends React.PureComponent<Props, State> {
   };
 
   private handlePickerDrag = (
-    evnt: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
   ) => {
     // prevents external elements from being selected
-    evnt.preventDefault();
+    event.preventDefault();
   };
 }

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -127,8 +127,9 @@ export default class ColorPicker extends React.PureComponent<Props, State> {
   };
 
   private handlePickerDrag = (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    evnt: React.MouseEvent<HTMLDivElement, MouseEvent>,
   ) => {
-    e.preventDefault();
+    // prevents external elements from being selected
+    evnt.preventDefault();
   };
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1542. Text outside the color picker was being selected when dragging the picker.

### WHAT is this pull request doing?

No UI changes. Simply prevented the mousedown event from bubbling up to other elements in the DOM to stop other text from being able to detect they were being dragged over to select.



### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing) (iPhone XS, Safari/Chrome)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers) (MBP, Safari/Chrome)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] ~Updated the component's `README.md` with documentation changes~ N/A
* [x] ~[Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide~ N/A

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
