### PR TITLE
[WIP] [Modal] Add fullScreen capability

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -60,6 +60,7 @@ export interface Props extends FooterProps {
    * @embeddedAppOnly
    */
   size?: Size;
+  fullScreen?: boolean;
   /**
    * Message to display inside modal
    * @embeddedAppOnly
@@ -217,6 +218,7 @@ class Modal extends React.Component<CombinedProps, State> {
       secondaryActions,
       polaris: {intl},
       onScrolledToBottom,
+      fullScreen,
     } = this.props;
 
     const {iframeHeight} = this.state;
@@ -288,6 +290,9 @@ class Modal extends React.Component<CombinedProps, State> {
           onExited={this.handleExited}
           large={large}
           limitHeight={limitHeight}
+          fullScreen={fullScreen}
+          width={this.dialogWidth}
+          height={this.dialogHeight}
         >
           {headerMarkup}
           <div className={styles.BodyWrapper}>{bodyMarkup}</div>
@@ -295,7 +300,7 @@ class Modal extends React.Component<CombinedProps, State> {
         </Dialog>
       );
 
-      backdrop = <Backdrop />;
+      backdrop = fullScreen ? null : <Backdrop />;
     }
 
     const animated = !instant;
@@ -377,6 +382,18 @@ class Modal extends React.Component<CombinedProps, State> {
         }),
       },
     };
+  }
+
+  private get dialogWidth() {
+    if (this.props.fullScreen) {
+      return `${window.innerWidth}`;
+    }
+  }
+
+  private get dialogHeight() {
+    if (this.props.fullScreen) {
+      return `${window.innerHeight}`;
+    }
   }
 }
 

--- a/src/components/Modal/components/Dialog/Dialog.scss
+++ b/src/components/Modal/components/Dialog/Dialog.scss
@@ -4,6 +4,8 @@ $horizontal-spacing: spacing(extra-loose) * 2;
 $height-limit: 600px;
 $small-width: rem(620px);
 $large-width: rem(980px);
+$viewport-height: 100vh;
+$viewport-width: 100vw;
 
 .Container {
   position: fixed;
@@ -64,6 +66,18 @@ $large-width: rem(980px);
 
     @include breakpoint-after($large-width + $horizontal-spacing) {
       max-width: $large-width;
+    }
+  }
+
+  &.fullScreen {
+    height: $viewport-height;
+    width: $viewport-width;
+    max-height: $viewport-height;
+    max-width: $viewport-width;
+    border-radius: 0;
+
+    iframe {
+      height: 100%;
     }
   }
 }

--- a/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/src/components/Modal/components/Dialog/Dialog.tsx
@@ -15,6 +15,9 @@ export interface DialogProps {
   instant?: boolean;
   children?: React.ReactNode;
   limitHeight?: boolean;
+  fullScreen?: boolean;
+  width?: string;
+  height?: string;
   large?: boolean;
   onClose(): void;
   onEntered?(): void;
@@ -40,12 +43,16 @@ export default function Dialog({
   onEntered,
   large,
   limitHeight,
+  width,
+  height,
+  fullScreen,
   ...props
 }: Props) {
   const classes = classNames(
     styles.Modal,
     large && styles.sizeLarge,
     limitHeight && styles.limitHeight,
+    fullScreen && styles.fullScreen,
   );
   const TransitionChild = instant ? Transition : FadeUp;
 
@@ -64,6 +71,7 @@ export default function Dialog({
             className={classes}
             role="dialog"
             aria-labelledby={labelledBy}
+            style={{width, height}}
             tabIndex={-1}
           >
             <KeypressListener


### PR DESCRIPTION
### WHY are these changes introduced?

In Embedded App, we need to use `@shopify/polaris-react` Modal instead of the internal `@shopify/polaris-next` one. 

### WHAT is this pull request doing?

To be able to do that we need to enhance Polaris Modal with `fullScreen` capability as in `@shopify/polaris-next`.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        {/* Add the code you want to test here */}
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
