### PR TITLE
[Frame] Make skip to content link an actual link

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,10 +14,11 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-- Added the rollover and Windows high contrast mode to `Disclosure` button on `Tabs`. ([#1755](https://github.com/Shopify/polaris-react/pull/1755))
+- Added the rollover and Windows high contrast mode to `Disclosure` button on `Tabs` ([#1755](https://github.com/Shopify/polaris-react/pull/1755))
 
 - Added support for disabling all choices in `ChoiceList` ([#1758](https://github.com/Shopify/polaris-react/pull/1758))
-- Components in our sass build (the `styles` folder) are now precompiled to avoid the chance of accidentally overwriting any of our global variables, mixins and functions ([#1764](https://github.com/Shopify/polaris-react/pull/1764)).
+- Components in our sass build (the `styles` folder) are now precompiled to avoid the chance of accidentally overwriting any of our global variables, mixins and functions ([#1764](https://github.com/Shopify/polaris-react/pull/1764))
+- Changed `Skip to content` to render a anchor instead of a button to meet accessiblity level A guidelines ([#1785](https://github.com/Shopify/polaris-react/pull/1785))
 
 ### Bug fixes
 

--- a/src/components/Frame/Frame.scss
+++ b/src/components/Frame/Frame.scss
@@ -208,3 +208,7 @@ $skip-vertical-offset: rem(10px);
     opacity: 1;
   }
 }
+
+.SkipAnchor {
+  @include button-base;
+}

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -4,7 +4,6 @@ import {classNames} from '@shopify/css-utilities';
 import {durationSlow} from '@shopify/polaris-tokens';
 import {CSSTransition} from 'react-transition-group';
 import {navigationBarCollapsed} from '../../utilities/breakpoints';
-import Button from '../Button';
 import Icon from '../Icon';
 import EventListener from '../EventListener';
 import {withAppProvider, WithAppProviderProps} from '../AppProvider';
@@ -72,6 +71,8 @@ class Frame extends React.PureComponent<CombinedProps, State> {
   private contextualSaveBar: ContextualSaveBarProps | null;
 
   private globalRibbonContainer: HTMLDivElement | null = null;
+
+  private mainContentNode = React.createRef<HTMLDivElement>();
 
   getChildContext(): FrameContext {
     return {
@@ -212,13 +213,15 @@ class Frame extends React.PureComponent<CombinedProps, State> {
 
     const skipMarkup = (
       <div className={skipClassName}>
-        <Button
-          onClick={this.handleClick}
+        <a
+          href={`#${APP_FRAME_MAIN}`}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
+          onClick={this.handleClick}
+          className={styles.SkipAnchor}
         >
           {intl.translate('Polaris.Frame.skipToContent')}
-        </Button>
+        </a>
       </div>
     );
 
@@ -261,6 +264,8 @@ class Frame extends React.PureComponent<CombinedProps, State> {
           className={styles.Main}
           id={APP_FRAME_MAIN}
           data-has-global-ribbon={Boolean(globalRibbon)}
+          ref={this.mainContentNode}
+          tabIndex={-1}
         >
           <div className={styles.Content}>{children}</div>
         </main>
@@ -351,16 +356,19 @@ class Frame extends React.PureComponent<CombinedProps, State> {
     }
   };
 
-  private handleClick = () => {
-    focusAppFrameMain();
-  };
-
   private handleFocus = () => {
     this.setState({skipFocused: true});
   };
 
   private handleBlur = () => {
     this.setState({skipFocused: false});
+  };
+
+  private handleClick = () => {
+    if (this.mainContentNode.current == null) {
+      return;
+    }
+    this.mainContentNode.current.focus();
   };
 
   private handleNavigationDismiss = () => {
@@ -398,10 +406,6 @@ const contextualSaveBarTransitionClasses = {
   exit: classNames(styles['ContextualSaveBar-exit']),
   exitActive: classNames(styles['ContextualSaveBar-exitActive']),
 };
-
-function focusAppFrameMain() {
-  window.location.assign(`${window.location.pathname}#${APP_FRAME_MAIN}`);
-}
 
 function isMobileView() {
   return navigationBarCollapsed().matches;

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import {CSSTransition} from 'react-transition-group';
 import {animationFrame} from '@shopify/jest-dom-mocks';
-import {mountWithAppProvider, documentHasStyle} from 'test-utilities';
+import {mountWithAppProvider, documentHasStyle, trigger} from 'test-utilities';
 import {
   TrapFocus,
   ContextualSaveBar as PolarisContextualSavebar,
   Loading as PolarisLoading,
 } from 'components';
 import Frame from '../Frame';
-import Button from '../../Button';
 import {
   ContextualSaveBar as FrameContextualSavebar,
   Loading as FrameLoading,
@@ -142,11 +141,18 @@ describe('<Frame />', () => {
   });
 
   it('renders a skip to content link with the proper text', () => {
-    const skipToContentButtonText = mountWithAppProvider(<Frame />)
-      .find(Button)
+    const skipToContentLinkText = mountWithAppProvider(<Frame />)
+      .find('a')
       .text();
 
-    expect(skipToContentButtonText).toStrictEqual('Skip to content');
+    expect(skipToContentLinkText).toStrictEqual('Skip to content');
+  });
+
+  it('sets focus to the <main> element when the skip to content link is clicked', () => {
+    const frame = mountWithAppProvider(<Frame />);
+    const mainEl = frame.find('main');
+    trigger(frame.find('a'), 'onClick');
+    expect(mainEl.getDOMNode()).toBe(document.activeElement);
   });
 
   it('renders with a has nav data attribute when nav is passed', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1746

### WHAT is this pull request doing?

Uses an actual link for the `skipToContent` link as opposed to a button.

This was done as opposed to using a `<Link>`or a `<Button>` with a URL because there's an issue with react router and anchors. By using an `<a>` 

![skiptocontent](https://user-images.githubusercontent.com/1229901/60686519-4b1d0280-9e77-11e9-9e1e-e9087b288d1f.gif)


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        {/* Add the code you want to test here */}
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
