### PR TITLE
[v4] Update no unsafe eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
     "react/button-has-type": "off",
     "react/no-array-index-key": "off",
     "react/jsx-fragments": ["error", "element"],
+    "react/no-unsafe": ["error", {"checkAliases": true}],
     "shopify/jsx-no-complex-expressions": "off",
     "shopify/jsx-prefer-fragment-wrappers": "off",
     "shopify/no-ancestor-directory-import": "error",

--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -44,6 +44,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Code quality
 
+- Enabled react/no-unsafe with checkAliases ([#1695](https://github.com/Shopify/polaris-react/pull/1695))
 - Added hooks to storybooks scope ([#1672](https://github.com/Shopify/polaris-react/pull/1672))
 - Simplified `WithinContentContainer` context type ([#1602](https://github.com/Shopify/polaris-react/pull/1602))
 - Updated `Collapsible` to no longer use `componentWillReceiveProps`([#1670](https://github.com/Shopify/polaris-react/pull/1670))


### PR DESCRIPTION
### WHY are these changes introduced?

We removed the last deprecated lifecycle method 🎉 I was going to add strict mode to storybook but it looks like we use ReactDOM.findDOMNode which is also a nono for strict mode, and will need to be handled but should be an easy fix.