### PR TITLE
[Banner] Support disabling screen reader announcements when changing content.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added the `stopAnnouncements` prop to `Banner`, which disables screen reader announcements when content changes ([#1719](https://github.com/Shopify/polaris-react/pull/1719))
 - Add `selectable` prop to `ResourceList` component ([#1614](https://github.com/Shopify/polaris-react/pull/1614))
 - Allow `Link` and `Button` interactions when rendered as `prefix/suffix` within `<TextField />` ([#1394](https://github.com/Shopify/polaris-react/pull/1394))
 - Improve `TextField` so that character count is only announced on focus. ([#1720](https://github.com/Shopify/polaris-react/pull/1720))

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -40,6 +40,8 @@ export interface Props {
   secondaryAction?: Action;
   /** Callback when banner is dismissed */
   onDismiss?(): void;
+  /** Disables screen reader announcements when changing the content of the banner */
+  stopAnnouncements?: boolean;
 }
 
 export default class Banner extends React.PureComponent<Props, never> {
@@ -59,6 +61,7 @@ export default class Banner extends React.PureComponent<Props, never> {
       children,
       status,
       onDismiss,
+      stopAnnouncements,
     } = this.props;
     const {withinContentContainer} = this.context;
 
@@ -162,7 +165,7 @@ export default class Banner extends React.PureComponent<Props, never> {
         tabIndex={0}
         ref={this.wrapper}
         role={ariaRoleType}
-        aria-live="polite"
+        aria-live={stopAnnouncements ? 'off' : 'polite'}
         onMouseUp={handleMouseUp}
         aria-labelledby={headingID}
         aria-describedby={contentID}

--- a/src/components/Banner/README.md
+++ b/src/components/Banner/README.md
@@ -611,6 +611,7 @@ Banners provide context and assist workflows for merchants with disabilities.
 
 - Critical and warning banners have a `role=”alert”` and are announced by assistive technologies when they appear.
 - All other banners have a `role=”status”` and are read after any critical announcements.
+- All banners have an `aria-live` attribute and are announced by assistive technologies when their content is updated. These announcements can be disabled by using the prop `stopAnnouncements`.
 - Banners use `aria-describedby` to describe their purpose to assistive technologies when they’re announced or receive focus. If a banner has a `title`, then the title content is used for the `aria-describedby`. If the banner doesn’t have a `title`, then all of the banner content is used for the `aria-describedby`.
 - Banner containers have a `tabindex=”0”` and display a visible keyboard focus indicator. Because of this, merchants can discover banners while tabbing through forms or other interactions, and developers can programmatically move focus to banners.
 - Banners use a combination of [icons](/design/icons) and [colors](/design/colors) to show their meaning and level of importance to merchants.

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -49,6 +49,22 @@ describe('<Banner />', () => {
     expect(banner.find(Icon).prop('color')).toBe('yellowDark');
   });
 
+  it('disables aria-live when stopAnnouncements is enabled', () => {
+    const politeBanner = mountWithAppProvider(<Banner />)
+      .find('div')
+      .filterWhere(
+        (element: ReactWrapper) => element.prop('aria-live') === 'polite',
+      );
+    expect(politeBanner).toBeTruthy();
+
+    const quietBanner = mountWithAppProvider(<Banner stopAnnouncements />)
+      .find('div')
+      .filterWhere(
+        (element: ReactWrapper) => element.prop('aria-live') === 'off',
+      );
+    expect(quietBanner).toBeTruthy();
+  });
+
   it('uses a redDark circleBarred if status is critical', () => {
     const banner = mountWithAppProvider(<Banner status="critical" />);
     expect(banner.find(Icon).prop('source')).toBe(CircleDisabledMajorTwotone);


### PR DESCRIPTION
(Try 2 for CodeCov)

### WHY are these changes introduced?

We're using the `Banner` component multiple times on a page to communicate information in a form. When switching context (e.g. changing the form data but keeping the form), we need to update the banners. 

When doing so, the `aria-live` state of the banners is causing them to be read out one after another. I'd like the option of turning `aria-live` off until we need it.

Feel free to slack `@emarchak` for more context on this.

### WHAT is this pull request doing?

Adding a new prop to the banner component, `stopAnnouncements` that allows devs to set `aria-live` to `off`.

### How to 🎩

1. Set up the playground with the following code. You'll get a warning banner that has a primary action that updates text.
2. Boot up your screen reader, and click the `Update banner` button. 
    - You should hear the new content being read out.
3. Uncomment `// stopAnnouncements` and allow the component to reload.
4. Boot up your screen reader, and click the `Update banner` button. 
   - You should _not_ hear the new content being read out.

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Banner} from '../src';

interface State {
  bannerTitle: string;
  bannerContent: string;
}

export default class Playground extends React.Component<State> {
  constructor(props) {
    super(props);
    this.state = {
      bannerTitle: 'This is this original banner title.',
      bannerContent: 'This is the original banner content.',
    };
  }

  render() {
    const {bannerTitle, bannerContent} = this.state;
    return (
      <Banner
        title={bannerTitle}
        // stopAnnouncements
        status="warning"
        action={{
          content: 'Update banner',
          onAction: () => {
            this.setState({
              bannerTitle: 'This is a new banner title',
              bannerContent: 'This is some new banner content',
            });
          },
        }}
      >
        {bannerContent}
      </Banner>
    );
  }
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes.
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
