### PR TITLE
Fixed toast manager

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -25,6 +25,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed `ToastManager` from not working correctly in `React.StrictMode` ([#1741](https://github.com/Shopify/polaris-react/pull/1741))
 - Updated translation.yml with the new locales path ([#1649](https://github.com/Shopify/polaris-react/pull/1649))
 - Fixed a bug that affected sizing and spacing of elements in some writing systems (notably Chinese, Japanese, and Korean) ([#1590](https://github.com/Shopify/polaris-react/pull/1590))
 - Fixed a bug when converting `em` units to `rem` units ([#1590](https://github.com/Shopify/polaris-react/pull/1590))

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,9 +1,9 @@
-import React, {useContext, useEffect, useRef} from 'react';
+import React, {useContext, useRef} from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {Toast as AppBridgeToast} from '@shopify/app-bridge/actions';
 
 import {DEFAULT_TOAST_DURATION, FrameContext, ToastProps} from '../Frame';
-import {usePolaris} from '../../hooks';
+import {usePolaris, useDeepCompare} from '../../hooks';
 
 const createId = createUniqueIDFactory('Toast');
 
@@ -19,7 +19,7 @@ export default React.memo(function Toast(props: Props) {
   const frame = useContext(FrameContext);
   const {appBridge} = usePolaris();
 
-  useEffect(
+  useDeepCompare(
     () => {
       const {
         error,
@@ -61,7 +61,6 @@ export default React.memo(function Toast(props: Props) {
         }
       };
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [appBridge, props],
   );
 

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -61,7 +61,8 @@ export default React.memo(function Toast(props: Props) {
         }
       };
     },
-    [appBridge, frame, props],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [appBridge, props],
   );
 
   return null;

--- a/src/hooks/use-deep-compare/use-deep-compare.tsx
+++ b/src/hooks/use-deep-compare/use-deep-compare.tsx
@@ -1,22 +1,6 @@
-import {useEffect, useRef} from 'react';
-import isEqual from 'lodash/isEqual';
-
-type EffectCallback = () => void | (() => void | undefined);
-type DependencyList = ReadonlyArray<unknown>;
-type Comparator = (a: DependencyList, b: DependencyList) => boolean;
-
-function useDeepCompareRef(
-  dependencies: DependencyList,
-  comparator: Comparator = isEqual,
-) {
-  const dependencyList = useRef<DependencyList>(dependencies);
-
-  if (!comparator(dependencyList.current, dependencies)) {
-    dependencyList.current = dependencies;
-  }
-
-  return dependencyList.current;
-}
+import {useEffect} from 'react';
+import {EffectCallback, DependencyList, Comparator} from '../../types';
+import {useDeepCompareRef} from '../../utilities/use-deep-compare-ref';
 
 function useDeepCompare(
   callback: EffectCallback,

--- a/src/types.ts
+++ b/src/types.ts
@@ -260,3 +260,7 @@ export type DeepPartial<T> = {
 };
 
 export type Discard<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+export type EffectCallback = () => void | (() => void | undefined);
+export type DependencyList = ReadonlyArray<unknown>;
+export type Comparator = (a: DependencyList, b: DependencyList) => boolean;

--- a/src/utilities/use-deep-callback.tsx
+++ b/src/utilities/use-deep-callback.tsx
@@ -1,0 +1,11 @@
+import {useCallback} from 'react';
+import {EffectCallback, DependencyList, Comparator} from '../types';
+import {useDeepCompareRef} from './use-deep-compare-ref';
+
+export function useDeepCallback(
+  callback: EffectCallback,
+  dependencies: DependencyList,
+  customCompare?: Comparator,
+) {
+  return useCallback(callback, useDeepCompareRef(dependencies, customCompare));
+}

--- a/src/utilities/use-deep-compare-ref.tsx
+++ b/src/utilities/use-deep-compare-ref.tsx
@@ -1,0 +1,18 @@
+import {useRef} from 'react';
+import isEqual from 'lodash/isEqual';
+
+type DependencyList = ReadonlyArray<unknown>;
+type Comparator = (a: DependencyList, b: DependencyList) => boolean;
+
+export function useDeepCompareRef(
+  dependencies: DependencyList,
+  comparator: Comparator = isEqual,
+) {
+  const dependencyList = useRef<DependencyList>(dependencies);
+
+  if (!comparator(dependencyList.current, dependencies)) {
+    dependencyList.current = dependencies;
+  }
+
+  return dependencyList.current;
+}


### PR DESCRIPTION
### WHY are these changes introduced?

StrictMode found an error in toast and is currently breaking it. `ToastManager` is currently relying on side-effects to work properly

### WHAT is this pull request doing?

* abstracting some of the logic in useDeepCompare to create useDeepCallback
* change toast manager logic
* add eslint ignore because we're smarter 🤔 

### How to 🎩

Check out toast examples in the deploy 😄 

If you want to see `Toast` not working check out `version-4.0.0` (doesn't currently have a deployment)