### PR TITLE
[a11y] Adds docs for the modal

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -47,6 +47,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added accessibility documentation for the `Form` component ([#1636](https://github.com/Shopify/polaris-react/pull/1636))
 - Added accessibility documentation for the `ExceptionList` component ([#1635](https://github.com/Shopify/polaris-react/pull/1635))
 - Added accessibility documentation for the `KeyboardKey` component ([#1640](https://github.com/Shopify/polaris-react/pull/1640))
+- Added accessibility documentation for the `Modal` component ([#1648](https://github.com/Shopify/polaris-react/pull/1648))
 
 ### Development workflow
 

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -89,10 +89,13 @@ As of v3.17.0, using `Modal` in an embedded app is deprecated. Support for this 
 
 ## Best practices
 
+Use modals when merchants must complete an action before they can continue with the main workflow. Avoid using modals to display complex forms or large amounts of information.
+
 Modals should:
 
-- Only be closed by clicking the `X` or `Cancel` button and not by clicking the backdrop outside the modal, which is a large touch target that could result in accidental presses. Modals require merchants to take an action and should prevent the merchant from accidentally closing the modal without completing the required task.
-- Avoid having more than two buttons (primary and secondary) at the bottom. This prevents unclear action hierarchy and crowding on mobile screens. Since modals are for focused tasks, they should have focused actions. In some cases however, a [tertiary action](#tertiary-actions) may be appropriate.
+- Require that merchants take an action.
+- Close when merchants press the `X` button, the `Cancel` button, or the <kbd>Esc</kbd> key, not when merchants click or tap the area outside the modal.
+- Not have more than two buttons (primary and secondary) at the bottom. This prevents unclear action hierarchy and crowding on mobile screens. Since modals are for focused tasks, they should have focused actions. In some cases however, a [tertiary action](#tertiary-actions) may be appropriate.
 
 ---
 
@@ -717,3 +720,39 @@ Use to make it clear to the merchant that the action is potentially dangerous. O
 - To present large amounts of additional information or actions that don’t require confirmation, [use the collapsible component](/components/behavior/collapsible) to expand content in place within the page
 - To present a small amount of content or a menu of actions in a non-blocking overlay, [use the popover component](/components/popover)
 - To communicate a change or condition that needs the merchant’s attention within the context of a page, [use the banner component](/components/feedback-indicators/banner)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+- Modals use ARIA `role=”dialog”` to convey to screen reader users that they work like native dialog windows.
+- If you set the `title` prop to give the modal component a heading, then the `title` is used to label the dialog element with `aria-labelledby`. This helps to convey the purpose of the modal to screen reader users when it displays.
+
+### Keyboard support
+
+- When a modal opens, focus moves automatically to the modal container so it can be accessed by keyboard users
+- While the modal is open, keyboard focus shouldn’t leave the modal
+- Merchants can dismiss the modal with the keyboard by activating the `X` button, the `Cancel` button if one is provided, or by pressing the <kbd>Esc</kbd> key
+- After a modal is closed, focus returns to the button that launched it
+
+<!-- /content-for -->


### PR DESCRIPTION
### WHY are these changes introduced?

Adds accessibility guidance for the [modal component](https://polaris.shopify.com/components/overlays/modal), to appear in `polaris-react` docs and in the style guide.

### WHAT is this pull request doing?

- [X] Adds accessibility information to the component `README.md`
- [X] Updates the best practices section to simplify descriptions of behaviors and make the language input agnostic
- [x] Adds an entry to the documentation section of `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide`
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project)
1. In the `polaris-styleguide` tab, run `dev up && dev start`
1. View changes after examples and props, and in the best practices section: https://polaris.myshopify.io/components/overlays/modal (web, iOS, and Android)

## Screenshots

### Best practices

<img width="660" alt="Screenshot of best practices" src="https://user-images.githubusercontent.com/1462085/59071924-7a8b2000-8875-11e9-90ab-11af418d2c1a.png">

### New a11y content for web

<img width="691" alt="Screenshot of accessibility content for web" src="https://user-images.githubusercontent.com/1462085/59071941-8bd42c80-8875-11e9-8586-974f46eb9e0f.png">

### Android

<img width="609" alt="Screenshot of the generic accessibility content for Android" src="https://user-images.githubusercontent.com/1462085/58982537-8c8f9480-8789-11e9-9a48-efc0c0a71c27.png">

### iOS

<img width="559" alt="Screenshot of the generic accessibility content for iOS" src="https://user-images.githubusercontent.com/1462085/58982573-9fa26480-8789-11e9-9c5f-05294bf5832b.png">