### PR TITLE
[v4] Remove deprecated functionality

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -17,6 +17,9 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed support for `<Icon untrusted>`. Passing a string into `source` will now always load an untrusted icon, you don't need that additional property. ([#1604](https://github.com/Shopify/polaris-react/pull/1604)).
 - Now `i18n` is a required prop on `AppProvider`. [Usage instructions](https://polaris.shopify.com/components/structure/app-provider#using-translations) are included in the `AppProvider` docs ([#1530](https://github.com/Shopify/polaris-react/pull/1530))
 - Removed `Autocomplete.ComboBox.TextField` and `Autocomplete.ComboBox.OptionList`. You should use the `Autocomplete.TextField` and `OptionList` components instead. ([#1830](https://github.com/Shopify/polaris-react/pull/1830))
+- Removed `secondaryFooterAction` prop on `Card`. Pass an array of secondary actions to the `secondaryFooterActions` prop instead. ([#1830](https://github.com/Shopify/polaris-react/pull/1830))
+- Removed `iconBody` prop on `Navigation`. Pass a string into the `icon` prop instead. ([#1830](https://github.com/Shopify/polaris-react/pull/1830))
+- Removed `groups` prop on `Select`. Pass groups to the `options` prop instead. ([#1830](https://github.com/Shopify/polaris-react/pull/1830))
 
 ### New components
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -29,8 +29,6 @@ export interface Props {
   actions?: DisableableAction[];
   /** Primary action in the card footer */
   primaryFooterAction?: ComplexAction;
-  /** @deprecated Secondary action in the card footer */
-  secondaryFooterAction?: ComplexAction;
   /** Secondary actions in the card footer */
   secondaryFooterActions?: ComplexAction[];
   /** The content of the disclosure button rendered when there is more than one secondary footer action */
@@ -60,7 +58,6 @@ class Card extends React.PureComponent<CombinedProps, State> {
       sectioned,
       actions,
       primaryFooterAction,
-      secondaryFooterAction,
       secondaryFooterActions,
       secondaryFooterActionsDisclosureText,
       polaris: {intl},
@@ -75,17 +72,6 @@ class Card extends React.PureComponent<CombinedProps, State> {
 
     const primaryFooterActionMarkup = primaryFooterAction
       ? buttonFrom(primaryFooterAction, {primary: true})
-      : null;
-
-    if (secondaryFooterAction) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Deprecation: The secondaryFooterAction prop on Card has been deprecated. Pass an array of secondary actions to the secondaryFooterActions prop instead.',
-      );
-    }
-
-    const secondaryFooterActionMarkup = secondaryFooterAction
-      ? buttonFrom(secondaryFooterAction)
       : null;
 
     let secondaryFooterActionsMarkup = null;
@@ -113,12 +99,10 @@ class Card extends React.PureComponent<CombinedProps, State> {
     }
 
     const footerMarkup =
-      primaryFooterActionMarkup ||
-      secondaryFooterActionMarkup ||
-      secondaryFooterActionsMarkup ? (
+      primaryFooterActionMarkup || secondaryFooterActionsMarkup ? (
         <div className={styles.Footer}>
           <ButtonGroup>
-            {secondaryFooterActionsMarkup || secondaryFooterActionMarkup}
+            {secondaryFooterActionsMarkup}
             {primaryFooterActionMarkup}
           </ButtonGroup>
         </div>

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -357,7 +357,7 @@ Use when a card action will delete merchant data or be otherwise difficult to re
 ```jsx
 <Card
   title="Shipment 1234"
-  secondaryFooterAction={{content: 'Cancel shipment', destructive: true}}
+  secondaryFooterActions={[{content: 'Cancel shipment', destructive: true}]}
   primaryFooterAction={{content: 'Add tracking number'}}
 >
   <Card.Section title="Items">

--- a/src/components/Card/tests/Card.test.tsx
+++ b/src/components/Card/tests/Card.test.tsx
@@ -87,19 +87,6 @@ describe('<Card />', () => {
     expect(primaryAction.text()).toBe('test action');
   });
 
-  it('renders a secondary footer action', () => {
-    const card = mountWithAppProvider(
-      <Card secondaryFooterAction={{content: 'test action'}}>
-        <p>Some card content.</p>
-      </Card>,
-    );
-
-    const secondaryAction = card.find(Button).first();
-
-    expect(secondaryAction).toHaveLength(1);
-    expect(secondaryAction.text()).toBe('test action');
-  });
-
   describe('secondaryFooterActions', () => {
     it('renders a single secondary footer action button when only 1 is supplied', () => {
       const card = mountWithAppProvider(
@@ -186,21 +173,6 @@ describe('<Card />', () => {
       const disclosureButton = card.find(Button).first();
       expect(disclosureButton).toHaveLength(1);
       expect(disclosureButton.text()).toBe('Show more');
-    });
-
-    it('will prefer secondaryFooterActions to secondaryFooterAction if both are provided', () => {
-      const card = mountWithAppProvider(
-        <Card
-          secondaryFooterActions={[{content: 'a'}]}
-          secondaryFooterAction={{content: 'b'}}
-        >
-          <p>Some card content.</p>
-        </Card>,
-      );
-
-      const button = card.find(Button).first();
-      expect(button).toHaveLength(1);
-      expect(button.text()).toBe('a');
     });
   });
 

--- a/src/components/Navigation/README.md
+++ b/src/components/Navigation/README.md
@@ -123,7 +123,6 @@ The content of the navigation component consists of navigation items. Each item 
 | matchPaths         | string[]            | A string property providing a collection of additional paths for the navigation item to respond to                                         |
 | excludePaths       | string[]            | A string property providing an explicit collection of paths the navigation item should not respond to                                      |
 | icon               | IconProps['source'] | An icon to be displayed next to the navigation item                                                                                        |
-| iconBody           | string              | (deprecated) Pass a string representing an `SVG` element into the `icon` prop instead                                                      |
 | badge              | string \| null      | A string property allowing content to be displayed in a badge next to the navigation item                                                  |
 | label              | string              | A string property allowing content to be displayed as link text in the navigation item                                                     |
 | disabled           | boolean             | A boolean property indicating whether the navigation item is disabled                                                                      |

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -47,8 +47,6 @@ interface SecondaryAction {
 
 export interface Props extends ItemURLDetails {
   icon?: IconProps['source'];
-  /** @deprecated The iconBody prop is deprecated and will be removed. Pass a string into the icon prop instead */
-  iconBody?: string;
   badge?: ReactNode;
   label: string;
   disabled?: boolean;
@@ -78,7 +76,6 @@ export default function Item({
   disabled,
   onClick,
   accessibilityLabel,
-  iconBody,
   selected: selectedOverride,
   badge,
   new: isNew,
@@ -122,17 +119,9 @@ export default function Item({
     </span>
   ) : null;
 
-  if (iconBody) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: The iconBody prop is deprecated. Pass a string into the icon prop instead',
-    );
-  }
-
-  const iconBodyOrIcon = iconBody || icon;
-  const iconMarkup = iconBodyOrIcon ? (
+  const iconMarkup = icon ? (
     <div className={styles.Icon}>
-      <Icon source={iconBodyOrIcon} />
+      <Icon source={icon} />
     </div>
   ) : null;
 

--- a/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -206,22 +206,6 @@ describe('<Nav.Item />', () => {
       expect(item.find(Icon).prop('source')).toBe(PlusMinor);
     });
 
-    it('delegates iconBody to <Icon />', () => {
-      const iconBody = `<svg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'><path d='M10.707 17.707l5-5a.999.999 0 1 0-1.414-1.414L11 14.586V3a1 1 0 1 0-2 0v11.586l-3.293-3.293a.999.999 0 1 0-1.414 1.414l5 5a.999.999 0 0 0 1.414 0' /></svg>`;
-      const item = mountWithNavigationProvider(
-        <Item
-          label="some label"
-          url="foo"
-          disabled={false}
-          iconBody={iconBody}
-        />,
-        {
-          location: 'bar',
-        },
-      );
-      expect(item.find(Icon).prop('source')).toBe(iconBody);
-    });
-
     it('delegates label to <UnstyledLink />', () => {
       const item = mountWithNavigationProvider(
         <Item url="foo" disabled={false} label="baz" />,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -39,8 +39,6 @@ export interface SelectGroup {
 export interface BaseProps {
   /** List of options or option groups to choose from */
   options?: (SelectOption | SelectGroup)[];
-  /** @deprecated List of grouped options to choose from */
-  groups?: (SelectOption | SelectGroup)[];
   /** Label for the select */
   label: string;
   /** Adds an action to the label */
@@ -78,7 +76,6 @@ const getUniqueID = createUniqueIDFactory('Select');
 
 export default function Select({
   options: optionsProp,
-  groups: groupsProp,
   label,
   labelAction,
   labelHidden: labelHiddenProp,
@@ -115,14 +112,7 @@ export default function Select({
     describedBy.push(`${id}Error`);
   }
 
-  if (groupsProp != null) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: the `groups` prop is deprecated and will be removed in the next major version. Pass groups to the `options` prop instead.',
-    );
-  }
-
-  const options = optionsProp || groupsProp || [];
+  const options = optionsProp || [];
   let normalizedOptions = options.map(normalizeOption);
 
   if (placeholder) {

--- a/src/components/Select/tests/Select.test.tsx
+++ b/src/components/Select/tests/Select.test.tsx
@@ -141,21 +141,6 @@ describe('<Select />', () => {
         testOptions(optionOrGroup, optionOrOptgroupElement);
       });
     });
-
-    // Expectations are ran within the call to testOptions()
-    // eslint-disable-next-line jest/expect-expect
-    it('translates legacy groups into optgroup tags', () => {
-      const optionOrOptgroupElements = mountWithAppProvider(
-        <Select label="Select" groups={optionsAndGroups} onChange={noop} />,
-      )
-        .find('select')
-        .children();
-
-      optionsAndGroups.forEach((optionOrGroup, index) => {
-        const optionOrOptgroupElement = optionOrOptgroupElements.at(index);
-        testOptions(optionOrGroup, optionOrOptgroupElement);
-      });
-    });
   });
 
   describe('value', () => {

--- a/src/styles/shared/lists.scss
+++ b/src/styles/shared/lists.scss
@@ -3,9 +3,3 @@
   padding: 0;
   list-style: none;
 }
-
-@mixin plain-list {
-  @warn '[DEPRECATION] The `plain-list` mixin has been replaced with `unstyled-list`. Please update your app to use the new mixin.';
-
-  @include unstyled-list;
-}


### PR DESCRIPTION
### WHY are these changes introduced?

Removing deprecated functionality that we said we'd remove in v4

### WHAT is this pull request doing?

- Remove `secondaryFooterAction` prop on `Card`
- `iconBody` prop on `Navigation`
- `groups` prop on `Select`
- `plain-list` sass mixin



### How to 🎩

Ensure the above items continue to work by checking tests
Search the codebase for other deprecated functionality and ensure the only ones left are things that will go in v5 (namely app-bridge related things)