### PR TITLE
Hooky withAppProvider

### DIFF
--- a/src/components/Avatar/tests/Avatar-ssr.test.tsx
+++ b/src/components/Avatar/tests/Avatar-ssr.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import {mountWithAppProvider} from 'test-utilities/legacy';
+import {Image} from 'components';
+import Avatar from '../Avatar';
+
+jest.mock('../../../utilities/target', () => ({
+  get isServer() {
+    return true;
+  },
+}));
+
+describe('<Avatar /> Server-side only', () => {
+  it('does not render an Image', () => {
+    const src = 'image/path/';
+    const avatar = mountWithAppProvider(<Avatar source={src} />);
+    expect(avatar.find(Image)).toHaveLength(0);
+  });
+});

--- a/src/components/Avatar/tests/Avatar.test.tsx
+++ b/src/components/Avatar/tests/Avatar.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {Image} from 'components';
-
 import Avatar from '../Avatar';
 
 describe('<Avatar />', () => {
@@ -26,28 +25,6 @@ describe('<Avatar />', () => {
       expect(() => {
         avatar.setProps({source: 'image/new/path'});
       }).not.toThrow();
-    });
-
-    it('does not render an Image on the server', () => {
-      jest.resetModules();
-      jest.mock('../../../utilities/target', () => ({
-        ...require.requireActual('../../../utilities/target'),
-        isServer: () => {
-          return true;
-        },
-      }));
-
-      const Avatar = require('../Avatar').default;
-      const AppProvider = require('../../AppProvider').default;
-      const Image = require('components').Image;
-
-      const src = 'image/path/';
-      const avatar = mountWithAppProvider(
-        <AppProvider i18n={{}}>
-          <Avatar source={src} />
-        </AppProvider>,
-      );
-      expect(avatar.find(Image)).toHaveLength(0);
     });
   });
 

--- a/src/components/ColorPicker/tests/ColorPicker-ssr.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker-ssr.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {mountWithAppProvider} from 'test-utilities/legacy';
+import {Slidable} from '../components';
+import ColorPicker from '../ColorPicker';
+
+const red = {
+  hue: 0,
+  saturation: 1,
+  brightness: 1,
+};
+
+jest.mock('../../../utilities/target', () => ({
+  get isServer() {
+    return true;
+  },
+}));
+
+describe('<ColorPicker /> Server-side only', () => {
+  it('does not attach the touchmove handler to the window', () => {
+    const colorPicker = mountWithAppProvider(
+      <ColorPicker color={red} onChange={noop} />,
+    );
+
+    colorPicker
+      .find(Slidable)
+      .first()
+      .simulate('mousedown');
+
+    const touch = {clientX: 0, clientY: 0};
+    const event = new TouchEvent('touchmove', {
+      touches: [touch],
+      cancelable: true,
+    } as TouchEventInit);
+    Object.assign(event, {preventDefault: jest.fn()});
+
+    window.dispatchEvent(event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+});
+
+function noop() {}

--- a/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -156,40 +156,6 @@ describe('<ColorPicker />', () => {
 
       expect(event.preventDefault).not.toHaveBeenCalled();
     });
-
-    describe('isServer', () => {
-      jest.resetModules();
-      jest.mock('../../../utilities/target', () => ({
-        ...require.requireActual('../../../utilities/target'),
-        isServer: () => {
-          return true;
-        },
-      }));
-      const ColorPicker = require('../ColorPicker').default;
-      const Slidable = require('../components/Slidable').default;
-
-      it('does not attach the touchmove handler to the window when server side rendered', () => {
-        const colorPicker = mountWithAppProvider(
-          <ColorPicker color={red} onChange={noop} />,
-        );
-
-        colorPicker
-          .find(Slidable)
-          .first()
-          .simulate('mousedown');
-
-        const touch = {clientX: 0, clientY: 0};
-        const event = new TouchEvent('touchmove', {
-          touches: [touch],
-          cancelable: true,
-        } as TouchEventInit);
-        Object.assign(event, {preventDefault: jest.fn()});
-
-        window.dispatchEvent(event);
-
-        expect(event.preventDefault).toHaveBeenCalledTimes(1);
-      });
-    });
   });
 });
 

--- a/src/utilities/with-app-provider.tsx
+++ b/src/utilities/with-app-provider.tsx
@@ -1,16 +1,17 @@
-import React, {useContext} from 'react';
+import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 import {ClientApplication} from '@shopify/app-bridge';
 import {PolarisContext} from '../components/types';
-import {I18n, I18nContext} from './i18n';
-import {Link, LinkContext} from './link';
+import {I18n, useI18n} from './i18n';
+import {Link, useLink} from './link';
+import {ScrollLockManager, useScrollLockManager} from './scroll-lock-manager';
+import {ThemeProviderContextType, useTheme} from './theme';
 import {
-  ScrollLockManager,
-  ScrollLockManagerContext,
-} from './scroll-lock-manager';
-import {ThemeProviderContextType, ThemeProviderContext} from './theme';
-import {StickyManager, StickyManagerContext} from './sticky-manager';
-import {AppBridgeContext} from './app-bridge';
+  StickyManager,
+  StickyManagerContext,
+  useStickyManager,
+} from './sticky-manager';
+import {useAppBridge} from './app-bridge';
 
 export type ReactComponent<P, C> =
   | React.ComponentClass<P> & C
