### PR TITLE
[v4] Change matcher layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@percy/storybook": "^3.0.2",
     "@shopify/jest-dom-mocks": "^2.1.1",
     "@shopify/js-uploader": "github:shopify/js-uploader",
-    "@shopify/react-testing": "^1.5.3",
+    "@shopify/react-testing": "^1.7.0",
     "@shopify/sewing-kit": "0.88.0",
     "@storybook/addon-a11y": "^5.1.9",
     "@storybook/addon-actions": "^5.1.9",

--- a/src/test-utilities/matchers/index.ts
+++ b/src/test-utilities/matchers/index.ts
@@ -1,2 +1,0 @@
-import '@shopify/react-testing/matchers';
-import './react';

--- a/src/test-utilities/matchers/types.ts
+++ b/src/test-utilities/matchers/types.ts
@@ -1,3 +1,0 @@
-import {Root, Element} from '@shopify/react-testing';
-
-export type Node<Props> = Root<Props> | Element<Props>;

--- a/tests/each-test.ts
+++ b/tests/each-test.ts
@@ -1,5 +1,6 @@
 import {destroyAll} from '@shopify/react-testing';
-import '../src/test-utilities/matchers';
+import '@shopify/react-testing/matchers';
+import './matchers';
 
 afterEach(() => {
   destroyAll();

--- a/tests/matchers/index.ts
+++ b/tests/matchers/index.ts
@@ -1,0 +1,11 @@
+import {toBeDisabled} from './props';
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeDisabled(): void;
+    }
+  }
+}
+
+expect.extend({toBeDisabled});

--- a/tests/matchers/props.ts
+++ b/tests/matchers/props.ts
@@ -1,15 +1,7 @@
 import chalk from 'chalk';
-import {Node} from './types';
+import {Node} from '@shopify/react-testing';
 
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toBeDisabled(): void;
-    }
-  }
-}
-
-function toBeDisabled(received: Node<any>) {
+export function toBeDisabled(received: Node<any>) {
   const pass = received.prop('disabled') === true;
 
   return {
@@ -21,5 +13,3 @@ function toBeDisabled(received: Node<any>) {
     },
   };
 }
-
-expect.extend({toBeDisabled});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
       "scripthost"
     ]
   },
-  "include": ["./config/typescript/**/*", "./src/**/*"]
+  "include": ["./config/typescript/**/*", "./src/**/*", "./tests/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1431,10 +1431,10 @@
     url-search-params-polyfill "^5.0.0"
     whatwg-fetch "^3.0.0"
 
-"@shopify/react-testing@^1.5.3":
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/@shopify/react-testing/-/react-testing-1.5.3.tgz#98c54f93ca2906d5fa1d3b1f7de22a7480893e57"
-  integrity sha512-uvRR/80iJVxF/zTNbKDDD/1qPfdROdXe9vKVkOl+bGunKRHEr7BVX+snKrhGqGCuB2AVq1A5P5NuBt7N7Wq02g==
+"@shopify/react-testing@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@shopify/react-testing/-/react-testing-1.7.0.tgz#025f109b09b9abdad10148a0ec670bade4ec582f"
+  integrity sha512-AAK+QCVBiuIzcI/hNjRVkd7/+H1hwFUOgQCmwOiOZxpC1uDIsj2VWAY9bsMKmCmuvGfpRSOhVUMlQRi5fa4Ybg==
   dependencies:
     "@shopify/useful-types" "^1.3.0"
     jest-matcher-utils "^24.5.0"


### PR DESCRIPTION
### WHY are these changes introduced?

Sorry, I missed the PR where we added react-testing.

I noticed a few things that I dislike:

- ~`The test-utilities folder should only contain things we want to share with the world to make their test harnesses easier to work with Polaris. Matchers should be private to only our tests, we don't want anybody else to use them, so they shouldn't live in the src folder.~ The test-utilities folder should only contain things we need to import in our test files, matchers get imported by each-test.ts, so they should live in the tests folder
- Our own custom matchers are cool but I'd like to try and stick with using the ones `@shopify/react-testing` provides until it is clearly untenable. `toBeDisabled()` can be trivially implemented as `.toHaveReactProps({disabled: true})`, I don't think saving those 20 chars is worth the indirection.

In the future should we add matchers, they should live in the tests folder, not the src folder.

### WHAT is this pull request doing?

- Moves the registration of  `@shopify/react-testing`'s matchers directly into the `each-test.ts` file. 
- Moves our custom matchers into the `tests` folder.

### How to 🎩
 Check tests pass