### PR TITLE
[ContextualSaveBar] Add closing of confirmation modal

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,7 +15,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added the rollover and Windows high contrast mode to `Disclosure` button on `Tabs` ([#1755](https://github.com/Shopify/polaris-react/pull/1755))
-
 - Added support for disabling all choices in `ChoiceList` ([#1758](https://github.com/Shopify/polaris-react/pull/1758))
 - Components in our sass build (the `styles` folder) are now precompiled to avoid the chance of accidentally overwriting any of our global variables, mixins and functions ([#1764](https://github.com/Shopify/polaris-react/pull/1764))
 - Changed `Skip to content` to render a anchor instead of a button to meet accessiblity level A guidelines ([#1785](https://github.com/Shopify/polaris-react/pull/1785))
@@ -23,7 +22,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed a regression introduced in #1247, where icons inside of `Link` would always be recolored to match the text color ([#1729](https://github.com/Shopify/polaris-react/pull/1729))
-
+- Fixed the `DiscardConfirmationModal` not closing when the discard button is clicked ([#1784](https://github.com/Shopify/polaris-react/pull/1784))
 - Fixed `Navigation.Item` `secondaryAction` wrapping when content wraps ([#1678](https://github.com/Shopify/polaris-react/pull/1678))
 
 ### Documentation

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -55,7 +55,7 @@ class ContextualSaveBar extends React.PureComponent<CombinedProps, State> {
         <DiscardConfirmationModal
           open={discardConfirmationModalVisible}
           onCancel={this.toggleDiscardConfirmationModal}
-          onDiscard={discardAction.onAction}
+          onDiscard={this.handleDiscardAction}
         />
       );
 
@@ -121,6 +121,14 @@ class ContextualSaveBar extends React.PureComponent<CombinedProps, State> {
       </React.Fragment>
     );
   }
+
+  private handleDiscardAction = () => {
+    const {discardAction} = this.props;
+    if (discardAction && discardAction.onAction) {
+      discardAction.onAction();
+    }
+    this.setState({discardConfirmationModalVisible: false});
+  };
 
   private toggleDiscardConfirmationModal = () => {
     this.setState((prevState) => ({

--- a/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/tests/DiscardConfirmationModal.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/tests/DiscardConfirmationModal.test.tsx
@@ -1,15 +1,31 @@
 import * as React from 'react';
 
-import {shallowWithAppProvider, trigger} from 'test-utilities';
+import {mountWithAppProvider, trigger} from 'test-utilities';
 
 import {Modal} from 'components';
 
 import DiscardConfirmationModal from '../DiscardConfirmationModal';
 
 describe('<DiscardConfirmationModal />', () => {
+  it('passes its open prop value to the Modal', () => {
+    const discardConfirmationModalOpen = mountWithAppProvider(
+      <DiscardConfirmationModal open onDiscard={noop} onCancel={noop} />,
+    );
+    expect(discardConfirmationModalOpen.find(Modal).prop('open')).toBe(true);
+
+    const discardConfirmationModalClosed = mountWithAppProvider(
+      <DiscardConfirmationModal
+        open={false}
+        onDiscard={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(discardConfirmationModalClosed.find(Modal).prop('open')).toBe(false);
+  });
+
   it('calls onDiscard when primaryAction is triggered', () => {
     const spy = jest.fn();
-    const discardConfirmationModal = shallowWithAppProvider(
+    const discardConfirmationModal = mountWithAppProvider(
       <DiscardConfirmationModal open onDiscard={spy} onCancel={noop} />,
     );
 
@@ -19,7 +35,7 @@ describe('<DiscardConfirmationModal />', () => {
 
   it('calls onCancel when secondaryAction is triggered', () => {
     const spy = jest.fn();
-    const discardConfirmationModal = shallowWithAppProvider(
+    const discardConfirmationModal = mountWithAppProvider(
       <DiscardConfirmationModal open onDiscard={noop} onCancel={spy} />,
     );
 

--- a/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import {polarisAppProviderContextTypes} from 'components/AppProvider';
 import {createThemeContext, ThemeContext} from 'components/ThemeProvider';
-import {createAppProviderContext, Button, Image, Modal} from 'components';
+import {createAppProviderContext, Button, Image} from 'components';
+import {DiscardConfirmationModal} from '../components';
 import ContextualSaveBar from '../ContextualSaveBar';
 
 describe('<ContextualSaveBar />', () => {
@@ -22,50 +23,145 @@ describe('<ContextualSaveBar />', () => {
       expect(button.prop('children')).toBe(discardAction.content);
     });
 
-    it('calls the discardAction when discardConfirmationModal is false', () => {
-      const discardAction = {
-        content: 'Discard',
-        onAction: jest.fn(),
-        discardConfirmationModal: false,
-      };
+    describe('discardConfirmationModal is false', () => {
+      it('calls the discardAction when the discard button is clicked', () => {
+        const discardAction = {
+          content: 'Discard',
+          onAction: jest.fn(),
+          discardConfirmationModal: false,
+        };
 
-      const contextualSaveBar = mountWithAppProvider(
-        <ContextualSaveBar discardAction={discardAction} />,
-      );
+        const contextualSaveBar = mountWithAppProvider(
+          <ContextualSaveBar discardAction={discardAction} />,
+        );
 
-      contextualSaveBar.find(Button).simulate('click');
-      expect(discardAction.onAction).toHaveBeenCalled();
+        contextualSaveBar.find(Button).simulate('click');
+        expect(discardAction.onAction).toHaveBeenCalled();
+      });
+
+      it('does not render a DiscardConfirmationModal', () => {
+        const discardAction = {
+          content: 'Discard',
+          onAction: noop,
+          discardConfirmationModal: false,
+        };
+
+        const contextualSaveBar = mountWithAppProvider(
+          <ContextualSaveBar discardAction={discardAction} />,
+        );
+
+        expect(contextualSaveBar.find(DiscardConfirmationModal)).toHaveLength(
+          0,
+        );
+      });
     });
 
-    it('does not call the discardAction when discardConfirmationModal is true', () => {
-      const discardAction = {
-        content: 'Discard',
-        onAction: jest.fn(),
-        discardConfirmationModal: true,
-      };
+    describe('discardConfirmationModal is true', () => {
+      it('does not call the discardAction when the discard button is clicked', () => {
+        const discardAction = {
+          content: 'Discard',
+          onAction: jest.fn(),
+          discardConfirmationModal: true,
+        };
 
-      const contextualSaveBar = mountWithAppProvider(
-        <ContextualSaveBar discardAction={discardAction} />,
-      );
+        const contextualSaveBar = mountWithAppProvider(
+          <ContextualSaveBar discardAction={discardAction} />,
+        );
 
-      contextualSaveBar.find(Button).simulate('click');
-      expect(discardAction.onAction).not.toHaveBeenCalled();
-    });
+        contextualSaveBar.find(Button).simulate('click');
+        expect(discardAction.onAction).not.toHaveBeenCalled();
+      });
 
-    it('opens a modal with the discardAction when discardConfirmationModal is true', () => {
-      const discardAction = {
-        content: 'Discard',
-        onAction: jest.fn(),
-        discardConfirmationModal: true,
-      };
+      it('renders a DiscardConfirmationModal with an `open` prop set to false', () => {
+        const discardAction = {
+          content: 'Discard',
+          onAction: noop,
+          discardConfirmationModal: true,
+        };
 
-      const contextualSaveBar = mountWithAppProvider(
-        <ContextualSaveBar discardAction={discardAction} />,
-      );
+        const discardConfirmationModal = mountWithAppProvider(
+          <ContextualSaveBar discardAction={discardAction} />,
+        ).find(DiscardConfirmationModal);
 
-      contextualSaveBar.find(Button).simulate('click');
-      trigger(contextualSaveBar.find(Modal), 'primaryAction.onAction');
-      expect(discardAction.onAction).toHaveBeenCalled();
+        expect(discardConfirmationModal.prop('open')).toBe(false);
+      });
+
+      it('sets the DiscardConfirmationModal `open` prop to true when the discard button is clicked', () => {
+        const discardAction = {
+          content: 'Discard',
+          onAction: noop,
+          discardConfirmationModal: true,
+        };
+
+        const contextualSaveBar = mountWithAppProvider(
+          <ContextualSaveBar discardAction={discardAction} />,
+        );
+
+        contextualSaveBar.find(Button).simulate('click');
+        const discardConfirmationModal = contextualSaveBar.find(
+          DiscardConfirmationModal,
+        );
+        expect(discardConfirmationModal).toHaveLength(1);
+        expect(discardConfirmationModal.prop('open')).toBe(true);
+      });
+
+      it("sets the DiscardConfirmationModal `open` prop to false when it's `onCancel` handler is triggered", () => {
+        const discardAction = {
+          content: 'Discard',
+          onAction: noop,
+          discardConfirmationModal: true,
+        };
+
+        const contextualSaveBar = mountWithAppProvider(
+          <ContextualSaveBar discardAction={discardAction} />,
+        );
+
+        const discardConfirmationModal = contextualSaveBar.find(
+          DiscardConfirmationModal,
+        );
+        trigger(discardConfirmationModal, 'onCancel');
+
+        expect(discardConfirmationModal.prop('open')).toBe(false);
+      });
+
+      it("calls the discardAction prop when it's `onDiscard` handler is triggered", () => {
+        const discardAction = {
+          content: 'Discard',
+          onAction: jest.fn(),
+          discardConfirmationModal: true,
+        };
+
+        const contextualSaveBar = mountWithAppProvider(
+          <ContextualSaveBar discardAction={discardAction} />,
+        );
+
+        contextualSaveBar.find(Button).simulate('click');
+        const discardConfirmationModal = contextualSaveBar.find(
+          DiscardConfirmationModal,
+        );
+
+        trigger(discardConfirmationModal, 'onDiscard');
+        expect(discardAction.onAction).toHaveBeenCalled();
+      });
+
+      it("sets the DiscardConfirmationModal `open` prop to false when it's `onDiscard` handler is triggered", () => {
+        const discardAction = {
+          content: 'Discard',
+          onAction: noop,
+          discardConfirmationModal: true,
+        };
+
+        const contextualSaveBar = mountWithAppProvider(
+          <ContextualSaveBar discardAction={discardAction} />,
+        );
+
+        const discardConfirmationModal = contextualSaveBar.find(
+          DiscardConfirmationModal,
+        );
+        trigger(discardConfirmationModal, 'onDiscard');
+
+        expect(discardConfirmationModal.prop('open')).toBe(false);
+      });
     });
   });
 
@@ -197,3 +293,5 @@ function addPolarisContext(logo: ThemeContext) {
     childContextTypes: polarisAppProviderContextTypes,
   };
 }
+
+function noop() {}


### PR DESCRIPTION

### WHY are these changes introduced?

resolves: https://github.com/Shopify/polaris-react/issues/1052

### WHAT is this pull request doing?

Ensure the `DiscardConfirmationModal` gets closed when Discard is clicked.

![discardAction](https://user-images.githubusercontent.com/1229901/60673567-088f0200-9e46-11e9-81db-41e5b376181b.gif)


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Frame, ContextualSaveBar} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Frame>
        <ContextualSaveBar
          message="Unsaved changes"
          saveAction={{
            onAction: () => console.log('add form submit logic'),
            loading: false,
            disabled: false,
          }}
          discardAction={{
            onAction: () => console.log('add clear form logic'),
            discardConfirmationModal: true,
          }}
        />
        <Page title="Playground">Hello</Page>
      </Frame>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
