### PR TITLE
[Content] Remove Latin abbreviations from component pages

### DIFF
--- a/src/components/AccountConnection/README.md
+++ b/src/components/AccountConnection/README.md
@@ -117,7 +117,7 @@ Connect to app
 
 ### Default account connection
 
-Use to let merchants connect or disconnect their store to their third-party accounts (e.g. Facebook).
+Use to let merchants connect or disconnect their store to their third-party accounts, like Facebook.
 
 ```jsx
 class AccountConnectionExample extends React.Component {

--- a/src/components/ActionList/README.md
+++ b/src/components/ActionList/README.md
@@ -133,7 +133,7 @@ class ActionListExample extends React.Component {
 
 ### Action list with icons or image
 
-Use when the items benefit from an associated action or image (e.g. a list of products).
+Use when the items benefit from an associated action or image, such as a list of products.
 
 ```jsx
 class ActionListExample extends React.Component {

--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -38,7 +38,7 @@ Avatars should be one of 3 sizes:
 
 - Small (32 x 32 px): use when the medium size is too big for the layout, or when the avatar has less importance
 - Medium (40 x 40 px): use as the default size
-- Large (60 x 60 px): use when an avatar is a focal point (e.g. on a single customer card)
+- Large (60 x 60 px): use when an avatar is a focal point, such as on a single customer card
 
 ---
 

--- a/src/components/Badge/README.md
+++ b/src/components/Badge/README.md
@@ -28,11 +28,11 @@ Badges are used to inform merchants of the status of an object or of an action t
 
 ## Best practices
 
-Great badges benefit merchants by:
+Badges benefit merchants by:
 
 - Using established color patterns so that merchants can quickly identify their status or importance level
 - Being clearly labeled with short, scannable text
-- Being positioned to clearly identify the object they’re informing or labelling (e.g. an order)
+- Being positioned to clearly identify the object they’re informing or labelling
 
 ---
 

--- a/src/components/DatePicker/README.md
+++ b/src/components/DatePicker/README.md
@@ -32,7 +32,7 @@ consistently applied wherever dates need to be selected across Shopify.
 
 Date pickers should:
 
-- Use smart defaults and highlight common selections (e.g. Today)
+- Use smart defaults and highlight common selections
 - Close after a single date is selected unless a range with a start and end date is required
 - Set the start date on first click or tap and the end date on second click or tap if a range
   is required

--- a/src/components/Layout/README.md
+++ b/src/components/Layout/README.md
@@ -154,7 +154,7 @@ Section titles should be:
 
 Links should be:
 
-- Used for secondary or persistent actions: links are for lower priority actions than buttons, or persistent actions that merchants may take at any time (e.g. a persistent Edit link).
+- Used for secondary or persistent actions: links are for lower priority actions than buttons, or persistent actions (such as an Edit link) that merchants can take at any time.
 - Clearly labeled: merchants should not need to guess where they’ll end up if they click on an action link. Never use “click here” as a link because it doesn’t set expectations about what’s next.
 - Similar to buttons: follow the same content guidelines as when you’re writing buttons.
 
@@ -196,7 +196,7 @@ Use to have a single section on its own in a full-width container. Use for simpl
 
 ### Two columns with primary and secondary widths
 
-Use to follow a normal section with a secondary section to create a 2/3 + 1/3 layout on detail pages (e.g. individual product or order pages). Can also be used on any page that needs to structure a lot of content. This layout will stack the columns on small screens.
+Use to follow a normal section with a secondary section to create a 2/3 + 1/3 layout on detail pages (such as individual product or order pages). Can also be used on any page that needs to structure a lot of content. This layout stacks the columns on small screens.
 
 ```jsx
 <Layout>

--- a/src/components/List/README.md
+++ b/src/components/List/README.md
@@ -28,7 +28,7 @@ Lists should:
 
 - Break up chunks of related content to make the information easier for
   merchants to scan
-- Be phrased consistently (e.g. try to start each item with a noun or a
+- Be phrased consistently (try to start each item with a noun or a
   verb and be consistent with each item)
 - Not be used for lists where the entire item represents an action
 

--- a/src/components/PageActions/README.md
+++ b/src/components/PageActions/README.md
@@ -86,7 +86,7 @@ Buttons should be:
 
 ### Default page actions
 
-Used on a resource page (e.g. individual order or product page) to let merchants take key actions at the bottom of the page. Usually, the primary action is Save and the secondary action is Delete.
+Used on a resource page (such as an individual order or product page) to let merchants take key actions at the bottom of the page. Usually, the primary action is Save and the secondary action is Delete.
 
 ```jsx
 <PageActions

--- a/src/components/SettingToggle/README.md
+++ b/src/components/SettingToggle/README.md
@@ -29,7 +29,7 @@ Settings toggles should:
 
 - Include different body content for the enabled and disabled states
 - Clearly indicate whether the setting is enabled or disabled and explain the
-  implications of the state of the setting to merchants (e.g. “Automatic messages
+  implications of the state of the setting to merchants (“Automatic messages
   are disabled. Your customers won’t receive automatic shipping updates.”)
 - Clearly state when a setting or feature is not available and why. Provide
   actionable steps for merchants to unlock the functionality.
@@ -44,7 +44,7 @@ Toggle descriptions should:
 
 - Clearly indicate whether the setting is enabled or disabled
 - Explain the implications of the state of the setting to merchants
-  (e.g. “Automatic messages are disabled. Your customers won’t receive automatic
+  (“Automatic messages are disabled. Your customers won’t receive automatic
   shipping updates.”)
 
 ### Primary button

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -486,7 +486,7 @@ class PlaceholderExample extends React.Component {
 
 ### Text field with help text
 
-Use to show short instructional content below the text field. Use especially when incorrect formatting will result in an error and merchants don’t know what format is required (e.g. to explain the correct format for dates, or requirements for a password). If more explanation is needed, link to the Shopify Help Center.
+Use to show short instructional content below the text field. Help text works to help merchants understand how to fix errors that result from incorrect formatting (such as dates or passwords with specific character requirements). If more explanation is needed, link to the Shopify Help Center.
 
 ```jsx
 class HelpTextExample extends React.Component {
@@ -528,8 +528,8 @@ class HelpTextExample extends React.Component {
 
 Use as a special form of help text that works best inline.
 
-- Use a prefix for things like currency symbols (e.g. “\$”, “¥”, “£”).
-- Use suffix for things like units of measure (e.g. “in”, “cm”).
+- Use a prefix for things like currency symbols (“\$”, “¥”, “£”).
+- Use suffix for things like units of measure (“in”, “cm”).
 
 ```jsx
 class PrefixExample extends React.Component {
@@ -605,7 +605,7 @@ class ConnectedFieldsExample extends React.Component {
 
 <!-- content-for: android -->
 
-If inputting weight as a number and a separate unit of measurement, use a text field with a selector (e.g. “kg”, “lb”) as a connected field.
+If inputting weight as a number and a separate unit of measurement, use a text field with a selector (like “kg” or “lb”) as a connected field.
 
 ![Text field with connected selector](/public_images/components/TextField/android/connected-fields@2x.png)
 
@@ -613,7 +613,7 @@ If inputting weight as a number and a separate unit of measurement, use a text f
 
 <!-- content-for: ios -->
 
-If inputting weight as a number and a separate unit of measurement, use a text field with a selector (e.g. “kg”, “lb”) as a connected field.
+If inputting weight as a number and a separate unit of measurement, use a text field with a selector (like “kg” or “lb”) as a connected field.
 
 ![Text field with connected selector](/public_images/components/TextField/ios/connected-fields@2x.png)
 


### PR DESCRIPTION
([Project themes](https://vault.shopify.io/projects/8503): **Style** )

### WHY are these changes introduced?

Latin abbreviations:
- are more likely to be unfamiliar than English phrases 
- can make content more difficult to localize or internationalize

### WHAT is this pull request doing?

Removing the following Latin abbreviations, often replacing them with English phrases: 
- e.g. 
- etc.
- ie.