### PR TITLE
[a11y] Description list a11y docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -41,6 +41,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Updated icon documentation to use imports from polaris-icons ([#1561](https://github.com/Shopify/polaris-react/pull/1561))
 - Fixed an accessibility issue in the `Collapsible` component example ([#1591](https://github.com/Shopify/polaris-react/pull/1591))
 - Added accessibility documentation for the `Collapsible` component ([#1631](https://github.com/Shopify/polaris-react/pull/1631))
+- Added accessibility documentation for the `DescriptionList` component ([#1634](https://github.com/Shopify/polaris-react/pull/1634))
 
 ### Development workflow
 

--- a/src/components/DescriptionList/README.md
+++ b/src/components/DescriptionList/README.md
@@ -146,3 +146,31 @@ Use when you need to present merchants with a list of items or terms alongside d
 ## Related components
 
 - To create a list of actions or navigation, [use the action list component](/components/actions/action-list).
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+The description list component produces a description list wrapper (`<dl>`), terms (`<dt>`), and definitions (`<dd>`) to convey the relationships between the list items to assistive technology users.
+
+<!-- /content-for -->


### PR DESCRIPTION
### WHY are these changes introduced?

Adds accessibility guidance for the description list component, to appear in `polaris-react` docs and in the style guide.

### WHAT is this pull request doing?

- [X] Adds accessibility information to the component `README.md`
- [x] Adds an entry to the documentation section of `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project)
1. In the `polaris-styleguide` tab, run `dev up && dev start`
1. View changes after examples and props: https://polaris.myshopify.io/components/lists-and-tables/description-list (web, iOS, and Android)

## Screenshots

### Web

<img width="652" alt="Screenshot of the updated web content" src="https://user-images.githubusercontent.com/1462085/58993875-a50ca880-87a3-11e9-90a0-c3f3ad002fdf.png">

### Android

<img width="609" alt="Screenshot of the generic accessibility content for Android" src="https://user-images.githubusercontent.com/1462085/58982537-8c8f9480-8789-11e9-9a48-efc0c0a71c27.png">

### iOS

<img width="559" alt="Screenshot of the generic accessibility content for iOS" src="https://user-images.githubusercontent.com/1462085/58982573-9fa26480-8789-11e9-9c5f-05294bf5832b.png">