### PR TITLE
[Banner] Improve colour contrast ratio of links passed as children

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -28,6 +28,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed text and other elements from being selected in Safari when dragging the color picker ([#1562](https://github.com/Shopify/polaris-react/pull/1562))
 - Fixed `Banner` `title` overflowing when set to a single long word ([#1553](https://github.com/Shopify/polaris-react/pull/1553))
 - Fixed improper spacing and coloring on a `TextField` prefix ([#1132](https://github.com/Shopify/polaris-react/issues/1132))
+- Fixed color contrast ratio of `Link` components rendered as children of `Banner` components ([#1651](https://github.com/Shopify/polaris-react/pull/1651))
 
 ### Documentation
 

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -8,6 +8,7 @@ import {
   CircleInformationMajorTwotone,
 } from '@shopify/polaris-icons';
 
+import BannerContext from '../../utilities/banner-context';
 import {classNames, variationName} from '../../utilities/css';
 import {Action, DisableableAction, LoadableAction} from '../../types';
 import Button, {buttonFrom} from '../Button';
@@ -15,6 +16,7 @@ import Heading from '../Heading';
 import ButtonGroup from '../ButtonGroup';
 import UnstyledLink from '../UnstyledLink';
 import Icon, {Props as IconProps} from '../Icon';
+
 import WithinContentContext from '../WithinContentContext';
 
 import styles from './Banner.scss';
@@ -47,133 +49,135 @@ export default class Banner extends React.PureComponent<Props, never> {
 
   render() {
     return (
-      <WithinContentContext.Consumer>
-        {(withinContentContainer) => {
-          const {
-            icon,
-            action,
-            secondaryAction,
-            title,
-            children,
-            status,
-            onDismiss,
-          } = this.props;
-          let color: IconProps['color'];
-          let defaultIcon: IconProps['source'];
-          let ariaRoleType = 'status';
+      <BannerContext.Provider value>
+        <WithinContentContext.Consumer>
+          {(withinContentContainer) => {
+            const {
+              icon,
+              action,
+              secondaryAction,
+              title,
+              children,
+              status,
+              onDismiss,
+            } = this.props;
+            let color: IconProps['color'];
+            let defaultIcon: IconProps['source'];
+            let ariaRoleType = 'status';
 
-          switch (status) {
-            case 'success':
-              color = 'greenDark';
-              defaultIcon = CircleTickMajorTwotone;
-              break;
-            case 'info':
-              color = 'tealDark';
-              defaultIcon = CircleInformationMajorTwotone;
-              break;
-            case 'warning':
-              color = 'yellowDark';
-              defaultIcon = CircleAlertMajorTwotone;
-              ariaRoleType = 'alert';
-              break;
-            case 'critical':
-              color = 'redDark';
-              defaultIcon = CircleDisabledMajorTwotone;
-              ariaRoleType = 'alert';
-              break;
-            default:
-              color = 'inkLighter';
-              defaultIcon = FlagMajorTwotone;
-          }
-          const className = classNames(
-            styles.Banner,
-            status && styles[variationName('status', status)],
-            onDismiss && styles.hasDismiss,
-            withinContentContainer
-              ? styles.withinContentContainer
-              : styles.withinPage,
-          );
-
-          const id = uniqueID();
-          const iconName = icon || defaultIcon;
-
-          let headingMarkup: React.ReactNode = null;
-          let headingID: string | undefined;
-
-          if (title) {
-            headingID = `${id}Heading`;
-            headingMarkup = (
-              <div className={styles.Heading} id={headingID}>
-                <Heading element="p">{title}</Heading>
-              </div>
+            switch (status) {
+              case 'success':
+                color = 'greenDark';
+                defaultIcon = CircleTickMajorTwotone;
+                break;
+              case 'info':
+                color = 'tealDark';
+                defaultIcon = CircleInformationMajorTwotone;
+                break;
+              case 'warning':
+                color = 'yellowDark';
+                defaultIcon = CircleAlertMajorTwotone;
+                ariaRoleType = 'alert';
+                break;
+              case 'critical':
+                color = 'redDark';
+                defaultIcon = CircleDisabledMajorTwotone;
+                ariaRoleType = 'alert';
+                break;
+              default:
+                color = 'inkLighter';
+                defaultIcon = FlagMajorTwotone;
+            }
+            const className = classNames(
+              styles.Banner,
+              status && styles[variationName('status', status)],
+              onDismiss && styles.hasDismiss,
+              withinContentContainer
+                ? styles.withinContentContainer
+                : styles.withinPage,
             );
-          }
 
-          const buttonSizeValue = withinContentContainer ? 'slim' : undefined;
+            const id = uniqueID();
+            const iconName = icon || defaultIcon;
 
-          const secondaryActionMarkup = secondaryAction
-            ? secondaryActionFrom(secondaryAction)
-            : null;
+            let headingMarkup: React.ReactNode = null;
+            let headingID: string | undefined;
 
-          const actionMarkup = action ? (
-            <div className={styles.Actions}>
-              <ButtonGroup>
-                <div className={styles.PrimaryAction}>
-                  {buttonFrom(action, {outline: true, size: buttonSizeValue})}
+            if (title) {
+              headingID = `${id}Heading`;
+              headingMarkup = (
+                <div className={styles.Heading} id={headingID}>
+                  <Heading element="p">{title}</Heading>
                 </div>
-                {secondaryActionMarkup}
-              </ButtonGroup>
-            </div>
-          ) : null;
+              );
+            }
 
-          let contentMarkup = null;
-          let contentID: string | undefined;
+            const buttonSizeValue = withinContentContainer ? 'slim' : undefined;
 
-          if (children || actionMarkup) {
-            contentID = `${id}Content`;
-            contentMarkup = (
-              <div className={styles.Content} id={contentID}>
-                {children}
-                {actionMarkup}
+            const secondaryActionMarkup = secondaryAction
+              ? secondaryActionFrom(secondaryAction)
+              : null;
+
+            const actionMarkup = action ? (
+              <div className={styles.Actions}>
+                <ButtonGroup>
+                  <div className={styles.PrimaryAction}>
+                    {buttonFrom(action, {outline: true, size: buttonSizeValue})}
+                  </div>
+                  {secondaryActionMarkup}
+                </ButtonGroup>
+              </div>
+            ) : null;
+
+            let contentMarkup = null;
+            let contentID: string | undefined;
+
+            if (children || actionMarkup) {
+              contentID = `${id}Content`;
+              contentMarkup = (
+                <div className={styles.Content} id={contentID}>
+                  {children}
+                  {actionMarkup}
+                </div>
+              );
+            }
+
+            const dismissButton = onDismiss ? (
+              <div className={styles.Dismiss}>
+                <Button
+                  plain
+                  icon={CancelSmallMinor}
+                  onClick={onDismiss}
+                  accessibilityLabel="Dismiss notification"
+                />
+              </div>
+            ) : null;
+
+            return (
+              <div
+                className={className}
+                // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+                tabIndex={0}
+                ref={this.wrapper}
+                role={ariaRoleType}
+                aria-live="polite"
+                onMouseUp={handleMouseUp}
+                aria-labelledby={headingID}
+                aria-describedby={contentID}
+              >
+                {dismissButton}
+                <div className={styles.Ribbon}>
+                  <Icon source={iconName} color={color} backdrop />
+                </div>
+                <div>
+                  {headingMarkup}
+                  {contentMarkup}
+                </div>
               </div>
             );
-          }
-
-          const dismissButton = onDismiss ? (
-            <div className={styles.Dismiss}>
-              <Button
-                plain
-                icon={CancelSmallMinor}
-                onClick={onDismiss}
-                accessibilityLabel="Dismiss notification"
-              />
-            </div>
-          ) : null;
-
-          return (
-            <div
-              className={className}
-              // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-              tabIndex={0}
-              ref={this.wrapper}
-              role={ariaRoleType}
-              aria-live="polite"
-              onMouseUp={handleMouseUp}
-              aria-labelledby={headingID}
-              aria-describedby={contentID}
-            >
-              {dismissButton}
-              <div className={styles.Ribbon}>
-                <Icon source={iconName} color={color} backdrop />
-              </div>
-              <div>
-                {headingMarkup}
-                {contentMarkup}
-              </div>
-            </div>
-          );
-        }}
-      </WithinContentContext.Consumer>
+          }}
+        </WithinContentContext.Consumer>
+      </BannerContext.Provider>
     );
   }
 }

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '@shopify/polaris-icons';
 import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import BannerContext from 'utilities/banner-context';
 import {Button, Icon, UnstyledLink, Heading} from 'components';
 import Banner from '..';
 import WithinContentContext from '../../WithinContentContext';
@@ -132,6 +133,31 @@ describe('<Banner />', () => {
         .filterWhere((element: ReactWrapper) => element.prop('tabIndex') === 0);
 
       expect(div.getDOMNode()).toBe(document.activeElement);
+    });
+  });
+
+  describe('context', () => {
+    it('passes the within banner context', () => {
+      const Child: React.SFC<{}> = (_props) => {
+        return (
+          <BannerContext.Consumer>
+            {(BannerContext) => (BannerContext ? <div /> : null)}
+          </BannerContext.Consumer>
+        );
+      };
+
+      const banner = mountWithAppProvider(
+        <Banner>
+          <Child />
+        </Banner>,
+      );
+
+      const div = banner
+        .find(Child)
+        .find('div')
+        .first();
+
+      expect(div.exists()).toBe(true);
     });
   });
 });

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {ExternalSmallMinor} from '@shopify/polaris-icons';
 
+import BannerContext from '../../utilities/banner-context';
 import {classNames} from '../../utilities/css';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import UnstyledLink from '../UnstyledLink';
@@ -35,7 +36,6 @@ function Link({
   monochrome,
   polaris,
 }: CombinedProps) {
-  const className = classNames(styles.Link, monochrome && styles.monochrome);
   let childrenMarkup = children;
 
   if (external && typeof children === 'string') {
@@ -55,21 +55,34 @@ function Link({
     );
   }
 
-  return url ? (
-    <UnstyledLink
-      onClick={onClick}
-      className={className}
-      url={url}
-      external={external}
-      id={id}
-      polaris={polaris}
-    >
-      {childrenMarkup}
-    </UnstyledLink>
-  ) : (
-    <button type="button" onClick={onClick} className={className} id={id}>
-      {childrenMarkup}
-    </button>
+  return (
+    <BannerContext.Consumer>
+      {(BannerContext) => {
+        const shouldBeMonochrome = monochrome || BannerContext;
+
+        const className = classNames(
+          styles.Link,
+          shouldBeMonochrome && styles.monochrome,
+        );
+
+        return url ? (
+          <UnstyledLink
+            onClick={onClick}
+            className={className}
+            url={url}
+            external={external}
+            id={id}
+            polaris={polaris}
+          >
+            {childrenMarkup}
+          </UnstyledLink>
+        ) : (
+          <button type="button" onClick={onClick} className={className} id={id}>
+            {childrenMarkup}
+          </button>
+        );
+      }}
+    </BannerContext.Consumer>
   );
 }
 

--- a/src/components/Link/README.md
+++ b/src/components/Link/README.md
@@ -92,6 +92,15 @@ Use for text links that are the same color as the surrounding text.
 </Link>
 ```
 
+Monochrome styles will be applied to links rendered within a `Banner`
+
+```jsx
+<Banner>
+  Learn more about{' '}
+  <Link url="https://help.shopify.com/manual">fulfilling orders</Link>
+</Banner>
+```
+
 ### External link
 
 Use for text links that point to a different website. They will open in a new browser tab or window.

--- a/src/components/Link/tests/Link.test.tsx
+++ b/src/components/Link/tests/Link.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
-import {UnstyledLink, Icon} from 'components';
+import {Banner, UnstyledLink, Icon} from 'components';
 import en from '../../../../locales/en.json';
 import Link from '../Link';
 
@@ -79,6 +79,44 @@ describe('<Link />', () => {
         </Link>,
       );
       expect(link.find(Icon).exists()).toBe(false);
+    });
+  });
+
+  describe('monochrome link', () => {
+    it('outputs a monochrome unstyled link if rendered within a banner', () => {
+      const link = mountWithAppProvider(
+        <Banner>
+          <Link url="https://examp.le">Some content</Link>
+        </Banner>,
+      ).find(UnstyledLink);
+
+      expect(link.hasClass('monochrome')).toBe(true);
+    });
+
+    it('does not output a monochrome unstyled link if it is not rendered within a banner', () => {
+      const link = mountWithAppProvider(
+        <Link url="https://examp.le">Some content</Link>,
+      ).find(UnstyledLink);
+
+      expect(link.hasClass('monochrome')).toBe(false);
+    });
+
+    it('outputs a monochrome button if rendered within a banner', () => {
+      const button = mountWithAppProvider(
+        <Banner>
+          <Link>Some content</Link>
+        </Banner>,
+      ).find('button');
+
+      expect(button.hasClass('monochrome')).toBe(true);
+    });
+
+    it('does not output a monochrome button if it is not rendered within a banner', () => {
+      const button = mountWithAppProvider(<Link>Some content</Link>).find(
+        'button',
+      );
+
+      expect(button.hasClass('monochrome')).toBe(false);
     });
   });
 });

--- a/src/utilities/banner-context.tsx
+++ b/src/utilities/banner-context.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const BannerContext = React.createContext<boolean>(false);
+
+export default BannerContext;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1620

When links are passed as children to the `Banner`, they are rendered in the `blue` colour that is applied to `Link` components. The colour contrast ratio between the link text colour and the background colours used for Banner components fails to meet WCAG 2.1 standards.

### WHAT is this pull request doing?
This PR uses the `withinContentContainer` context to ensures that links passed as children of a Banner component are rendered as monochrome links. This means they will be underlined and will inherit the grey font colour used for other text content in the Banner, which meets Level AA and AAA standards of WCAG 2.1.

![image](https://user-images.githubusercontent.com/8534230/59447115-c2a7c680-8dd0-11e9-9f85-cf5a5f0f7307.png)

![image](https://user-images.githubusercontent.com/8534230/59125090-58ee6f00-892f-11e9-82a4-f34c75c3289b.png)

![image](https://user-images.githubusercontent.com/8534230/59125099-5be95f80-892f-11e9-9818-3493c440e0dc.png)

![image](https://user-images.githubusercontent.com/8534230/59125100-5db32300-892f-11e9-9155-1a36c39eb427.png)

![image](https://user-images.githubusercontent.com/8534230/59125104-5ee45000-892f-11e9-8249-01bf0d2db929.png)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Banner, Card, Link, Page, Stack} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <Stack vertical>
          <Card>
            <Card.Section>
              <Link>Not a monochromatic link</Link>
            </Card.Section>
            <Card.Section>
              <Link monochrome>Monochromatic link</Link>
            </Card.Section>
          </Card>
          <Banner
            title="Some of your product variants are missing weights"
            action={{content: 'Edit variant weights'}}
            secondaryAction={{
              content: 'Secondary action',
              url: 'https://example.com',
            }}
            onDismiss={() => {}}
          >
            <p>
              Add weights to show accurate rates at checkout and when{' '}
              <Link url="https://localhost">
                buying shipping labels in Shopify
              </Link>
              .
            </p>
          </Banner>
          <Banner
            title="Some of your product variants are missing weights"
            status="warning"
            action={{content: 'Edit variant weights'}}
            secondaryAction={{
              content: 'Secondary action',
              url: 'https://example.com',
            }}
            onDismiss={() => {}}
          >
            <p>
              Add weights to show accurate rates at checkout and when{' '}
              <Link url="https://localhost">
                buying shipping labels in Shopify
              </Link>
              .
            </p>
          </Banner>
          <Banner
            title="Some of your product variants are missing weights"
            status="success"
            action={{content: 'Edit variant weights'}}
            secondaryAction={{
              content: 'Secondary action',
              url: 'https://example.com',
            }}
            onDismiss={() => {}}
          >
            <p>
              Add weights to show accurate rates at checkout and when{' '}
              <Link url="https://localhost">
                buying shipping labels in Shopify
              </Link>
              .
            </p>
          </Banner>
          <Banner
            title="Some of your product variants are missing weights"
            status="critical"
            action={{content: 'Edit variant weights'}}
            secondaryAction={{
              content: 'Secondary action',
              url: 'https://example.com',
            }}
            onDismiss={() => {}}
          >
            <p>
              Add weights to show accurate rates at checkout and when{' '}
              <Link url="https://localhost">
                buying shipping labels in Shopify
              </Link>
              .
            </p>
          </Banner>
          <Banner
            title="Some of your product variants are missing weights"
            status="info"
            action={{content: 'Edit variant weights'}}
            secondaryAction={{
              content: 'Secondary action',
              url: 'https://example.com',
            }}
            onDismiss={() => {}}
          >
            <p>
              Add weights to show accurate rates at checkout and when{' '}
              <Link url="https://localhost">
                buying shipping labels in Shopify
              </Link>
              .
            </p>
          </Banner>
        </Stack>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing) - Found an existing issue in production: https://github.com/Shopify/polaris-react/issues/1652
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
