### PR TITLE
Simplify the internals of our styles plugin

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Renamed `yarn run ts` to `yarn run type-check` to match most other Shopify projects
 - Fixed deprecation notice in build ([#1754](https://github.com/Shopify/polaris-react/pull/1754))
+- Simplified our rollup plugin for sass compilation while retaining identical behaviour ([#1753](https://github.com/Shopify/polaris-react/pull/1753))
 
 ### Dependency upgrades
 

--- a/config/rollup/index.js
+++ b/config/rollup/index.js
@@ -9,8 +9,6 @@ const {dependencies, peerDependencies} = require('../../package.json');
 const styles = require('./plugins/styles');
 const image = require('./plugins/image');
 
-const getNamespacedClassName = require('./namespaced-classname');
-
 const project = resolve(__dirname, '../..');
 const buildRoot = resolve(project, './build-intermediate');
 const styleRoot = resolve(buildRoot, './styles');
@@ -53,7 +51,6 @@ module.exports = function createRollupConfig({entry, cssPath}) {
         output: cssPath,
         includePaths: [styleRoot],
         includeAlways: sassResources,
-        generateScopedName: getNamespacedClassName,
       }),
       image({
         exclude: ['node_modules/**'],

--- a/config/rollup/plugins/styles.js
+++ b/config/rollup/plugins/styles.js
@@ -16,6 +16,7 @@ const postcssShopify = require('postcss-shopify');
 const generateScopedName = require('../namespaced-classname');
 
 const renderSass = promisify(nodeSass.render);
+
 module.exports = function styles(options = {}) {
   const filter = createFilter(
     options.include || ['**/*.css', '**/*.scss'],
@@ -67,8 +68,15 @@ module.exports = function styles(options = {}) {
     },
 
     async generateBundle(generateOptions, bundles) {
+      // generateBundle gets called once per call to bundle.write(). We call
+      // that twice - one for the cjs build (polaris.js), one for the esm build
+      // (polaris.es.js). We only want to do perform this logic once though
+      if (generateOptions.file.endsWith('/polaris.js')) {
+        return;
+      }
+
       if (typeof output !== 'string') {
-        return null;
+        return;
       }
 
       // Items are added to cssAndTokensByFile in an unspecified order as

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.6.0",
     "fs-extra": "^7.0.1",
-    "generic-names": "^2.0.1",
     "glob": "^7.1.3",
     "gray-matter": "^4.0.2",
     "in-publish": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8151,13 +8151,6 @@ generate-object-property@^1.1.0:
   dependencies:
     is-property "^1.0.0"
 
-generic-names@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/generic-names/-/generic-names-2.0.1.tgz#f8a378ead2ccaa7a34f0317b05554832ae41b872"
-  integrity sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==
-  dependencies:
-    loader-utils "^1.1.0"
-
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"


### PR DESCRIPTION
### WHY are these changes introduced?

This is the preliminary work on my investigation of how we can have a simpler and stricter sass build.

This simplifies the contents of our styles rollup plugin while retaining functionality identical to current build output. The one change is that the final item in `styles` objects that gets provided to js files
does not have a trailing comma.

e.g. 

```
const object = {
foo: "Foo",
bar: "Bar",
};
```

becomes

```
const object = {
foo: "Foo",
bar: "Bar"
};
```

This will make future changes easier to make and understand as there's less indirection and boilerplate.

### WHAT is this pull request doing?

- Prefer using sync APIs over async ones where possible (cssnano is the only case where a promise is required)
- Use JSON.stringify over an object instead of rolling our own version.
- Hardcode some values instead of them being options. We only ever call this in one place so we can be opinionated in how it works to reduce indirection.

### How to 🎩

- Checkout master do a build and copy it to a master-build folder `git checkout master && yarn && yarn run build && mv build master-build`
- Checkout this branch and do a build `git checkout simpler-sass && yarn && yarn run build`
- Diff the master-build and build folders `diff -ru master-build build`
- Note that the only changes is the removal of  trailing commas on the final item of style objects