### PR TITLE
Don't pass polaris from Link into UnstyledLink

### DIFF
--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -34,13 +34,13 @@ function Link({
   external,
   id,
   monochrome,
-  polaris,
+  polaris: {intl},
 }: CombinedProps) {
   const className = classNames(styles.Link, monochrome && styles.monochrome);
   let childrenMarkup = children;
 
   if (external && typeof children === 'string') {
-    const iconLabel = polaris.intl.translate(
+    const iconLabel = intl.translate(
       'Polaris.Common.newWindowAccessibilityHint',
     );
 
@@ -63,7 +63,6 @@ function Link({
       url={url}
       external={external}
       id={id}
-      polaris={polaris}
     >
       {childrenMarkup}
     </UnstyledLink>


### PR DESCRIPTION

### WHY are these changes introduced?
#1247 made Link be wrapped in withAppProvider as it needed translations. It also passed down that prop to UnstyledLink, however UnstyledLink is already wrapped in withAppProvider which already handles passing in the polaris context.

Having Link pass that through isn't needed

### WHAT is this pull request doing?

Stopping passing polaris into UnstyledLink

### How to 🎩

View the external Link example and see it still gets a translation in the aria label.