### PR TITLE
[v4] Use hooks in components where it's easy

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -78,6 +78,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Refactored `Frame` and its subcomponents to use the `createContext` API instead of legacy context ([#803](https://github.com/Shopify/polaris-react/pull/803))
 - Removed `withContext` from `Toast` ([#1494](https://github.com/Shopify/polaris-react/pull/1494))
 - Update React imports to use the default imports intead of `import * as` ([1523](https://github.com/Shopify/polaris-react/pull/1523))
+- Updated several components to use hooks instead of `withAppProvider` ([#1797](https://github.com/Shopify/polaris-react/pull/1797))
 
 ### Deprecations
 

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import {classNames, variationName} from '../../utilities/css';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
+import {useI18n} from '../../utilities/i18n';
 import VisuallyHidden from '../VisuallyHidden';
 import styles from './Badge.scss';
 
@@ -25,8 +22,6 @@ export interface Props {
   size?: Size;
 }
 
-type CombinedProps = Props & WithAppProviderProps;
-
 export const PROGRESS_LABELS: {[key in Progress]: Progress} = {
   incomplete: 'incomplete',
   partiallyComplete: 'partiallyComplete',
@@ -43,13 +38,14 @@ export const STATUS_LABELS: {[key in Status]: Status} = {
 
 const DEFAULT_SIZE = 'medium';
 
-function Badge({
+export default function Badge({
   children,
   status,
   progress,
   size = DEFAULT_SIZE,
-  polaris: {intl},
-}: CombinedProps) {
+}: Props) {
+  const intl = useI18n();
+
   const className = classNames(
     styles.Badge,
     status && styles[variationName('status', status)],
@@ -111,5 +107,3 @@ function Badge({
     </span>
   );
 }
-
-export default withAppProvider<Props>()(Badge);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import {CaretDownMinor} from '@shopify/polaris-icons';
 import {classNames, variationName} from '../../utilities/css';
-
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
+import {useI18n} from '../../utilities/i18n';
 import UnstyledLink from '../UnstyledLink';
 import Icon from '../Icon';
 import {IconProps} from '../../types';
@@ -81,11 +77,9 @@ export interface Props {
   onKeyDown?(event: React.KeyboardEvent<HTMLButtonElement>): void;
 }
 
-type CombinedProps = Props & WithAppProviderProps;
-
 const DEFAULT_SIZE = 'medium';
 
-function Button({
+export default function Button({
   id,
   url,
   disabled,
@@ -114,8 +108,9 @@ function Button({
   size = DEFAULT_SIZE,
   textAlign,
   fullWidth,
-  polaris: {intl},
-}: CombinedProps) {
+}: Props) {
+  const intl = useI18n();
+
   const isDisabled = disabled || loading;
 
   const className = classNames(
@@ -247,5 +242,3 @@ function isIconSource(x: any): x is IconSource {
     typeof x === 'function'
   );
 }
-
-export default withAppProvider<Props>()(Button);

--- a/src/components/ChoiceList/ChoiceList.tsx
+++ b/src/components/ChoiceList/ChoiceList.tsx
@@ -2,10 +2,6 @@ import React from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 
 import {classNames} from '../../utilities/css';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
 import Checkbox from '../Checkbox';
 import RadioButton from '../RadioButton';
 import InlineError from '../InlineError';
@@ -28,7 +24,7 @@ export interface ChoiceDescriptor {
 
 export type Choice = ChoiceDescriptor;
 
-export interface BaseProps {
+export interface Props {
   /** Label for list of choices */
   title: string;
   /** Collection of choices */
@@ -47,12 +43,9 @@ export interface BaseProps {
   onChange?(selected: string[], name: string): void;
 }
 
-export interface Props extends BaseProps {}
-type CombinedProps = Props & WithAppProviderProps;
-
 const getUniqueID = createUniqueIDFactory('ChoiceList');
 
-function ChoiceList({
+export default function ChoiceList({
   title,
   titleHidden,
   allowMultiple,
@@ -61,7 +54,7 @@ function ChoiceList({
   onChange = noop,
   error,
   name = getUniqueID(),
-}: CombinedProps) {
+}: Props) {
   // Type asserting to any is required for TS3.2 but can be removed when we update to 3.3
   // see https://github.com/Microsoft/TypeScript/issues/28768
   const ControlComponent: any = allowMultiple ? Checkbox : RadioButton;
@@ -149,5 +142,3 @@ function updateSelectedChoices(
 
   return selected.filter((selectedChoice) => selectedChoice !== value);
 }
-
-export default withAppProvider<Props>()(ChoiceList);

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -5,7 +5,6 @@ import {
 } from '@shopify/javascript-utilities/events';
 import {durationSlow} from '@shopify/polaris-tokens';
 import {classNames} from '../../utilities/css';
-import {withAppProvider} from '../../utilities/with-app-provider';
 
 import styles from './Collapsible.scss';
 
@@ -22,7 +21,7 @@ const CSS_VAR_COLLAPSIBLE_HEIGHT = '--polaris-collapsible-height';
 const CSS_VAR_COLLAPSIBLE_TRANSITION_DURATION =
   '--polaris-collapsible-transition-duration';
 
-function Collapsible({id, open, children}: Props) {
+export default function Collapsible({id, open, children}: Props) {
   const [height, setHeight] = useState<number | null>(null);
   const node = useRef<HTMLDivElement>(null);
 
@@ -73,5 +72,3 @@ function Collapsible({id, open, children}: Props) {
     </div>
   );
 }
-
-export default withAppProvider<Props>()(Collapsible);

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -2,11 +2,8 @@ import React from 'react';
 import {CaretUpMinor, CaretDownMinor} from '@shopify/polaris-icons';
 
 import {classNames} from '../../../../utilities/css';
+import {useI18n} from '../../../../utilities/i18n';
 import {headerCell} from '../../../shared';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../../../utilities/with-app-provider';
 import Icon from '../../../Icon';
 import {SortDirection} from '../../types';
 
@@ -29,9 +26,7 @@ export interface Props {
   onSort?(): void;
 }
 
-type CombinedProps = Props & WithAppProviderProps;
-
-function Cell({
+export default function Cell({
   height,
   content,
   contentType,
@@ -44,11 +39,9 @@ function Cell({
   sortable,
   sortDirection,
   defaultSortDirection,
-  polaris: {
-    intl: {translate},
-  },
   onSort,
-}: CombinedProps) {
+}: Props) {
+  const {translate} = useI18n();
   const numeric = contentType === 'numeric';
 
   const className = classNames(
@@ -126,5 +119,3 @@ function Cell({
 
   return cellMarkup;
 }
-
-export default withAppProvider<Props>()(Cell);

--- a/src/components/DataTable/components/Navigation/Navigation.tsx
+++ b/src/components/DataTable/components/Navigation/Navigation.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import {ChevronLeftMinor, ChevronRightMinor} from '@shopify/polaris-icons';
 
 import {classNames} from '../../../../utilities/css';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../../../utilities/with-app-provider';
+import {useI18n} from '../../../../utilities/i18n';
 import Button from '../../../Button';
 
 import {ColumnVisibilityData} from '../../types';
@@ -20,18 +17,15 @@ export interface Props {
   navigateTableRight?(): void;
 }
 
-type CombinedProps = Props & WithAppProviderProps;
-
-function Navigation({
+export default function Navigation({
   columnVisibilityData,
   isScrolledFarthestLeft,
   isScrolledFarthestRight,
   navigateTableLeft,
   navigateTableRight,
-  polaris: {
-    intl: {translate},
-  },
-}: CombinedProps) {
+}: Props) {
+  const {translate} = useI18n();
+
   const pipMarkup = columnVisibilityData.map((column, index) => {
     const className = classNames(
       styles.Pip,
@@ -69,5 +63,3 @@ function Navigation({
     </div>
   );
 }
-
-export default withAppProvider<Props>()(Navigation);

--- a/src/components/DatePicker/components/Month/Month.tsx
+++ b/src/components/DatePicker/components/Month/Month.tsx
@@ -13,10 +13,7 @@ import {
   getNewRange,
 } from '@shopify/javascript-utilities/dates';
 import {classNames} from '../../../../utilities/css';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../../../utilities/with-app-provider';
+import {useI18n} from '../../../../utilities/i18n';
 import styles from '../../DatePicker.scss';
 import Day from '../Day';
 import Weekday from '../Weekday';
@@ -39,8 +36,6 @@ export interface Props {
   weekdayName?(weekday: Weekdays): string;
 }
 
-type CombinedProps = Props & WithAppProviderProps;
-
 const WEEKDAYS = [
   Weekdays.Sunday,
   Weekdays.Monday,
@@ -51,7 +46,7 @@ const WEEKDAYS = [
   Weekdays.Saturday,
 ];
 
-function Month({
+export default function Month({
   focusedDate,
   selected,
   hoverDate,
@@ -64,8 +59,9 @@ function Month({
   month,
   year,
   weekStartsOn,
-  polaris: {intl},
-}: CombinedProps) {
+}: Props) {
+  const intl = useI18n();
+
   const isInHoveringRange = allowRange ? hoveringDateIsInRange : () => false;
   const now = new Date();
   const current = now.getMonth() === month && now.getFullYear() === year;
@@ -139,8 +135,6 @@ function Month({
     </div>
   );
 }
-
-export default withAppProvider<Props>()(Month);
 
 function noop() {}
 

--- a/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/DiscardConfirmationModal.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/DiscardConfirmationModal.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../../../../../utilities/with-app-provider';
+import {useI18n} from '../../../../../../utilities/i18n';
 import Modal from '../../../../../Modal';
 
 export interface Props {
@@ -12,14 +9,13 @@ export interface Props {
   onCancel(): void;
 }
 
-type CombinedProps = Props & WithAppProviderProps;
-
-function DiscardConfirmationModal({
+export default function DiscardConfirmationModal({
   open,
   onDiscard,
   onCancel,
-  polaris: {intl},
-}: CombinedProps) {
+}: Props) {
+  const intl = useI18n();
+
   return (
     <Modal
       title={intl.translate('Polaris.DiscardConfirmationModal.title')}
@@ -46,5 +42,3 @@ function DiscardConfirmationModal({
     </Modal>
   );
 }
-
-export default withAppProvider<Props>()(DiscardConfirmationModal);

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import {classNames, variationName} from '../../utilities/css';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
+import {useI18n} from '../../utilities/i18n';
 import {IconProps} from '../../types';
 
 import styles from './Icon.scss';
@@ -22,15 +19,14 @@ const COLORS_WITH_BACKDROPS = [
 // styleguide to generate the props explorer
 interface Props extends IconProps {}
 
-type CombinedProps = Props & WithAppProviderProps;
-
-function Icon({
+export default function Icon({
   source,
   color,
   backdrop,
   accessibilityLabel,
-  polaris: {intl},
-}: CombinedProps) {
+}: Props) {
+  const intl = useI18n();
+
   if (color && backdrop && COLORS_WITH_BACKDROPS.indexOf(color) < 0) {
     // eslint-disable-next-line no-console
     console.warn(
@@ -77,5 +73,3 @@ function Icon({
     </span>
   );
 }
-
-export default withAppProvider<Props>()(Icon);

--- a/src/components/Modal/components/CloseButton/CloseButton.tsx
+++ b/src/components/Modal/components/CloseButton/CloseButton.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import {MobileCancelMajorMonotone} from '@shopify/polaris-icons';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../../../utilities/with-app-provider';
 import {classNames} from '../../../../utilities/css';
+import {useI18n} from '../../../../utilities/i18n';
 
 import Icon from '../../../Icon';
 
@@ -15,9 +12,9 @@ export interface Props {
   onClick(): void;
 }
 
-type CombinedProps = Props & WithAppProviderProps;
+export default function CloseButton({title = true, onClick}: Props) {
+  const intl = useI18n();
 
-function CloseButton({title = true, onClick, polaris: {intl}}: CombinedProps) {
   const className = classNames(
     styles.CloseButton,
     !title && styles.withoutTitle,
@@ -33,5 +30,3 @@ function CloseButton({title = true, onClick, polaris: {intl}}: CombinedProps) {
     </button>
   );
 }
-
-export default withAppProvider<Props>()(CloseButton);

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import {ArrowLeftMinor, ArrowRightMinor} from '@shopify/polaris-icons';
 import {classNames} from '../../utilities/css';
+import {useI18n} from '../../utilities/i18n';
 import {isInputFocused} from '../../utilities/is-input-focused';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
 import Icon from '../Icon';
 import UnstyledLink from '../UnstyledLink';
 import Tooltip from '../Tooltip';
@@ -45,9 +42,7 @@ export interface Props extends PaginationDescriptor {
   plain?: boolean;
 }
 
-type CombinedProps = Props & WithAppProviderProps;
-
-function Pagination({
+export default function Pagination({
   hasNext,
   hasPrevious,
   nextURL,
@@ -60,8 +55,9 @@ function Pagination({
   previousKeys,
   plain,
   accessibilityLabel,
-  polaris: {intl},
-}: CombinedProps) {
+}: Props) {
+  const intl = useI18n();
+
   const node: React.RefObject<HTMLElement> = React.createRef();
   let label: string;
 
@@ -197,5 +193,3 @@ function handleCallback(fn: () => void) {
     fn();
   };
 }
-
-export default withAppProvider<Props>()(Pagination);

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import {classNames, variationName} from '../../utilities/css';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
+import {useI18n} from '../../utilities/i18n';
 import styles from './ProgressBar.scss';
 
 export type Size = 'small' | 'medium' | 'large';
@@ -21,13 +18,9 @@ export interface Props {
   size?: Size;
 }
 
-type CombinedProps = Props & WithAppProviderProps;
+export default function ProgressBar({progress = 0, size = 'medium'}: Props) {
+  const intl = useI18n();
 
-function ProgressBar({
-  progress = 0,
-  size = 'medium',
-  polaris: {intl},
-}: CombinedProps) {
   const className = classNames(
     styles.ProgressBar,
     size && styles[variationName('size', size)],
@@ -70,5 +63,3 @@ function parseProgress(progress: number, warningMessage: string) {
   }
   return progressWidth;
 }
-
-export default withAppProvider<Props>()(ProgressBar);

--- a/src/components/ProgressBar/tests/ProgressBar.test.tsx
+++ b/src/components/ProgressBar/tests/ProgressBar.test.tsx
@@ -4,28 +4,22 @@ import ProgressBar from '../ProgressBar';
 
 describe('<ProgressBar />', () => {
   it('sets the progress element to 80 when the progress is 80', () => {
-    const progress = mountWithAppProvider(
-      <ProgressBar progress={80}>test</ProgressBar>,
-    );
+    const progress = mountWithAppProvider(<ProgressBar progress={80} />);
     expect(progress.find('progress').prop('value')).toBe(80);
   });
 
   it('sets the progress element to 0 when the progress is negative', () => {
-    const progress = mountWithAppProvider(
-      <ProgressBar progress={-40}>test</ProgressBar>,
-    );
+    const progress = mountWithAppProvider(<ProgressBar progress={-40} />);
     expect(progress.find('progress').prop('value')).toBe(0);
   });
 
   it('sets the progress element to 100 when the progress is greater than 100', () => {
-    const progress = mountWithAppProvider(
-      <ProgressBar progress={120}>test</ProgressBar>,
-    );
+    const progress = mountWithAppProvider(<ProgressBar progress={120} />);
     expect(progress.find('progress').prop('value')).toBe(100);
   });
 
   it('sets the progress element to 0 when progress is not provided', () => {
-    const progress = mountWithAppProvider(<ProgressBar>test</ProgressBar>);
+    const progress = mountWithAppProvider(<ProgressBar />);
     expect(progress.find('progress').prop('value')).toBe(0);
   });
 
@@ -50,7 +44,7 @@ describe('<ProgressBar />', () => {
     it('warns when a negative number is passed to progress in development', () => {
       process.env.NODE_ENV = 'development';
 
-      mountWithAppProvider(<ProgressBar progress={-1}>test</ProgressBar>);
+      mountWithAppProvider(<ProgressBar progress={-1} />);
 
       expect(warnSpy).toHaveBeenCalledWith(
         'Values passed to the progress prop shouldn’t be negative. Resetting -1 to 0.',
@@ -60,7 +54,7 @@ describe('<ProgressBar />', () => {
     it('warns when a number larger than 100 is passed to progress in development', () => {
       process.env.NODE_ENV = 'development';
 
-      mountWithAppProvider(<ProgressBar progress={101}>test</ProgressBar>);
+      mountWithAppProvider(<ProgressBar progress={101} />);
 
       expect(warnSpy).toHaveBeenCalledWith(
         'Values passed to the progress prop shouldn’t exceed 100. Setting 101 to 100.',

--- a/src/components/ResourceList/components/CheckableButton/CheckableButton.tsx
+++ b/src/components/ResourceList/components/CheckableButton/CheckableButton.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import {classNames} from '../../../../utilities/css';
 import Checkbox from '../../../Checkbox';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../../../utilities/with-app-provider';
 
 import styles from './CheckableButton.scss';
 
@@ -19,9 +15,7 @@ export interface Props {
   onToggleAll?(): void;
 }
 
-type CombinedProps = Props & WithAppProviderProps;
-
-function CheckableButton({
+export default function CheckableButton({
   accessibilityLabel,
   label = '',
   onToggleAll,
@@ -30,7 +24,7 @@ function CheckableButton({
   plain,
   measuring,
   disabled,
-}: CombinedProps) {
+}: Props) {
   const className = plain
     ? classNames(styles.CheckableButton, styles['CheckableButton-plain'])
     : classNames(
@@ -55,5 +49,3 @@ function CheckableButton({
     </div>
   );
 }
-
-export default withAppProvider<Props>()(CheckableButton);

--- a/src/components/Sheet/Sheet.tsx
+++ b/src/components/Sheet/Sheet.tsx
@@ -14,7 +14,6 @@ import {navigationBarCollapsed} from '../../utilities/breakpoints';
 import {Key} from '../../types';
 import {layer, overlay, Duration} from '../shared';
 import {FrameContext} from '../Frame';
-import {withAppProvider} from '../../utilities/with-app-provider';
 import {useI18n} from '../../utilities/i18n';
 
 import Backdrop from '../Backdrop';
@@ -52,7 +51,7 @@ export interface State {
   mobile: boolean;
 }
 
-function Sheet({children, open, onClose}: Props) {
+export default function Sheet({children, open, onClose}: Props) {
   const container = useRef<HTMLDivElement>(null);
   const [mobile, setMobile] = useState(false);
   const frame = useContext(FrameContext);
@@ -130,5 +129,3 @@ function Sheet({children, open, onClose}: Props) {
 function isMobile(): boolean {
   return navigationBarCollapsed().matches;
 }
-
-export default withAppProvider<Props>()(Sheet);

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import {classNames, variationName} from '../../utilities/css';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
+import {useI18n} from '../../utilities/i18n';
 import Image from '../Image';
 import styles from './Spinner.scss';
 import {spinnerLarge, spinnerSmall} from './images';
@@ -29,14 +26,13 @@ export interface Props {
   accessibilityLabel?: string;
 }
 
-type CombinedProps = Props & WithAppProviderProps;
-
-function Spinner({
+export default function Spinner({
   size = 'large',
   color = 'teal',
   accessibilityLabel,
-  polaris: {intl},
-}: CombinedProps) {
+}: Props) {
+  const intl = useI18n();
+
   if (size === 'large' && COLORS_FOR_LARGE_SPINNER.indexOf(color) < 0) {
     if (process.env.NODE_ENV === 'development') {
       // eslint-disable-next-line no-console
@@ -72,5 +68,3 @@ function Spinner({
     />
   );
 }
-
-export default withAppProvider<Props>()(Spinner);

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import {CancelSmallMinor} from '@shopify/polaris-icons';
 import {classNames} from '../../utilities/css';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
+import {useI18n} from '../../utilities/i18n';
 import Icon from '../Icon';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 import styles from './Tag.scss';
@@ -18,14 +15,8 @@ export interface Props {
   onRemove?(): void;
 }
 
-type CombinedProps = Props & WithAppProviderProps;
-
-function Tag({
-  children,
-  disabled = false,
-  onRemove,
-  polaris: {intl},
-}: CombinedProps) {
+export default function Tag({children, disabled = false, onRemove}: Props) {
+  const intl = useI18n();
   const className = classNames(disabled && styles.disabled, styles.Tag);
   const ariaLabel = intl.translate('Polaris.Tag.ariaLabel', {children});
 
@@ -47,5 +38,3 @@ function Tag({
     </span>
   );
 }
-
-export default withAppProvider<Props>()(Tag);


### PR DESCRIPTION
### WHY are these changes introduced?

Hooks! Hooks! Hooks!

Death to withAppProvider! Death to withAppProvider! Death to withAppProvider!

### WHAT is this pull request doing?

Many of our components are already functions, but got wrapped with withAppProvider to provide translations. This PR changes them to use the `useI18n` hook so we avoid the need for the withAppProvider HoC.

Class components haven't been touched, so we're still using withAppProvider in plenty of places, but this targets the components where this change is easy to make.

### How to 🎩

Check everything still gets translations