### PR TITLE
[EmptyState] Make action prop optional

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Made the `action` prop optional on `EmptyState` ([#1583](https://github.com/Shopify/polaris-react/pull/1583))
+
 ### Bug fixes
 
 - Fixed inconsistent width depending on your browser/version in `Sheet` ([#1569](https://github.com/Shopify/polaris-react/pull/1569))

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -22,7 +22,7 @@ export interface Props {
   /** Elements to display inside empty state */
   children?: React.ReactNode;
   /** Primary action for empty state */
-  action: Action;
+  action?: Action;
   /** Secondary action for empty state */
   secondaryAction?: Action;
   /** Secondary elements to display below empty state actions */
@@ -78,26 +78,53 @@ export default class EmptyState extends React.PureComponent<Props, never> {
       </div>
     ) : null;
 
+    const primaryActionMarkup = action
+      ? buttonFrom(action, {primary: true, size: 'large'})
+      : null;
+
+    const headingMarkup = heading ? (
+      <DisplayText size="medium">{heading}</DisplayText>
+    ) : null;
+
+    const childrenMarkup = children ? (
+      <div className={styles.Content}>{children}</div>
+    ) : null;
+
+    const textContentMarkup =
+      headingMarkup || children ? (
+        <TextContainer>
+          {headingMarkup}
+          {childrenMarkup}
+        </TextContainer>
+      ) : null;
+
+    const actionsMarkup =
+      primaryActionMarkup || secondaryActionMarkup ? (
+        <div className={styles.Actions}>
+          <Stack alignment="center">
+            {primaryActionMarkup}
+            {secondaryActionMarkup}
+          </Stack>
+        </div>
+      ) : null;
+
+    const detailsMarkup =
+      textContentMarkup || actionsMarkup || footerContentMarkup ? (
+        <div className={styles.DetailsContainer}>
+          <div className={styles.Details}>
+            {textContentMarkup}
+            {actionsMarkup}
+            {footerContentMarkup}
+          </div>
+        </div>
+      ) : (
+        <div className={styles.DetailsContainer} />
+      );
+
     return (
       <div className={className}>
         <div className={styles.Section}>
-          <div className={styles.DetailsContainer}>
-            <div className={styles.Details}>
-              <TextContainer>
-                <DisplayText size="medium">{heading}</DisplayText>
-                <div className={styles.Content}>{children}</div>
-              </TextContainer>
-
-              <div className={styles.Actions}>
-                <Stack alignment="center">
-                  {buttonFrom(action, {primary: true, size: 'large'})}
-                  {secondaryActionMarkup}
-                </Stack>
-              </div>
-              {footerContentMarkup}
-            </div>
-          </div>
-
+          {detailsMarkup}
           <div className={styles.ImageContainer}>{imageMarkup}</div>
         </div>
       </div>

--- a/src/components/EmptyState/tests/EmptyState.test.tsx
+++ b/src/components/EmptyState/tests/EmptyState.test.tsx
@@ -1,55 +1,48 @@
 import * as React from 'react';
 import {mountWithAppProvider} from 'test-utilities';
-import {
-  Image,
-  DisplayText,
-  TextContainer,
-  Link,
-  Button,
-  ButtonGroup,
-} from 'components';
+import {Image, DisplayText, TextContainer, UnstyledLink} from 'components';
 import EmptyState from '../EmptyState';
 
 describe('<EmptyState />', () => {
-  let imgSrc: string;
-  let footerContentMarkup: React.ReactNode;
-  let emptyState: any;
+  let imgSrc =
+    'https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg';
 
-  beforeAll(() => {
-    imgSrc =
-      'https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg';
-    footerContentMarkup = (
-      <p>
-        If you don’t want to add a transfer, you can import your inventory from{' '}
-        <Link url="/settings">settings</Link>.
-      </p>
-    );
+  describe('primaryAction', () => {
+    it('renders a button with the action content if a primaryAction is provided', () => {
+      const emptyState = mountWithAppProvider(
+        <EmptyState action={{content: 'Add transfer'}} image={imgSrc} />,
+      );
+      expect(emptyState.find('button').contains('Add transfer')).toBe(true);
+    });
 
-    emptyState = mountWithAppProvider(
-      <EmptyState
-        heading="Manage your inventory transfers"
-        action={{content: 'Add transfer'}}
-        image={imgSrc}
-        secondaryAction={{
-          content: 'Learn more',
-          url: 'https://help.shopify.com',
-        }}
-        footerContent={footerContentMarkup}
-      >
-        <p>Track and receive your incoming inventory from suppliers.</p>
-      </EmptyState>,
-    );
+    it('renders does not render button with the action content if no primaryAction is provided', () => {
+      const emptyState = mountWithAppProvider(<EmptyState image={imgSrc} />);
+      expect(emptyState.find('button').contains('Add transfer')).toBe(false);
+    });
   });
 
-  it('renders a button with the action content', () => {
-    expect(emptyState.find('button').contains('Add transfer')).toBe(true);
-  });
+  describe('children', () => {
+    it('renders children', () => {
+      const expectedContent =
+        'If you don’t want to add a transfer, you can import your inventory from settings.';
+      const children = (
+        <p>
+          If you don’t want to add a transfer, you can import your inventory
+          from settings.
+        </p>
+      );
 
-  it('renders children and footer content', () => {
-    expect(emptyState.find(TextContainer)).toHaveLength(2);
+      const emptyState = mountWithAppProvider(
+        <EmptyState image={imgSrc}>{children}</EmptyState>,
+      );
+
+      expect(emptyState.find(TextContainer).text()).toContain(expectedContent);
+    });
   });
 
   describe('img', () => {
+    const emptyState = mountWithAppProvider(<EmptyState image={imgSrc} />);
+
     it('passes the provided source to Image', () => {
       expect(emptyState.find(Image).prop('source')).toBe(imgSrc);
     });
@@ -57,27 +50,9 @@ describe('<EmptyState />', () => {
     it('renders an Image with a sourceSet when largeImage is passed', () => {
       imgSrc =
         'https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg';
-      footerContentMarkup = (
-        <p>
-          If you don’t want to add a transfer, you can import your inventory
-          from <Link url="/settings">settings</Link>.
-        </p>
-      );
 
-      emptyState = mountWithAppProvider(
-        <EmptyState
-          heading="Manage your inventory transfers"
-          action={{content: 'Add transfer'}}
-          image={imgSrc}
-          secondaryAction={{
-            content: 'Learn more',
-            url: 'https://help.shopify.com',
-          }}
-          largeImage={imgSrc}
-          footerContent={footerContentMarkup}
-        >
-          <p>Track and receive your incoming inventory from suppliers.</p>
-        </EmptyState>,
+      const emptyState = mountWithAppProvider(
+        <EmptyState image={imgSrc} largeImage={imgSrc} />,
       );
 
       expect(emptyState.find(Image).props().sourceSet).toStrictEqual([
@@ -96,12 +71,14 @@ describe('<EmptyState />', () => {
   });
 
   describe('role', () => {
+    const emptyState = mountWithAppProvider(<EmptyState image={imgSrc} />);
     it('passes the presentation role to Image', () => {
       expect(emptyState.find(Image).prop('role')).toBe('presentation');
     });
   });
 
   describe('alt', () => {
+    const emptyState = mountWithAppProvider(<EmptyState image={imgSrc} />);
     it('passes an empty alt to Image', () => {
       expect(emptyState.find(Image).prop('alt')).toBe('');
     });
@@ -109,59 +86,49 @@ describe('<EmptyState />', () => {
 
   describe('heading', () => {
     it('passes the provided heading to DisplayText', () => {
+      const expectedHeading = 'Manage your inventory transfers';
+      const emptyState = mountWithAppProvider(
+        <EmptyState heading={expectedHeading} image={imgSrc} />,
+      );
       expect(emptyState.find(DisplayText).prop('size')).toBe('medium');
-      expect(
-        emptyState
-          .find(DisplayText)
-          .contains('Manage your inventory transfers'),
-      ).toBe(true);
+      expect(emptyState.find(DisplayText).contains(expectedHeading)).toBe(true);
     });
   });
 
   describe('secondaryAction', () => {
-    it('only renders one button if secondaryAction is not provided', () => {
-      const emptyStateWithoutSecondaryAction = mountWithAppProvider(
+    it('renders secondaryAction if provided', () => {
+      const emptyState = mountWithAppProvider(
         <EmptyState
-          heading="Manage your inventory transfers"
-          action={{content: 'Add transfer'}}
-          image={imgSrc}
-        >
-          <p>Track and receive your incoming inventory from suppliers.</p>
-        </EmptyState>,
-      );
-
-      expect(emptyStateWithoutSecondaryAction.find(Button)).toHaveLength(1);
-      expect(emptyStateWithoutSecondaryAction.find(ButtonGroup)).toHaveLength(
-        0,
-      );
-    });
-  });
-
-  describe('footerContent', () => {
-    it('passes the provided content to TextContainer', () => {
-      const footerContentTextContainer = emptyState.find(TextContainer).last();
-
-      expect(footerContentTextContainer.text()).toContain(
-        'If you don’t want to add a transfer, you can import your inventory from settings.',
-      );
-    });
-
-    it('does not create a footer when footerContent is not provided', () => {
-      const footerlessEmptyState = mountWithAppProvider(
-        <EmptyState
-          heading="Manage your inventory transfers"
-          action={{content: 'Add transfer'}}
-          image={imgSrc}
           secondaryAction={{
             content: 'Learn more',
             url: 'https://help.shopify.com',
           }}
-        >
-          <p>Track and receive your incoming inventory from suppliers.</p>
-        </EmptyState>,
+          image={imgSrc}
+        />,
       );
 
-      expect(footerlessEmptyState.find(TextContainer)).toHaveLength(1);
+      expect(emptyState.find(UnstyledLink).text()).toContain('Learn more');
+    });
+  });
+
+  describe('footerContent', () => {
+    const expectedContent =
+      'If you don’t want to add a transfer, you can import your inventory from settings';
+    const footerContentMarkup = <p>{expectedContent}</p>;
+
+    it('renders footer content', () => {
+      const emptyState = mountWithAppProvider(
+        <EmptyState footerContent={footerContentMarkup} image={imgSrc} />,
+      );
+      const footerContentTextContainer = emptyState.find(TextContainer).last();
+
+      expect(footerContentTextContainer.text()).toContain(expectedContent);
+    });
+
+    it('does not create a footer when footerContent is not provided', () => {
+      const emptyState = mountWithAppProvider(<EmptyState image={imgSrc} />);
+
+      expect(emptyState.find(TextContainer)).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
To match our rails implementation this PR makes the action prop optional on the EmptyState component

Also took advantage and polished the code and reorganized tests.

![empty-state](https://user-images.githubusercontent.com/1229901/58477297-29668800-8121-11e9-893a-68515eab7682.gif)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

- Ensure EmptyState renders as it did before in various browser size with various prop combinations

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {EmptyState} from '../src';

export default class Playground extends React.Component<{}, never> {
  render() {
    return (
      <EmptyState
        heading="testing"
        action={{content: 'Add transfer'}}
        secondaryAction={{
          content: 'Learn more',
          url: 'https://help.shopify.com',
        }}
        image="https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg"
      >
        <p>Track and receive your incoming inventory from suppliers.</p>
      </EmptyState>
    );
  }
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
