### PR TITLE
[v4][TextField] Fix textfield examples

### DIFF
--- a/.storybook/polaris-readme-loader.js
+++ b/.storybook/polaris-readme-loader.js
@@ -2,6 +2,9 @@
 const chalk = require('chalk');
 const grayMatter = require('gray-matter');
 const MdParser = require('./md-parser');
+const React = require('react');
+
+const HOOK_PREFIX = 'use';
 
 /**
  * A Webpack loader, that expects a Polaris README file, and returns metadata,
@@ -68,8 +71,12 @@ module.exports = function loader(source) {
     return eval(`(${fnString})`).apply(null, Object.values(scope));
   };
 
+  const hooks = Object.keys(React)
+    .filter((key) => key.startsWith(HOOK_PREFIX))
+    .join(', ');
+
   return `
-import React, {useState} from 'react';
+import React, {${hooks}} from 'react';
 import * as Polaris from '@shopify/polaris';
 import {
   PlusMinor,

--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -42,6 +42,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Code quality
 
+- Added hooks to storybooks scope ([#1672](https://github.com/Shopify/polaris-react/pull/1672))
 - Simplified `WithinContentContainer` context type ([#1602](https://github.com/Shopify/polaris-react/pull/1602))
 - Remove `withRef` and `withContext` from `DropZone.FileUpload` ([#1491](https://github.com/Shopify/polaris-react/pull/1491))
 - Updated `OptionList` to no longer use `componentWillReceiveProps`([#1557](https://github.com/Shopify/polaris-react/pull/1557))

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -175,13 +175,9 @@ Use to allow merchants to provide text input when the expected input is short. F
 ```jsx
 function TextFieldExample() {
   const [value, setValue] = useState('Jaded Pixel');
-  return (
-    <TextField
-      label="Store name"
-      value={value}
-      onChange={(newValue) => setValue(newValue)}
-    />
-  );
+  const handleChange = useCallback((newValue) => setValue(newValue), []);
+
+  return <TextField label="Store name" value={value} onChange={handleChange} />;
 }
 ```
 
@@ -204,12 +200,14 @@ Use when input text should be a number.
 ```jsx
 function NumberFieldExample() {
   const [value, setValue] = useState('1');
+  const handleChange = useCallback((newValue) => setValue(newValue), []);
+
   return (
     <TextField
       label="Quantity"
       type="number"
       value={value}
-      onChange={(newValue) => setValue(newValue)}
+      onChange={handleChange}
     />
   );
 }
@@ -238,12 +236,14 @@ Use when the text input should be an email address.
 ```jsx
 function EmailFieldExample() {
   const [value, setValue] = useState('bernadette.lapresse@jadedpixel.com');
+  const handleChange = useCallback((newValue) => setValue(newValue), []);
+
   return (
     <TextField
       label="Email"
       type="email"
       value={value}
-      onChange={(newValue) => setValue(newValue)}
+      onChange={handleChange}
     />
   );
 }
@@ -272,11 +272,13 @@ Use when the expected input could be more than one line. The field will automati
 ```jsx
 function MultilineFieldExample() {
   const [value, setValue] = useState('1776 Barnes Street\nOrlando, FL 32801');
+  const handleChange = useCallback((newValue) => setValue(newValue), []);
+
   return (
     <TextField
       label="Shipping address"
       value={value}
-      onChange={(newValue) => setValue(newValue)}
+      onChange={handleChange}
       multiline
     />
   );
@@ -305,6 +307,12 @@ Use to visually hide the label when the text field’s purpose is clear from con
 function HiddenLabelExample() {
   const [value, setValue] = useState('12');
   const [selected, setSelected] = useState('yes');
+  const handleTextChange = useCallback((newValue) => setValue(newValue), []);
+  const handleChoiceChange = useCallback(
+    (selections) => setSelected(selections[0]),
+    [],
+  );
+
   return (
     <FormLayout>
       <ChoiceList
@@ -314,7 +322,7 @@ function HiddenLabelExample() {
           {label: 'Gift cards expire', value: 'yes'},
         ]}
         selected={[selected]}
-        onChange={(selections) => setSelected(selections[0])}
+        onChange={handleChoiceChange}
       />
       <TextField
         label="Gift cards expire after"
@@ -322,7 +330,7 @@ function HiddenLabelExample() {
         labelHidden
         value={value}
         disabled={selected === 'no'}
-        onChange={(newValue) => setValue(newValue)}
+        onChange={handleTextChange}
         connectedRight={
           <Select
             label="Unit of time"


### PR DESCRIPTION
### WHY are these changes introduced?

These examples were introduced in https://github.com/Shopify/polaris-react/pull/1665

### WHAT is this pull request doing?

* use usecallback

### Notes

* skipping a changelog entry since one was never added noting the conversion