### PR TITLE
[Card] Add example for card with footer action + plain button

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -31,6 +31,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Documentation
 
 - Mentioned Polaris icons in the Icon component documentation ([#1693](https://github.com/Shopify/polaris-react/pull/1693))
+- Added an example to `Card` for custom action layout with a secondary action and a plain button ([#1705](https://github.com/Shopify/polaris-react/pull/1705))
 
 ### Development workflow
 

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -324,6 +324,30 @@ When multiple secondary footer actions are provided, they will render in an acti
 </Card>
 ```
 
+### Card with custom footer actions
+
+<!-- example-for: web -->
+
+Use to present actionable content that is optional or not the primary purpose of the page.
+
+```jsx
+<Card title="Secure your account with 2-step authentication">
+  <Card.Section>
+    <Stack spacing="loose" vertical>
+      <p>
+        Two-step authentication adds an extra layer of security when logging in
+        to your account. A special code will be required each time you log in,
+        ensuring only you can access your account.
+      </p>
+      <ButtonGroup>
+        <Button>Enable two-step authentication</Button>
+        <Button plain>Learn more</Button>
+      </ButtonGroup>
+    </Stack>
+  </Card.Section>
+</Card>
+```
+
 ### Card with destructive footer action
 
 <!-- example-for: web -->


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #562

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds an example of the card where custom buttons are added, similar to how they are used in some parts of Shopify. The example adds a secondary button and a plain button to the footer of the card.

<img width="560" alt="Screenshot 2019-06-18 15 51 48" src="https://user-images.githubusercontent.com/305807/59715035-00498c80-91e1-11e9-9e39-ae055c9fd7d6.png">
