### PR TITLE
[a11y] Docs for the tag component

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -46,6 +46,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added accessibility documentation for the `Form` component ([#1636](https://github.com/Shopify/polaris-react/pull/1636))
 - Added accessibility documentation for the `ExceptionList` component ([#1635](https://github.com/Shopify/polaris-react/pull/1635))
 - Added accessibility documentation for the `KeyboardKey` component ([#1640](https://github.com/Shopify/polaris-react/pull/1640))
+- Added accessibility documentation for the `Tag` component ([#1647](https://github.com/Shopify/polaris-react/pull/1647))
 
 ### Development workflow
 

--- a/src/components/Tag/README.md
+++ b/src/components/Tag/README.md
@@ -63,3 +63,42 @@ Use to allow merchants to add attributes to, and remove attributes from, an obje
 
 - To show the status of an object, [use the badge component](/components/images-and-icons/badge)
 - To add and remove tags, [use the text field component](/components/forms/text-field)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+### Labeling
+
+The button to remove a tag is automatically given a label using `aria-label` so that screen reader users can distinguish which tag will be removed.
+
+### Keyboard support
+
+The control to remove a tag is implemented as a button with standard keyboard support.
+
+- Give buttons keyboard focus with the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
+- To activate a button, press the <kbd>enter</kbd>/<kbd>return</kbd> or <kbd>space</kbd> key
+
+When a merchant uses the button to remove a tag, it is important to make sure that keyboard focus is managed. Moving focus to the next element in the page is recommended.
+
+<!-- /content-for -->


### PR DESCRIPTION
### WHY are these changes introduced?

Adds accessibility guidance for the [tag component](https://polaris.shopify.com/components/forms/tag), to appear in `polaris-react` docs and in the style guide.

### WHAT is this pull request doing?

- [X] Adds accessibility information to the component `README.md`
- [x] Adds an entry to the documentation section of `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project)
1. In the `polaris-styleguide` tab, run `dev up && dev start`
1. View changes after examples and props: https://polaris.myshopify.io/components/forms/tag (web, iOS, and Android)

## Screenshots

### Web

<img width="658" alt="Screenshot of the new web content" src="https://user-images.githubusercontent.com/1462085/59069794-21b78980-886d-11e9-835a-5f1de40b676a.png">

### Android

<img width="609" alt="Screenshot of the generic accessibility content for Android" src="https://user-images.githubusercontent.com/1462085/58982537-8c8f9480-8789-11e9-9a48-efc0c0a71c27.png">

### iOS

<img width="559" alt="Screenshot of the generic accessibility content for iOS" src="https://user-images.githubusercontent.com/1462085/58982573-9fa26480-8789-11e9-9c5f-05294bf5832b.png">