### PR TITLE
[WIP] Removed aria roles from Tab

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -8,6 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Increased peer-dependencies on `react` and `react-dom` to 16.8.6 to enable the use of hooks ([#1525](https://github.com/Shopify/polaris-react/pull/1525))
 - We now use default imports for React. Applications that consume polaris using sewing-kit shall need to enable [`esModuleInterop`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-from-commonjs-modules-with---esmoduleinterop) in their `tsconfig.json` files. ([#1523](https://github.com/Shopify/polaris-react/pull/1523))
+- `Tabs` removed props that handled focus management, `Tabs` now work like a horizontal navigation ([1579](https://github.com/Shopify/polaris-react/pull/1579))
 
 ### New components
 

--- a/a11y_shitlist.json
+++ b/a11y_shitlist.json
@@ -579,14 +579,6 @@
       "type": "error",
       "typeCode": 1,
       "selector": "#root > div > div > div > div > div:nth-child(2) > button"
-    },
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F92,ARIA4",
-      "context": "<li role=\"presentation\" class=\"Tabs-DisclosureTab_1_TJd\"><div><button tabindex=\"-1\" clas...</li>",
-      "message": "This element's role is \"presentation\" but contains child elements with semantic meaning.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#root > div > div > div > div > ul > li:nth-child(3)"
     }
   ],
   "all-components-tabs--default-tabs": [
@@ -597,14 +589,6 @@
       "type": "error",
       "typeCode": 1,
       "selector": "#root > div > div > div > div > div:nth-child(2) > button"
-    },
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F92,ARIA4",
-      "context": "<li role=\"presentation\" class=\"Tabs-DisclosureTab_1_TJd\"><div><button tabindex=\"-1\" clas...</li>",
-      "message": "This element's role is \"presentation\" but contains child elements with semantic meaning.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#root > div > div > div > div > ul > li:nth-child(5)"
     }
   ],
   "all-components-text-field--text-field-with-separate-validation-error": [

--- a/src/components/Tabs/components/Item/Item.tsx
+++ b/src/components/Tabs/components/Item/Item.tsx
@@ -5,7 +5,6 @@ import UnstyledLink from '../../../UnstyledLink';
 
 export interface Props {
   id: string;
-  focused: boolean;
   panelID?: string;
   children?: React.ReactNode;
   url?: string;
@@ -14,26 +13,6 @@ export interface Props {
 }
 
 export default class Item extends React.PureComponent<Props, never> {
-  private focusedNode: HTMLElement | React.ReactElement<any> | null = null;
-
-  componentDidMount() {
-    const {focusedNode} = this;
-    const {focused} = this.props;
-
-    if (focusedNode && focusedNode instanceof HTMLElement && focused) {
-      focusedNode.focus();
-    }
-  }
-
-  componentDidUpdate() {
-    const {focusedNode} = this;
-    const {focused} = this.props;
-
-    if (focusedNode && focusedNode instanceof HTMLElement && focused) {
-      focusedNode.focus();
-    }
-  }
-
   render() {
     const {
       id,
@@ -46,7 +25,6 @@ export default class Item extends React.PureComponent<Props, never> {
 
     const sharedProps = {
       id,
-      ref: this.setFocusedNode,
       onClick,
       className: styles.Item,
       'aria-controls': panelID,
@@ -62,14 +40,8 @@ export default class Item extends React.PureComponent<Props, never> {
       </button>
     );
 
-    return <li role="presentation">{markup}</li>;
+    return <li>{markup}</li>;
   }
-
-  private setFocusedNode = (
-    node: HTMLElement | React.ReactElement<any> | null,
-  ) => {
-    this.focusedNode = node;
-  };
 }
 
 function noop() {}

--- a/src/components/Tabs/components/List/List.tsx
+++ b/src/components/Tabs/components/List/List.tsx
@@ -5,58 +5,23 @@ import {TabDescriptor} from '../../types';
 import styles from '../../Tabs.scss';
 
 export interface Props {
-  focusIndex: number;
   disclosureTabs: TabDescriptor[];
   onClick?(id: string): void;
-  onKeyPress?(event: React.KeyboardEvent<HTMLElement>): void;
 }
 
 export default class List extends React.PureComponent<Props, never> {
   render() {
-    const {focusIndex, disclosureTabs, onClick = noop} = this.props;
-    const tabs = disclosureTabs.map(({id, content, ...tabProps}, index) => {
+    const {disclosureTabs, onClick = noop} = this.props;
+    const tabs = disclosureTabs.map(({id, content, ...tabProps}) => {
       return (
-        <Item
-          {...tabProps}
-          key={id}
-          id={id}
-          focused={index === focusIndex}
-          onClick={onClick.bind(null, id)}
-        >
+        <Item {...tabProps} key={id} id={id} onClick={onClick.bind(null, id)}>
           {content}
         </Item>
       );
     });
 
-    return (
-      <ul
-        className={styles.List}
-        onKeyDown={handleKeyDown}
-        onKeyUp={this.handleKeypress}
-      >
-        {tabs}
-      </ul>
-    );
+    return <ul className={styles.List}>{tabs}</ul>;
   }
-
-  private handleKeypress = (event: React.KeyboardEvent<HTMLElement>) => {
-    const {onKeyPress = noop} = this.props;
-    onKeyPress(event);
-  };
 }
 
 function noop() {}
-
-function handleKeyDown(event: React.KeyboardEvent<HTMLElement>) {
-  const {key} = event;
-
-  if (
-    key === 'ArrowUp' ||
-    key === 'ArrowDown' ||
-    key === 'ArrowLeft' ||
-    key === 'ArrowRight'
-  ) {
-    event.preventDefault();
-    event.stopPropagation();
-  }
-}

--- a/src/components/Tabs/components/List/tests/List.test.tsx
+++ b/src/components/Tabs/components/List/tests/List.test.tsx
@@ -5,7 +5,6 @@ import Item from '../../Item';
 
 describe('<List />', () => {
   const mockProps = {
-    focusIndex: -1,
     disclosureTabs: [
       {
         id: 'repeat-customers',
@@ -21,26 +20,6 @@ describe('<List />', () => {
   it('renders an unordered list', () => {
     const list = mountWithAppProvider(<List {...mockProps} />);
     expect(list.find('ul')).toHaveLength(1);
-  });
-
-  describe('focusIndex', () => {
-    it('does not pass focusIndex to last Item', () => {
-      const focusIndex = 1;
-      const list = mountWithAppProvider(
-        <List {...mockProps} focusIndex={focusIndex} />,
-      );
-      const items = list.find(Item);
-      expect(items.first().prop('focused')).toBe(false);
-    });
-
-    it('passes focusIndex to first Item', () => {
-      const focusIndex = 1;
-      const list = mountWithAppProvider(
-        <List {...mockProps} focusIndex={focusIndex} />,
-      );
-      const items = list.find(Item);
-      expect(items.last().prop('focused')).toBe(true);
-    });
   });
 
   describe('disclosureTabs', () => {

--- a/src/components/Tabs/components/Panel/Panel.tsx
+++ b/src/components/Tabs/components/Panel/Panel.tsx
@@ -3,19 +3,12 @@ import styles from '../../Tabs.scss';
 
 export interface Props {
   id: string;
-  tabID: string;
   children?: React.ReactNode;
 }
 
-export default function Panel({id, tabID, children}: Props) {
+export default function Panel({id, children}: Props) {
   return (
-    <div
-      className={styles.Panel}
-      id={id}
-      role="tabpanel"
-      aria-labelledby={tabID}
-      tabIndex={-1}
-    >
+    <div className={styles.Panel} id={id}>
       {children}
     </div>
   );

--- a/src/components/Tabs/components/Panel/tests/Panel.test.tsx
+++ b/src/components/Tabs/components/Panel/tests/Panel.test.tsx
@@ -3,26 +3,10 @@ import {mountWithAppProvider} from 'test-utilities';
 import Panel from '../Panel';
 
 describe('<Panel />', () => {
-  it('adds the tabpanel role', () => {
-    const panel = mountWithAppProvider(<Panel id="panel" tabID="tab" />);
-    expect(panel.find('div').prop('role')).toBe('tabpanel');
-  });
-
   describe('id', () => {
     it('uses the ID for panel', () => {
-      const panel = mountWithAppProvider(
-        <Panel id="my-panel" tabID="my-tab" />,
-      );
+      const panel = mountWithAppProvider(<Panel id="my-panel" />);
       expect(panel.find('div').prop('id')).toBe('my-panel');
-    });
-  });
-
-  describe('tabID', () => {
-    it('uses the ID as the labeling element', () => {
-      const panel = mountWithAppProvider(
-        <Panel id="my-panel" tabID="my-tab" />,
-      );
-      expect(panel.find('div').prop('aria-labelledby')).toBe('my-tab');
     });
   });
 });

--- a/src/components/Tabs/components/Tab/Tab.tsx
+++ b/src/components/Tabs/components/Tab/Tab.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {classNames} from '@shopify/css-utilities';
-import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
 
 import UnstyledLink from '../../../UnstyledLink';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
@@ -10,8 +9,6 @@ import styles from '../../Tabs.scss';
 
 export interface Props {
   id: string;
-  focused?: boolean;
-  siblingTabHasFocus?: boolean;
   selected?: boolean;
   panelID?: string;
   children?: React.ReactNode;
@@ -24,57 +21,13 @@ export interface Props {
 export type CombinedProps = Props & WithAppProviderProps;
 
 export class Tab extends React.PureComponent<CombinedProps, never> {
-  private node: HTMLElement | null = null;
-
-  // A tab can start selected when it is moved from the disclosure dropdown
-  // into the main list, so we need to send focus from the tab to the panel
-  // on mount and update
-  componentDidMount() {
-    const {id, measuring, selected, panelID, focused} = this.props;
-
-    if (measuring) {
-      return;
-    }
-
-    // Because of timing issues with the render, we may still have the old,
-    // in-disclosure version of the tab that has focus. Check for this
-    // as a second indicator of focus
-    const itemHadFocus =
-      focused || (document.activeElement && document.activeElement.id === id);
-
-    // If we just check for selected, the panel for the active tab will
-    // be focused on page load, which we don’t want
-    if (itemHadFocus && selected && panelID != null) {
-      focusPanelID(panelID);
-    }
-  }
-
-  componentDidUpdate(previousProps: Props) {
-    const {selected: wasSelected} = previousProps;
-    const {focused, measuring, selected, panelID} = this.props;
-
-    if (measuring) {
-      return;
-    }
-
-    if (selected && !wasSelected && panelID != null) {
-      focusPanelID(panelID);
-    } else if (focused && this.node != null) {
-      focusFirstFocusableNode(this.node);
-    }
-  }
-
   render() {
     const {
       id,
-      focused,
-      siblingTabHasFocus,
       children,
       onClick,
       selected,
       url,
-      panelID,
-      measuring,
       accessibilityLabel,
     } = this.props;
 
@@ -85,26 +38,12 @@ export class Tab extends React.PureComponent<CombinedProps, never> {
       selected && styles['Tab-selected'],
     );
 
-    let tabIndex: 0 | -1;
-
-    if (selected && !siblingTabHasFocus && !measuring) {
-      tabIndex = 0;
-    } else if (focused && !measuring) {
-      tabIndex = 0;
-    } else {
-      tabIndex = -1;
-    }
-
     const markup = url ? (
       <UnstyledLink
         id={id}
         url={url}
-        role="tab"
-        tabIndex={tabIndex}
         onClick={handleClick}
         className={className}
-        aria-selected={selected}
-        aria-controls={panelID}
         aria-label={accessibilityLabel}
         onMouseUp={handleMouseUpByBlurring}
       >
@@ -113,13 +52,9 @@ export class Tab extends React.PureComponent<CombinedProps, never> {
     ) : (
       <button
         id={id}
-        role="tab"
         type="button"
-        tabIndex={tabIndex}
         className={className}
         onClick={handleClick}
-        aria-selected={selected}
-        aria-controls={panelID}
         aria-label={accessibilityLabel}
         onMouseUp={handleMouseUpByBlurring}
       >
@@ -127,26 +62,7 @@ export class Tab extends React.PureComponent<CombinedProps, never> {
       </button>
     );
 
-    return (
-      <li
-        role="presentation"
-        className={styles.TabContainer}
-        ref={this.setNode}
-      >
-        {markup}
-      </li>
-    );
-  }
-
-  private setNode = (node: HTMLElement | null) => {
-    this.node = node;
-  };
-}
-
-function focusPanelID(panelID: string) {
-  const panel = document.getElementById(panelID);
-  if (panel) {
-    panel.focus();
+    return <li className={styles.TabContainer}>{markup}</li>;
   }
 }
 

--- a/src/components/Tabs/components/Tab/tests/Tab.test.tsx
+++ b/src/components/Tabs/components/Tab/tests/Tab.test.tsx
@@ -3,49 +3,10 @@ import {mountWithAppProvider} from 'test-utilities';
 import Tab from '../Tab';
 
 describe('<Tab />', () => {
-  it('has the tab role', () => {
-    const tab = mountWithAppProvider(<Tab id="my-tab">Tab</Tab>);
-    expect(tab.find('button').prop('role')).toBe('tab');
-  });
-
   describe('id', () => {
     it('uses the ID for the underlying actionable item', () => {
       const tab = mountWithAppProvider(<Tab id="my-tab">Tab</Tab>);
       expect(tab.find('button').prop('id')).toBe('my-tab');
-    });
-  });
-
-  describe('selected', () => {
-    it('is aria-selected when the tab is selected', () => {
-      const tab = mountWithAppProvider(
-        <Tab id="my-tab" selected>
-          Tab
-        </Tab>,
-      );
-      expect(tab.find('button').prop('aria-selected')).toBe(true);
-    });
-
-    it('is not aria-selected when the tab is not selected', () => {
-      let tab = mountWithAppProvider(<Tab id="my-tab">Tab</Tab>);
-      expect(tab.find('button').prop('aria-selected')).toBeFalsy();
-
-      tab = mountWithAppProvider(
-        <Tab id="my-tab" selected={false}>
-          Tab
-        </Tab>,
-      );
-      expect(tab.find('button').prop('aria-selected')).toBeFalsy();
-    });
-  });
-
-  describe('panelID', () => {
-    it('uses the panelID as the controlled element’s ID', () => {
-      const tab = mountWithAppProvider(
-        <Tab id="my-tab" panelID="my-panel">
-          Tab
-        </Tab>,
-      );
-      expect(tab.find('button').prop('aria-controls')).toBe('my-panel');
     });
   });
 

--- a/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
+++ b/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
@@ -14,8 +14,6 @@ export interface TabMeasurements {
 }
 
 export interface Props {
-  tabToFocus: number;
-  siblingTabHasFocus: boolean;
   activator: React.ReactElement<{}>;
   selected: number;
   tabs: TabDescriptor[];
@@ -42,22 +40,13 @@ export default class TabMeasurer extends React.PureComponent<Props, never> {
   }
 
   render() {
-    const {
-      selected,
-      tabs,
-      activator,
-      tabToFocus,
-      siblingTabHasFocus,
-    } = this.props;
+    const {selected, tabs, activator} = this.props;
 
     const tabsMarkup = tabs.map((tab, index) => {
       return (
         <Tab
-          measuring
           key={`${index}${tab.id}Hidden`}
           id={`${tab.id}Measurer`}
-          siblingTabHasFocus={siblingTabHasFocus}
-          focused={index === tabToFocus}
           selected={index === selected}
           onClick={noop}
           url={tab.url}

--- a/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
+++ b/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
@@ -6,8 +6,7 @@ import Item from '../../Item';
 
 describe('<TabMeasurer />', () => {
   const mockProps = {
-    tabToFocus: 0,
-    activator: <Item id="id" focused />,
+    activator: <Item id="id" />,
     selected: 1,
     tabs: [
       {
@@ -23,40 +22,9 @@ describe('<TabMeasurer />', () => {
     handleMeasurement: noop,
   };
 
-  describe('tabToFocus', () => {
-    const tabToFocus = 0;
-
-    it('passes focused value of 0 to Tab', () => {
-      const tabMeasurer = mountWithAppProvider(
-        <TabMeasurer {...mockProps} tabToFocus={tabToFocus} />,
-      );
-      const tabs = tabMeasurer.find(Tab);
-      expect(tabs.first().prop('focused')).toBe(true);
-    });
-
-    it('does not pass wrong focused value to Tab', () => {
-      const tabMeasurer = mountWithAppProvider(
-        <TabMeasurer {...mockProps} tabToFocus={tabToFocus} />,
-      );
-      const tabs = tabMeasurer.find(Tab);
-      expect(tabs.last().prop('focused')).toBe(false);
-    });
-  });
-
-  describe('siblingTabHasFocus', () => {
-    it('gets passed to Tab', () => {
-      const siblingTabHasFocus = true;
-      const tabMeasurer = mountWithAppProvider(
-        <TabMeasurer {...mockProps} siblingTabHasFocus={siblingTabHasFocus} />,
-      );
-      const tabs = tabMeasurer.find(Tab);
-      expect(tabs.first().prop('siblingTabHasFocus')).toBe(true);
-    });
-  });
-
   describe('activator', () => {
     it('renders activator', () => {
-      const activator = <Item id="id" focused />;
+      const activator = <Item id="id" />;
       const tabMeasurer = mountWithAppProvider(
         <TabMeasurer {...mockProps} activator={activator} />,
       );

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -138,36 +138,6 @@ describe('<Tabs />', () => {
     });
   });
 
-  describe('selected', () => {
-    let getElementById: jest.SpyInstance;
-    let panelStub: {focus: jest.Mock<any>};
-
-    beforeEach(() => {
-      panelStub = {focus: jest.fn()};
-      getElementById = jest.spyOn(document, 'getElementById');
-      getElementById.mockReturnValue(panelStub);
-    });
-
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
-
-    it('focuses the panel when a tab becomes selected', () => {
-      const panelIDedTabs = [
-        {...tabs[0], panelID: 'panel-1'},
-        {...tabs[1], panelID: 'panel-2'},
-      ];
-
-      const wrapper = mountWithAppProvider(
-        <Tabs {...mockProps} tabs={panelIDedTabs}>
-          Panel contents
-        </Tabs>,
-      );
-      wrapper.setProps({selected: 1});
-      expect(panelStub.focus).toHaveBeenCalled();
-    });
-  });
-
   describe('children', () => {
     it('wraps the children in a Panel with matching aria attributes to the tab', () => {
       const content = <p>Tab content</p>;
@@ -223,118 +193,11 @@ describe('<Tabs />', () => {
       {content: 'Tab 3', id: 'tab-3'},
     ];
 
-    it('is not set to anything by default', () => {
-      const tabs = mountWithAppProvider(<Tabs {...mockProps} />);
-      expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(-1);
-    });
-
     it('passes the provided selected value if given', () => {
       const tabs = mountWithAppProvider(
         <Tabs {...mockProps} selected={1} tabs={mockTabs} />,
       );
       expect(tabs.find(TabMeasurer).prop('selected')).toBe(1);
-    });
-
-    describe('ArrowRight', () => {
-      it('shifts focus to the next tab when pressing ArrowRight', () => {
-        const tabs = mountWithAppProvider(
-          <Tabs {...mockProps} tabs={mockTabs} />,
-        );
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowRight',
-        });
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
-      });
-
-      it('shifts focus to the first tab when pressing ArrowRight on the last tab', () => {
-        const tabs = mountWithAppProvider(
-          <Tabs {...mockProps} tabs={mockTabs} />,
-        );
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowRight',
-        });
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowRight',
-        });
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowRight',
-        });
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowRight',
-        });
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
-      });
-    });
-
-    describe('ArrowDown', () => {
-      it('shifts focus to the next tab when pressing ArrowDown', () => {
-        const tabs = mountWithAppProvider(
-          <Tabs {...mockProps} tabs={mockTabs} />,
-        );
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowDown',
-        });
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
-      });
-
-      it('shifts focus to the first tab when pressing ArrowDown on the last tab', () => {
-        const tabs = mountWithAppProvider(
-          <Tabs {...mockProps} tabs={mockTabs} />,
-        );
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowDown',
-        });
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowDown',
-        });
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowDown',
-        });
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowDown',
-        });
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
-      });
-    });
-
-    describe('ArrowLeft', () => {
-      it('shifts focus to the last tab when pressing ArrowLeft', () => {
-        const tabs = mountWithAppProvider(
-          <Tabs {...mockProps} tabs={mockTabs} />,
-        );
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowLeft',
-        });
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(2);
-      });
-    });
-
-    describe('ArrowUp', () => {
-      it('shifts focus to the last tab when pressing ArrowUp', () => {
-        const tabs = mountWithAppProvider(
-          <Tabs {...mockProps} tabs={mockTabs} selected={0} />,
-        );
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowUp',
-        });
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(2);
-      });
-
-      it('shifts focus to the first tab when pressing ArrowUp on the second tab', () => {
-        const tabs = mountWithAppProvider(
-          <Tabs {...mockProps} tabs={mockTabs} />,
-        );
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowRight',
-        });
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowRight',
-        });
-        trigger(tabs.find('ul'), 'onKeyUp', {
-          key: 'ArrowLeft',
-        });
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
-      });
     });
   });
 
@@ -389,26 +252,6 @@ describe('<Tabs />', () => {
 
       const popover = tabs.find(Popover);
       expect(popover.prop('activator').type).toBe('button');
-    });
-
-    describe('ArrowRight', () => {
-      it('shifts focus to the first tab when pressing ArrowRight', () => {
-        const tabs = mountWithAppProvider(<Tabs {...mockProps} />);
-        const tabMeasurer = tabs.find(TabMeasurer);
-        trigger(tabMeasurer, 'handleMeasurement', {
-          hiddenTabWidths: [82, 160, 150, 100, 80, 120],
-          containerWidth: 300,
-          disclosureWidth: 0,
-        });
-
-        const popoverContents = getPopoverContents(tabs);
-        async () => {
-          trigger(popoverContents.find(List), 'onKeyPress', {
-            key: 'ArrowRight',
-          });
-          await expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
-        };
-      });
     });
   });
 });

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider, trigger} from 'test-utilities';
-import {Tab, Panel, TabMeasurer, List} from '../components';
+import {Tab, Panel, TabMeasurer} from '../components';
 import Tabs, {Props} from '../Tabs';
 import {getVisibleAndHiddenTabIndices} from '../utilities';
 import Popover from '../../Popover';
@@ -17,12 +16,6 @@ describe('<Tabs />', () => {
     tabs,
     onSelect: noop,
   };
-
-  function getPopoverContents(tabs: ReactWrapper) {
-    return mountWithAppProvider(
-      <div>{tabs.find(Popover).prop('children')}</div>,
-    );
-  }
 
   afterEach(() => {
     if (document.activeElement) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1577. In our tabs there is an unordered list of individual Tab components. These have an aria-controls that points to a non existent tabpanel.

### WHAT is this pull request doing?

Removes aria roles from tabs and makes them work like a navigation.

### How to 🎩

Make sure the tabs work the same way as expected in the user interface.

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
