### PR TITLE
Avoid recoloring any old icon inside Link

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed a regression introduced in #1247, where icons inside of `Link` would always be recolored to match the text color ([#1729](https://github.com/Shopify/polaris-react/pull/1729))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -1,5 +1,4 @@
 .Link {
-  @include recolor-icon(currentColor);
   appearance: none;
   display: inline;
   text-align: inherit;
@@ -18,6 +17,7 @@
 }
 
 .IconLockup {
+  @include recolor-icon(currentColor);
   display: inline;
   white-space: nowrap;
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1724

### WHAT is this pull request doing?

The Link component is primarily intended for text links, but it can and is used for links around images and other content. Currently, all icons inside `Link` are set to the current text color, which doesn’t make sense except for text links

This problem was introduced in #1247 which adds an icon automatically for `external` links.

The fix is to scope the icon color change to the external link case only.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {ImageMajorMonotone} from '@shopify/polaris-icons';
import {Page, TextContainer, Link, Icon} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <TextContainer>
          <p>
            <Link url="#">
              <Icon source={ImageMajorMonotone} />
            </Link>
          </p>
          <p>
            <Link url="https://help.shopify.com/manual" external>
              Shopify Help Center
            </Link>
          </p>
        </TextContainer>
      </Page>
    );
  }
}

```

</details>

### 🎩 checklist

* [N/A] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [N/A] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [N/A] Updated the component's `README.md` with documentation changes
* [N/A] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
