### PR TITLE
[v4][PositionedOverlay] Add unsafe to componentWillReceiveProps

### DIFF
--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -52,6 +52,7 @@ export interface State {
   lockPosition: boolean;
 }
 
+// eslint-disable-next-line react/no-unsafe
 export default class PositionedOverlay extends React.PureComponent<
   Props,
   State
@@ -92,7 +93,8 @@ export default class PositionedOverlay extends React.PureComponent<
     }
   }
 
-  componentWillReceiveProps() {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps() {
     this.handleMeasurement();
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Part of #519

### WHAT is this pull request doing?

* adds unsafe and eslint ignores
* skipping the changelog entry since this isn't a meaningful change

Removing `componentWillReceiveProps` is out of scope for the `v4` project and can be a stretch goal. It seems there is a larger issue then `componentWillReceiveProps` being used. As mentioned by [Chris, Dom, Matt and Utkarsh](https://github.com/Shopify/polaris-react-deprecated/pull/506) this was only supposed to be a temporary change that seems to have fallen through the cracks and can't really be converted to other lifecycles/hooks. We will probably need to rearchitect `PositionedOverlay` to fix this problem. After this is merged I'll open an issue outlining the problem. 

