### PR TITLE
[examples/webpack] Fixing webpack dependencies in package.json

### DIFF
--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -15,10 +15,10 @@
     "react-dom": "^16.8.4"
   },
   "devDependencies": {
-    "babel-core": "6.26.3",
+    "@babel/core": "^7.4.5",
+    "@babel/preset-env": "^7.4.5",
+    "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.5",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-react": "^6.24.1",
     "css-loader": "^2.1.1",
     "html-webpack-plugin": "^3.2.0",
     "rimraf": "^2.6.3",


### PR DESCRIPTION
### WHY are these changes introduced?

Currently `npm start` throws the following errors:
```
ERROR in ./src/index.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: Cannot find module '@babel/core'
 babel-loader@8 requires Babel 7.x (the package '@babel/core'). If you'd like to use Babel 6.x ('babel-core'), you should install 'babel-loader@7'.
```
```
ERROR in ./src/index.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: Cannot find module '@babel/preset-env'
```
```
ERROR in ./src/index.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: Cannot find module '@babel/preset-react'
```

### WHAT is this pull request doing?

Simply updating webpack dependencies in package.json so that `npm start` works.