### PR TITLE
[Button] Add textAlign Property

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Prevented Firefox from showing an extra dotted border on focused buttons ([#1409](https://github.com/Shopify/polaris-react/pull/1409))
 - Added `resolveItemId` prop to `ResourceList` which is used in the new multiselect feature ([#1261](https://github.com/Shopify/polaris-react/pull/1261))
 - Removed transition on tag button hover state [#1337](https://github.com/Shopify/polaris-react/pull/1337)
+- Added `textAlign` prop to Button ([#1576](https://github.com/Shopify/polaris-react/pull/1576))
 
 ### Bug fixes
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -24,6 +24,21 @@ $spinner-size: rem(20px);
   min-height: 1px;
 }
 
+.textAlignLeft {
+  justify-content: flex-start;
+  text-align: left;
+}
+
+.textAlignCenter {
+  justify-content: center;
+  text-align: center;
+}
+
+.textAlignRight {
+  justify-content: flex-end;
+  text-align: right;
+}
+
 .Icon {
   transition: color duration() easing();
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -11,6 +11,8 @@ import styles from './Button.scss';
 
 export type Size = 'slim' | 'medium' | 'large';
 
+export type TextAlign = 'left' | 'right' | 'center';
+
 export type IconSource = IconProps['source'];
 
 export interface Props {
@@ -33,6 +35,8 @@ export interface Props {
    * @default 'medium'
    */
   size?: Size;
+  /** Changes the inner text alignment of the button */
+  textAlign?: TextAlign;
   /** Gives the button a subtle alternative to the default button styling, appropriate for certain backdrops */
   outline?: boolean;
   /** Allows the button to grow to the width of its container */
@@ -47,7 +51,7 @@ export interface Props {
   monochrome?: boolean;
   /** Forces url to open in a new tab */
   external?: boolean;
-  /** Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value. */
+  /** Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value */
   download?: string | boolean;
   /** Icon to display to the left of the button content */
   icon?: React.ReactElement | IconSource;
@@ -104,10 +108,12 @@ function Button({
   monochrome,
   submit,
   size = DEFAULT_SIZE,
+  textAlign,
   fullWidth,
   polaris: {intl},
 }: CombinedProps) {
   const isDisabled = disabled || loading;
+
   const className = classNames(
     styles.Button,
     primary && styles.primary,
@@ -118,6 +124,7 @@ function Button({
     plain && styles.plain,
     monochrome && styles.monochrome,
     size && size !== DEFAULT_SIZE && styles[variationName('size', size)],
+    textAlign && styles[variationName('textAlign', textAlign)],
     fullWidth && styles.fullWidth,
     icon && children == null && styles.iconOnly,
   );

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -257,6 +257,20 @@ Use for buttons placed in a narrow column (especially when stacking multiple but
 <Button fullWidth>Add customer</Button>
 ```
 
+### Text-aligned button
+
+<!-- example-for: web -->
+
+Use for plain or monochrome buttons that could have a long length and should be aligned when they potentially overflow onto the next line.
+
+```jsx
+<Button plain textAlign="left">
+  This is a really long string of text that overflows onto the next line we need
+  to put in a lot of words now you can see the alignment. It is very long but a
+  customer could potentially name something this long.
+</Button>
+```
+
 ### Disabled state
 
 Use for actions that aren’t currently available. The surrounding interface should make it clear why the button is disabled and what needs to be done to enable it.


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Needed for edge case of https://github.com/Shopify/web/issues/13270.

<!--
  Context about the problem that’s being addressed.
-->
We wanted left-align on plain buttons which means we needed a new prop since we weren't sure if all plain buttons want left-alignment.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This prop changes the inner text-align of the button. It is useful for edge-cases when the button overflows to another line. It will be used mainly for plain and monochrome buttons but it also works with fullsize buttons. By default it will not affect any styling unless the prop is used.

![image](https://user-images.githubusercontent.com/21130966/58434089-fb813500-8087-11e9-8e92-33e49e83bb0a.png)


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Button} from '../src';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        <Stack vertical>
          <Button textAlign="left">
            LEFT ALIGNMENT This is a really long string of text in order to
            overflow onto the next line we need to put in a lot of words now you
            can see the alignment.
          </Button>
          <Button plain textAlign="center">
            CENTER ALIGNMENT This is a really long string of text in order to
            overflow onto the next line we need to put in a lot of words now you
            can see the alignment.
          </Button>
          <Button plain monochrome textAlign="right">
            RIGHT ALIGNMENT This is a really long string of text in order to
            overflow onto the next line we need to put in a lot of words now you
            can see the alignment.
          </Button>
          <Button>
            DEFAULT ALIGNMENT This is a really long string of text in order to
            overflow onto the next line we need to put in a lot of words now you
            can see the alignment.
          </Button>

          <Button fullWidth textAlign="left">
            Fullwidth left
          </Button>
          <Button plain fullWidth textAlign="right">
            Fullwidth right
          </Button>
          <Button plain monochrome fullWidth textAlign="center">
            Fullwidth center
          </Button>
          <Button fullWidth>Fullwidth default</Button>
        </Stack>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

Since it only modifies text-align and justify it is safe to say it will work everywhere.

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
