### PR TITLE
[a11y] Form a11y docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -42,6 +42,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed an accessibility issue in the `Collapsible` component example ([#1591](https://github.com/Shopify/polaris-react/pull/1591))
 - Added accessibility documentation for the `RangeSlider` component ([#1630](https://github.com/Shopify/polaris-react/pull/1630))
 - Added accessibility documentation for the `Collapsible` component ([#1631](https://github.com/Shopify/polaris-react/pull/1631))
+- Added accessibility documentation for the `Form` component ([#1636](https://github.com/Shopify/polaris-react/pull/1636))
 
 ### Development workflow
 

--- a/src/components/Form/README.md
+++ b/src/components/Form/README.md
@@ -154,7 +154,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 The form component wraps content in an HTML `<form>` element. This helps to support assistive technologies that use different interaction and browse modes.
 
-By default, any buttons that you add to the form are given a `type` attribute set to `button`. Use the `submit` prop to set the `type` attribute to `submit` instead. The form can have only one submit button, and it must be at the end of the form.
+Forms can have only one submit button and it must be at the end of the form. By default, buttons added to the form are given a `type` attribute set to `button` to avoid conflicts. To make a button the submit button instead (`type="submit"`), set the `submit` prop on the button.
 
 ### Keyboard support
 

--- a/src/components/Form/README.md
+++ b/src/components/Form/README.md
@@ -127,3 +127,37 @@ class FormExample extends React.Component {
 
 - To arrange fields within a form using standard spacing, [use the form layout component](/components/forms/form-layout)
 - To see all of the components that make up a form, [visit the form section](/components/forms/checkbox#navigation) of the component library
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+The form component wraps content in an HTML `<form>` element. This helps to support assistive technologies that use different interaction and browse modes.
+
+By default, any buttons that you add to the form are given a `type` attribute set to `button`. Use the `submit` prop to set the `type` attribute to `submit` instead. The form can have only one submit button, and it must be at the end of the form.
+
+### Keyboard support
+
+By default, the `implicitSubmit` prop is set to `true`. This allows merchants to submit the form with the <kbd>enter</kbd>/<kbd>return</kbd> key when focus is in any text field inside the form. This provides a shortcut for keyboard users. If this behavior doesn’t fit the form, then set the prop to `false`.
+
+<!-- /content-for -->


### PR DESCRIPTION
### WHY are these changes introduced?

Adds accessibility guidance for the [form component](https://polaris.shopify.com/components/forms/form), to appear in `polaris-react` docs and in the style guide.

### WHAT is this pull request doing?

- [X] Adds accessibility information to the component `README.md`
- [x] Adds an entry to the documentation section of `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project)
1. In the `polaris-styleguide` tab, run `dev up && dev start`
1. View changes after examples and props: https://polaris.myshopify.io/components/forms/form (web only)

## Screenshots

### Web

<img width="658" alt="Screenshot of the updated content" src="https://user-images.githubusercontent.com/1462085/58996137-cb364680-87ab-11e9-9a15-8ebe77d0f19d.png">
