### PR TITLE
[Skip to content] Fix tabIndex issue

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixed a bug preventing the display of `Tooltip` when cursor enters from a disabled element ([#1783](https://github.com/Shopify/polaris-react/pull/1783)).
 - Fixed React imports in the `Filters` component to use `import * as React` for projects that don't use `esModuleInterop` ([#1820](https://github.com/Shopify/polaris-react/pull/1820))
+- Fixed `tabIndex` on `main` element causing event delegation issues ([#1821](https://github.com/Shopify/polaris-react/pull/1821))
 
 ### Documentation
 

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -50,6 +50,7 @@ export interface State {
 
 export const GLOBAL_RIBBON_CUSTOM_PROPERTY = '--global-ribbon-height';
 export const APP_FRAME_MAIN = 'AppFrameMain';
+export const APP_FRAME_MAIN_ANCHOR_TARGET = 'AppFrameMainContent';
 const APP_FRAME_NAV = 'AppFrameNav';
 const APP_FRAME_TOP_BAR = 'AppFrameTopBar';
 const APP_FRAME_LOADING_BAR = 'AppFrameLoadingBar';
@@ -72,7 +73,7 @@ class Frame extends React.PureComponent<CombinedProps, State> {
 
   private globalRibbonContainer: HTMLDivElement | null = null;
 
-  private mainContentNode = React.createRef<HTMLDivElement>();
+  private skipoToMainContentTargetNode = React.createRef<HTMLAnchorElement>();
 
   getChildContext(): FrameContext {
     return {
@@ -214,7 +215,7 @@ class Frame extends React.PureComponent<CombinedProps, State> {
     const skipMarkup = (
       <div className={skipClassName}>
         <a
-          href={`#${APP_FRAME_MAIN}`}
+          href={`#${APP_FRAME_MAIN_ANCHOR_TARGET}`}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           onClick={this.handleClick}
@@ -246,6 +247,15 @@ class Frame extends React.PureComponent<CombinedProps, State> {
         />
       ) : null;
 
+    const skipToMainContentTarget = (
+      // eslint-disable-next-line jsx-a11y/anchor-is-valid
+      <a
+        id={APP_FRAME_MAIN_ANCHOR_TARGET}
+        ref={this.skipoToMainContentTargetNode}
+        tabIndex={-1}
+      />
+    );
+
     return (
       <div
         className={frameClassName}
@@ -264,9 +274,8 @@ class Frame extends React.PureComponent<CombinedProps, State> {
           className={styles.Main}
           id={APP_FRAME_MAIN}
           data-has-global-ribbon={Boolean(globalRibbon)}
-          ref={this.mainContentNode}
-          tabIndex={-1}
         >
+          {skipToMainContentTarget}
           <div className={styles.Content}>{children}</div>
         </main>
         <ToastManager toastMessages={toastMessages} />
@@ -365,10 +374,10 @@ class Frame extends React.PureComponent<CombinedProps, State> {
   };
 
   private handleClick = () => {
-    if (this.mainContentNode.current == null) {
+    if (this.skipoToMainContentTargetNode.current == null) {
       return;
     }
-    this.mainContentNode.current.focus();
+    this.skipoToMainContentTargetNode.current.focus();
   };
 
   private handleNavigationDismiss = () => {

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -143,16 +143,17 @@ describe('<Frame />', () => {
   it('renders a skip to content link with the proper text', () => {
     const skipToContentLinkText = mountWithAppProvider(<Frame />)
       .find('a')
+      .at(0)
       .text();
 
     expect(skipToContentLinkText).toStrictEqual('Skip to content');
   });
 
-  it('sets focus to the <main> element when the skip to content link is clicked', () => {
+  it('sets focus to the main content target anchor element when the skip to content link is clicked', () => {
     const frame = mountWithAppProvider(<Frame />);
-    const mainEl = frame.find('main');
-    trigger(frame.find('a'), 'onClick');
-    expect(mainEl.getDOMNode()).toBe(document.activeElement);
+    const mainAnchor = frame.find('main').find('a');
+    trigger(frame.find('a').at(0), 'onClick');
+    expect(mainAnchor.getDOMNode()).toBe(document.activeElement);
   });
 
   it('renders with a has nav data attribute when nav is passed', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

In this PR: https://github.com/Shopify/polaris-react/pull/1785 We added focus to the `<main>` element by adding tabIndex={-1}. This broke the Polaris-rails popover. In rails clicking the popover sends the target and hides the popover if the target isn't inside a popover. Adding the tabIndex on the main element made it the target, therefore always closed the popover.

Fixes #1816

### WHAT is this pull request doing?

Adding an `<a>` tag at the beginning of the content and focusing it instead.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

To test this properly it is best to do it web.

1. Start web
2. In polaris-react: `yarn build-consumer web`.
3. Tab to the skip to content link and click it. You should skip to the content. Also, use voice over to ensure the correct text is being read.



<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        {/* Add the code you want to test here */}
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
