### PR TITLE
[Modal] Fix example so the modal closes

### DIFF
--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -672,7 +672,7 @@ class ModalExample extends React.Component {
       <div style={{height: '500px'}}>
         <Button onClick={this.handleChange}>Open</Button>
         <Modal
-          open
+          open={active}
           title="Scrollable content"
           onClose={this.toggleModalVisibility}
           onScrolledToBottom={() => alert('Scrolled to bottom')}


### PR DESCRIPTION
The modal was fixed in the `open` state