### PR TITLE
Add children typing to Frame and Stack

### DIFF
--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -24,6 +24,8 @@ import {ToastManager, Loading, ContextualSaveBar} from './components';
 import styles from './Frame.scss';
 
 export interface Props {
+  /** The content to display inside the frame. */
+  children?: React.ReactNode;
   /** Accepts a top bar component that will be rendered at the top-most portion of an application frame */
   topBar?: React.ReactNode;
   /** Accepts a navigation component that will be rendered in the left sidebar of an application frame */

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -17,7 +17,7 @@ export type Distribution =
 
 export interface Props {
   /** Elements to display inside stack */
-  children?: any;
+  children?: React.ReactNode;
   /** Wrap stack elements to additional rows as needed on small screens (Defaults to true) */
   wrap?: boolean;
   /** Stack the elements vertically */


### PR DESCRIPTION
### WHY are these changes introduced?

Frame was missing this (it's implied by React.Component but we state
this in every other component with children and it's desired by UXPin)

Stack had the typing set to any which is way too broad (and
React.ReactNode is desired by UXPin)


### WHAT is this pull request doing?

Adds typing to Frame, and fixes the type on Stack

### How to 🎩

Ensure type-check still passes