### PR TITLE
[TextField] [a11y] Define aria-labelledby only if multiple labels are required

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -33,6 +33,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `Banner` `title` overflowing when set to a single long word ([#1553](https://github.com/Shopify/polaris-react/pull/1553))
 - Fixed improper spacing and coloring on a `TextField` prefix ([#1132](https://github.com/Shopify/polaris-react/issues/1132))
 - Fixed `ResourcePicker` not updating function references for `onSelection` and `onCancel` callbacks [#1451](https://github.com/Shopify/polaris-react/pull/1451)
+- Fixed `TextField` `label` being set as the value of the `label` node, as well as the `aria-label` `aria-labelledby` attributes, when only one method will suffice ([#1615](https://github.com/Shopify/polaris-react/pull/1615))
 
 ### Documentation
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -310,12 +310,16 @@ class TextField extends React.PureComponent<CombinedProps, State> {
       describedBy.push(`${id}CharacterCounter`);
     }
 
-    const labelledBy = [labelID(id)];
+    const labelledBy: string[] = [];
     if (prefix) {
       labelledBy.push(`${id}Prefix`);
     }
     if (suffix) {
       labelledBy.push(`${id}Suffix`);
+    }
+
+    if (labelledBy.length) {
+      labelledBy.unshift(labelID(id));
     }
 
     const inputClassName = classNames(
@@ -353,7 +357,7 @@ class TextField extends React.PureComponent<CombinedProps, State> {
       'aria-describedby': describedBy.length
         ? describedBy.join(' ')
         : undefined,
-      'aria-labelledby': labelledBy.join(' '),
+      'aria-labelledby': labelledBy.length ? labelledBy.join(' ') : undefined,
       'aria-invalid': Boolean(error),
       'aria-owns': ariaOwns,
       'aria-activedescendant': ariaActiveDescendant,

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -353,7 +353,6 @@ class TextField extends React.PureComponent<CombinedProps, State> {
       'aria-describedby': describedBy.length
         ? describedBy.join(' ')
         : undefined,
-      'aria-label': label,
       'aria-labelledby': labelledBy.join(' '),
       'aria-invalid': Boolean(error),
       'aria-owns': ariaOwns,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1587

The `TextField` component is unnecessarily defining the input's `aria-label` and `aria-labelledby` attributes in cases where the value of the label node is sufficient on its own.

As mentioned in https://github.com/Shopify/polaris-react/issues/1587, "Only one method is needed, and extra methods may cause duplicate reading by assistive tech."

<img width="793" alt="Screen Shot 2019-06-03 at 2 06 48 PM" src="https://user-images.githubusercontent.com/8534230/58823955-ef0d5700-8608-11e9-905d-9626b086f02c.png">

### WHAT is this pull request doing?
This pull request implements the recommended behaviour outlined in https://github.com/Shopify/polaris-react/issues/1587.

1. Use only the default <label> with the for/id pair by default, and do not set the `aria-label` and `aria-labelledby` attributes

<img width="681" alt="Screen Shot 2019-06-04 at 1 48 43 PM" src="https://user-images.githubusercontent.com/8534230/58901765-cf8d3180-86cf-11e9-8c33-877ee664a409.png">

<img width="1008" alt="Screen Shot 2019-06-03 at 2 26 47 PM" src="https://user-images.githubusercontent.com/8534230/58825135-be7aec80-860b-11e9-8c7b-7488987f15bb.png">


2. If multiple labels are required, set the `aria-labelledby` attribute

<img width="846" alt="Screen Shot 2019-06-04 at 1 52 18 PM" src="https://user-images.githubusercontent.com/8534230/58901866-fcd9df80-86cf-11e9-8af3-f9506678cc3d.png">

<img width="990" alt="Screen Shot 2019-06-03 at 2 28 07 PM" src="https://user-images.githubusercontent.com/8534230/58825198-e9654080-860b-11e9-9c91-7df1d46b481d.png">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
         <TextField label="Store name" prefix="Hello" suffix="Goodbye" />
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