@@ -53,12 +54,12 @@ export function withAppProvider<OwnProps>({withinScrollable}: Options = {}) {
     WrappedComponent: ReactComponent<OwnProps & WithAppProviderProps, C>,
   ): React.ComponentClass<OwnProps> & C {
     const WithProvider: React.FunctionComponent = (props: OwnProps) => {
-      const link = useContext(LinkContext);
-      const theme = useContext(ThemeProviderContext);
-      const intl = useContext(I18nContext);
-      const scrollLockManager = useContext(ScrollLockManagerContext);
-      const stickyManager = useContext(StickyManagerContext);
-      const appBridge = useContext(AppBridgeContext);
+      const link = useLink();
+      const theme = useTheme();
+      const intl = useI18n();
+      const scrollLockManager = useScrollLockManager();
+      const stickyManager = useStickyManager();
+      const appBridge = useAppBridge();
 
       const polarisContext: PolarisContext = {
         link,

--- a/src/utilities/with-app-provider.tsx
+++ b/src/utilities/with-app-provider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useContext} from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 import {ClientApplication} from '@shopify/app-bridge';
 import {PolarisContext} from '../components/types';
@@ -52,66 +52,32 @@ export function withAppProvider<OwnProps>({withinScrollable}: Options = {}) {
   return function addProvider<C>(
     WrappedComponent: ReactComponent<OwnProps & WithAppProviderProps, C>,
   ): React.ComponentClass<OwnProps> & C {
-    // eslint-disable-next-line react/prefer-stateless-function
-    class WithProvider extends React.Component<OwnProps, never> {
-      static contextTypes = WrappedComponent.contextTypes;
+    const WithProvider: React.FunctionComponent = (props: OwnProps) => {
+      const link = useContext(LinkContext);
+      const theme = useContext(ThemeProviderContext);
+      const intl = useContext(I18nContext);
+      const scrollLockManager = useContext(ScrollLockManagerContext);
+      const stickyManager = useContext(StickyManagerContext);
+      const appBridge = useContext(AppBridgeContext);
 
-      render() {
-        return (
-          <LinkContext.Consumer>
-            {(link) => (
-              <ThemeProviderContext.Consumer>
-                {(theme) => (
-                  <I18nContext.Consumer>
-                    {(intl) => (
-                      <ScrollLockManagerContext.Consumer>
-                        {(scrollLockManager) => (
-                          <StickyManagerContext.Consumer>
-                            {(stickyManager) => (
-                              <AppBridgeContext.Consumer>
-                                {(appBridge) => {
-                                  const polarisContext: PolarisContext = {
-                                    link,
-                                    intl,
-                                    scrollLockManager,
-                                    stickyManager,
-                                    theme,
-                                    appBridge,
-                                  };
+      const polarisContext: PolarisContext = {
+        link,
+        intl,
+        scrollLockManager,
+        stickyManager,
+        theme,
+        appBridge,
+      };
 
-                                  if (
-                                    !intl ||
-                                    !scrollLockManager ||
-                                    !stickyManager ||
-                                    !link ||
-                                    !theme
-                                  ) {
-                                    throw new Error(
-                                      `The <AppProvider> component is required as of v2.0 of Polaris React. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.`,
-                                    );
-                                  }
-
-                                  return (
-                                    <WrappedComponent
-                                      {...this.props as any}
-                                      polaris={polarisContext}
-                                    />
-                                  );
-                                }}
-                              </AppBridgeContext.Consumer>
-                            )}
-                          </StickyManagerContext.Consumer>
-                        )}
-                      </ScrollLockManagerContext.Consumer>
-                    )}
-                  </I18nContext.Consumer>
-                )}
-              </ThemeProviderContext.Consumer>
-            )}
-          </LinkContext.Consumer>
+      if (!intl || !scrollLockManager || !stickyManager || !link || !theme) {
+        throw new Error(
+          `The <AppProvider> component is required as of v2.0 of Polaris React. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.`,
         );
       }
-    }
+
+      return <WrappedComponent {...props as any} polaris={polarisContext} />;
+    };
+    WithProvider.contextTypes = WrappedComponent.contextTypes;
 
     let WithScrollable: React.ComponentClass<any> | undefined;
     if (withinScrollable) {


### PR DESCRIPTION
### WHY are these changes introduced?

Lots of indentation looks silly and it's a pain in React devtools, lets use hooks instead of render props in withAppProvider so we have a single wrapping component instead of 5.

### WHAT is this pull request doing?

Uses hooks in withAppProvider's wrapping component to save on indentation and nesting of components in the React devtools.

This didn't play nice with how we overrode isServer in
server-side-rendering tests due to funky mocking. Splitting the mocks
out into separate files fixes this. Strictly speaking this only caused
problems in Avatar as it is a functional component, but I figured lets
preemptively fix ColorPicker's test too

### How to 🎩

Confirm various AppProvider functionality still works:

- setting translations
- setting links
- settings themes
- scrolling / sticky managing