### PR TITLE
Fix deprecation warnings in build output

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Development workflow
 
 - Renamed `yarn run ts` to `yarn run type-check` to match most other Shopify projects
+- Fixed deprecation notice in build ([#1754](https://github.com/Shopify/polaris-react/pull/1754))
 
 ### Dependency upgrades
 

--- a/config/rollup/index.js
+++ b/config/rollup/index.js
@@ -33,9 +33,7 @@ module.exports = function createRollupConfig({entry, cssPath}) {
     plugins: [
       json(),
       nodeResolve({
-        module: true,
-        jsnext: true,
-        main: true,
+        mainFields: ['module', 'jsnext:main', 'main'],
         customResolveOptions: {
           moduleDirectory: ['../build-intermediate', 'node_modules'],
         },


### PR DESCRIPTION
### WHY are these changes introduced?

Fix deprecation warnings in build output


### WHAT is this pull request doing?

Use mainFields option in node-resolve plugin to fix the following
warnings:

node-resolve: setting options.module is deprecated, please override options.mainFields instead
node-resolve: setting options.jsnext is deprecated, please override options.mainFields instead
node-resolve: setting options.main is deprecated, please override options.mainFields instead

### How to 🎩

- Checkout master do a build and copy it to a master-build folder `git checkout master && yarn && yarn run build && mv build master-build`
- Checkout this branch and do a build `git checkout simpler-sass && yarn && yarn run build`
- Diff the master-build and build folders `diff -ru master-build build`
- Note that there are no changes to the build (except the sass zip file differing but that's because files have different create timestamps)