### PR TITLE
Storybook: Make babel read ts files instead of using ts-loader

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -62,14 +62,6 @@ module.exports = ({config, mode}) => {
             cacheDirectory: `${cacheDir}/typescript`,
           },
         },
-        {
-          loader: 'ts-loader',
-          options: {
-            silent: true,
-            transpileOnly: true,
-            experimentalFileCaching: true,
-          },
-        },
       ],
     },
     {

--- a/babel.config.js
+++ b/babel.config.js
@@ -6,8 +6,8 @@ module.exports = function(api) {
   });
 
   const runtimePreset = isWeb
-    ? ['babel-preset-shopify/web', {modules: false, useBuiltIns: 'entry'}]
-    : ['babel-preset-shopify/node', {modules: 'commonjs'}];
+    ? ['babel-preset-shopify/web', {modules: false, typescript: true}]
+    : ['babel-preset-shopify/node', {modules: 'commonjs', typescript: true}];
 
   // babel-preset-shopify/react only uses HMR if hot is true and the env is
   // development or test


### PR DESCRIPTION
### WHY are these changes introduced?

A few weeks ago I taught babel-plugin-shopify how to read typescript files with the flick of an option. We should use that instead having to pass TS files into ts-loader then into babel-loader.

### WHAT is this pull request doing?

- Enable typescript mode for our babel config
- Remove ts-loader from storybook config
- Remove `useBuiltins: entry` from babel config as it is the default so no need to specify it.

### To test:

- Ensure storybook runs without errors (check percy). There will be some console warnings regarding unfound imports of interfaces but they were there before too.