### PR TITLE
[v4] Fixed popover overlay positioning

### DIFF
--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -115,19 +115,18 @@ export default class PopoverOverlay extends React.PureComponent<Props, State> {
     );
 
     return (
-      <div className={className}>
-        <PositionedOverlay
-          testID="positionedOverlay"
-          fullWidth={fullWidth}
-          active={active}
-          activator={activator}
-          preferredPosition={preferredPosition}
-          preferredAlignment={preferredAlignment}
-          render={this.renderPopover.bind(this)}
-          fixed={fixed}
-          onScrollOut={this.handleScrollOut}
-        />
-      </div>
+      <PositionedOverlay
+        testID="positionedOverlay"
+        fullWidth={fullWidth}
+        active={active}
+        activator={activator}
+        preferredPosition={preferredPosition}
+        preferredAlignment={preferredAlignment}
+        render={this.renderPopover.bind(this)}
+        fixed={fixed}
+        onScrollOut={this.handleScrollOut}
+        classNames={className}
+      />
     );
   }
 

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -35,6 +35,7 @@ export interface Props {
   preferredAlignment?: PreferredAlignment;
   fullWidth?: boolean;
   fixed?: boolean;
+  classNames?: string;
   render(overlayDetails: OverlayDetails): React.ReactNode;
   onScrollOut?(): void;
 }
@@ -117,7 +118,7 @@ export default class PositionedOverlay extends React.PureComponent<
 
   render() {
     const {left, top, zIndex, width} = this.state;
-    const {render, fixed} = this.props;
+    const {render, fixed, classNames: propClassNames} = this.props;
 
     const style = {
       top: top == null || isNaN(top) ? undefined : top,
@@ -129,6 +130,7 @@ export default class PositionedOverlay extends React.PureComponent<
     const className = classNames(
       styles.PositionedOverlay,
       fixed && styles.fixed,
+      propClassNames,
     );
 
     return (


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1799

### WHAT is this pull request doing?

* removing the problem div that's causing the positioning issue
* passing our animation class names to the overlay, similarly to how react-transition-group handles it
* consume the classes in overlay

### Media 📹

#### gif after

https://cl.ly/b64fde6f30e9

#### screen shot before

![Screen Shot 2019-07-09 at 5 05 58 PM](https://user-images.githubusercontent.com/24610840/60923403-d7129e00-a26c-11e9-8f8f-b72d16ef958d.png)

### How to 🎩

Check out some popover examples in the deployment to see if the animation is still 👌

### Notes

Skipping a changelog entry since this bug hasn't shipped
