### PR TITLE
Allow Autocomplete.TextField's autoComplete to be overridable

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -23,6 +23,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed React imports in the `Filters` component to use `import * as React` for projects that don't use `esModuleInterop` ([#1820](https://github.com/Shopify/polaris-react/pull/1820))
 - Fixed `tabIndex` on `main` element causing event delegation issues ([#1821](https://github.com/Shopify/polaris-react/pull/1821))
 - Fixed icon color for destructive ActionList items ([#1836](https://github.com/Shopify/polaris-react/pull/1836))
+- Fixed not being able to explictly set `autoComplete` prop on`Autoomplete.TextField`. ([#1839](https://github.com/Shopify/polaris-react/pull/1839))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -23,7 +23,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed React imports in the `Filters` component to use `import * as React` for projects that don't use `esModuleInterop` ([#1820](https://github.com/Shopify/polaris-react/pull/1820))
 - Fixed `tabIndex` on `main` element causing event delegation issues ([#1821](https://github.com/Shopify/polaris-react/pull/1821))
 - Fixed icon color for destructive ActionList items ([#1836](https://github.com/Shopify/polaris-react/pull/1836))
-- Fixed not being able to explictly set `autoComplete` prop on`Autoomplete.TextField`. ([#1839](https://github.com/Shopify/polaris-react/pull/1839))
+- Fixed not being able to explictly set `autoComplete` prop on`Autocomplete.TextField`. ([#1839](https://github.com/Shopify/polaris-react/pull/1839))
 
 ### Documentation
 

--- a/src/components/Autocomplete/components/TextField/TextField.tsx
+++ b/src/components/Autocomplete/components/TextField/TextField.tsx
@@ -17,10 +17,11 @@ export default class TextField extends React.PureComponent<
   render() {
     const {selectedOptionId, comboBoxId} = this.context;
 
+    // autoComplete should be overridable by the user, but not the other values
     return (
       <BaseTextField
-        {...this.props}
         autoComplete={false}
+        {...this.props}
         ariaAutocomplete="list"
         ariaActiveDescendant={selectedOptionId}
         ariaControls={comboBoxId}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1834

### WHAT is this pull request doing?

Allows users to set Autocomplete.TextField's autoComplete prop that gets passed into TextField

### How to 🎩

In the playground, create an Autcomplete with user-defined autoComplete field, and see that value is applied to the rendered input element. See code below.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page, Autocomplete} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    const noop = () => {};
    const textField = (
      <Autocomplete.TextField
        label="Tags"
        value=""
        placeholder="Search"
        onChange={noop}
        autoComplete="braaaap"
      />
    );

    return (
      <Page title="Playground">
        <Autocomplete
          textField={textField}
          options={[]}
          selected={[]}
          onSelect={noop}
        />
      </Page>
    );
  }
}
```

</details>