### PR TITLE
[a11y] Collapsible a11y docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -40,6 +40,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Updated icon documentation to use imports from polaris-icons ([#1561](https://github.com/Shopify/polaris-react/pull/1561))
 - Fixed an accessibility issue in the `Collapsible` component example ([#1591](https://github.com/Shopify/polaris-react/pull/1591))
+- Added accessibility documentation for the `Collapsible` component ([#1631](https://github.com/Shopify/polaris-react/pull/1631))
 
 ### Development workflow
 

--- a/src/components/Collapsible/README.md
+++ b/src/components/Collapsible/README.md
@@ -117,3 +117,37 @@ class CollapsibleExample extends React.Component {
 
 - To control a collapsible component, use the [button](/components/actions/button) component
 - To put long sections of information in a container that allows for scrolling, [use the scrollable component](/components/behavior/scrollable)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Use the collapsible component in conjunction with a [button](/components/actions/button).
+
+- Use the required `id` prop of the collapsible component to give the content a unique `id` value
+- Use the `ariaExpanded` prop on the button component to add an `aria-expanded` attribute, which conveys the expanded or collapsed state to screen reader users
+- Use the `ariaControls` prop on the button component, and set its value to the `id` value of the collapsible component
+
+Place the collapsible content immediately after the button that controls it, so merchants with vision or attention issues can easily discover what content is being affected.
+
+<!-- /content-for -->

--- a/src/components/Collapsible/README.md
+++ b/src/components/Collapsible/README.md
@@ -142,12 +142,10 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-Use the collapsible component in conjunction with a [button](/components/actions/button).
+Use the collapsible component in conjunction with a [button](/components/actions/button). Place the collapsible content immediately after the button that controls it, so merchants with vision or attention issues can easily discover what content is being affected.
 
 - Use the required `id` prop of the collapsible component to give the content a unique `id` value
 - Use the `ariaExpanded` prop on the button component to add an `aria-expanded` attribute, which conveys the expanded or collapsed state to screen reader users
 - Use the `ariaControls` prop on the button component, and set its value to the `id` value of the collapsible component
-
-Place the collapsible content immediately after the button that controls it, so merchants with vision or attention issues can easily discover what content is being affected.
 
 <!-- /content-for -->


### PR DESCRIPTION
### WHY are these changes introduced?

Adds accessibility guidance for the collapsible component, to appear in `polaris-react` docs and in the style guide.

### WHAT is this pull request doing?

- [X] Adds accessibility information to the component `README.md`
- [x] Adds an entry to the documentation section of `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project)
1. In the `polaris-styleguide` tab, run `dev up && dev start`
1. View changes after examples and props: https://polaris.myshopify.io/components/behavior/collapsible (web, iOS, and Android)

## Screenshots

### Web

<img width="639" alt="Screenshot of the content update for web" src="https://user-images.githubusercontent.com/1462085/58984833-d9c23500-878e-11e9-97b6-64cca986735b.png">

### Android

<img width="609" alt="Screenshot of the generic accessibility content for Android" src="https://user-images.githubusercontent.com/1462085/58982537-8c8f9480-8789-11e9-9a48-efc0c0a71c27.png">

### iOS

<img width="559" alt="Screenshot of the generic accessibility content for iOS" src="https://user-images.githubusercontent.com/1462085/58982573-9fa26480-8789-11e9-9c5f-05294bf5832b.png">