### PR TITLE
[v4] Removed default exports from utils

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -50,6 +50,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Simplified `WithinContentContainer` context type ([#1602](https://github.com/Shopify/polaris-react/pull/1602))
 - Updated `Collapsible` to no longer use `componentWillReceiveProps`([#1670](https://github.com/Shopify/polaris-react/pull/1670))
 - Remove `withRef` and `withContext` from `DropZone.FileUpload` ([#1491](https://github.com/Shopify/polaris-react/pull/1491))
+- Updated exports in `src/utilities` and `src/test-utilities` to named exports ([#1717](https://github.com/Shopify/polaris-react/pull/1717))
 - Updated `PositionedOverlay` to no longer use `componentWillReceiveProps`([#1621](https://github.com/Shopify/polaris-react/pull/1621))
 - Updated `OptionList` to no longer use `componentWillReceiveProps`([#1557](https://github.com/Shopify/polaris-react/pull/1557))
 - Updated all our context files to export react context rather than a provider and consumer ([#1459](https://github.com/Shopify/polaris-react/pull/1459))

--- a/examples/create-react-app/src/tests/utils/enzyme.js
+++ b/examples/create-react-app/src/tests/utils/enzyme.js
@@ -1,4 +1,4 @@
-import merge from 'lodash/merge';
+import {merge} from 'lodash/merge';
 import {shallow, mount} from 'enzyme';
 import {createPolarisContext, polarisContextTypes} from '@shopify/polaris';
 

--- a/src/components/AppProvider/utilities/Intl/Intl.ts
+++ b/src/components/AppProvider/utilities/Intl/Intl.ts
@@ -1,5 +1,5 @@
 import {get} from '../../../../utilities/get';
-import merge from '../../../../utilities/merge';
+import {merge} from '../../../../utilities/merge';
 import {
   TranslationDictionary,
   PrimitiveReplacementDictionary,

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -8,7 +8,7 @@ import {
   CircleInformationMajorTwotone,
 } from '@shopify/polaris-icons';
 
-import BannerContext from '../../utilities/banner-context';
+import {BannerContext} from '../../utilities/banner-context';
 import {classNames, variationName} from '../../utilities/css';
 import {Action, DisableableAction, LoadableAction} from '../../types';
 import Button, {buttonFrom} from '../Button';

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -9,7 +9,7 @@ import {
 } from '@shopify/polaris-icons';
 import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider} from 'test-utilities/legacy';
-import BannerContext from 'utilities/banner-context';
+import {BannerContext} from 'utilities/banner-context';
 import {Button, Icon, UnstyledLink, Heading} from 'components';
 import Banner from '..';
 import WithinContentContext from '../../WithinContentContext';

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -11,7 +11,7 @@ import {
 } from '@shopify/polaris-icons';
 
 import {classNames} from '../../utilities/css';
-import capitalize from '../../utilities/capitalize';
+import {capitalize} from '../../utilities/capitalize';
 import Icon from '../Icon';
 import Stack from '../Stack';
 import Caption from '../Caption';

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -2,7 +2,7 @@ import React, {useContext} from 'react';
 import {DragDropMajorMonotone} from '@shopify/polaris-icons';
 
 import {classNames} from '../../../../utilities/css';
-import capitalize from '../../../../utilities/capitalize';
+import {capitalize} from '../../../../utilities/capitalize';
 
 import Link from '../../../Link';
 import Icon from '../../../Icon';

--- a/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -3,7 +3,7 @@ import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {Button, Image, Modal} from 'components';
 import ContextualSaveBar from '../ContextualSaveBar';
 import {ThemeProviderContextType} from '../../../../ThemeProvider';
-import merge from '../../../../../utilities/merge';
+import {merge} from '../../../../../utilities/merge';
 
 describe('<ContextualSaveBar />', () => {
   describe('discardAction', () => {

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {ExternalSmallMinor} from '@shopify/polaris-icons';
 
-import BannerContext from '../../utilities/banner-context';
+import {BannerContext} from '../../utilities/banner-context';
 import {classNames} from '../../utilities/css';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import UnstyledLink from '../UnstyledLink';

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -9,7 +9,7 @@ import WithinContentContext from '../WithinContentContext';
 import {wrapWithComponent} from '../../utilities/components';
 
 import {transformActions} from '../../utilities/app-bridge-transformers';
-import pick from '../../utilities/pick';
+import {pick} from '../../utilities/pick';
 
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import Backdrop from '../Backdrop';

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -10,7 +10,7 @@ import {
   transformActions,
   generateRedirect,
 } from '../../utilities/app-bridge-transformers';
-import pick from '../../utilities/pick';
+import {pick} from '../../utilities/pick';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 
 import {Header, HeaderProps} from './components';

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {ArrowLeftMinor, ArrowRightMinor} from '@shopify/polaris-icons';
 import {classNames} from '../../utilities/css';
-import isInputFocused from '../../utilities/is-input-focused';
+import {isInputFocused} from '../../utilities/is-input-focused';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
 import Icon from '../Icon';
 import UnstyledLink from '../UnstyledLink';

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {classNames} from '../../../../utilities/css';
-import clamp from '../../../../utilities/clamp';
+import {clamp} from '../../../../utilities/clamp';
 import Labelled, {helpTextID} from '../../../Labelled';
 
 import {invertNumber, CSS_VAR_PREFIX} from '../../utilities';

--- a/src/components/TopBar/tests/TopBar.test.tsx
+++ b/src/components/TopBar/tests/TopBar.test.tsx
@@ -4,7 +4,7 @@ import {Image, UnstyledLink} from 'components';
 import {ThemeProviderContextType} from '../../ThemeProvider';
 import TopBar from '../TopBar';
 import {Menu, SearchField, UserMenu, Search} from '../components';
-import merge from '../../../utilities/merge';
+import {merge} from '../../../utilities/merge';
 
 const actions = [
   {

--- a/src/test-utilities/document-has-style.ts
+++ b/src/test-utilities/document-has-style.ts
@@ -1,4 +1,4 @@
-export default function documentHasStyle(key: string, value?: string): boolean {
+export function documentHasStyle(key: string, value?: string): boolean {
   if (!document) {
     return false;
   }

--- a/src/test-utilities/index.ts
+++ b/src/test-utilities/index.ts
@@ -1,2 +1,2 @@
 export * from './react-testing';
-export {default as documentHasStyle} from './document-has-style';
+export {documentHasStyle} from './document-has-style';

--- a/src/test-utilities/legacy.tsx
+++ b/src/test-utilities/legacy.tsx
@@ -2,7 +2,7 @@ import {ReactWrapper, CommonWrapper, mount} from 'enzyme';
 import React from 'react';
 import {noop} from '@shopify/javascript-utilities/other';
 import {get} from '../utilities/get';
-import merge from '../utilities/merge';
+import {merge} from '../utilities/merge';
 import {PolarisContext} from '../components/types';
 import {DeepPartial} from '../types';
 import translations from '../../locales/en.json';

--- a/src/test-utilities/react-testing.tsx
+++ b/src/test-utilities/react-testing.tsx
@@ -15,7 +15,7 @@ import {
 } from '../components/ThemeProvider';
 import {PolarisContext} from '../components/types';
 import {DeepPartial} from '../types';
-import merge from '../utilities/merge';
+import {merge} from '../utilities/merge';
 
 interface Providers {
   polaris: PolarisContext;

--- a/src/utilities/banner-context.tsx
+++ b/src/utilities/banner-context.tsx
@@ -1,5 +1,3 @@
 import React from 'react';
 
-const BannerContext = React.createContext<boolean>(false);
-
-export default BannerContext;
+export const BannerContext = React.createContext<boolean>(false);

--- a/src/utilities/capitalize.ts
+++ b/src/utilities/capitalize.ts
@@ -1,6 +1,4 @@
-function capitalize(word = '') {
+export function capitalize(word = '') {
   const wordLower = word.toLowerCase();
   return wordLower.charAt(0).toUpperCase() + wordLower.slice(1);
 }
-
-export default capitalize;

--- a/src/utilities/clamp.ts
+++ b/src/utilities/clamp.ts
@@ -1,4 +1,4 @@
-export default function clamp(number: number, min: number, max: number) {
+export function clamp(number: number, min: number, max: number) {
   if (number < min) return min;
   if (number > max) return max;
   return number;

--- a/src/utilities/is-input-focused.ts
+++ b/src/utilities/is-input-focused.ts
@@ -5,7 +5,7 @@ export enum EditableTarget {
   ContentEditable = 'contenteditable',
 }
 
-function isInputFocused() {
+export function isInputFocused() {
   if (document == null || document.activeElement == null) {
     return false;
   }
@@ -18,5 +18,3 @@ function isInputFocused() {
     document.activeElement.hasAttribute(EditableTarget.ContentEditable)
   );
 }
-
-export default isInputFocused;

--- a/src/utilities/merge.ts
+++ b/src/utilities/merge.ts
@@ -3,30 +3,30 @@ import {GeneralObject} from '../types';
 // Unfortunately, this is how we have to type this at the moment.
 // There is currently a proposal to support variadic kinds.
 // https://github.com/Microsoft/TypeScript/issues/5453
-function merge<TSource1, TSource2>(
+export function merge<TSource1, TSource2>(
   source1: TSource1,
   source2: TSource2,
 ): TSource1 & TSource2;
-function merge<TSource1, TSource2, TSource3>(
+export function merge<TSource1, TSource2, TSource3>(
   source1: TSource1,
   source2: TSource2,
   source3: TSource3,
 ): TSource1 & TSource2 & TSource3;
-function merge<TSource1, TSource2, TSource3, TSource4>(
+export function merge<TSource1, TSource2, TSource3, TSource4>(
   source1: TSource1,
   source2: TSource2,
   source3: TSource3,
   source4: TSource4,
 ): TSource1 & TSource2 & TSource3 & TSource4;
-function merge<TSource1, TSource2, TSource3, TSource4, TSource5>(
+export function merge<TSource1, TSource2, TSource3, TSource4, TSource5>(
   source1: TSource1,
   source2: TSource2,
   source3: TSource3,
   source4: TSource4,
   source5: TSource5,
 ): TSource1 & TSource2 & TSource3 & TSource4 & TSource5;
-function merge<TResult>(...objs: any[]): TResult;
-function merge<TSource1, TSource2, TSource3, TSource4, TSource5>(
+export function merge<TResult>(...objs: any[]): TResult;
+export function merge<TSource1, TSource2, TSource3, TSource4, TSource5>(
   ...objs: (TSource1 | TSource2 | TSource3 | TSource4 | TSource5)[]
 ) {
   const final = {};
@@ -55,5 +55,3 @@ function mergeRecursively(objA: GeneralObject, objB: GeneralObject) {
 function isMergeableValue(value: any) {
   return value !== null && typeof value === 'object';
 }
-
-export default merge;

--- a/src/utilities/pick.ts
+++ b/src/utilities/pick.ts
@@ -14,7 +14,10 @@ function pickValueAndLength(obj: GeneralObject, key: string) {
   return {keyPaths, value};
 }
 
-function pick(obj: GeneralObject | null, ...keyPaths: (string | string[])[]) {
+export function pick(
+  obj: GeneralObject | null,
+  ...keyPaths: (string | string[])[]
+) {
   const flattenedKeypaths = ([] as string[]).concat(...keyPaths);
   if (obj == null || flattenedKeypaths.length === 0) return {};
   return flattenedKeypaths.reduce((acc, key) => {
@@ -37,5 +40,3 @@ function pick(obj: GeneralObject | null, ...keyPaths: (string | string[])[]) {
     return {...acc, ...innerObject};
   }, {});
 }
-
-export default pick;

--- a/src/utilities/tests/capitalize.test.ts
+++ b/src/utilities/tests/capitalize.test.ts
@@ -1,4 +1,4 @@
-import capitalize from '../capitalize';
+import {capitalize} from '../capitalize';
 
 describe('capitalize', () => {
   it('capitalizes a word', () => {

--- a/src/utilities/tests/clamp.test.ts
+++ b/src/utilities/tests/clamp.test.ts
@@ -1,4 +1,4 @@
-import clamp from '../clamp';
+import {clamp} from '../clamp';
 
 describe('clamp', () => {
   it('adjusts the given number to be at least the min', () => {

--- a/src/utilities/tests/is-input-focused.test.tsx
+++ b/src/utilities/tests/is-input-focused.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import isInputFocused from '../is-input-focused';
+import {isInputFocused} from '../is-input-focused';
 
 describe('isInputFocused', () => {
   it('returns true when the the focused element is not input, textarea, select or has the attribute contenteditable', () => {

--- a/src/utilities/tests/merge.test.ts
+++ b/src/utilities/tests/merge.test.ts
@@ -1,4 +1,4 @@
-import merge from '../merge';
+import {merge} from '../merge';
 
 describe('merge', () => {
   it('returns an object', () => {

--- a/src/utilities/tests/pick.test.ts
+++ b/src/utilities/tests/pick.test.ts
@@ -1,4 +1,4 @@
-import pick from '../pick';
+import {pick} from '../pick';
 
 describe('pick', () => {
   it('returns an empty object when null is provided', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

To stay consistent. Occasionally we had default exports, other times we had named exports. This will keep all our utilities / test-utilities consistent.

### WHAT is this pull request doing?

* using named exports for utils/test-utils
