### PR TITLE
[App bridge] Add deprecation messages

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -35,3 +35,5 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Code quality
 
 ### Deprecations
+
+- Deprecated all usage of the Shopify App Bridge in Polaris React ([#1573](https://github.com/Shopify/polaris-react/pull/1573))

--- a/src/components/AppProvider/README.md
+++ b/src/components/AppProvider/README.md
@@ -369,7 +369,7 @@ class ProviderThemeExample extends React.Component {
 
 ---
 
-## Initializing the Shopify App Bridge
+## Initializing the Shopify App Bridge (deprecated)
 
 When using Polaris, you don’t need to go through the initialization of the Shopify App Bridge as described in the [Shopify Help Center](https://help.shopify.com/en/api/embedded-apps/app-bridge#set-up-your-app). Instead, configure the connection to the Shopify admin through the [app provider component](https://polaris.shopify.com/components/structure/app-provider), which wraps all components in an embedded app. The app provider component initializes the Shopify App Bridge using the `apiKey` and `shopOrigin` that you provide. **The `apiKey` and the `shopOrigin` attributes are required.** Find the API key for your app in the Apps section of your [Shopify Partner Dashboard](https://partners.shopify.com). Learn how to get and store the shop origin in the [Shopify Help Center](https://help.shopify.com/en/api/embedded-apps/shop-origin).
 
@@ -389,9 +389,45 @@ ReactDOM.render(
 );
 ```
 
+#### Deprecation rationale
+
+As of v3.17.0, using `apiKey` and `shopOrigin` on `AppProvider` to initialize the Shopify App Bridge is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. More information can be found [here](https://github.com/Shopify/polaris-react/issues/814). Use `Provider` from `@shopify/app-bridge-react` instead. For example:
+
+```jsx
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {Provider, TitleBar} from '@shopify/app-bridge-react';
+
+function MyApp() {
+  const config = {apiKey: 'YOUR_API_KEY', shopOrigin: 'SHOP_ORIGIN'};
+  return (
+    <Provider config={config}>
+      <TitleBar
+        title="Hello world!"
+        primaryAction={{
+          content: 'Foo',
+          url: '/foo',
+        }}
+        secondaryActions={[{content: 'Bar', url: '/bar'}]}
+        actionGroups={[
+          {
+            title: 'Baz',
+            actions: [{content: 'Baz', url: '/baz'}],
+          },
+        ]}
+      />
+    </Provider>
+  );
+}
+
+const root = document.createElement('div');
+document.body.appendChild(root);
+ReactDOM.render(<MyApp />, root);
+```
+
 ---
 
-## Access to the Shopify App Bridge instance
+## Access to the Shopify App Bridge instance (deprecated)
 
 To provide access to your initialized Shopify App Bridge instance, we make it available through [React’s `context`](https://facebook.github.io/react/docs/context.html). The example below demonstrates how to access the `appBridge` object from React’s `context`, in order to use the [`Redirect` action](https://help.shopify.com/en/api/embedded-apps/app-bridge/actions/navigation/redirect) to navigate:
 
@@ -424,6 +460,10 @@ render(
   document.querySelector('#app'),
 );
 ```
+
+#### Deprecation rationale
+
+As of v3.17.0, using the Shopify App Bridge instance in context is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. More information can be found [here](https://github.com/Shopify/polaris-react/issues/814). Use the [Shopify App Bridge](https://help.shopify.com/en/api/embedded-apps/app-bridge) directly instead.
 
 ---
 

--- a/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
+++ b/src/components/AppProvider/utilities/createAppProviderContext/createAppProviderContext.ts
@@ -38,6 +38,13 @@ export default function createAppProviderContext({
       })
     : undefined;
 
+  if (appBridge != null) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "Deprecation: Using `apiKey` and `shopOrigin` on `AppProvider` to initialize the Shopify App Bridge is deprecated. Support for this will be removed in v5.0. Use `Provider` from `@shopify/app-bridge-react` instead. For example, `import {Provider} from '@shopify/app-bridge-react';`",
+    );
+  }
+
   if (appBridge && appBridge.hooks) {
     appBridge.hooks.set(LifecycleHook.DispatchAction, setClientInterfaceHook);
   }

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -17,6 +17,10 @@ export class Loading extends React.PureComponent<ComposedProps, never> {
     if (appBridge == null) {
       this.context.frame.startLoading();
     } else {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Deprecation: Using `Loading` in an embedded app is deprecated and will be removed in v5.0. Use `Loading` from `@shopify/app-bridge-react` instead. For example, `import {Loading} from '@shopify/app-bridge-react';`",
+      );
       this.appBridgeLoading = AppBridgeLoading.create(appBridge);
       this.appBridgeLoading.dispatch(AppBridgeLoading.Action.START);
     }

--- a/src/components/Loading/README.md
+++ b/src/components/Loading/README.md
@@ -36,7 +36,7 @@ The loading component must be wrapped in the [frame](/components/structure/frame
 
 ---
 
-## Use in an embedded application
+## Use in an embedded application (deprecated)
 
 Passing an API key to the [app provider component](https://polaris.shopify.com/components/structure/app-provider#section-initializing-the-shopify-app-bridge) causes the loading component to delegate to the [Shopify App Bridge](https://help.shopify.com/en/api/embedded-apps/app-bridge) instead of rendering as it would in a stand-alone application.
 
@@ -53,6 +53,10 @@ class EmbeddedAppLoadingExample extends React.Component {
   }
 }
 ```
+
+#### Deprecation rationale
+
+As of v3.17.0, using `Loading` in an embedded app is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. More information can be found [here](https://github.com/Shopify/polaris-react/issues/814). Use `Loading` from `@shopify/app-bridge-react` instead. For example, `import {Loading} from '@shopify/app-bridge-react';`.
 
 ---
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -119,6 +119,11 @@ export class Modal extends React.Component<CombinedProps, State> {
       return;
     }
 
+    // eslint-disable-next-line no-console
+    console.warn(
+      "Deprecation: Using `Modal` in an embedded app is deprecated and will be removed in v5.0. Use `Modal` from `@shopify/app-bridge-react` instead. For example, `import {Modal} from '@shopify/app-bridge-react';`",
+    );
+
     this.appBridgeModal = AppBridgeModal.create(
       this.props.polaris.appBridge,
       this.transformProps(),

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -40,7 +40,7 @@ Modals are overlays that prevent merchants from interacting with the rest of the
 
 ---
 
-## Use in an embedded application
+## Use in an embedded application (deprecated)
 
 Passing an API key to the [app provider component](https://polaris.shopify.com/components/structure/app-provider#section-initializing-the-shopify-app-bridge) causes the modal component to delegate to the [Shopify App Bridge](https://help.shopify.com/en/api/embedded-apps/app-bridge) instead of rendering as it would in a stand-alone application.
 
@@ -80,6 +80,10 @@ class EmbeddedAppModalExample extends React.Component {
   }
 }
 ```
+
+#### Deprecation rationale
+
+As of v3.17.0, using `Modal` in an embedded app is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. More information can be found [here](https://github.com/Shopify/polaris-react/issues/814). Use `Modal` from `@shopify/app-bridge-react` instead. For example, `import {Modal} from '@shopify/app-bridge-react';`.
 
 ---
 

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -50,6 +50,11 @@ export class Page extends React.PureComponent<ComposedProps, never> {
       return;
     }
 
+    // eslint-disable-next-line no-console
+    console.warn(
+      "Deprecation: Using `Page` to render an embedded app title bar is deprecated and will be removed in v5.0. Use `TitleBar` from `@shopify/app-bridge-react` instead. For example, `import {TitleBar} from '@shopify/app-bridge-react';`",
+    );
+
     this.titlebar = AppBridgeTitleBar.create(
       this.props.polaris.appBridge,
       this.transformProps(),

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -36,7 +36,7 @@ Use to build the outer wrapper of a page, including the page title and associate
 
 ---
 
-## Use in an embedded application
+## Use in an embedded application (deprecated)
 
 Passing an API key to the [app provider component](https://polaris.shopify.com/components/structure/app-provider#section-initializing-the-shopify-app-bridge) causes the page component to delegate to the [Shopify App Bridge](https://help.shopify.com/en/api/embedded-apps/app-bridge) instead of rendering as it would in a stand-alone application.
 
@@ -76,6 +76,10 @@ ReactDOM.render(
   </AppProvider>,
 );
 ```
+
+#### Deprecation rationale
+
+As of v3.17.0, using `Page` to render an embedded app title bar is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. More information can be found [here](https://github.com/Shopify/polaris-react/issues/814). Use `TitleBar` from `@shopify/app-bridge-react` instead. For example, `import {TitleBar} from '@shopify/app-bridge-react';`.
 
 ---
 

--- a/src/components/ResourcePicker/README.md
+++ b/src/components/ResourcePicker/README.md
@@ -18,6 +18,7 @@ keywords:
   - search
   - embedded app
   - app bridge
+  - deprecated
 ---
 
 # Resource picker
@@ -26,13 +27,17 @@ keywords:
 
 ---
 
-## Use in an embedded application
+## Use in an embedded application (deprecated)
 
 Enable the resource picker component to delegate to the [Shopify App Bridge](https://help.shopify.com/en/api/embedded-apps/app-bridge) by passing an API key to the [app provider component](https://polaris.shopify.com/components/structure/app-provider#section-initializing-the-shopify-app-bridge).
 
 Use of the resource picker component is only supported in an embedded application—it will not render in a stand-alone application. To help visualize the resource picker component in an embedded application, we've provided the following screenshot.
 
 ![Screenshot product picker - multiple product selection component](/public_images/embedded/resource-picker/product-picker-multiple@2x.jpg)
+
+### Deprecation rationale
+
+As of v3.17.0, `ResourcePicker` is deprecated. It will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. More information can be found [here](https://github.com/Shopify/polaris-react/issues/814). Use `ResourcePicker` from `@shopify/app-bridge-react` instead. For example, `import {ResourcePicker} from '@shopify/app-bridge-react';`.
 
 ---
 

--- a/src/components/ResourcePicker/ResourcePicker.tsx
+++ b/src/components/ResourcePicker/ResourcePicker.tsx
@@ -39,6 +39,7 @@ export interface Props {
 
 export type CombinedProps = Props & WithAppProviderProps;
 
+/** @deprecated Use `ResourcePicker` from `@shopify/app-bridge-react` instead. */
 export class ResourcePicker extends React.PureComponent<CombinedProps, never> {
   private focusReturnPoint: HTMLElement | null = null;
   private appBridgeResourcePicker:
@@ -46,6 +47,11 @@ export class ResourcePicker extends React.PureComponent<CombinedProps, never> {
     | undefined;
 
   componentDidMount() {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "Deprecation: `ResourcePicker` is deprecated and will be removed in v5.0. Use `ResourcePicker` from `@shopify/app-bridge-react` instead. For example, `import {ResourcePicker} from '@shopify/app-bridge-react';`",
+    );
+
     if (this.props.polaris.appBridge == null) {
       return;
     }

--- a/src/components/Toast/README.md
+++ b/src/components/Toast/README.md
@@ -37,7 +37,7 @@ The toast component must be wrapped in the [frame](/components/structure/frame) 
 
 ---
 
-## Use in an embedded application
+## Use in an embedded application (deprecated)
 
 Passing an API key to the [app provider component](https://polaris.shopify.com/components/structure/app-provider#section-initializing-the-shopify-app-bridge) causes the toast component to delegate to the [Shopify App Bridge](https://help.shopify.com/en/api/embedded-apps/app-bridge) instead of rendering as it would in a stand-alone application.
 
@@ -61,6 +61,10 @@ class EmbeddedAppToastExample extends React.Component {
   }
 }
 ```
+
+#### Deprecation rationale
+
+As of v3.17.0, using `Toast` in an embedded app is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. More information can be found [here](https://github.com/Shopify/polaris-react/issues/814). Use `Toast` from `@shopify/app-bridge-react` instead. For example, `import {Toast} from '@shopify/app-bridge-react';`.
 
 ---
 

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -43,6 +43,11 @@ export class Toast extends React.PureComponent<ComposedProps, never> {
         ...(props as Props),
       });
     } else {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Deprecation: Using `Toast` in an embedded app is deprecated and will be removed in v5.0. Use `Toast` from `@shopify/app-bridge-react` instead. For example, `import {Toast} from '@shopify/app-bridge-react';`",
+      );
+
       this.appBridgeToast = AppBridgeToast.create(appBridge, {
         message: content,
         duration,


### PR DESCRIPTION
### WHY are these changes introduced?

Adds deprecation messages for our App Bridge usage.

For example:

<img width="2032" alt="Screen Shot 2019-05-24 at 5 24 46 PM" src="https://user-images.githubusercontent.com/344839/58362184-2598e400-7e49-11e9-8d5c-1ff7bf6c2f7e.png">

### WHAT is this pull request doing?

Adds console warnings, a deprecation doc tag, and deprecation rationale in the component documentation.

### 🎩 checklist

* [x] 🎩 in the style guide
