### PR TITLE
[TextField][Segment] 🔥 will-change causing perf issues

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -30,6 +30,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixes `monochrome` variant of `Link` and `Button` components to support multi-line link text ([#1686](https://github.com/Shopify/polaris-react/pull/1686))
 - Fixed the first column of `DataTable` not rendering in iOS Safari (([#1605](https://github.com/Shopify/polaris-react/pull/1605))
+- Fixed paint loss on scroll of `TextField` `Spinner` ([#1740](https://github.com/Shopify/polaris-react/pull/1740))
 
 ### Documentation
 

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -289,7 +289,6 @@ $stacking-order: (
   );
   border: none;
   border-left: border(dark);
-  will-change: background, box-shadow;
   transition: background duration(fast) easing(),
     box-shadow duration(fast) easing();
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1739 

The use of `will-change` for the background of the text field segment button is causing paint loss on scroll when several textfields are rendered on a page in Chrome 75. This can be seen in production if you look at the Inventory list view at `/admin/inventory`.

This bug brings to light a greater issue with the use of `will-change` across the code base. I believe we are pre-maturely addressing performance issues where they don't exist, causing paint flash unintentionally. [MDN strongly advises against this](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change). Creating a separate issue for this.

### WHAT is this pull request doing?

Removes the `will-change` property from the `.Segment`, fixing the paint loss. This does not affect the performance of the transitions.

|  Before | After  |
|---|---|
|![2019-06-26 12 01 00](https://user-images.githubusercontent.com/18447883/60196976-7024cc00-980c-11e9-9ac0-2b3669d3d36d.gif)|![2019-06-26 12 19 29](https://user-images.githubusercontent.com/18447883/60197098-c0039300-980c-11e9-91bc-c5f20dfc005c.gif)|

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {
  Page,
  AppProvider,
  TextField,
  Stack,
  Form,
  Button,
  Layout,
  Card,
} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  state = {};

  render() {
    const fields = Array.from(Array(100)).map((_, idx) => {
      return this.renderTextField(idx);
    });

    return (
      <Page title="Weird bug ">
        <Layout>
          <Layout.Section>
            <Card sectioned>
              <Form onSubmit={() => {}}>
                <Stack vertical spacing="extraLoose">
                  {fields}
                </Stack>
              </Form>
            </Card>
          </Layout.Section>
        </Layout>
      </Page>
    );
  }

  private handleChange = (key) => (value) => {
    this.setState({[`textfield-${key}`]: value});
  };

  /* eslint-disable-next-line shopify/react-no-multiple-render-methods */
  private renderTextField(key) {
    return (
      <TextField
        labelHidden
        key={key}
        type="number"
        label={`Text field ${key}`}
        onChange={this.handleChange(key)}
        value={this.state[`textfield-${key}`]}
        connectedLeft={<Button>testing</Button>}
        connectedRight={<Button primary>testing</Button>}
      />
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
