### PR TITLE
[v4] Deprecate icon source

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -10,6 +10,10 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - We now use default imports for React. Applications that consume polaris using sewing-kit shall need to enable [`esModuleInterop`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-from-commonjs-modules-with---esmoduleinterop) in their `tsconfig.json` files. ([#1523](https://github.com/Shopify/polaris-react/pull/1523))
 - `ChoiceList` `title` is required for accessibility. It can be hidden with `titleHidden`. ([#1575](https://github.com/Shopify/polaris-react/pull/1575))
 - Remove the WithRef component. This was never documented and was intended for internal use only but was part of our public API ([#1610](https://github.com/Shopify/polaris-react/pull/1610)).
+- Removed support for passing a string into `<Icon source>` to load a bundled icon. You must load the required icon directly from `@shopify/polaris-icons` instead ([#1604](https://github.com/Shopify/polaris-react/pull/1604)).
+- Removed support for passing a "SvgSource" shaped object into `<Icon source>` to load an icon imported using Shopify's legacy icon loader. You must update sewing-kit to at least v0.82.0 which replaced the legacy loader with using SVGR ([#1604](https://github.com/Shopify/polaris-react/pull/1604)).
+- Removed support for passing a React Element into `<Icon source>`. You must pass in a React Component that returns an SVG element instead. ([#1604](https://github.com/Shopify/polaris-react/pull/1604)).
+- Removed support for `<Icon untrusted>`. Passing a string into `source` will now always load an untrusted icon, you don't need that additional property. ([#1604](https://github.com/Shopify/polaris-react/pull/1604)).
 
 ### New components
 

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {PlusMinor} from '@shopify/polaris-icons';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {UnstyledLink, Icon, Spinner} from 'components';
 import Button, {IconWrapper} from '../Button';
@@ -141,15 +142,9 @@ describe('<Button />', () => {
   });
 
   describe('icon', () => {
-    it('renders an icon if it’s a string', () => {
-      const source = 'delete';
-      const button = mountWithAppProvider(<Button icon={source} />);
-      expect(button.find(Icon).prop('source')).toBe(source);
-    });
-    it('renders an icon if it’s an SVGSource object', () => {
-      const source = {body: '<SVG />', viewBox: ''};
-      const button = mountWithAppProvider(<Button icon={source} />);
-      expect(button.find(Icon).prop('source')).toBe(source);
+    it('renders an icon if it’s a component', () => {
+      const button = mountWithAppProvider(<Button icon={PlusMinor} />);
+      expect(button.find(Icon).prop('source')).toBe(PlusMinor);
     });
     it('renders a react node if it is one', () => {
       const Icon = () => <div>Hi there!</div>;

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,59 +1,5 @@
 import React from 'react';
 import {classNames, variationName} from '@shopify/css-utilities';
-import {
-  PlusMinor,
-  AlertMinor,
-  ArrowDownMinor,
-  ArrowLeftMinor,
-  ArrowRightMinor,
-  ArrowUpMinor,
-  ArrowUpDownMinor,
-  CalendarMinor,
-  MobileCancelMajorMonotone,
-  CancelSmallMinor,
-  CaretDownMinor,
-  CaretUpMinor,
-  TickSmallMinor,
-  ChevronDownMinor,
-  ChevronLeftMinor,
-  ChevronRightMinor,
-  ChevronUpMinor,
-  CircleCancelMinor,
-  CircleChevronDownMinor,
-  CircleChevronLeftMinor,
-  CircleChevronRightMinor,
-  CircleChevronUpMinor,
-  CircleInformationMajorTwotone,
-  CirclePlusMinor,
-  CirclePlusOutlineMinor,
-  ConversationMinor,
-  DeleteMinor,
-  CircleDisableMinor,
-  DisputeMinor,
-  DuplicateMinor,
-  EmbedMinor,
-  ExportMinor,
-  ExternalMinor,
-  QuestionMarkMajorTwotone,
-  HomeMajorMonotone,
-  HorizontalDotsMinor,
-  ImportMinor,
-  LogOutMinor,
-  MobileHamburgerMajorMonotone,
-  NoteMinor,
-  NotificationMajorMonotone,
-  OnlineStoreMajorTwotone,
-  OrdersMajorTwotone,
-  PrintMinor,
-  ProductsMajorTwotone,
-  ProfileMinor,
-  MinusMinor,
-  RefreshMinor,
-  RiskMinor,
-  SaveMinor,
-  SearchMinor,
-  ViewMinor,
-} from '@shopify/polaris-icons';
 
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 
@@ -97,61 +43,6 @@ export type Color =
   | 'redDark'
   | 'purple';
 
-export const BUNDLED_ICONS = {
-  add: PlusMinor,
-  alert: AlertMinor,
-  arrowDown: ArrowDownMinor,
-  arrowLeft: ArrowLeftMinor,
-  arrowRight: ArrowRightMinor,
-  arrowUp: ArrowUpMinor,
-  arrowUpDown: ArrowUpDownMinor,
-  calendar: CalendarMinor,
-  cancel: MobileCancelMajorMonotone,
-  cancelSmall: CancelSmallMinor,
-  caretDown: CaretDownMinor,
-  caretUp: CaretUpMinor,
-  checkmark: TickSmallMinor,
-  chevronDown: ChevronDownMinor,
-  chevronLeft: ChevronLeftMinor,
-  chevronRight: ChevronRightMinor,
-  chevronUp: ChevronUpMinor,
-  circleCancel: CircleCancelMinor,
-  circleChevronDown: CircleChevronDownMinor,
-  circleChevronLeft: CircleChevronLeftMinor,
-  circleChevronRight: CircleChevronRightMinor,
-  circleChevronUp: CircleChevronUpMinor,
-  circleInformation: CircleInformationMajorTwotone,
-  circlePlus: CirclePlusMinor,
-  circlePlusOutline: CirclePlusOutlineMinor,
-  conversation: ConversationMinor,
-  delete: DeleteMinor,
-  disable: CircleDisableMinor,
-  dispute: DisputeMinor,
-  duplicate: DuplicateMinor,
-  embed: EmbedMinor,
-  export: ExportMinor,
-  external: ExternalMinor,
-  help: QuestionMarkMajorTwotone,
-  home: HomeMajorMonotone,
-  horizontalDots: HorizontalDotsMinor,
-  import: ImportMinor,
-  logOut: LogOutMinor,
-  menu: MobileHamburgerMajorMonotone,
-  notes: NoteMinor,
-  notification: NotificationMajorMonotone,
-  onlineStore: OnlineStoreMajorTwotone,
-  orders: OrdersMajorTwotone,
-  print: PrintMinor,
-  products: ProductsMajorTwotone,
-  profile: ProfileMinor,
-  refresh: RefreshMinor,
-  risk: RiskMinor,
-  save: SaveMinor,
-  search: SearchMinor,
-  subtract: MinusMinor,
-  view: ViewMinor,
-};
-
 const COLORS_WITH_BACKDROPS = [
   'teal',
   'tealDark',
@@ -162,22 +53,11 @@ const COLORS_WITH_BACKDROPS = [
   'inkLighter',
 ];
 
-interface SVGSource {
-  body: string;
-  viewBox: string;
-}
-
-export type BundledIcon = keyof typeof BUNDLED_ICONS;
-
-export type UntrustedSVG = string;
-
 export type IconSource =
-  | React.ReactNode
   | React.SFC<React.SVGProps<SVGSVGElement>>
-  | SVGSource
   | 'placeholder'
-  | BundledIcon
-  | UntrustedSVG;
+  | string;
+
 export interface Props {
   /** The SVG contents to display in the icon (icons should fit in a 20 × 20 pixel viewBox) */
   source: IconSource;
@@ -187,9 +67,6 @@ export interface Props {
   backdrop?: boolean;
   /** Descriptive text to be read to screenreaders */
   accessibilityLabel?: string;
-  /** Render the icon in an img element instead of an svg to prevent cross-site scripting */
-  /** @deprecated the untrusted prop is deprecated and will be removed (all raw strings passed into the Icon component will be assumed to be untrusted) */
-  untrusted?: boolean;
 }
 
 export type CombinedProps = Props & WithAppProviderProps;
@@ -199,7 +76,6 @@ function Icon({
   color,
   backdrop,
   accessibilityLabel,
-  untrusted = false,
   polaris: {intl},
 }: CombinedProps) {
   if (color && backdrop && COLORS_WITH_BACKDROPS.indexOf(color) < 0) {
@@ -219,43 +95,19 @@ function Icon({
     backdrop && styles.hasBackdrop,
   );
 
-  const defaultIconProps = {
-    className: styles.Svg,
-    focusable: 'false',
-    'aria-hidden': true,
-  };
-
-  if (untrusted) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: The untrusted prop is no longer needed, all strings passed into the Icon component are rendered as unsafe',
-    );
-  }
-
-  let SourceComponent = source as React.SFC<React.SVGProps<SVGSVGElement>>;
   let contentMarkup: React.ReactNode;
-  if (source === 'placeholder') {
+  if (typeof source === 'function') {
+    const SourceComponent = source;
+    contentMarkup = (
+      <SourceComponent
+        className={styles.Svg}
+        focusable="false"
+        aria-hidden="true"
+      />
+    );
+  } else if (source === 'placeholder') {
     contentMarkup = <div className={styles.Placeholder} />;
-  } else if (isBundledIcon(source)) {
-    SourceComponent = BUNDLED_ICONS[source];
-    const componentImportName = importForStringIcon(source);
-    // eslint-disable-next-line no-console
-    console.warn(
-      `Deprecation: passing the string "${source}" into <Icon source> is deprecated and will be removed in the next major version. Pass in the "${componentImportName}" React Component from the @shopify/polaris-icons package instead.`,
-    );
-    contentMarkup = <SourceComponent {...defaultIconProps} />;
-  } else if (typeof source === 'function') {
-    const sourceElement = <SourceComponent {...defaultIconProps} />;
-    if (React.isValidElement(sourceElement)) {
-      contentMarkup = sourceElement;
-    }
-  } else if (React.isValidElement(source)) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: passing a React Element to the Icon component is deprecated and will be removed in the next major version. Pass a React Component instead.',
-    );
-    contentMarkup = source;
-  } else if (isUntrustedSVG(source)) {
+  } else if (typeof source === 'string') {
     contentMarkup = (
       <img
         className={styles.Img}
@@ -264,8 +116,6 @@ function Icon({
         aria-hidden="true"
       />
     );
-  } else if (isSVGSource(source)) {
-    contentMarkup = renderSVG(source);
   }
 
   return (
@@ -273,91 +123,6 @@ function Icon({
       {contentMarkup}
     </span>
   );
-}
-
-function renderSVG(iconSource: SVGSource) {
-  return (
-    <svg
-      className={styles.Svg}
-      viewBox={iconSource.viewBox}
-      dangerouslySetInnerHTML={{__html: iconSource.body}}
-      focusable="false"
-      aria-hidden="true"
-    />
-  );
-}
-
-function isBundledIcon(key: IconSource): key is BundledIcon {
-  return typeof key === 'string' && Object.keys(BUNDLED_ICONS).includes(key);
-}
-
-function isSVGSource(source: IconSource): source is SVGSource {
-  return (
-    source != null &&
-    source.hasOwnProperty('viewBox') &&
-    source.hasOwnProperty('body')
-  );
-}
-
-function isUntrustedSVG(source: IconSource): source is UntrustedSVG {
-  return typeof source === 'string';
-}
-
-function importForStringIcon(string: BundledIcon) {
-  return {
-    add: 'PlusMinor',
-    alert: 'AlertMinor',
-    arrowDown: 'ArrowDownMinor',
-    arrowLeft: 'ArrowLeftMinor',
-    arrowRight: 'ArrowRightMinor',
-    arrowUp: 'ArrowUpMinor',
-    arrowUpDown: 'ArrowUpDownMinor',
-    calendar: 'CalendarMinor',
-    cancel: 'MobileCancelMajorMonotone',
-    cancelSmall: 'CancelSmallMinor',
-    caretDown: 'CaretDownMinor',
-    caretUp: 'CaretUpMinor',
-    checkmark: 'TickSmallMinor',
-    chevronDown: 'ChevronDownMinor',
-    chevronLeft: 'ChevronLeftMinor',
-    chevronRight: 'ChevronRightMinor',
-    chevronUp: 'ChevronUpMinor',
-    circleCancel: 'CircleCancelMinor',
-    circleChevronDown: 'CircleChevronDownMinor',
-    circleChevronLeft: 'CircleChevronLeftMinor',
-    circleChevronRight: 'CircleChevronRightMinor',
-    circleChevronUp: 'CircleChevronUpMinor',
-    circleInformation: 'CircleInformationMajorTwotone',
-    circlePlus: 'CirclePlusMinor',
-    circlePlusOutline: 'CirclePlusOutlineMinor',
-    conversation: 'ConversationMinor',
-    delete: 'DeleteMinor',
-    disable: 'CircleDisableMinor',
-    dispute: 'DisputeMinor',
-    duplicate: 'DuplicateMinor',
-    embed: 'EmbedMinor',
-    export: 'ExportMinor',
-    external: 'ExternalMinor',
-    help: 'QuestionMarkMajorTwotone',
-    home: 'HomeMajorMonotone',
-    horizontalDots: 'HorizontalDotsMinor',
-    import: 'ImportMinor',
-    logOut: 'LogOutMinor',
-    menu: 'MobileHamburgerMajorMonotone',
-    notes: 'NoteMinor',
-    notification: 'NotificationMajorMonotone',
-    onlineStore: 'OnlineStoreMajorTwotone',
-    orders: 'OrdersMajorTwotone',
-    print: 'PrintMinor',
-    products: 'ProductsMajorTwotone',
-    profile: 'ProfileMinor',
-    refresh: 'RefreshMinor',
-    risk: 'RiskMinor',
-    save: 'SaveMinor',
-    search: 'SearchMinor',
-    subtract: 'MinusMinor',
-    view: 'ViewMinor',
-  }[string];
 }
 
 export default withAppProvider<Props>()(Icon);

--- a/src/components/Icon/tests/Icon.test.tsx
+++ b/src/components/Icon/tests/Icon.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {PlusMinor} from '@shopify/polaris-icons';
 import {mountWithAppProvider} from 'test-utilities';
 import Icon from '../Icon';
-import Button from '../../Button';
 
 describe('<Icon />', () => {
   describe('accessibilityLabel', () => {
@@ -20,56 +19,16 @@ describe('<Icon />', () => {
       expect(element.find('div')).toHaveLength(1);
     });
 
-    it('renders an SVG when source is given a BundledIcon', () => {
-      const element = mountWithAppProvider(<Icon source="add" />);
-      expect(element.find(PlusMinor)).toHaveLength(1);
-    });
-
-    it('renders an SVG when source is given an SVG', () => {
-      const svg = {
-        body:
-          "<path d='M17 9h-6V3a1 1 0 1 0-2 0v6H3a1 1 0 1 0 0 2h6v6a1 1 0 1 0 2 0v-6h6a1 1 0 1 0 0-2'  fill-rule='evenodd'/>",
-        viewBox: '0 0 20 20',
-      };
-      const element = mountWithAppProvider(<Icon source={svg} />);
-      expect(element.find('svg')).toHaveLength(1);
-    });
-
-    it('renders a React Element when source is given a React Element', () => {
-      const element = <PlusMinor />;
-      const iconElement = mountWithAppProvider(<Icon source={element} />);
-      expect(iconElement.find(PlusMinor)).toHaveLength(1);
-    });
-
-    it('spits out a console warning when rendering a React Element', () => {
-      const spy = jest.spyOn(global.console, 'warn');
-      mountWithAppProvider(<Icon source={<PlusMinor />} />);
-      expect(spy).toHaveBeenCalled();
-    });
-
     it('renders a React Element when source is given a React Stateless Functional Component', () => {
       const element = mountWithAppProvider(<Icon source={PlusMinor} />);
       expect(element.find(PlusMinor)).toHaveLength(1);
     });
 
-    it('renders a React Element when source is given a React Component', () => {
-      const component = <Button>Icon</Button>;
-      const element = mountWithAppProvider(<Icon source={component} />);
-      expect(element.find(Button)).toHaveLength(1);
-    });
-
     it('renders an img when source is given an untrusted SVG', () => {
       const svg =
         "<svg><path d='M17 9h-6V3a1 1 0 1 0-2 0v6H3a1 1 0 1 0 0 2h6v6a1 1 0 1 0 2 0v-6h6a1 1 0 1 0 0-2'  fill-rule='evenodd'/></svg>";
-      const element = mountWithAppProvider(<Icon source={svg} untrusted />);
+      const element = mountWithAppProvider(<Icon source={svg} />);
       expect(element.find('img')).toHaveLength(1);
-    });
-
-    it('spits out a console warning when passing in untrusted', () => {
-      const spy = jest.spyOn(global.console, 'warn');
-      const svg = "<svg><path d='M10 10'/></svg>";
-      mountWithAppProvider(<Icon source={svg} untrusted />);
-      expect(spy).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Remove deprecated functionality.

Fixes #1298 and is the final step in #1061

### WHAT is this pull request doing?

Icon now only supports a source of 'placeholder' to use a placeholder,
a component that returns an SVG element (i.e. something provided by
polaris-icons or svgr imports) or a string (for untrusted svgs)

- Remove passing a string into source to use a bundled icon
- Remove passing a SvgSource shaped object into source (this was the legacy shopify-style icon imports that we have replaced with using SVGr in sewing-kit)
- Remove passing a React element into source
- Remove the deprecated 'untrusted' prop

### How to 🎩

check tests and an storybook for no regressions