### PR TITLE
[DataTable] Remove fixed column UX

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -27,6 +27,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixes `monochrome` variant of `Link` and `Button` components to support multi-line link text ([#1686](https://github.com/Shopify/polaris-react/pull/1686))
+- Fixed the first column of `DataTable` not rendering in iOS Safari (([#1605](https://github.com/Shopify/polaris-react/pull/1605))
 
 ### Documentation
 

--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -90,6 +90,7 @@ $breakpoint: 768px;
   white-space: nowrap;
   overflow-x: hidden;
   text-overflow: ellipsis;
+  max-width: $first-column-width;
 }
 
 .Cell-header {

--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -20,12 +20,6 @@ $breakpoint: 768px;
   }
 }
 
-.hasFooter {
-  .ScrollContainer {
-    margin-bottom: rem(52px);
-  }
-}
-
 .Navigation {
   display: none;
 }
@@ -61,10 +55,6 @@ $breakpoint: 768px;
       background: color('sky', 'lighter');
     }
   }
-}
-
-.TableFoot {
-  border-bottom: 0;
 }
 
 .Cell {
@@ -148,16 +138,9 @@ $breakpoint: 768px;
   border-bottom: border();
 }
 
-.Cell-footer {
-  @include text-emphasis-normal;
-  position: absolute;
-  top: 100%;
-  left: 0;
-  width: 100%;
-  border-bottom: 0;
+.Footer {
+  padding: spacing();
   background: color('sky', 'light');
   color: color('ink', 'lighter');
-  white-space: unset;
   text-align: center;
-  backface-visibility: hidden; // stop painting on scroll (due to positioning)
 }

--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -1,4 +1,4 @@
-$fixed-column-width: rem(145px);
+$first-column-width: rem(145px);
 $breakpoint: 768px;
 
 .DataTable {
@@ -26,7 +26,7 @@ $breakpoint: 768px;
   }
 
   .ScrollContainer {
-    margin-left: rem($fixed-column-width);
+    margin-left: rem($first-column-width);
   }
 }
 
@@ -71,7 +71,7 @@ $breakpoint: 768px;
     position: absolute;
     top: 0;
     bottom: 0;
-    left: $fixed-column-width;
+    left: $first-column-width;
     display: none;
     width: rem(6px);
     background: linear-gradient(
@@ -111,9 +111,10 @@ $breakpoint: 768px;
   @include text-emphasis-normal;
   @include text-breakword;
   position: absolute;
+  z-index: 5;
   top: auto;
   left: 0;
-  width: $fixed-column-width;
+  width: $first-column-width;
   white-space: unset;
   text-align: left;
   backface-visibility: hidden; // stops painting on scroll (due to positioning)

--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -6,7 +6,7 @@ $breakpoint: 768px;
   max-width: 100vw;
 }
 
