### PR TITLE
[MODAL] remove unnecessary border radius from modal body

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Removed unnecessary border-radius from `Modal` body ([#1584](https://github.com/Shopify/polaris-react/pull/1584))
 - Fixed inconsistent width depending on your browser/version in `Sheet` ([#1569](https://github.com/Shopify/polaris-react/pull/1569))
 - Fixed text and other elements from being selected in Safari when dragging the color picker ([#1562](https://github.com/Shopify/polaris-react/pull/1562))
 - Fixed `Banner` `title` overflowing when set to a single long word ([#1553](https://github.com/Shopify/polaris-react/pull/1553))

--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -3,7 +3,6 @@ $small-width: rem(620px);
 .BodyWrapper {
   display: flex;
   flex-grow: 1;
-  border-radius: border-radius(large);
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Nobody seems to be able to remember why it was added in the first place and it is preventing full width body content.

We are currently building a non-white full width content application in React and noticed that the `Modal` body has a border radius that we are not sure it should have.
Usually you don’t notice it, because the backgrounds are white and the content has no borders.

### WHAT is this pull request doing?
Removes the border radius from the modal body

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Modal} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <Modal open large>
          <Modal.Section>hello</Modal.Section>
        </Modal>
      </Page>
    );
  }
}

```

</details>

- Inspect modal
- Notice border radius is gone from `BodyWrapper`

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
