### PR TITLE
[TextField] Improve TextField so that character count is only announced on focus.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Add `selectable` prop to `ResourceList` component ([#1614](https://github.com/Shopify/polaris-react/pull/1614))
 - Allow `Link` and `Button` interactions when rendered as `prefix/suffix` within `<TextField />` ([#1394](https://github.com/Shopify/polaris-react/pull/1394))
+- Improve `TextField` so that character count is only announced on focus. ([#1720](https://github.com/Shopify/polaris-react/pull/1720))
 - `ActionList` can now pass a unique `accessibilityLabel` to each `Item` ([#1653](https://github.com/Shopify/polaris-react/pull/1653))
 - Greatly reduced complexity of `Page > Header` ([#1653](https://github.com/Shopify/polaris-react/pull/1653))
 - Long `Page > Header` breadcrumb labels will now truncate instead of breaking layout ([#1653](https://github.com/Shopify/polaris-react/pull/1653))

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -212,7 +212,7 @@ class TextField extends React.PureComponent<CombinedProps, State> {
 
     const normalizedValue = value != null ? value : '';
 
-    const {height} = this.state;
+    const {height, focus} = this.state;
 
     const className = classNames(
       styles.TextField,
@@ -260,7 +260,7 @@ class TextField extends React.PureComponent<CombinedProps, State> {
         id={`${id}CharacterCounter`}
         className={characterCountClassName}
         aria-label={characterCountLabel}
-        aria-live="polite"
+        aria-live={focus ? 'polite' : 'off'}
         aria-atomic="true"
       >
         {characterCountText}

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -465,6 +465,28 @@ describe('<TextField />', () => {
 
       expect(characterCount.text()).toBe('4/10');
     });
+
+    it('announces updated character count only when input field is in focus', () => {
+      const textField = mountWithAppProvider(
+        <TextField
+          value="test"
+          showCharacterCount
+          label="TextField"
+          id="MyField"
+          onChange={noop}
+        />,
+      );
+
+      expect(
+        textField.find('#MyFieldCharacterCounter').prop<string>('aria-live'),
+      ).toBe('off');
+
+      textField.find('input').simulate('focus');
+
+      expect(
+        textField.find('#MyFieldCharacterCounter').prop<string>('aria-live'),
+      ).toBe('polite');
+    });
   });
 
   describe('type', () => {


### PR DESCRIPTION
(Try 2 for CodeCov) 

### WHY are these changes introduced?

We're using the TextField component inside a very long form. When switching context (e.g. changing the form data but keeping the form), we need to update the values of the form..

When doing so, the `aria-live` state of the character counters is causing them to be read out one after another without any context. I'm setting the aria-live state to off unless the TextField has focus.

Feel free to slack `@emarchak` for more context on this. Related to the same problem as #1699.

### WHAT is this pull request doing?

I'm piggy-backing off of the existing `focus` state in the TextField component to toggle between `off` and `polite` to the character count.

### How to 🎩

1. Set up the playground with the following code. You'll get an input field with a character count and a button that says "Update textfield."
2. Boot up your screen reader, and edit the text in the textfield
   - You should hear the screen reader read out the character count as your typing.
3. Tab out of the text field and click the "Update textfield." button.
   - You should _not_ hear the screen reader read out the new character count.

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {TextField, Button} from '../src';

interface State {
  value: string;
}

export default class Playground extends React.Component<State> {
  constructor(props) {
    super(props);
    this.state = {
      value: 'This is this original value.',
    };
  }

  handleTextChange = (value) => {
    this.setState({value});
  };

  updateTextField = () => {
    this.setState({value: 'This is a new value'});
  };

  render() {
    const {value} = this.state;

    return (
      <React.Fragment>
        <TextField
          label="Input Value name"
          value={value}
          showCharacterCount
          onChange={this.handleTextChange}
        />

        <Button onClick={this.updateTextField}>Update textfield</Button>
      </React.Fragment>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* ~Updated the component's `README.md` with documentation changes~ (Nothing to update)
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide


cc @Shopify/accessibility 