### PR TITLE
[ActionList] Fix color of icon in destructive ActionList item

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed a bug preventing the display of `Tooltip` when cursor enters from a disabled element ([#1783](https://github.com/Shopify/polaris-react/pull/1783)).
 - Fixed React imports in the `Filters` component to use `import * as React` for projects that don't use `esModuleInterop` ([#1820](https://github.com/Shopify/polaris-react/pull/1820))
 - Fixed `tabIndex` on `main` element causing event delegation issues ([#1821](https://github.com/Shopify/polaris-react/pull/1821))
+- Fixed icon color for destructive ActionList items ([#1836](https://github.com/Shopify/polaris-react/pull/1836))
 
 ### Documentation
 

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -77,8 +77,8 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   }
 
   &.destructive {
+    @include recolor-icon(color('red', 'dark'));
     color: color('red', 'dark');
-
     &:active {
       @include state(active-destructive);
 

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -79,6 +79,7 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   &.destructive {
     @include recolor-icon(color('red', 'dark'));
     color: color('red', 'dark');
+
     &:active {
       @include state(active-destructive);
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1835

Before | After
----------|----------
![image](https://user-images.githubusercontent.com/351842/61245968-bd190580-a71b-11e9-8cbd-4bd08f73d258.png) | ![image](https://user-images.githubusercontent.com/351842/61245949-b25e7080-a71b-11e9-8aae-e4e77c18c162.png) 

### WHAT is this pull request doing?

Uses the `recolor-icon()` mixin to recolor the icon for destructive ActionList items. 

### How to 🎩

Please see the _Action list with destructive item_ example in Storybook.

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)
