### PR TITLE
[Navigation] Fix item secondary action wrapping

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixed a regression introduced in #1247, where icons inside of `Link` would always be recolored to match the text color ([#1729](https://github.com/Shopify/polaris-react/pull/1729))
 
+- Fixed `Navigation.Item` `secondaryAction` wrapping when content wraps ([#1678](https://github.com/Shopify/polaris-react/pull/1678))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Navigation/Navigation.scss
+++ b/src/components/Navigation/Navigation.scss
@@ -74,6 +74,12 @@ $disabled-fade: 0.6;
 
 .Badge {
   margin-left: spacing(tight);
+  display: inline-flex;
+  margin-top: spacing(base-tight);
+
+  @include breakpoint-after(nav-min-window-corrected()) {
+    margin-top: spacing(tight);
+  }
 }
 
 .Icon {

--- a/src/components/Navigation/Navigation.scss
+++ b/src/components/Navigation/Navigation.scss
@@ -73,7 +73,6 @@ $disabled-fade: 0.6;
 }
 
 .Badge {
-  margin-right: spacing(extra-tight);
   margin-left: spacing(tight);
 }
 
@@ -89,7 +88,12 @@ $disabled-fade: 0.6;
   max-width: calc(
     100% - #{nav(icon-size) + spacing() * 2 + spacing(extra-tight)}
   );
-  padding-right: 0;
+}
+
+.ItemWrapper {
+  display: flex;
+  flex-wrap: nowrap;
+  width: 100%;
 }
 
 .Text {

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -262,17 +262,19 @@ export class BaseItem extends React.Component<CombinedProps, State> {
 
     return (
       <li className={className}>
-        <UnstyledLink
-          url={url}
-          className={itemClassName}
-          tabIndex={tabIndex}
-          aria-disabled={disabled}
-          aria-label={accessibilityLabel}
-          onClick={this.getClickHandler(onClick)}
-        >
-          {itemContentMarkup}
-        </UnstyledLink>
-        {secondaryActionMarkup}
+        <div className={styles.ItemWrapper}>
+          <UnstyledLink
+            url={url}
+            className={itemClassName}
+            tabIndex={tabIndex}
+            aria-disabled={disabled}
+            aria-label={accessibilityLabel}
+            onClick={this.getClickHandler(onClick)}
+          >
+            {itemContentMarkup}
+          </UnstyledLink>
+          {secondaryActionMarkup}
+        </div>
         {secondaryNavigationMarkup}
       </li>
     );

--- a/src/components/Navigation/variables.scss
+++ b/src/components/Navigation/variables.scss
@@ -32,7 +32,7 @@ $nav-animation-variables: (
   line-height: nav(item-line-height);
   display: flex;
   flex-grow: 1;
-  align-items: center;
+  align-items: flex-start;
   max-width: 100%;
   padding: 0 spacing(tight);
   margin: 0 spacing(tight);
@@ -125,6 +125,7 @@ $nav-animation-variables: (
   margin-top: nav(mobile-spacing);
   margin-bottom: nav(mobile-spacing);
   line-height: $text-line-height;
+
   @include breakpoint-after(nav-min-window-corrected()) {
     margin-top: nav(desktop-spacing);
     margin-bottom: nav(desktop-spacing);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1659

### WHAT is this pull request doing?

Wraps the item content, excluding sub-navigation items, in a non-wrapping flex container. Alignment of the content was changed to `flex-start` to ensure the badge stays where expected.

|  Before | After  |
|---|---|
|<img width="230" alt="Screen Shot 2019-06-12 at 4 06 50 PM" src="https://user-images.githubusercontent.com/18447883/59452082-f556bc80-8dda-11e9-8703-ac00256af70b.png">|<img width="235" alt="Screen Shot 2019-06-12 at 4 03 59 PM" src="https://user-images.githubusercontent.com/18447883/59452115-08698c80-8ddb-11e9-820a-71c23d039e00.png">|

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {
  HomeMajorMonotone,
  OrdersMajorTwotone,
  ProductsMajorTwotone,
  CirclePlusOutlineMinor,
  OnlineStoreMajorTwotone,
  ViewMinor,
} from '@shopify/polaris-icons';
import {Frame, Page, Navigation} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <Frame>
          <Navigation location="/">
            <Navigation.Section
              items={[
                {
                  url: '/path/to/place',
                  label: 'Home',
                  icon: HomeMajorMonotone,
                },
                {
                  url: '/path/to/place',
                  label: 'Orders',
                  badge: '15',
                  icon: OrdersMajorTwotone,
                },
                {
                  url: '/path/to/place',
                  label: 'Products',
                  icon: ProductsMajorTwotone,
                },
              ]}
            />
            <Navigation.Section
              separator
              title="Sales channels"
              action={{
                accessibilityLabel: 'Add sales channel',
                icon: CirclePlusOutlineMinor,
                onClick: () => {},
              }}
              items={[
                {
                  icon: OnlineStoreMajorTwotone,
                  url: '#',
                  label: 'Kedai Dalam Talian',
                  badge: '15',
                  secondaryAction: {
                    url: '#',
                    icon: ViewMinor,
                    accessibilityLabel: 'View store',
                  },
                  subNavigationItems: [
                    {
                      label: 'Themes',
                      url: '/online-store/themes',
                    },
                  ],
                },
              ]}
            />
          </Navigation>
        </Frame>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
