### PR TITLE
[Collapsible] Hide content when exited

### DIFF
--- a/src/components/Collapsible/Collapsible.scss
+++ b/src/components/Collapsible/Collapsible.scss
@@ -6,7 +6,7 @@
   opacity: 0;
   will-change: opacity, height;
   transition-property: opacity, height;
-  transition-duration: var(--polaris-collapsible-transition-duration);
+  transition-duration: duration(slow);
   transition-timing-function: easing(out);
 }
 

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -17,12 +17,23 @@ export interface Props {
   children?: React.ReactNode;
 }
 
+enum TransitionStatus {
+  Entering = 'entering',
+  Entered = 'entered',
+  Exiting = 'exiting',
+  Exited = 'exited',
+}
+
 const CSS_VAR_COLLAPSIBLE_HEIGHT = '--polaris-collapsible-height';
 const CSS_VAR_COLLAPSIBLE_TRANSITION_DURATION =
   '--polaris-collapsible-transition-duration';
 
 export default function Collapsible({id, open, children}: Props) {
   const [height, setHeight] = useState<number | null>(null);
+  const [transitionStatus, setTransitionStatus] = useState(
+    open ? TransitionStatus.Entering : TransitionStatus.Exited,
+  );
+  const isMounted = useRef(false);
   const node = useRef<HTMLDivElement>(null);
 
   const handleResize = useCallback(() => {
@@ -30,6 +41,29 @@ export default function Collapsible({id, open, children}: Props) {
 
     setHeight(node.current.scrollHeight);
   }, []);
+
+  useEffect(
+    () => {
+      if (!isMounted.current) return;
+      transitionStatus === TransitionStatus.Entering &&
+        changeTransitionStatus(TransitionStatus.Entered);
+
+      transitionStatus === TransitionStatus.Exiting &&
+        setTimeout(() => {
+          changeTransitionStatus(TransitionStatus.Exited);
+        }, durationSlow);
+    },
+    [transitionStatus],
+  );
+
+  useEffect(
+    () => {
+      if (!isMounted.current) return;
+      open && changeTransitionStatus(TransitionStatus.Entered);
+      !open && changeTransitionStatus(TransitionStatus.Exiting);
+    },
+    [open],
+  );
 
   useEffect(
     () => {
@@ -64,11 +98,27 @@ export default function Collapsible({id, open, children}: Props) {
     [height],
   );
 
+  // Hooks always execute in the same sequence. It's
+  // important this hooks runs after the animation effects
+  useEffect(() => {
+    isMounted.current = true;
+  }, []);
+
   const wrapperClassName = classNames(styles.Collapsible, open && styles.open);
+
+  const content =
+    transitionStatus === TransitionStatus.Exited && !open ? null : children;
 
   return (
     <div id={id} aria-hidden={!open} className={wrapperClassName} ref={node}>
-      <div>{children}</div>
+      <div>{content}</div>
     </div>
   );
+
+  function changeTransitionStatus(transitionStatus: TransitionStatus) {
+    setTransitionStatus(transitionStatus);
+    // Forcing a reflow to enable the animation
+    if (transitionStatus === TransitionStatus.Entering)
+      node.current && node.current.getBoundingClientRect();
+  }
 }

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -25,8 +25,6 @@ enum TransitionStatus {
 }
 
 const CSS_VAR_COLLAPSIBLE_HEIGHT = '--polaris-collapsible-height';
-const CSS_VAR_COLLAPSIBLE_TRANSITION_DURATION =
-  '--polaris-collapsible-transition-duration';
 
 export default function Collapsible({id, open, children}: Props) {
   const [height, setHeight] = useState<number | null>(null);
@@ -89,10 +87,6 @@ export default function Collapsible({id, open, children}: Props) {
       node.current.style.setProperty(
         CSS_VAR_COLLAPSIBLE_HEIGHT,
         `${height || 0}px`,
-      );
-      node.current.style.setProperty(
-        CSS_VAR_COLLAPSIBLE_TRANSITION_DURATION,
-        `${durationSlow}ms`,
       );
     },
     [height],

--- a/src/components/Collapsible/tests/Collapsible.test.tsx
+++ b/src/components/Collapsible/tests/Collapsible.test.tsx
@@ -5,6 +5,18 @@ import Collapsible from '../Collapsible';
 describe('<Collapsible />', () => {
   const ariaHiddenSelector = '[aria-hidden=true]';
 
+  it('does not render its children and indicates hidden with aria-hidden', () => {
+    const collapsible = mountWithAppProvider(
+      <Collapsible id="test-collapsible" open={false}>
+        content
+      </Collapsible>,
+    );
+
+    const hidden = collapsible.find(ariaHiddenSelector);
+    expect(hidden.exists()).toBe(true);
+    expect(collapsible.contains('content')).toBe(false);
+  });
+
   it('renders its children and does not render aria-hidden when open', () => {
     const collapsible = mountWithAppProvider(
       <Collapsible id="test-collapsible" open>


### PR DESCRIPTION
### WHY are these changes introduced?

This was the original functionality and some tests in consuming apps relied on this. 

### WHAT is this pull request doing?

Content is no longer rendered when exited

### Gif of animation / dev tools

https://cl.ly/5b62ec0b699a

### How to 🎩

Check the animation in the chrome dev tools 🔍 