### PR TITLE
[Collapsible] Add aria-controls on the button in the example

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -29,6 +29,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Documentation
 
 - Updated icon documentation to use imports from polaris-icons ([#1561](https://github.com/Shopify/polaris-react/pull/1561))
+- Fixed an accessibility issue in the `Collapsible` component example ([#1591](https://github.com/Shopify/polaris-react/pull/1591))
 
 ### Development workflow
 

--- a/src/components/Collapsible/README.md
+++ b/src/components/Collapsible/README.md
@@ -68,7 +68,7 @@ class CollapsibleExample extends React.Component {
       <div style={{height: '200px'}}>
         <Card sectioned>
           <Stack vertical>
-            <Button onClick={this.handleToggleClick} ariaExpanded={open}>
+            <Button onClick={this.handleToggleClick} ariaExpanded={open} ariaControls="basic-collapsible">
               Toggle
             </Button>
             <Collapsible open={open} id="basic-collapsible">

--- a/src/components/Collapsible/README.md
+++ b/src/components/Collapsible/README.md
@@ -68,7 +68,11 @@ class CollapsibleExample extends React.Component {
       <div style={{height: '200px'}}>
         <Card sectioned>
           <Stack vertical>
-            <Button onClick={this.handleToggleClick} ariaExpanded={open} ariaControls="basic-collapsible">
+            <Button
+              onClick={this.handleToggleClick}
+              ariaExpanded={open}
+              ariaControls="basic-collapsible"
+            >
               Toggle
             </Button>
             <Collapsible open={open} id="basic-collapsible">


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

(I was browsing the example for my own personal project and came across this documentation issue)

### WHAT is this pull request doing?

As described in the props of the component, the `Button` toggler should have an `aria-controls` prop pointing to the collapsible component it controls.