### PR TITLE
[v4] Remove unwanted subcomponent aliases in Autocomplete Combobox

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -16,6 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed support for passing a React Element into `<Icon source>`. You must pass in a React Component that returns an SVG element instead. ([#1604](https://github.com/Shopify/polaris-react/pull/1604)).
 - Removed support for `<Icon untrusted>`. Passing a string into `source` will now always load an untrusted icon, you don't need that additional property. ([#1604](https://github.com/Shopify/polaris-react/pull/1604)).
 - Now `i18n` is a required prop on `AppProvider`. [Usage instructions](https://polaris.shopify.com/components/structure/app-provider#using-translations) are included in the `AppProvider` docs ([#1530](https://github.com/Shopify/polaris-react/pull/1530))
+- Removed `Autocomplete.ComboBox.TextField` and `Autocomplete.ComboBox.OptionList`. You should use the `Autocomplete.TextField` and `OptionList` components instead. ([#1830](https://github.com/Shopify/polaris-react/pull/1830))
 
 ### New components
 

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -6,7 +6,6 @@ import Popover from '../../../Popover';
 import {PreferredPosition} from '../../../PositionedOverlay';
 import {ActionListItemDescriptor, Key} from '../../../../types';
 import KeypressListener from '../../../KeypressListener';
-import TextField from '../TextField';
 import ComboBoxContext from './context';
 
 import styles from './ComboBox.scss';
@@ -55,9 +54,6 @@ export interface Props {
 }
 
 export default class ComboBox extends React.PureComponent<Props, State> {
-  static TextField = TextField;
-  static OptionList = OptionList;
-
   static getDerivedStateFromProps(
     {
       options: nextOptions,


### PR DESCRIPTION
## WHY are these changes introduced?

Removing some odd aliases when people should use the original

Instead of using Autocomplete.ComboBox.TextField use Autocomplete.Textfield
Instead of using Autocomplete.ComboBox.Optionlist use Optionlist

I can't see any point where people used these component aliases and triggering a deprecation warning for them is convoluted as it requires creating intermediate components so I'm going to skip that.


### WHAT is this pull request doing?

Removes those two static definitions

### How to 🎩

Check Autocomplete still works