### PR TITLE
[a11y] Add keyboard key docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -43,6 +43,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed an accessibility issue in the `Collapsible` component example ([#1591](https://github.com/Shopify/polaris-react/pull/1591))
 - Added accessibility documentation for the `RangeSlider` component ([#1630](https://github.com/Shopify/polaris-react/pull/1630))
 - Added accessibility documentation for the `Collapsible` component ([#1631](https://github.com/Shopify/polaris-react/pull/1631))
+- Added accessibility documentation for the `KeyboardKey` component ([#1640](https://github.com/Shopify/polaris-react/pull/1640))
 
 ### Development workflow
 

--- a/src/components/KeyboardKey/README.md
+++ b/src/components/KeyboardKey/README.md
@@ -101,7 +101,7 @@ Press the <KeyboardKey>Ctrl</KeyboardKey> key.
 
 #### Don't
 
-Don't use the keyboard key component alone to convey keyboard instructions.
+- Use the keyboard key component alone to convey keyboard instructions.
 
 ```JSX
 Use <KeyboardKey>Ctrl</KeyboardKey>

--- a/src/components/KeyboardKey/README.md
+++ b/src/components/KeyboardKey/README.md
@@ -61,3 +61,52 @@ Use to list a related set of keyboard shortcuts.
 ## Related components
 
 - To add a tooltip for a button with an associated keyboard shortcut, [use the tooltip component](/components/tooltip)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+The text of the keyboard key component is read by screen readers, but the visual formatting isn’t conveyed. Ensure that merchants are able to understand information about keyboard shortcuts without relying on the visual style of the component.
+
+<!-- usageblock -->
+
+#### Do
+
+- Pair lists of keyboard shortcut information with a heading that describes the section (“Keyboard shortcuts”).
+- Provide inline keyboard instructions with context.
+
+```JSX
+Press the <KeyboardKey>Ctrl</KeyboardKey> key.
+```
+
+#### Don't
+
+Don't use the keyboard key component alone to convey keyboard instructions.
+
+```JSX
+Use <KeyboardKey>Ctrl</KeyboardKey>
+```
+
+<!-- end -->
+
+<!-- /content-for -->


### PR DESCRIPTION
### WHY are these changes introduced?

Adds accessibility guidance for the [keyboard key component](https://polaris.shopify.com/components/images-and-icons/keyboard-key), to appear in `polaris-react` docs and in the style guide.

### WHAT is this pull request doing?

- [X] Adds accessibility information to the component `README.md`
- [x] Adds an entry to the documentation section of `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project)
1. In the `polaris-styleguide` tab, run `dev up && dev start`
1. View changes after examples and props: https://polaris.myshopify.io/components/images-and-icons/keyboard-key (web only)

## Screenshots

### Web

<img width="916" alt="Screenshot of the content changes" src="https://user-images.githubusercontent.com/1462085/59054991-b3150480-8849-11e9-9b02-264786d938c9.png">

