### PR TITLE
[a11y] Exception list a11y docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -41,6 +41,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Updated icon documentation to use imports from polaris-icons ([#1561](https://github.com/Shopify/polaris-react/pull/1561))
 - Fixed an accessibility issue in the `Collapsible` component example ([#1591](https://github.com/Shopify/polaris-react/pull/1591))
 - Added accessibility documentation for the `Collapsible` component ([#1631](https://github.com/Shopify/polaris-react/pull/1631))
+- Added accessibility documentation for the `ExceptionList` component ([#1635](https://github.com/Shopify/polaris-react/pull/1635))
 
 ### Development workflow
 

--- a/src/components/ExceptionList/README.md
+++ b/src/components/ExceptionList/README.md
@@ -117,7 +117,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-Items in an exception list are organized as list items (`<li>`) in an unordered list wrapper (`<ul>`), so they are conveyed as a group of related elements to assistive technology users.
+Items in an exception list are organized as list items (`<li>`) in an unordered list wrapper (`<ul>`), so they’re conveyed as a group of related elements to assistive technology users.
 
 Icons displayed with exception list items are meant to visually reinforce the adjacent information, not to convey information on their own. They are skipped by screen readers using `aria-hidden="true"`.
 

--- a/src/components/ExceptionList/README.md
+++ b/src/components/ExceptionList/README.md
@@ -119,6 +119,6 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 Items in an exception list are organized as list items (`<li>`) in an unordered list wrapper (`<ul>`), so they are conveyed as a group of related elements to assistive technology users.
 
-Icons displayed with exception list items are meant to reinforce the tone of the adjacent text visually, not to convey information on their own. They are skipped by screen readers using `aria-hidden="true"`.
+Icons displayed with exception list items are meant to visually reinforce the adjacent information, not to convey information on their own. They are skipped by screen readers using `aria-hidden="true"`.
 
 <!-- /content-for -->

--- a/src/components/ExceptionList/README.md
+++ b/src/components/ExceptionList/README.md
@@ -92,3 +92,33 @@ Use icons to add clarity or assist in visualizing the meaning
 
 - To display an error at the top of a page, or to indicate multiple errors in a form, use the [banner](https://polaris.shopify.com/components/feedback-indicators/banner) component
 - Exceptions lists are often used in the [resource list](https://polaris.shopify.com/components/lists-and-tables/resource-list) component to display conditional content
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Items in an exception list are organized as list items (`<li>`) in an unordered list wrapper (`<ul>`), so they are conveyed as a group of related elements to assistive technology users.
+
+Icons displayed with exception list items are meant to provide visual cues for the adjacent text, and are skipped by screen readers using `aria-hidden=”true”`.
+
+<!-- /content-for -->

--- a/src/components/ExceptionList/README.md
+++ b/src/components/ExceptionList/README.md
@@ -119,6 +119,6 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 Items in an exception list are organized as list items (`<li>`) in an unordered list wrapper (`<ul>`), so they are conveyed as a group of related elements to assistive technology users.
 
-Icons displayed with exception list items are meant to reinforce the tone of the adjacent text visually, not to convey information on their own. They are skipped by screen readers using `aria-hidden=”true”`.
+Icons displayed with exception list items are meant to reinforce the tone of the adjacent text visually, not to convey information on their own. They are skipped by screen readers using `aria-hidden="true"`.
 
 <!-- /content-for -->

--- a/src/components/ExceptionList/README.md
+++ b/src/components/ExceptionList/README.md
@@ -119,6 +119,6 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 Items in an exception list are organized as list items (`<li>`) in an unordered list wrapper (`<ul>`), so they are conveyed as a group of related elements to assistive technology users.
 
-Icons displayed with exception list items are meant to provide visual cues for the adjacent text, and are skipped by screen readers using `aria-hidden=”true”`.
+Icons displayed with exception list items are meant to reinforce the tone of the adjacent text visually, not to convey information on their own. They are skipped by screen readers using `aria-hidden=”true”`.
 
 <!-- /content-for -->


### PR DESCRIPTION
### WHY are these changes introduced?

Adds accessibility guidance for the [exception list component](https://polaris.shopify.com/components/lists-and-tables/exception-list), to appear in `polaris-react` docs and in the style guide.

### WHAT is this pull request doing?

- [X] Adds accessibility information to the component `README.md`
- [x] Adds an entry to the documentation section of `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project)
1. In the `polaris-styleguide` tab, run `dev up && dev start`
1. View changes after examples and props: https://polaris.myshopify.io/components/lists-and-tables/exception-list (web only)

## Screenshots

### Web

<img width="653" alt="Screenshot of the content changes" src="https://user-images.githubusercontent.com/1462085/58995117-c1124900-87a7-11e9-98bb-cf3ff0d589a4.png">