### PR TITLE
[Code Quality] Replace rem(8px) with spacing(tight)

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -130,8 +130,8 @@ $spinner-size: rem(20px);
 .plain {
   @include recolor-icon(color('blue'));
   margin: (-1 * $vertical-padding) rem(-8px);
-  padding-left: rem(8px);
-  padding-right: rem(8px);
+  padding-left: spacing(tight);
+  padding-right: spacing(tight);
   background: transparent;
   border: 0;
   box-shadow: none;
@@ -237,8 +237,8 @@ $spinner-size: rem(20px);
 }
 
 .iconOnly {
-  padding-left: rem(8px);
-  padding-right: rem(8px);
+  padding-left: spacing(tight);
+  padding-right: spacing(tight);
 
   &.sizeLarge {
     padding-left: spacing(base-tight);

--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -67,7 +67,7 @@ $stacking-order: (
   align-items: center;
   width: 100%;
   min-height: control-height();
-  padding: control-vertical-padding() rem(8px) control-vertical-padding()
+  padding: control-vertical-padding() spacing(tight) control-vertical-padding()
     spacing(base-tight);
 }
 


### PR DESCRIPTION
I stumbled upon two instances where we were using `rem(8px)` for padding values. Just swapping that out for `spacing(tight)`.