### PR TITLE
[EmptyState] Add content context variant

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,9 @@
 - Moved `Button` styles from the `Buttongroup` CSS file to the `Button` CSS file ([#2441](https://github.com/Shopify/polaris-react/pull/2441))
 - Added `footerActionAlignment` prop to control `<Card>` footer action alignment, defaults to `'right'`
 - Improved contrast of `MessageIndicator` with a border ([#2428](https://github.com/Shopify/polaris-react/pull/2428))
+- Removed the need for z-indexes in `Icon` ([#2207](https://github.com/Shopify/polaris-react/pull/2207))
+- Added `features` prop to `AppProvider` ([#2204](https://github.com/Shopify/polaris-react/pull/2204))
+- Added support for using `EmptyState` in a content context ([#1570](https://github.com/Shopify/polaris-react/pull/1570))
 
 ### Bug fixes
 

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -1,7 +1,6 @@
 @import '../../styles/common';
 
 $detail-width: rem(336px);
-
 $stacking-order: (
   illustration: 0,
   details: 10,
@@ -70,14 +69,70 @@ $illustration-width-cropped: calc(
   }
 }
 
-.Details {
-  position: relative;
-  z-index: z-index(details, $stacking-order);
-  padding: 0 spacing();
-  width: $detail-width;
+.withinContentContainer {
+  .Section {
+    position: unset;
+    flex-direction: column-reverse;
+    align-items: center;
+    justify-content: center;
+  }
 
-  @include page-content-when-not-fully-condensed {
-    padding: 0;
+  .DetailsContainer {
+    padding-top: spacing();
+  }
+
+  .Details {
+    display: flex;
+    text-align: center;
+    flex-direction: column;
+    align-items: center;
+
+    @include page-content-when-not-fully-condensed {
+      max-width: $detail-width;
+    }
+  }
+
+  .Image {
+    margin: 0;
+    width: initial;
+  }
+
+  .Content {
+    @include text-style-body;
+    padding-bottom: spacing(tight);
+  }
+}
+
+.withinPage {
+  .Details {
+    position: relative;
+    z-index: z-index(details, $stacking-order);
+    padding: 0 spacing();
+    width: $detail-width;
+
+    @include page-content-when-not-fully-condensed {
+      padding: 0;
+    }
+  }
+
+  .Image {
+    position: relative;
+    z-index: z-index(illustration, $stacking-order);
+    margin-top: spacing(loose) * -1;
+    margin-left: $illustration-left-margin;
+    width: $illustration-width-cropped;
+    max-width: none;
+
+    @include page-content-when-not-fully-condensed {
+      margin-left: 0;
+      width: 100%;
+    }
+
+    @include page-content-when-not-partially-condensed {
+      margin-top: 0;
+      margin-left: $illustration-left-margin;
+      width: $illustration-width;
+    }
   }
 }
 
@@ -88,26 +143,6 @@ $illustration-width-cropped: calc(
 
 .Actions {
   margin-top: spacing();
-}
-
-.Image {
-  position: relative;
-  z-index: z-index(illustration, $stacking-order);
-  margin-top: spacing(loose) * -1;
-  margin-left: $illustration-left-margin;
-  width: $illustration-width-cropped;
-  max-width: none;
-
-  @include page-content-when-not-fully-condensed {
-    margin-left: 0;
-    width: 100%;
-  }
-
-  @include page-content-when-not-partially-condensed {
-    margin-top: 0;
-    margin-left: $illustration-left-margin;
-    width: $illustration-width;
-  }
 }
 
 .FooterContent {

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useContext} from 'react';
 import {classNames} from '../../utilities/css';
 import {WithinContentContext} from '../../utilities/within-content-context';
 
@@ -30,117 +30,101 @@ export interface EmptyStateProps {
   footerContent?: React.ReactNode;
 }
 
-export class EmptyState extends React.PureComponent<EmptyStateProps, never> {
-  render() {
-    return (
-      <WithinContentContext.Consumer>
-        {(withinContentContainer) => {
-          const {
-            children,
-            heading,
-            image,
-            largeImage,
-            imageContained,
-            action,
-            secondaryAction,
-            footerContent,
-          } = this.props;
+export function EmptyState({
+  children,
+  heading,
+  image,
+  largeImage,
+  imageContained,
+  action,
+  secondaryAction,
+  footerContent,
+}: EmptyStateProps) {
+  const withinContentContainer = useContext(WithinContentContext);
+  const className = classNames(
+    styles.EmptyState,
+    imageContained && styles.imageContained,
+    withinContentContainer ? styles.withinContentContainer : styles.withinPage,
+  );
 
-          const className = classNames(
-            styles.EmptyState,
-            imageContained && styles.imageContained,
-            withinContentContainer
-              ? styles.withinContentContainer
-              : styles.withinPage,
-          );
+  const imageMarkup = largeImage ? (
+    <Image
+      alt=""
+      role="presentation"
+      className={styles.Image}
+      source={largeImage}
+      sourceSet={[
+        {source: image, descriptor: '568w'},
+        {source: largeImage, descriptor: '1136w'},
+      ]}
+      sizes="(max-width: 568px) 60vw"
+    />
+  ) : (
+    <Image role="presentation" alt="" className={styles.Image} source={image} />
+  );
 
-          const imageMarkup = largeImage ? (
-            <Image
-              alt=""
-              role="presentation"
-              className={styles.Image}
-              source={largeImage}
-              sourceSet={[
-                {source: image, descriptor: '568w'},
-                {source: largeImage, descriptor: '1136w'},
-              ]}
-              sizes="(max-width: 568px) 60vw"
-            />
-          ) : (
-            <Image
-              role="presentation"
-              alt=""
-              className={styles.Image}
-              source={image}
-            />
-          );
+  const secondaryActionMarkup = secondaryAction
+    ? buttonFrom(secondaryAction, {plain: true})
+    : null;
 
-          const secondaryActionMarkup = secondaryAction
-            ? buttonFrom(secondaryAction, {plain: true})
-            : null;
+  const footerContentMarkup = footerContent ? (
+    <div className={styles.FooterContent}>
+      <TextContainer>{footerContent}</TextContainer>
+    </div>
+  ) : null;
 
-          const footerContentMarkup = footerContent ? (
-            <div className={styles.FooterContent}>
-              <TextContainer>{footerContent}</TextContainer>
-            </div>
-          ) : null;
+  const headingSize = withinContentContainer ? 'small' : 'medium';
+  const primaryActionSize = withinContentContainer ? 'medium' : 'large';
 
-          const headingSize = withinContentContainer ? 'small' : 'medium';
-          const primaryActionSize = withinContentContainer ? 'medium' : 'large';
+  const primaryActionMarkup = action
+    ? buttonFrom(action, {primary: true, size: primaryActionSize})
+    : null;
 
-          const primaryActionMarkup = action
-            ? buttonFrom(action, {primary: true, size: primaryActionSize})
-            : null;
+  const headingMarkup = heading ? (
+    <DisplayText size={headingSize}>{heading}</DisplayText>
+  ) : null;
 
-          const headingMarkup = heading ? (
-            <DisplayText size={headingSize}>{heading}</DisplayText>
-          ) : null;
+  const childrenMarkup = children ? (
+    <div className={styles.Content}>{children}</div>
+  ) : null;
 
-          const childrenMarkup = children ? (
-            <div className={styles.Content}>{children}</div>
-          ) : null;
+  const textContentMarkup =
+    headingMarkup || children ? (
+      <TextContainer>
+        {headingMarkup}
+        {childrenMarkup}
+      </TextContainer>
+    ) : null;
 
-          const textContentMarkup =
-            headingMarkup || children ? (
-              <TextContainer>
-                {headingMarkup}
-                {childrenMarkup}
-              </TextContainer>
-            ) : null;
+  const actionsMarkup =
+    primaryActionMarkup || secondaryActionMarkup ? (
+      <div className={styles.Actions}>
+        <Stack alignment="center">
+          {primaryActionMarkup}
+          {secondaryActionMarkup}
+        </Stack>
+      </div>
+    ) : null;
 
-          const actionsMarkup =
-            primaryActionMarkup || secondaryActionMarkup ? (
-              <div className={styles.Actions}>
-                <Stack alignment="center">
-                  {primaryActionMarkup}
-                  {secondaryActionMarkup}
-                </Stack>
-              </div>
-            ) : null;
-
-          const detailsMarkup =
-            textContentMarkup || actionsMarkup || footerContentMarkup ? (
-              <div className={styles.DetailsContainer}>
-                <div className={styles.Details}>
-                  {textContentMarkup}
-                  {actionsMarkup}
-                  {footerContentMarkup}
-                </div>
-              </div>
-            ) : (
-              <div className={styles.DetailsContainer} />
-            );
-
-          return (
-            <div className={className}>
-              <div className={styles.Section}>
-                {detailsMarkup}
-                <div className={styles.ImageContainer}>{imageMarkup}</div>
-              </div>
-            </div>
-          );
-        }}
-      </WithinContentContext.Consumer>
+  const detailsMarkup =
+    textContentMarkup || actionsMarkup || footerContentMarkup ? (
+      <div className={styles.DetailsContainer}>
+        <div className={styles.Details}>
+          {textContentMarkup}
+          {actionsMarkup}
+          {footerContentMarkup}
+        </div>
+      </div>
+    ) : (
+      <div className={styles.DetailsContainer} />
     );
-  }
+
+  return (
+    <div className={className}>
+      <div className={styles.Section}>
+        {detailsMarkup}
+        <div className={styles.ImageContainer}>{imageMarkup}</div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {classNames} from '../../utilities/css';
+import {WithinContentContext} from '../../utilities/within-content-context';
 
 import {Action} from '../../types';
 import {Image} from '../Image';
@@ -31,103 +32,115 @@ export interface EmptyStateProps {
 
 export class EmptyState extends React.PureComponent<EmptyStateProps, never> {
   render() {
-    const {
-      children,
-      heading,
-      image,
-      largeImage,
-      imageContained,
-      action,
-      secondaryAction,
-      footerContent,
-    } = this.props;
-
-    const className = classNames(
-      styles.EmptyState,
-      imageContained && styles.imageContained,
-    );
-
-    const imageMarkup = largeImage ? (
-      <Image
-        alt=""
-        role="presentation"
-        className={styles.Image}
-        source={largeImage}
-        sourceSet={[
-          {source: image, descriptor: '568w'},
-          {source: largeImage, descriptor: '1136w'},
-        ]}
-        sizes="(max-width: 568px) 60vw"
-      />
-    ) : (
-      <Image
-        role="presentation"
-        alt=""
-        className={styles.Image}
-        source={image}
-      />
-    );
-
-    const secondaryActionMarkup = secondaryAction
-      ? buttonFrom(secondaryAction, {plain: true})
-      : null;
-
-    const footerContentMarkup = footerContent ? (
-      <div className={styles.FooterContent}>
-        <TextContainer>{footerContent}</TextContainer>
-      </div>
-    ) : null;
-
-    const primaryActionMarkup = action
-      ? buttonFrom(action, {primary: true, size: 'large'})
-      : null;
-
-    const headingMarkup = heading ? (
-      <DisplayText size="medium">{heading}</DisplayText>
-    ) : null;
-
-    const childrenMarkup = children ? (
-      <div className={styles.Content}>{children}</div>
-    ) : null;
-
-    const textContentMarkup =
-      headingMarkup || children ? (
-        <TextContainer>
-          {headingMarkup}
-          {childrenMarkup}
-        </TextContainer>
-      ) : null;
-
-    const actionsMarkup =
-      primaryActionMarkup || secondaryActionMarkup ? (
-        <div className={styles.Actions}>
-          <Stack alignment="center">
-            {primaryActionMarkup}
-            {secondaryActionMarkup}
-          </Stack>
-        </div>
-      ) : null;
-
-    const detailsMarkup =
-      textContentMarkup || actionsMarkup || footerContentMarkup ? (
-        <div className={styles.DetailsContainer}>
-          <div className={styles.Details}>
-            {textContentMarkup}
-            {actionsMarkup}
-            {footerContentMarkup}
-          </div>
-        </div>
-      ) : (
-        <div className={styles.DetailsContainer} />
-      );
-
     return (
-      <div className={className}>
-        <div className={styles.Section}>
-          {detailsMarkup}
-          <div className={styles.ImageContainer}>{imageMarkup}</div>
-        </div>
-      </div>
+      <WithinContentContext.Consumer>
+        {(withinContentContainer) => {
+          const {
+            children,
+            heading,
+            image,
+            largeImage,
+            imageContained,
+            action,
+            secondaryAction,
+            footerContent,
+          } = this.props;
+
+          const className = classNames(
+            styles.EmptyState,
+            imageContained && styles.imageContained,
+            withinContentContainer
+              ? styles.withinContentContainer
+              : styles.withinPage,
+          );
+
+          const imageMarkup = largeImage ? (
+            <Image
+              alt=""
+              role="presentation"
+              className={styles.Image}
+              source={largeImage}
+              sourceSet={[
+                {source: image, descriptor: '568w'},
+                {source: largeImage, descriptor: '1136w'},
+              ]}
+              sizes="(max-width: 568px) 60vw"
+            />
+          ) : (
+            <Image
+              role="presentation"
+              alt=""
+              className={styles.Image}
+              source={image}
+            />
+          );
+
+          const secondaryActionMarkup = secondaryAction
+            ? buttonFrom(secondaryAction, {plain: true})
+            : null;
+
+          const footerContentMarkup = footerContent ? (
+            <div className={styles.FooterContent}>
+              <TextContainer>{footerContent}</TextContainer>
+            </div>
+          ) : null;
+
+          const headingSize = withinContentContainer ? 'small' : 'medium';
+          const primaryActionSize = withinContentContainer ? 'medium' : 'large';
+
+          const primaryActionMarkup = action
+            ? buttonFrom(action, {primary: true, size: primaryActionSize})
+            : null;
+
+          const headingMarkup = heading ? (
+            <DisplayText size={headingSize}>{heading}</DisplayText>
+          ) : null;
+
+          const childrenMarkup = children ? (
+            <div className={styles.Content}>{children}</div>
+          ) : null;
+
+          const textContentMarkup =
+            headingMarkup || children ? (
+              <TextContainer>
+                {headingMarkup}
+                {childrenMarkup}
+              </TextContainer>
+            ) : null;
+
+          const actionsMarkup =
+            primaryActionMarkup || secondaryActionMarkup ? (
+              <div className={styles.Actions}>
+                <Stack alignment="center">
+                  {primaryActionMarkup}
+                  {secondaryActionMarkup}
+                </Stack>
+              </div>
+            ) : null;
+
+          const detailsMarkup =
+            textContentMarkup || actionsMarkup || footerContentMarkup ? (
+              <div className={styles.DetailsContainer}>
+                <div className={styles.Details}>
+                  {textContentMarkup}
+                  {actionsMarkup}
+                  {footerContentMarkup}
+                </div>
+              </div>
+            ) : (
+              <div className={styles.DetailsContainer} />
+            );
+
+          return (
+            <div className={className}>
+              <div className={styles.Section}>
+                {detailsMarkup}
+                <div className={styles.ImageContainer}>{imageMarkup}</div>
+              </div>
+            </div>
+          );
+        }}
+      </WithinContentContext.Consumer>
     );
   }
 }

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -197,6 +197,29 @@ Use to provide additional but non-critical context for a new product or feature.
 </EmptyState>
 ```
 
+### Empty state within a content context
+
+<!-- example-for: web -->
+
+Use to explain a section or feature before merchants have used it within the context of a content container like a card or a resource list.
+
+```jsx
+<Card>
+  <Card.Section>
+    <EmptyState
+      heading="Upload a file to get started"
+      action={{content: 'Upload files'}}
+      image="https://cdn.shopify.com/s/files/1/2376/3301/products/file-upload-empty-state.png"
+    >
+      <p>
+        You can use the Files section to upload images, videos, and other
+        documents
+      </p>
+    </EmptyState>
+  </Card.Section>
+</Card>
+```
+
 ---
 
 ## Related components

--- a/src/components/EmptyState/tests/EmptyState.test.tsx
+++ b/src/components/EmptyState/tests/EmptyState.test.tsx
@@ -1,23 +1,51 @@
 import React from 'react';
-import {Image, DisplayText, TextContainer, UnstyledLink} from 'components';
+import {
+  Image,
+  DisplayText,
+  TextContainer,
+  UnstyledLink,
+  Button,
+} from 'components';
+
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import {WithinContentContext} from '../../../utilities/within-content-context';
 import {EmptyState} from '../EmptyState';
 
 describe('<EmptyState />', () => {
   let imgSrc =
     'https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg';
 
-  describe('primaryAction', () => {
-    it('renders a button with the action content if a primaryAction is provided', () => {
+  describe('action', () => {
+    it('renders a button with the action content if action is set', () => {
       const emptyState = mountWithAppProvider(
         <EmptyState action={{content: 'Add transfer'}} image={imgSrc} />,
       );
       expect(emptyState.find('button').contains('Add transfer')).toBe(true);
     });
 
-    it('renders does not render button with the action content if no primaryAction is provided', () => {
+    it('does not render a button when no action is set', () => {
       const emptyState = mountWithAppProvider(<EmptyState image={imgSrc} />);
       expect(emptyState.find('button').contains('Add transfer')).toBe(false);
+    });
+
+    it('renders a large button by default', () => {
+      const emptyState = mountWithAppProvider(
+        <EmptyState image={imgSrc} action={{content: 'Upload files'}} />,
+      );
+
+      expect(emptyState.find(Button).prop('size')).toBe('large');
+    });
+
+    it('renders a medium button when in a content context', () => {
+      const emptyStateInContentContext = mountWithAppProvider(
+        <WithinContentContext.Provider value>
+          <EmptyState image={imgSrc} action={{content: 'Upload files'}} />
+        </WithinContentContext.Provider>,
+      );
+
+      expect(emptyStateInContentContext.find(Button).prop('size')).toBe(
+        'medium',
+      );
     });
   });
 
@@ -92,6 +120,20 @@ describe('<EmptyState />', () => {
       );
       expect(emptyState.find(DisplayText).prop('size')).toBe('medium');
       expect(emptyState.find(DisplayText).contains(expectedHeading)).toBe(true);
+    });
+
+    it('renders a small DisplayText when in a content context', () => {
+      const emptyStateInContentContext = mountWithAppProvider(
+        <WithinContentContext.Provider value>
+          <EmptyState heading="Heading" image={imgSrc} />
+        </WithinContentContext.Provider>,
+      );
+
+      const headingSize = emptyStateInContentContext
+        .find(DisplayText)
+        .prop('size');
+
+      expect(headingSize).toBe('small');
     });
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

This PR is one of two that will enable the improvement of transitions from skeleton loading states to empty states by adding support for use of the empty state component in a content context. For example, within a `Card` or `ResourceList`**. 
 
### WHAT is this pull request doing?

Adds content context consumer to `EmptyState`

Empty state in a card (small screen on right):

<img width="974" alt="Screen Shot 2019-10-01 at 7 39 01 PM" src="https://user-images.githubusercontent.com/18447883/66008176-4cb09380-e483-11e9-9635-9371d6997920.png">

**Note: I'm adding empty state handling to `ResourceList` in a [separate PR](https://github.com/Shopify/polaris-react/pull/2160).

### How to 🎩

<details>
<summary>Click to view collapsed tophatting instructions</summary>
<br />

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

View the "Empty state in content context" example in the [Chroma deployment](https://www.chromaui.com/component?appId=5d559397bae39100201eedc1&name=All%20Components%7CEmpty%20state&buildNumber=783&specName=Empty%20state%20within%20a%20content%20context). The latest deployment can be found by clicking the "Details" link in the `ci/chroma` check line item of the PR checks below.

I recommend reviewing the code with whitespace changes removed from the diff so it's easier to see what actually changed (since I converted the component from a class to a function, most of the code in `EmptyState.tsx` shifted left one tab).

<img width="253" alt="Screen Shot 2019-09-17 at 7 27 02 PM" src="https://user-images.githubusercontent.com/18447883/65086842-5d401480-d981-11e9-9c86-fda3be8e855e.png">


*_or_*

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';
import {Page, Layout, EmptyState, Card} from '../src';

export function Playground() {
  const [contentContext, setContentContext] = useState(true);
  const toggleContentContext = useCallback(
    () => setContentContext((contentContext) => !contentContext),
    [],
  );

  const emptyStateMarkup = contentContext ? (
    <Card sectioned>
      <EmptyState
        heading="Upload a file to get started"
        action={{content: 'Upload files'}}
        image="https://user-images.githubusercontent.com/18447883/59945230-fa4be980-9434-11e9-9106-a373f0efbe08.png"
      >
        <p>
          You can use the Files section to upload images, videos, and other
          documents
        </p>
      </EmptyState>
    </Card>
  ) : (
    <EmptyState
      heading="Manage your inventory transfers"
      action={{content: 'Add transfer'}}
      secondaryAction={{content: 'Learn more', url: 'https://help.shopify.com'}}
      image="https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg"
    >
      <p>Track and receive your incoming inventory from suppliers.</p>
    </EmptyState>
  );

  const markup = contentContext ? (
    <Card>{emptyStateMarkup}</Card>
  ) : (
    emptyStateMarkup
  );

  const secondaryLayoutSection = contentContext ? (
    <Layout.Section secondary>{markup}</Layout.Section>
  ) : null;

  const title = contentContext
    ? 'Empty state content context'
    : 'Empty state standard';

  return (
    <Page
      title={title}
      primaryAction={{
        content: 'Toggle content context',
        onAction: toggleContentContext,
      }}
    >
      <Layout>
        <Layout.Section>{markup}</Layout.Section>
        {secondaryLayoutSection}
      </Layout>
    </Page>
  );
}
```

</details>

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->


</details>

---

### How to test your use case in a content context 👩‍🔬
 
<details>
<summary>Click to view collapsed instructions for testing your use case</summary>

Add a comment to this PR with an explanation of your use case with your empty state image attached/embedded in the comment. 

For example, the image attached below is here so the playground code collapsed above will work for anyone locally. This is because the `EmptyState` `image` prop has the url of the attachment set as its string value. 

You can copy the link to your image attachment by right clicking on the image and selecting "Copy image address" from the right click menu.

![File-Upload-Spot](https://user-images.githubusercontent.com/18447883/59945230-fa4be980-9434-11e9-9106-a373f0efbe08.png)


</details>

---

### PR checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
~(n/a) Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)~
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
