### PR TITLE
[Storybook] Test Card individually in Percy

### DIFF
--- a/.storybook/stories-from-readme.js
+++ b/.storybook/stories-from-readme.js
@@ -11,7 +11,7 @@ import Playground from '../playground/Playground';
  * overlay each other as it stops the test being useful.
  */
 function percyShouldTestIndividualExamples(readmeName) {
-  return ['Modal'].includes(readmeName);
+  return ['Modal', 'Card'].includes(readmeName);
 }
 
 export function generateStories(readme, readmeModule) {

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -43,6 +43,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Made the a11y test that runs in CI fail if it finds any issues ([#1564](https://github.com/Shopify/polaris-react/pull/1564))
 - Updated Storybook to `v5.1.0-rc.4` ([#1616](https://github.com/Shopify/polaris-react/pull/1616))
+- Fixed a visual regression testing issue with the Card component ([#1618](https://github.com/Shopify/polaris-react/pull/1618))
 
 ### Dependency upgrades
 


### PR DESCRIPTION
Fixes an issue where the Card component example story wouldn't render correctly in Percy since Storybook was upgraded to 5.1.0 (https://github.com/Shopify/polaris-react/pull/1488).