### PR TITLE
[ResourceList] Fix shift-clicking on the checkbox in Firefox

### DIFF
--- a/src/components/ResourceList/components/Item/Item.tsx
+++ b/src/components/ResourceList/components/Item/Item.tsx
@@ -161,19 +161,17 @@ class Item extends React.Component<CombinedProps, State> {
           testID="LargerSelectionArea"
         >
           <div onClick={stopPropagation} className={styles.CheckboxWrapper}>
-            <div>
-              <Checkbox
-                testID="Checkbox"
-                id={this.checkboxId}
-                label={label}
-                labelHidden
-                checked={selected}
-                disabled={loading}
-                onChange={() => {
-                  this.handleLargerSelectionArea();
-                }}
-              />
-            </div>
+            <Checkbox
+              testID="Checkbox"
+              id={this.checkboxId}
+              label={label}
+              labelHidden
+              checked={selected}
+              disabled={loading}
+              onChange={() => {
+                this.handleLargerSelectionArea();
+              }}
+            />
           </div>
         </div>
       );


### PR DESCRIPTION
### WHY are these changes introduced?

At present, <kbd>Shift</kbd>-clicking an `Item`'s `Checkbox` in a `ResourceList` with multi-select does not work in Firefox. This is due to a long-standing bug (https://bugzilla.mozilla.org/show_bug.cgi?id=559506) that prevents an `<input type="checkbox"/>` from being checked when <kbd>Shift</kbd>-clicking the `<label>`.

Although our `Checkbox` component wraps the inner `<input>` in a `<label>` https://github.com/Shopify/polaris-react/blob/cb96a7aa749018efe344f2500f7b687783285c88/src/components/Choice/Choice.tsx#L45-L46 
it side-steps this issue by listening to the `<label>`'s `click` event rather than to `change` https://github.com/Shopify/polaris-react/blob/cb96a7aa749018efe344f2500f7b687783285c88/src/components/Checkbox/Checkbox.tsx#L116 https://github.com/Shopify/polaris-react/blob/cb96a7aa749018efe344f2500f7b687783285c88/src/components/Checkbox/Checkbox.tsx#L48-L55

However, `Checkbox`'s custom `onChange` property only passes a boolean to signify whether the checkbox is checked so there's no way of figuring out whether the <kbd>Shift</kbd> key is pressed. To work around this our current implementation listens to `Checkbox`'s inner `<input>`'s `onChange` event by registering a handler on the parent to catch it when it bubbles https://github.com/Shopify/polaris-react/blob/5bf432eed98e1d157a79bccbd5c314ecc002a3cb/src/components/ResourceList/components/Item/Item.tsx#L162
but `onChange` is never triggered on Firefox due to the aforementioned bug.

To fix this I believe there are essentially two options:

1. Expand `Checkbox`'s `onChange` callback signature to either pass along the event or an object containing a `shiftKey`. This would allow `Item` to use it instead of relying on the inner `<input>`'s bubbled `onChange`.<br><br>The only way to make this a backwards-compatible change would be to include a second argument, which has the downside of making `Checkbox`'s `onChange` diverge even further from typical event handlers which take an event object as the first argument.
2. Track the state of the <kbd>Shift</kbd> key separately and rely on that combined with `Checkbox`'s `onChange` to determine whether we should check or uncheck multiple items.

### WHAT is this pull request doing?

This PR currently implements option (2) by introducing a `KeyWatcher` class track the state of the <kbd>Shift</kbd> key and checking the value of `.isPressed()` instead of `event.nativeEvent.shiftKey` in `handleLargerSelectionArea`.

⚠️ I'm opening a PR with this implementation to spark some discussion around what the best way of fixing this is (and choosing to not fix it at all may be a legitimate outcome). It is by no means complete and has no test coverage at the moment.

### How to 🎩

`dev s` and open up http://localhost:6006/?path=/story/all-components-resource-list--resource-list-with-multiselect. The behaviour should be identical to before with the only difference being that it now works in Firefox.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

