### PR TITLE
Use `import * as React` in Filters

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed a bug preventing the display of `Tooltip` when cursor enters from a disabled element ([#1783](https://github.com/Shopify/polaris-react/pull/1783)).
+- Fixed React imports in the `Filters` component to use `import * as React` for projects that don't use `esModuleInterop` ([#1820](https://github.com/Shopify/polaris-react/pull/1820))
 
 ### Documentation
 

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import debounce from 'lodash/debounce';
 import compose from '@shopify/react-compose';
 import {classNames} from '@shopify/css-utilities';

--- a/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import debounce from 'lodash/debounce';
 import {classNames} from '@shopify/css-utilities';
 

--- a/src/components/Filters/components/ConnectedFilterControl/components/Item/Item.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {classNames} from '@shopify/css-utilities';
 import styles from '../../ConnectedFilterControl.scss';
 

--- a/src/components/Filters/components/ConnectedFilterControl/components/Item/tests/Item.test.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/components/Item/tests/Item.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 import Item from '../Item';
 

--- a/src/components/Filters/components/ConnectedFilterControl/tests/ConnectedFilterControl.test.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/tests/ConnectedFilterControl.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import {Popover, Button} from 'components';
 import {mountWithAppProvider} from 'test-utilities';

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {Button, Popover, Sheet, Tag} from 'components';


### PR DESCRIPTION


### WHY are these changes introduced?

We still need this syntax for the moment in v3, before we change to `import React` in v4.

This is because this syntax requires the consuming project to set `allowSyntheticDefaultImports` or `esModuleInterop` (which implies `allowSyntheticDefaultImports`) in their typescript options. It's an acceptable breaking change in v4 as the [typescript team recommends setting esModuleInterop](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-from-commonjs-modules-with---esmoduleinterop) for all projects, and it's only a flag for backwards compatibility reasons.

Fixes #1818

### WHAT is this pull request doing?

Replaces `import React` with `import * as React`
