### PR TITLE
[Tooltip] Implement fix for MouseOver event not firing when cursor enters after leaving a disabled element

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed a bug preventing the display of `Tooltip` when cursor enters from a disabled element ([#1783](https://github.com/Shopify/polaris-react/pull/1783)).
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -118,6 +118,7 @@ export default class Tooltip extends React.PureComponent<Props, State> {
   };
 
   private handleMouseEnter = () => {
+    this.mouseEntered = true;
     this.setState({active: true});
   };
 
@@ -129,10 +130,7 @@ export default class Tooltip extends React.PureComponent<Props, State> {
   // https://github.com/facebook/react/issues/10109
   // Mouseenter event not triggered when cursor moves from disabled button
   private handleMouseEnterFix = () => {
-    if (!this.mouseEntered) {
-      this.mouseEntered = true;
-      this.handleMouseEnter();
-    }
+    !this.mouseEntered && this.handleMouseEnter();
   };
 
   private setAccessibilityAttributes() {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -43,6 +43,7 @@ export default class Tooltip extends React.PureComponent<Props, State> {
 
   private id = getUniqueID();
   private activatorContainer: HTMLElement | null;
+  private mouseEntered = false;
 
   componentDidMount() {
     this.setAccessibilityAttributes();
@@ -87,8 +88,8 @@ export default class Tooltip extends React.PureComponent<Props, State> {
         testID="WrapperComponent"
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
-        onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
+        onMouseOver={this.handleMouseEnterFix}
         ref={this.setActivator}
       >
         {children}
@@ -121,7 +122,17 @@ export default class Tooltip extends React.PureComponent<Props, State> {
   };
 
   private handleMouseLeave = () => {
+    this.mouseEntered = false;
     this.setState({active: false});
+  };
+
+  // https://github.com/facebook/react/issues/10109
+  // Mouseenter event not triggered when cursor moves from disabled button
+  private handleMouseEnterFix = () => {
+    if (!this.mouseEntered) {
+      this.mouseEntered = true;
+      this.handleMouseEnter();
+    }
   };
 
   private setAccessibilityAttributes() {

--- a/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -31,8 +31,8 @@ describe('<Tooltip />', () => {
     );
   });
 
-  it('renders on mouseEnter', () => {
-    wrapperComponent.simulate('mouseEnter');
+  it('renders on mouseOver', () => {
+    wrapperComponent.simulate('mouseOver');
     expect(findByTestID(tooltip, 'TooltipOverlayLabel').exists()).toBe(true);
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1782.

MouseEnter events are not triggered when cursor enters from a disabled element.

### WHAT is this pull request doing?

Uses MouseOver with a "mouseEntered" boolean flag rather than MouseEnter.

#### Before
![polaris-tooltio-mouseenter-bug](https://user-images.githubusercontent.com/205551/60670332-628bc980-9e3e-11e9-819c-af6e82827a73.gif)

#### After
![polaris-tooltip-mouseenter-fix](https://user-images.githubusercontent.com/205551/60670310-5b64bb80-9e3e-11e9-9b12-2943906e4f40.gif)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Tooltip} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page title="Playground">
        <button type="button" disabled>
          Previous
        </button>
        <Tooltip content="Next">
          <button type="button">Next</button>
        </Tooltip>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
