### PR TITLE
Export classes immediatly instead of in a trailing line

### DIFF
--- a/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -12,7 +12,10 @@ import {
 // crashing if we write `ContextualSaveBar extends React.Component<ContextualSaveBarProps>`
 interface Props extends ContextualSaveBarProps {}
 
-class ContextualSaveBar extends React.PureComponent<Props, never> {
+export default class ContextualSaveBar extends React.PureComponent<
+  Props,
+  never
+> {
   static contextTypes = frameContextTypes;
   context: FrameContext;
 
@@ -49,5 +52,3 @@ function contextualSaveBarHasChanged(
       !isEqual(discardAction, oldDiscardAction),
   );
 }
-
-export default ContextualSaveBar;

--- a/src/components/InlineError/InlineError.tsx
+++ b/src/components/InlineError/InlineError.tsx
@@ -13,7 +13,7 @@ export interface Props {
   fieldID: string;
 }
 
-function InlineError({message, fieldID}: Props) {
+export default function InlineError({message, fieldID}: Props) {
   if (!message) {
     return null;
   }
@@ -27,5 +27,3 @@ function InlineError({message, fieldID}: Props) {
     </div>
   );
 }
-
-export default InlineError;

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -15,7 +15,7 @@ export interface Props {
   children?: React.ReactNode;
 }
 
-export default class ContentList extends React.PureComponent<Props, never> {
+export default class List extends React.PureComponent<Props, never> {
   static Item = Item;
 
   render() {


### PR DESCRIPTION
### WHY are these changes introduced?

When investigating UXPin I found that it is sometimes quite picky about formatting of code it expects. In particular it doesn't really like it when you define a function and then export it later, and if the component's name doesn't match the name of the function.

Conveniently we follow their expectations 99% of the time so fixing these foibles is also improving our own consistency.

### WHAT is this pull request doing?

- Immediately export functions
- Rename the function in List to match the name of the component

