### PR TITLE
[DataTable] Add vertical alignment prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added a `verticalAlign` prop to `DataTable` ([#1790](https://github.com/Shopify/polaris-react/pull/1790))
+
 ### Bug fixes
 
 - Fixed a bug preventing the display of `Tooltip` when cursor enters from a disabled element ([#1783](https://github.com/Shopify/polaris-react/pull/1783)).

--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -63,7 +63,6 @@ $breakpoint: 768px;
   white-space: nowrap;
   text-align: left;
   transition: background-color 0.2s ease-in-out;
-  vertical-align: top;
 }
 
 .Cell-firstColumn {
@@ -91,6 +90,22 @@ $breakpoint: 768px;
 
 .Cell-sortable {
   padding: 0;
+}
+
+.Cell-verticalAlignTop {
+  vertical-align: top;
+}
+
+.Cell-verticalAlignBottom {
+  vertical-align: bottom;
+}
+
+.Cell-verticalAlignMiddle {
+  vertical-align: middle;
+}
+
+.Cell-verticalAlignBaseline {
+  vertical-align: baseline;
 }
 
 .Icon {

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -9,7 +9,7 @@ import EventListener from '../EventListener';
 import {Cell, CellProps, Navigation} from './components';
 import {measureColumn, getPrevAndCurrentColumns} from './utilities';
 
-import {DataTableState, SortDirection} from './types';
+import {DataTableState, SortDirection, VerticalAlign} from './types';
 import styles from './DataTable.scss';
 
 type CombinedProps = Props & WithAppProviderProps;
@@ -31,6 +31,10 @@ export interface Props {
    * @default false
    */
   truncate?: boolean;
+  /** Vertical alignment of content in the cells.
+   * @default 'top'
+   */
+  verticalAlign?: VerticalAlign;
   /** Content centered in the full width cell of the table footer row. */
   footerContent?: TableData;
   /** List of booleans, which maps to whether sorting is enabled or not for each column. Defaults to false for all columns.  */
@@ -250,6 +254,7 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
       columnContentTypes,
       defaultSortDirection,
       initialSortColumnIndex = 0,
+      verticalAlign,
     } = this.props;
 
     const {
@@ -283,13 +288,14 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
         firstColumn={headingIndex === 0}
         truncate={truncate}
         {...sortableHeadingProps}
+        verticalAlign={verticalAlign}
       />
     );
   };
 
   private renderTotals = (total: TableData, index: number) => {
     const id = `totals-cell-${index}`;
-    const {truncate = false} = this.props;
+    const {truncate = false, verticalAlign} = this.props;
 
     let content;
     let contentType;
@@ -311,13 +317,14 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
         content={content}
         contentType={contentType}
         truncate={truncate}
+        verticalAlign={verticalAlign}
       />
     );
   };
 
   private defaultRenderRow = (row: TableData[], index: number) => {
     const className = classNames(styles.TableRow);
-    const {columnContentTypes, truncate = false} = this.props;
+    const {columnContentTypes, truncate = false, verticalAlign} = this.props;
 
     return (
       <tr key={`row-${index}`} className={className}>
@@ -331,6 +338,7 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
               contentType={columnContentTypes[cellIndex]}
               firstColumn={cellIndex === 0}
               truncate={truncate}
+              verticalAlign={verticalAlign}
             />
           );
         })}

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import {CaretUpMinor, CaretDownMinor} from '@shopify/polaris-icons';
-import {classNames} from '@shopify/css-utilities';
+import {classNames, variationName} from '@shopify/css-utilities';
 
 import {headerCell} from '../../../shared';
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 import Icon from '../../../Icon';
-import {SortDirection} from '../../types';
+import {SortDirection, VerticalAlign} from '../../types';
 
 import styles from '../../DataTable.scss';
 
@@ -20,6 +20,7 @@ export interface Props {
   sortable?: boolean;
   sortDirection?: SortDirection;
   defaultSortDirection?: SortDirection;
+  verticalAlign?: VerticalAlign;
   onSort?(): void;
 }
 
@@ -35,6 +36,7 @@ function Cell({
   sorted,
   sortable,
   sortDirection,
+  verticalAlign = 'top',
   defaultSortDirection = 'ascending',
   polaris: {
     intl: {translate},
@@ -44,6 +46,7 @@ function Cell({
   const numeric = contentType === 'numeric';
   const className = classNames(
     styles.Cell,
+    styles[`Cell-${variationName('verticalAlign', verticalAlign)}`],
     firstColumn && styles['Cell-firstColumn'],
     firstColumn && truncate && styles['Cell-truncated'],
     header && styles['Cell-header'],

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -200,6 +200,30 @@ describe('<DataTable />', () => {
     });
   });
 
+  describe('verticalAlign', () => {
+    it('defaults to undefined', () => {
+      const dataTable = mountWithAppProvider(<DataTable {...defaultProps} />);
+
+      const cells = dataTable.find(Cell);
+
+      cells.forEach((cell) =>
+        expect(cell.prop('verticalAlign')).toBeUndefined(),
+      );
+    });
+
+    it('passes the value provided to its cells', () => {
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} verticalAlign="middle" />,
+      );
+
+      const cells = dataTable.find(Cell);
+
+      cells.forEach((cell) =>
+        expect(cell.prop('verticalAlign')).toBe('middle'),
+      );
+    });
+  });
+
   describe('footerContent', () => {
     it('renders string footer content when provided', () => {
       const footerContent = 'Footer text';

--- a/src/components/DataTable/types.ts
+++ b/src/components/DataTable/types.ts
@@ -1,4 +1,5 @@
 export type SortDirection = 'ascending' | 'descending' | 'none';
+export type VerticalAlign = 'top' | 'bottom' | 'middle' | 'baseline';
 
 export interface ColumnVisibilityData {
   leftEdge: number;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1789

There is no good way to adjust the vertical alignment of text in `DataTable` cells:

<img width="947" alt="Screen Shot 2019-07-05 at 09 57 45" src="https://user-images.githubusercontent.com/5864726/60812351-48fcc180-a15f-11e9-91c8-194493066032.png">

### WHAT is this pull request doing?

This PR adds a `verticalAlign` prop to `DataTable` that controls the vertical alignment of content in the cells.

Possible values are `top`, `bottom`, `middle`, and `baseline`, mirroring the [possible CSS values](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align#Values_for_table_cells).
To preserve backwards-compatibility, the default value is `top`.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