-.collapsed {
+.condensed {
   .Navigation {
     display: flex;
     align-items: center;
@@ -78,7 +78,6 @@ $breakpoint: 768px;
 
 .Cell-firstColumn {
   @include text-emphasis-normal;
-  @include text-breakword;
   text-align: left;
   white-space: normal;
 }

--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -7,12 +7,6 @@ $breakpoint: 768px;
 }
 
 .collapsed {
-  .Table {
-    &::after {
-      display: block;
-    }
-  }
-
   .Navigation {
     display: flex;
     align-items: center;
@@ -23,10 +17,6 @@ $breakpoint: 768px;
     @include breakpoint-after($breakpoint, inclusive) {
       justify-content: flex-end;
     }
-  }
-
-  .ScrollContainer {
-    margin-left: rem($first-column-width);
   }
 }
 
@@ -57,29 +47,12 @@ $breakpoint: 768px;
 
 .ScrollContainer {
   overflow-x: auto;
-  // account for a mysterious gap in Safari when not collapsed
-  margin-left: rem(140px);
   -webkit-overflow-scrolling: touch;
 }
 
 .Table {
   width: 100%;
   border-spacing: 0;
-
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: $first-column-width;
-    display: none;
-    width: rem(6px);
-    background: linear-gradient(
-      to right,
-      rgba(color('black'), 0.12),
-      rgba(color('black'), 0)
-    );
-  }
 }
 
 .TableRow {
@@ -103,21 +76,17 @@ $breakpoint: 768px;
   vertical-align: top;
 }
 
-.Cell-numeric {
-  text-align: right;
-}
-
-.Cell-fixed {
+.Cell-firstColumn {
   @include text-emphasis-normal;
   @include text-breakword;
-  position: absolute;
-  z-index: 5;
-  top: auto;
-  left: 0;
-  width: $first-column-width;
-  white-space: unset;
+  min-width: $first-column-width;
+  max-width: $first-column-width;
   text-align: left;
-  backface-visibility: hidden; // stops painting on scroll (due to positioning)
+  white-space: normal;
+}
+
+.Cell-numeric {
+  text-align: right;
 }
 
 .Cell-truncated {

--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -79,8 +79,6 @@ $breakpoint: 768px;
 .Cell-firstColumn {
   @include text-emphasis-normal;
   @include text-breakword;
-  min-width: $first-column-width;
-  max-width: $first-column-width;
   text-align: left;
   white-space: normal;
 }

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -190,7 +190,7 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
         tableRightVisibleEdge,
       };
 
-      const columnVisibilityData = Array.from(headerCells).map(
+      const columnVisibilityData = [...headerCells].map(
         measureColumn(tableData),
       );
 

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -51,7 +51,7 @@ export interface Props {
 
 class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
   state: DataTableState = {
-    collapsed: false,
+    condensed: false,
     columnVisibilityData: [],
     heights: [],
     preservedScrollPosition: {},
@@ -71,18 +71,18 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
       scrollContainer: {current: scrollContainer},
     } = this;
 
-    let collapsed = false;
+    let condensed = false;
 
     if (table && scrollContainer) {
-      collapsed = table.scrollWidth > scrollContainer.clientWidth;
+      condensed = table.scrollWidth > scrollContainer.clientWidth;
       scrollContainer.scrollLeft = 0;
     }
 
     this.setState(
       {
-        collapsed,
+        condensed,
         heights: [],
-        ...this.calculateColumnVisibilityData(collapsed),
+        ...this.calculateColumnVisibilityData(condensed),
       },
       () => {
         if (footerContent || !truncate) {
@@ -130,7 +130,7 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
     } = this.props;
 
     const {
-      collapsed,
+      condensed,
       columnVisibilityData,
       heights,
       sortedColumnIndex = initialSortColumnIndex,
@@ -141,13 +141,13 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
 
     const className = classNames(
       styles.DataTable,
-      collapsed && styles.collapsed,
+      condensed && styles.condensed,
       footerContent && styles.hasFooter,
     );
 
     const wrapperClassName = classNames(
       styles.TableWrapper,
-      collapsed && styles.collapsed,
+      condensed && styles.condensed,
     );
 
     const footerClassName = classNames(footerContent && styles.TableFoot);
@@ -290,14 +290,14 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
     );
   };
 
-  private calculateColumnVisibilityData = (collapsed: boolean) => {
+  private calculateColumnVisibilityData = (condensed: boolean) => {
     const {
       table: {current: table},
       scrollContainer: {current: scrollContainer},
       dataTable: {current: dataTable},
     } = this;
 
-    if (collapsed && table && scrollContainer && dataTable) {
+    if (condensed && table && scrollContainer && dataTable) {
       const headerCells = table.querySelectorAll(
         headerCell.selector,
       ) as NodeListOf<HTMLElement>;
@@ -337,7 +337,7 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
 
   private scrollListener = () => {
     this.setState((prevState) => ({
-      ...this.calculateColumnVisibilityData(prevState.collapsed),
+      ...this.calculateColumnVisibilityData(prevState.condensed),
     }));
   };
 
@@ -358,7 +358,7 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
 
         requestAnimationFrame(() => {
           this.setState((prevState) => ({
-            ...this.calculateColumnVisibilityData(prevState.collapsed),
+            ...this.calculateColumnVisibilityData(prevState.condensed),
           }));
         });
       }

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -137,18 +137,6 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
       condensed && styles.condensed,
     );
 
-    const footerClassName = classNames(footerContent && styles.TableFoot);
-
-    const footerMarkup = footerContent ? (
-      <tfoot className={footerClassName}>
-        <tr>{this.renderFooter()}</tr>
-      </tfoot>
-    ) : null;
-
-    const totalsMarkup = totals ? (
-      <tr>{totals.map(this.renderTotals)}</tr>
-    ) : null;
-
     const headingMarkup = (
       <tr>
         {headings.map((heading, headingIndex) => {
@@ -185,7 +173,15 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
       </tr>
     );
 
+    const totalsMarkup = totals ? (
+      <tr>{totals.map(this.renderTotals)}</tr>
+    ) : null;
+
     const bodyMarkup = rows.map(this.defaultRenderRow);
+
+    const footerMarkup = footerContent ? (
+      <div className={styles.Footer}>{footerContent}</div>
+    ) : null;
 
     return (
       <div className={wrapperClassName}>
@@ -210,9 +206,9 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
                 {totalsMarkup}
               </thead>
               <tbody>{bodyMarkup}</tbody>
-              {footerMarkup}
             </table>
           </div>
+          {footerMarkup}
         </div>
       </div>
     );
@@ -345,17 +341,6 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
           );
         })}
       </tr>
-    );
-  };
-
-  private renderFooter = () => {
-    return (
-      <Cell
-        footer
-        testID="footer-cell"
-        content={this.props.footerContent}
-        truncate={this.props.truncate}
-      />
     );
   };
 

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -189,7 +189,7 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
               height={height}
               content={heading}
               contentType={columnContentTypes[headingIndex]}
-              fixed={headingIndex === 0}
+              firstColumn={headingIndex === 0}
               truncate={truncate}
               {...sortableHeadingProps}
             />
@@ -388,7 +388,7 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
     return (
       <Cell
         total
-        fixed={index === 0}
+        firstColumn={index === 0}
         testID={id}
         key={id}
         height={heights[1]}
@@ -426,7 +426,7 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
               height={bodyCellHeights[index]}
               content={content}
               contentType={columnContentTypes[cellIndex]}
-              fixed={cellIndex === 0}
+              firstColumn={cellIndex === 0}
               truncate={truncate}
             />
           );

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -70,11 +70,14 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
       table: {current: table},
       scrollContainer: {current: scrollContainer},
     } = this;
+
     let collapsed = false;
+
     if (table && scrollContainer) {
       collapsed = table.scrollWidth > scrollContainer.clientWidth;
       scrollContainer.scrollLeft = 0;
     }
+
     this.setState(
       {
         collapsed,
@@ -249,8 +252,8 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
 
       if (!truncate) {
         return (heights = rows.map((row) => {
-          const fixedCell = (row.childNodes as NodeListOf<HTMLElement>)[0];
-          return Math.max(row.clientHeight, fixedCell.clientHeight);
+          const firstCell = (row.childNodes as NodeListOf<HTMLElement>)[0];
+          return Math.max(row.clientHeight, firstCell.clientHeight);
         }));
       }
 
@@ -265,16 +268,15 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
   };
 
   private resetScrollPosition = () => {
-    const {
-      scrollContainer: {current: scrollContainer},
-    } = this;
+    const {current: scrollContainer} = this.scrollContainer;
+
     if (scrollContainer) {
-      const {
-        preservedScrollPosition: {left, top},
-      } = this.state;
+      const {left, top} = this.state.preservedScrollPosition;
+
       if (left) {
         scrollContainer.scrollLeft = left;
       }
+
       if (top) {
         window.scrollTo(0, top);
       }
@@ -294,35 +296,34 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
       scrollContainer: {current: scrollContainer},
       dataTable: {current: dataTable},
     } = this;
+
     if (collapsed && table && scrollContainer && dataTable) {
       const headerCells = table.querySelectorAll(
         headerCell.selector,
       ) as NodeListOf<HTMLElement>;
-      const collapsedHeaderCells = Array.from(headerCells).slice(1);
-      const fixedColumnWidth = headerCells[0].offsetWidth;
-      const firstVisibleColumnIndex = collapsedHeaderCells.length - 1;
-      const tableLeftVisibleEdge =
-        scrollContainer.scrollLeft + fixedColumnWidth;
+
+      const firstVisibleColumnIndex = headerCells.length - 1;
+      const tableLeftVisibleEdge = scrollContainer.scrollLeft;
+
       const tableRightVisibleEdge =
         scrollContainer.scrollLeft + dataTable.offsetWidth;
+
       const tableData = {
-        fixedColumnWidth,
         firstVisibleColumnIndex,
         tableLeftVisibleEdge,
         tableRightVisibleEdge,
       };
 
-      const columnVisibilityData = collapsedHeaderCells.map(
+      const columnVisibilityData = Array.from(headerCells).map(
         measureColumn(tableData),
       );
 
       const lastColumn = columnVisibilityData[columnVisibilityData.length - 1];
 
       return {
-        fixedColumnWidth,
         columnVisibilityData,
         ...getPrevAndCurrentColumns(tableData, columnVisibilityData),
-        isScrolledFarthestLeft: tableLeftVisibleEdge === fixedColumnWidth,
+        isScrolledFarthestLeft: tableLeftVisibleEdge === 0,
         isScrolledFarthestRight: lastColumn.rightEdge <= tableRightVisibleEdge,
       };
     }
@@ -341,21 +342,19 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
   };
 
   private navigateTable = (direction: string) => {
-    const {currentColumn, previousColumn, fixedColumnWidth} = this.state;
-    const {
-      scrollContainer: {current: scrollContainer},
-    } = this;
+    const {currentColumn, previousColumn} = this.state;
+    const {current: scrollContainer} = this.scrollContainer;
 
     const handleScroll = () => {
-      if (!currentColumn || !previousColumn || !fixedColumnWidth) {
+      if (!currentColumn || !previousColumn) {
         return;
       }
 
       if (scrollContainer) {
         scrollContainer.scrollLeft =
           direction === 'right'
-            ? currentColumn.rightEdge - fixedColumnWidth
-            : previousColumn.leftEdge - fixedColumnWidth;
+            ? currentColumn.rightEdge
+            : previousColumn.leftEdge;
 
         requestAnimationFrame(() => {
           this.setState((prevState) => ({

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -11,14 +11,12 @@ import styles from '../../DataTable.scss';
 
 export interface Props {
   testID?: string;
-  height?: number;
   content?: React.ReactNode;
   contentType?: string;
   firstColumn?: boolean;
   truncate?: boolean;
   header?: boolean;
   total?: boolean;
-  footer?: boolean;
   sorted?: boolean;
   sortable?: boolean;
   sortDirection?: SortDirection;
@@ -29,14 +27,12 @@ export interface Props {
 type CombinedProps = Props & WithAppProviderProps;
 
 function Cell({
-  height,
   content,
   contentType,
   firstColumn,
   truncate,
   header,
   total,
-  footer,
   sorted,
   sortable,
   sortDirection,
@@ -47,14 +43,12 @@ function Cell({
   onSort,
 }: CombinedProps) {
   const numeric = contentType === 'numeric';
-
   const className = classNames(
     styles.Cell,
     firstColumn && styles['Cell-firstColumn'],
     firstColumn && truncate && styles['Cell-truncated'],
     header && styles['Cell-header'],
     total && styles['Cell-total'],
-    footer && styles['Cell-footer'],
     numeric && styles['Cell-numeric'],
     sortable && styles['Cell-sortable'],
     sorted && styles['Cell-sorted'],
@@ -66,11 +60,6 @@ function Cell({
   );
 
   const iconClassName = classNames(sortable && styles.Icon);
-
-  const style = {
-    height: height ? `${height}px` : undefined,
-  };
-
   const direction = sorted ? sortDirection : defaultSortDirection;
   const source = direction === 'ascending' ? CaretUpMinor : CaretDownMinor;
   const oppositeDirection =
@@ -102,12 +91,11 @@ function Cell({
       className={className}
       scope="col"
       aria-sort={sortDirection}
-      style={style}
     >
       {columnHeadingContent}
     </th>
   ) : (
-    <th className={className} scope="row" style={style}>
+    <th className={className} scope="row">
       {content}
     </th>
   );
@@ -116,9 +104,7 @@ function Cell({
     header || firstColumn ? (
       headingMarkup
     ) : (
-      <td className={className} style={style}>
-        {content}
-      </td>
+      <td className={className}>{content}</td>
     );
 
   return cellMarkup;

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -14,7 +14,7 @@ export interface Props {
   height?: number;
   content?: React.ReactNode;
   contentType?: string;
-  fixed?: boolean;
+  firstColumn?: boolean;
   truncate?: boolean;
   header?: boolean;
   total?: boolean;
@@ -32,7 +32,7 @@ function Cell({
   height,
   content,
   contentType,
-  fixed,
+  firstColumn,
   truncate,
   header,
   total,
@@ -50,8 +50,8 @@ function Cell({
 
   const className = classNames(
     styles.Cell,
-    fixed && styles['Cell-fixed'],
-    fixed && truncate && styles['Cell-truncated'],
+    firstColumn && styles['Cell-firstColumn'],
+    firstColumn && truncate && styles['Cell-truncated'],
     header && styles['Cell-header'],
     total && styles['Cell-total'],
     footer && styles['Cell-footer'],
@@ -113,7 +113,7 @@ function Cell({
   );
 
   const cellMarkup =
-    header || fixed ? (
+    header || firstColumn ? (
       headingMarkup
     ) : (
       <td className={className} style={style}>

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -10,7 +10,6 @@ import {SortDirection} from '../../types';
 import styles from '../../DataTable.scss';
 
 export interface Props {
-  testID?: string;
   content?: React.ReactNode;
   contentType?: string;
   firstColumn?: boolean;
@@ -36,7 +35,7 @@ function Cell({
   sorted,
   sortable,
   sortDirection,
-  defaultSortDirection,
+  defaultSortDirection = 'ascending',
   polaris: {
     intl: {translate},
   },
@@ -61,7 +60,7 @@ function Cell({
 
   const iconClassName = classNames(sortable && styles.Icon);
   const direction = sorted ? sortDirection : defaultSortDirection;
-  const source = direction === 'ascending' ? CaretUpMinor : CaretDownMinor;
+  const source = direction === 'descending' ? CaretDownMinor : CaretUpMinor;
   const oppositeDirection =
     sortDirection === 'ascending' ? 'descending' : 'ascending';
 

--- a/src/components/DataTable/components/Cell/tests/Cell.test.tsx
+++ b/src/components/DataTable/components/Cell/tests/Cell.test.tsx
@@ -1,0 +1,263 @@
+import * as React from 'react';
+import {CaretUpMinor, CaretDownMinor} from '@shopify/polaris-icons';
+import {
+  mountWithAppProvider,
+  shallowWithAppProvider,
+  trigger,
+} from 'test-utilities';
+
+import {Icon} from '../../../..';
+import Cell from '../Cell';
+
+describe('<Cell />', () => {
+  describe('content', () => {
+    it('sets text content when provided', () => {
+      const cellContent = 'Data';
+      const cell = shallowWithAppProvider(<Cell content={cellContent} />);
+
+      expect(cell.text()).toBe(cellContent);
+    });
+
+    it('sets markup content when provided', () => {
+      const cellContent = 'Data';
+      const cellMarkup = <p>{cellContent}</p>;
+      const cell = shallowWithAppProvider(<Cell content={cellMarkup} />);
+
+      expect(cell.find('p')).toHaveLength(1);
+      expect(cell.text()).toBe(cellContent);
+    });
+  });
+
+  describe('firstColumn', () => {
+    it('renders a table heading element when true', () => {
+      const cell = shallowWithAppProvider(<Cell firstColumn />);
+
+      expect(cell.find('th')).toHaveLength(1);
+    });
+  });
+
+  describe('header', () => {
+    it('renders a table heading element when true', () => {
+      const cell = shallowWithAppProvider(<Cell header />);
+
+      expect(cell.find('th')).toHaveLength(1);
+    });
+  });
+
+  describe('sorted', () => {
+    it('sets the aria-sort attribute to the sortDirection when the table is currently sorted by that column', () => {
+      const sortDirection = 'ascending';
+      const cell = shallowWithAppProvider(
+        <Cell
+          header
+          firstColumn
+          sortable
+          sorted
+          sortDirection={sortDirection}
+        />,
+      );
+
+      expect(cell.prop('aria-sort')).toBe(sortDirection);
+    });
+
+    it('sets the aria-sort attribute to none when the table is not currently sorted by that column', () => {
+      const sortDirection = 'none';
+      const cell = shallowWithAppProvider(
+        <Cell
+          header
+          firstColumn
+          sortable
+          sorted={false}
+          sortDirection={sortDirection}
+        />,
+      );
+
+      expect(cell.prop('aria-sort')).toBe('none');
+    });
+  });
+
+  describe('sortable', () => {
+    it('renders an Icon when table is sortable by that column', () => {
+      const cell = shallowWithAppProvider(<Cell header firstColumn sortable />);
+
+      expect(cell.find(Icon)).toHaveLength(1);
+    });
+
+    it('renders no Icon when table is not sortable by that column', () => {
+      const cell = shallowWithAppProvider(
+        <Cell header firstColumn sortable={false} />,
+      );
+
+      expect(cell.find(Icon)).not.toHaveLength(1);
+    });
+  });
+
+  describe('sortDirection', () => {
+    describe('when set to none', () => {
+      it('renders a down caret Icon when defaultSortDirection is descending', () => {
+        const cell = shallowWithAppProvider(
+          <Cell
+            header
+            firstColumn
+            sortable
+            sortDirection="none"
+            defaultSortDirection="descending"
+          />,
+        );
+
+        expect(cell.find(Icon).prop('source')).toBe(CaretDownMinor);
+      });
+
+      it('renders an up caret Icon when defaultSortDirection is ascending', () => {
+        const cell = shallowWithAppProvider(
+          <Cell
+            header
+            firstColumn
+            sortable
+            sortDirection="none"
+            defaultSortDirection="ascending"
+          />,
+        );
+
+        expect(cell.find(Icon).prop('source')).toBe(CaretUpMinor);
+      });
+    });
+
+    describe('when set to ascending', () => {
+      it('renders an up caret Icon when table is currently sorted by that column', () => {
+        const cell = shallowWithAppProvider(
+          <Cell header firstColumn sortable sorted sortDirection="ascending" />,
+        );
+
+        expect(cell.find(Icon).prop('source')).toBe(CaretUpMinor);
+      });
+
+      it('renders an Icon with an accessibility label indicating the next sort direction is descending', () => {
+        const cell = mountWithAppProvider(
+          <Cell header firstColumn sortable sorted sortDirection="ascending" />,
+        );
+
+        const expectedLabel = cell
+          .instance()
+          .context.polaris.intl.translate(
+            'Polaris.DataTable.sortAccessibilityLabel',
+            {
+              direction: 'descending',
+            },
+          );
+
+        expect(cell.find(Icon).prop('accessibilityLabel')).toBe(expectedLabel);
+      });
+    });
+
+    describe('when set to descending', () => {
+      it('renders a down caret Icon when table is currently sorted by that column', () => {
+        const cell = shallowWithAppProvider(
+          <Cell
+            header
+            firstColumn
+            sortable
+            sorted
+            sortDirection="descending"
+          />,
+        );
+
+        expect(cell.find(Icon).prop('source')).toBe(CaretDownMinor);
+      });
+
+      it('renders an Icon with an accessibility label indicating the next sort direction is ascending', () => {
+        const cell = mountWithAppProvider(
+          <Cell
+            header
+            firstColumn
+            sortable
+            sorted
+            sortDirection="descending"
+          />,
+        );
+
+        const expectedLabel = cell
+          .instance()
+          .context.polaris.intl.translate(
+            'Polaris.DataTable.sortAccessibilityLabel',
+            {
+              direction: 'ascending',
+            },
+          );
+
+        expect(cell.find(Icon).prop('accessibilityLabel')).toBe(expectedLabel);
+      });
+    });
+  });
+
+  describe('defaultSortDirection', () => {
+    describe('when set to none', () => {
+      it('renders an up caret Icon when table is not currently sorted by that column', () => {
+        const cell = shallowWithAppProvider(
+          <Cell
+            header
+            firstColumn
+            sortable
+            sorted={false}
+            sortDirection="none"
+            defaultSortDirection="none"
+          />,
+        );
+
+        expect(cell.find(Icon).prop('source')).toBe(CaretUpMinor);
+      });
+    });
+    describe('when set to ascending', () => {
+      it('renders an up caret Icon when table is not currently sorted by that column', () => {
+        const cell = shallowWithAppProvider(
+          <Cell
+            header
+            firstColumn
+            sortable
+            sorted={false}
+            defaultSortDirection="ascending"
+          />,
+        );
+
+        expect(cell.find(Icon).prop('source')).toBe(CaretUpMinor);
+      });
+    });
+
+    describe('when set to descending', () => {
+      it('renders a down caret Icon when table is not currently sorted by that column', () => {
+        const cell = shallowWithAppProvider(
+          <Cell
+            header
+            firstColumn
+            sortable
+            sorted={false}
+            defaultSortDirection="descending"
+          />,
+        );
+
+        expect(cell.find(Icon).prop('source')).toBe(CaretDownMinor);
+      });
+    });
+  });
+
+  describe('onSort', () => {
+    it('gets called when a sortable cell heading is clicked', () => {
+      const sortSpy = jest.fn();
+      const cell = shallowWithAppProvider(
+        <Cell
+          header
+          firstColumn
+          sortable
+          sorted={false}
+          content="Heading 1"
+          defaultSortDirection="descending"
+          onSort={sortSpy}
+        />,
+      );
+
+      trigger(cell.find('button'), 'onClick');
+
+      expect(sortSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -1,27 +1,9 @@
 import * as React from 'react';
-import {mountWithAppProvider, findByTestID} from 'test-utilities';
-import {isEdgeVisible, getPrevAndCurrentColumns} from '../utilities';
-import {Cell, Navigation} from '../components';
+import {mountWithAppProvider, trigger} from 'test-utilities';
+import {Cell} from '../components';
 import DataTable, {Props} from '../DataTable';
 
-interface DataTableTestProps {
-  sortable?: Props['sortable'];
-  defaultSortDirection?: Props['defaultSortDirection'];
-  initialSortColumnIndex?: Props['initialSortColumnIndex'];
-  onSort?: Props['onSort'];
-}
-
-const sortable = [false, true, false, false, true, false];
-const columnContentTypes: Props['columnContentTypes'] = [
-  'text',
-  'numeric',
-  'numeric',
-  'numeric',
-  'numeric',
-];
-const spyOnSort = jest.fn();
-
-function setup(propOverrides?: DataTableTestProps) {
+describe('<DataTable />', () => {
   const headings = ['Product', 'Price', 'Order Number', 'Quantity', 'Subtotal'];
   const rows = [
     [
@@ -34,152 +16,316 @@ function setup(propOverrides?: DataTableTestProps) {
     ['Emerald Silk Gown', '$230.00', 124689, 32, '$19,090.00'],
     ['Mauve Cashmere Scarf', '$445.00', 124533, 140, '$14,240.00'],
   ];
-  const summary = ['', '', '', 255, '$155,830.00'];
 
-  const props = {
-    columnContentTypes,
-    headings,
-    rows,
-    summary,
-    ...propOverrides,
-  };
-  const dataTable = mountWithAppProvider(<DataTable {...props} />);
+  const columnContentTypes: Props['columnContentTypes'] = [
+    'text',
+    'numeric',
+    'numeric',
+    'numeric',
+    'numeric',
+  ];
 
-  return {
-    ...props,
-    dataTable,
-    twoClicks: true,
-  };
-}
+  const defaultProps: Props = {columnContentTypes, headings, rows};
 
-describe('<DataTable />', () => {
-  it('renders a table, thead and table body rows', () => {
-    const {dataTable} = setup();
-
-    expect(dataTable.find('table')).toHaveLength(1);
-    expect(dataTable.find('thead')).toHaveLength(1);
-    expect(dataTable.find('thead th')).toHaveLength(5);
-    expect(dataTable.find('tbody tr')).toHaveLength(3);
-  });
-
-  it('defaults to non-sorting column headings', () => {
-    const {dataTable} = setup();
-    const sortableHeadings = dataTable.find(Cell).filter({sortable: true});
-
-    expect(sortableHeadings).toHaveLength(0);
-  });
-
-  it('initial sort column defaults to first column if not specified', () => {
-    const firstColumnSortable = [true, true, false, false, true, false];
-    const {dataTable} = setup({
-      sortable: firstColumnSortable,
-      onSort: spyOnSort,
-    });
-    const firstHeadingCell = findByTestID(dataTable, `heading-cell-${0}`);
-
-    expect(firstHeadingCell.props().sorted).toBe(true);
-  });
-
-  it('sets specified initial sort column', () => {
-    const {dataTable} = setup({
-      sortable,
-      onSort: spyOnSort,
-      initialSortColumnIndex: 4,
-    });
-    const fifthHeadingCell = findByTestID(dataTable, `heading-cell-${4}`);
-
-    expect(fifthHeadingCell.props().sorted).toBe(true);
-  });
-
-  describe('<Cell />', () => {
-    const {dataTable} = setup();
-    it('passes props', () => {
-      expect(
-        dataTable
-          .find(Cell)
-          .first()
-          .prop('header'),
-      ).toBe(true);
-      expect(
-        dataTable
-          .find(Cell)
-          .first()
-          .prop('content'),
-      ).toStrictEqual('Product');
-      expect(
-        dataTable
-          .find(Cell)
-          .first()
-          .prop('contentType'),
-      ).toStrictEqual('text');
-    });
-  });
-
-  describe('<Navigation />', () => {
-    const {dataTable} = setup();
-    it('passes scroll props', () => {
-      expect(
-        dataTable
-          .find(Navigation)
-          .first()
-          .prop('isScrolledFarthestLeft'),
-      ).toBe(true);
-      expect(
-        dataTable
-          .find(Navigation)
-          .first()
-          .prop('isScrolledFarthestRight'),
-      ).toBe(false);
-    });
-  });
-
-  describe('isEdgeVisible()', () => {
-    it('returns true if there is enough room', () => {
-      const position = 175;
-      const tableStart = 145;
-      const tableEnd = 205;
-
-      const isVisible = isEdgeVisible(position, tableStart, tableEnd);
-
-      expect(isVisible).toBe(true);
-    });
-
-    it('returns false if there is not enough room', () => {
-      const position = 175;
-      const tableStart = 145;
-      const tableEnd = 200;
-
-      const isVisible = isEdgeVisible(position, tableStart, tableEnd);
-
-      expect(isVisible).toBe(false);
-    });
-  });
-
-  describe('getPrevAndCurrentColumns()', () => {
-    it('returns the calculated measurements', () => {
-      const columnVisibilityData = [
-        {leftEdge: 145, rightEdge: 236, isVisible: true},
-        {leftEdge: 236, rightEdge: 357, isVisible: true},
-        {leftEdge: 357, rightEdge: 474, isVisible: true},
-        {leftEdge: 474, rightEdge: 601, isVisible: true},
+  describe('columnContentTypes', () => {
+    it('sets the provided contentType of Cells in each column', () => {
+      const headings = ['Column 1', 'Column 2'];
+      const rows = [['Cell 1', '2']];
+      const columnContentTypes: Props['columnContentTypes'] = [
+        'text',
+        'numeric',
       ];
-
-      const tableData = {
-        fixedColumnWidth: 145,
-        firstVisibleColumnIndex: 3,
-        tableLeftVisibleEdge: 145,
-        tableRightVisibleEdge: 551,
-      };
-
-      const actualMeasurement = getPrevAndCurrentColumns(
-        tableData,
-        columnVisibilityData,
+      const dataTable = mountWithAppProvider(
+        <DataTable
+          {...defaultProps}
+          columnContentTypes={columnContentTypes}
+          headings={headings}
+          rows={rows}
+        />,
       );
-      const expectedMeasurement = {
-        previousColumn: {leftEdge: 357, rightEdge: 474, isVisible: true},
-        currentColumn: {leftEdge: 474, rightEdge: 601, isVisible: true},
-      };
-      expect(actualMeasurement).toStrictEqual(expectedMeasurement);
+
+      const cells = dataTable.find(Cell);
+      const firstColumnCells = cells.filterWhere(
+        (cell) => cell.prop('firstColumn') === true,
+      );
+
+      const secondColumnCells = cells.filterWhere(
+        (cell) => cell.prop('firstColumn') !== true,
+      );
+
+      expect(cells).toHaveLength(4);
+
+      firstColumnCells.forEach((cell) =>
+        expect(cell.prop('contentType')).toBe('text'),
+      );
+
+      secondColumnCells.forEach((cell) =>
+        expect(cell.prop('contentType')).toBe('numeric'),
+      );
+    });
+  });
+
+  describe('headings', () => {
+    it('renders a single table header row', () => {
+      const headings = ['Heading 1', 'Heading 2', 'Heading 3'];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} headings={headings} />,
+      );
+
+      expect(dataTable.find('thead tr')).toHaveLength(1);
+    });
+
+    it('renders each header Cell with the content provided', () => {
+      const headings = ['Heading 1', 'Heading 2', 'Heading 3'];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} headings={headings} />,
+      );
+
+      const headingCells = dataTable.find('thead tr').find(Cell);
+
+      headingCells.forEach((headingCell, headingCellIndex) =>
+        expect(headingCell.text()).toBe(headings[headingCellIndex]),
+      );
+    });
+  });
+
+  describe('totals', () => {
+    it('renders a second table header row with totals', () => {
+      const totals = ['', '$20.00', ''];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} totals={totals} />,
+      );
+
+      expect(dataTable.find('thead tr')).toHaveLength(2);
+
+      const totalsRow = dataTable.find('thead tr').at(1);
+
+      expect(totalsRow.text()).toContain(totals.join(''));
+    });
+
+    it('sets the content of the first total Cell to the totals row heading', () => {
+      const totals = ['', '', ''];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} totals={totals} />,
+      );
+
+      expect(dataTable.find('thead tr')).toHaveLength(2);
+
+      const expectedTotalsHeadingContent = dataTable
+        .instance()
+        .context.polaris.intl.translate('Polaris.DataTable.totalsRowHeading');
+
+      const firstTotalCell = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.prop('total') === true)
+        .first();
+
+      expect(firstTotalCell.prop('content')).toBe(expectedTotalsHeadingContent);
+    });
+
+    it('sets the contentType of non-empty total Cells to numeric', () => {
+      const totals = ['', '$20.00', ''];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} totals={totals} />,
+      );
+      const totalsCells = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.prop('total') === true);
+
+      const nonEmptyTotalCells = totalsCells.filterWhere(
+        (cell) => cell.prop('contentType') === 'numeric',
+      );
+
+      const secondTotalsCell = totalsCells.at(1);
+
+      expect(nonEmptyTotalCells).toHaveLength(1);
+      expect(secondTotalsCell.prop('contentType')).toBe('numeric');
+    });
+
+    it('renders an empty Cell for falsey total values', () => {
+      const totals = ['', '', ''];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} totals={totals} />,
+      );
+
+      expect(dataTable.find('thead tr')).toHaveLength(2);
+
+      const totalsCells = dataTable
+        .find(Cell)
+        .filterWhere(
+          (cell) =>
+            cell.prop('total') === true && cell.prop('firstColumn') !== true,
+        );
+
+      totalsCells.forEach((total) => expect(total.text()).toBe(''));
+    });
+  });
+
+  describe('rows', () => {
+    it('renders a table body row for each list of table data provided', () => {
+      const rows = [['First row'], ['Second row'], ['Third row']];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} rows={rows} />,
+      );
+
+      expect(dataTable.find('tbody tr')).toHaveLength(3);
+    });
+  });
+
+  describe('truncate', () => {
+    it('defaults to false', () => {
+      const dataTable = mountWithAppProvider(<DataTable {...defaultProps} />);
+
+      const firstColumnCells = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.prop('firstColumn') === true);
+
+      firstColumnCells.forEach((cell) =>
+        expect(cell.prop('truncate')).toBe(false),
+      );
+    });
+
+    it('passes the value provided to its cells', () => {
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} truncate />,
+      );
+
+      const firstColumnCells = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.prop('firstColumn') === true);
+
+      firstColumnCells.forEach((cell) =>
+        expect(cell.prop('truncate')).toBe(true),
+      );
+    });
+  });
+
+  describe('footerContent', () => {
+    it('renders string footer content when provided', () => {
+      const footerContent = 'Footer text';
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} footerContent={footerContent} />,
+      );
+
+      expect(dataTable.text()).toContain(footerContent);
+    });
+
+    it('renders JSX footer content when provided', () => {
+      const footerContent = <div>Footer text</div>;
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} footerContent={footerContent} />,
+      );
+
+      expect(dataTable.containsMatchingElement(footerContent)).toBe(true);
+    });
+  });
+
+  describe('sortable', () => {
+    it('defaults to a non-sortable table', () => {
+      const dataTable = mountWithAppProvider(<DataTable {...defaultProps} />);
+      const cells = dataTable.find(Cell);
+
+      cells.forEach((cell) => expect(cell.find('button')).toHaveLength(0));
+    });
+
+    it('renders a sortable header Cell for each true index', () => {
+      const sortable = [false, true, false, false, true];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} sortable={sortable} />,
+      );
+
+      const sortableCells = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.prop('sortable') === true);
+
+      expect(sortableCells).toHaveLength(2);
+    });
+
+    it('renders a plain header Cell for each false index', () => {
+      const sortable = [false, true, false, false, true];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} sortable={sortable} />,
+      );
+
+      const nonSortableCells = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.prop('sortable') === false);
+
+      expect(nonSortableCells).toHaveLength(3);
+    });
+  });
+
+  describe('defaultSortDirection', () => {
+    it('passes the value down to the Cell', () => {
+      const sortable = [false, true, false, false, true];
+      const dataTable = mountWithAppProvider(
+        <DataTable
+          {...defaultProps}
+          sortable={sortable}
+          defaultSortDirection="ascending"
+        />,
+      );
+
+      const firstHeadingCell = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.props().header === true)
+        .first();
+
+      expect(firstHeadingCell.prop('defaultSortDirection')).toBe('ascending');
+    });
+  });
+
+  describe('initialSortColumnIndex', () => {
+    it('defaults to first column if not specified', () => {
+      const sortable = [true, true, false, false, true, false];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} sortable={sortable} />,
+      );
+
+      const firstHeadingCell = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.props().header === true)
+        .first();
+
+      expect(firstHeadingCell.props().sorted).toBe(true);
+    });
+
+    it('sets specified initial sort column', () => {
+      const sortable = [true, true, false, false, true, false];
+      const initialSortColumnIndex = 4;
+      const dataTable = mountWithAppProvider(
+        <DataTable
+          {...defaultProps}
+          sortable={sortable}
+          initialSortColumnIndex={initialSortColumnIndex}
+        />,
+      );
+
+      const fifthHeadingCell = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.props().header === true)
+        .at(initialSortColumnIndex);
+
+      expect(fifthHeadingCell.props().sorted).toBe(true);
+    });
+  });
+
+  describe('onSort', () => {
+    it('gets called when sortable column heading is clicked', () => {
+      const spyOnSort = jest.fn();
+      const sortable = [true, false, false, false, false];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} sortable={sortable} onSort={spyOnSort} />,
+      );
+
+      const firstHeadingCell = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.props().header === true)
+        .first();
+
+      trigger(firstHeadingCell, 'onSort');
+
+      expect(spyOnSort).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/components/DataTable/types.ts
+++ b/src/components/DataTable/types.ts
@@ -12,7 +12,7 @@ interface ScrollPosition {
 }
 
 export interface DataTableState {
-  collapsed: boolean;
+  condensed: boolean;
   columnVisibilityData: ColumnVisibilityData[];
   previousColumn?: ColumnVisibilityData;
   currentColumn?: ColumnVisibilityData;

--- a/src/components/DataTable/types.ts
+++ b/src/components/DataTable/types.ts
@@ -6,11 +6,6 @@ export interface ColumnVisibilityData {
   isVisible?: boolean;
 }
 
-interface ScrollPosition {
-  left?: number;
-  top?: number;
-}
-
 export interface DataTableState {
   condensed: boolean;
   columnVisibilityData: ColumnVisibilityData[];
@@ -18,9 +13,6 @@ export interface DataTableState {
   currentColumn?: ColumnVisibilityData;
   sortedColumnIndex?: number;
   sortDirection?: SortDirection;
-  heights: number[];
-  fixedColumnWidth?: number;
-  preservedScrollPosition: ScrollPosition;
   isScrolledFarthestLeft?: boolean;
   isScrolledFarthestRight?: boolean;
 }

--- a/src/components/DataTable/utilities.ts
+++ b/src/components/DataTable/utilities.ts
@@ -1,7 +1,6 @@
 import {DataTableState} from './types';
 
 interface TableMeasurements {
-  fixedColumnWidth: number;
   firstVisibleColumnIndex: number;
   tableLeftVisibleEdge: number;
   tableRightVisibleEdge: number;
@@ -13,10 +12,9 @@ export function measureColumn(tableData: TableMeasurements) {
       firstVisibleColumnIndex,
       tableLeftVisibleEdge: tableStart,
       tableRightVisibleEdge: tableEnd,
-      fixedColumnWidth,
     } = tableData;
 
-    const leftEdge = column.offsetLeft + fixedColumnWidth;
+    const leftEdge = column.offsetLeft;
     const rightEdge = leftEdge + column.offsetWidth;
     const isVisibleLeft = isEdgeVisible(leftEdge, tableStart, tableEnd);
     const isVisibleRight = isEdgeVisible(rightEdge, tableStart, tableEnd);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1426 

### WHAT is this pull request doing?

The absolute positioning of the first column cells is no longer working across supported browsers, specifically Safari iOS (which means it doesn't work in any mobile browser in iOS). After @dleroux and I each explored other ways to accomplish the same UX with different CSS, there wasn't a clear path forward that doesn't cause other parts of the table to break. 

I concluded that the fixed column experience is not worth the hacks or tradeoffs needed to fix in iOS nor the risk of future breaks. Removing the fixed first column enables removal of all the excessive complexity that went into maintaining the default table behavior of row height change etc.

- [x] Removes table collapse/fixed first column 
- [x] Removes set width of first column unless `truncate` is true
- [x] Removes the logic that calculates and updates row heights for non-truncated tables
- [x] Removes the logic that preserves the horizontal scroll position of the table after sort of non-truncated tables

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {
  Page,
  Card,
  Link,
  DataTable,
  SortDirection,
  ColumnContentType,
  TableData,
} from '../src/components';

interface State {
  truncate: boolean;
  sortedRows?: TableData[][];
}

export default class Playground extends React.Component<never, State> {
  state: State = {
    truncate: false,
  };

  sortCurrency = (
    rows: TableData[][],
    index: number,
    direction: SortDirection,
  ) => {
    return [...rows].sort((rowA: string[], rowB: string[]) => {
      const amountA = parseFloat(rowA[index].substring(1));
      const amountB = parseFloat(rowB[index].substring(1));

      return direction === 'descending' ? amountB - amountA : amountA - amountB;
    });
  };

  sortText = (rows: TableData[][], index: number, direction: SortDirection) => {
    function extractText(cellContent: TableData) {
      return typeof cellContent === 'string'
        ? cellContent.toLowerCase()
        : cellContent.props.children.toLowerCase();
    }

    return [...rows].sort((rowA: TableData[], rowB: TableData[]) => {
      const textA = extractText(rowA[index]);
      const textB = extractText(rowB[index]);

      if (textA > textB) {
        return direction === 'descending' ? -1 : 1;
      }
      if (textA < textB) {
        return direction === 'descending' ? 1 : -1;
      }

      return 0;
    });
  };

  toggleTruncate = () => {
    this.setState(({truncate}) => ({truncate: !truncate}));
  };

  handleSort = (rows: TableData[][], contentTypes: string[]) => (
    index: number,
    direction: SortDirection,
  ) => {
    if (contentTypes[index] === 'text') {
      return this.setState({
        sortedRows: this.sortText(rows, index, direction),
      });
    }
    this.setState({sortedRows: this.sortCurrency(rows, index, direction)});
  };

  render() {
    const {sortedRows, truncate} = this.state;
    const columnContentTypes: ColumnContentType[] = [
      'text',
      'numeric',
      'numeric',
      'numeric',
      'numeric',
    ];

    const initiallySortedRows = [
      [
        <Link url="https://www.example.com">Emerald Silk Gown</Link>,
        '$875.00',
        124689,
        140,
        '$122,500.00',
      ],
      [
        <Link url="https://www.example.com">Mauve Cashmere Scarf</Link>,
        '$230.00',
        124533,
        83,
        '$19,090.00',
      ],
      [
        <Link url="https://www.example.com">
          Navy Merino Wool Blazer with khaki chinos and yellow belt
        </Link>,
        '$445.00',
        124518,
        32,
        '$14,240.00',
      ],
    ];

    const rows = sortedRows ? sortedRows : initiallySortedRows;

    return (
      <Page title="Playground">
        <Card
          title="Data table with fixed column UX removed"
          actions={[
            {content: 'Toggle truncate', onAction: this.toggleTruncate},
          ]}
        >
          <DataTable
            truncate={truncate}
            columnContentTypes={columnContentTypes}
            headings={[
              'Product',
              'Price',
              'SKU Number',
              'Net quantity',
              'Net sales',
            ]}
            rows={rows}
            totals={['', '', '', 255, '$155,830.00']}
            footerContent={`Showing ${rows.length} of ${rows.length} results`}
            sortable={[true, true, false, false, true]}
            defaultSortDirection="descending"
            initialSortColumnIndex={4}
            onSort={this.handleSort(rows, columnContentTypes)}
          />
        </Card>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
