### PR TITLE
[Content] Change template and heading for required components

### DIFF
--- a/.github/ISSUE_TEMPLATE/NEW_COMPONENT.md
+++ b/.github/ISSUE_TEMPLATE/NEW_COMPONENT.md
@@ -7,23 +7,28 @@ label: New component
 ## Component name
 
 Short intro description (try and keep to two sentences):
+
 > {Component name} are used to {x}. Merchants can use it to {x}.
 
 Other formats for the second sentence:
+
 > It can {x} so merchants can {x}.
 > They can {x} to help merchants {x}.
 
 Example:
+
 > Icons are used to {visually communicate core parts of the product and available actions}. They can {act as way-finding tools} to help merchants {more easily understand where they are in the product, and common interaction patterns that are available}.
 
-## Components dependencies
+## Required components
 
 This section is only used if the components is a dependency of or depends on another component. Include a link to the required component and a short explanation of how they interact.
 
 Example:
+
 > The {x} component must be wrapped in the {y} component.
 
 Example:
+
 > The {x} component must be passed to the {y} component.
 
 Otherwise if there are no component dependencies, remove this section.
@@ -33,16 +38,19 @@ Otherwise if there are no component dependencies, remove this section.
 ### Example name
 
 Description of example (clearly differentiate examples from each other). Use an image if applicable:
+
 > Use {component name} to let merchants {x}.
 >
 > ![Aww kitty](https://placeimg.com/300/100/arch/grayscale)
 
 Example for default callout card:
+
 > ### Default callout card
 >
 > Use to let merchants know about a feature or opportunity where there is a clear, single action they need to take to move to the next step.
 
 Example for Callout card with secondary action:
+
 > ### Callout card with secondary action
 >
 > Use to let merchants know about a feature or opportunity where there are two distinct actions they can take on the information.
@@ -67,6 +75,7 @@ This section is only used if any prop types use a structural subtype, called int
 > - **propName** (required or optional): `type` defaults to `value` – description of the prop
 
 Example:
+
 > ### ItemDescriptor
 >
 > - **accessibilityLabel** (optional): `string` – Visually hidden text for screen readers
@@ -80,6 +89,7 @@ The {x} component should:
 - This is where you should include design best practices and UX guidelines.
 
 Example:
+
 > The select component should:
 >
 > - Be used for lists of four or more items
@@ -93,20 +103,22 @@ Example:
 - Content guideline here
 
 | Do example | Don’t example |
-|------------|---------------|
-| Do this | Don’t do this |
+| ---------- | ------------- |
+| Do this    | Don’t do this |
 
 ## Subcomponent name
 
 This section is only used for components with subcomponents. Include a short intro description of the subcomponent purpose and how it relates to the main component.
 
 Example:
+
 > The content of a resource list consists of resource list items. Each item summarizes an individual resource and should link to its show page.
 > Because the content of items depends on the type of resource and merchant tasks, resource list items are flexible.
 
 ### Subcomponent examples
 
 Description of example (clearly differentiate examples from each other). Use an image if applicable:
+
 > **Subcomponent example name**
 >
 > Use {component name} to let merchants {x}.
@@ -114,6 +126,7 @@ Description of example (clearly differentiate examples from each other). Use an 
 > ![Aww kitty](https://placeimg.com/300/100/arch/grayscale)
 
 Example:
+
 > ### Item examples
 >
 > **Simple resource list item**
@@ -125,4 +138,5 @@ Example:
 - To {describe how the other component works}, [use the {x} component]
 
 Example:
+
 > - To {learn how to embed a link in a piece of text}, use the {link} component

--- a/src/components/Navigation/README.md
+++ b/src/components/Navigation/README.md
@@ -18,9 +18,9 @@ The navigation component is used to display the primary navigation in the sideba
 
 ---
 
-## Components dependencies
+## Required components
 
-The navigation component must be passed to the [frame](/components/structure/frame) component. The mobile version of the navigation component appears in the [topbar](/components/structure/top-bar) component.
+The navigation component must be passed to the [frame](/components/structure/frame) component. The mobile version of the navigation component appears in the [top bar](/components/structure/top-bar) component.
 
 ---
 

--- a/src/components/TopBar/README.md
+++ b/src/components/TopBar/README.md
@@ -22,7 +22,7 @@ Merchants can use the top bar component to search, access menus, and navigate by
 
 ---
 
-## Component dependencies
+## Required components
 
 The top bar component must be passed to the [frame](/components/structure/frame) component.
 


### PR DESCRIPTION
This PR changes instances of `Component dependencies` to `Required components` in the new component template and in the documentation for 2 components. 

This change was made following a component documentation clinic where folks agreed that `Required components` should be the standardized heading. 

