### PR TITLE
Add warning message for v4 removals

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,6 +26,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Added warning log for internal types and components that are being removed in `v4` ([#1840](https://github.com/Shopify/polaris-react/pull/1840))
 - Added links to App Bridge React component documentation in deprecation notices for embedded components ([#1765](https://github.com/Shopify/polaris-react/pull/1765))
 - Improved link text for App Bridge deprecation notices. [#1802](https://github.com/Shopify/polaris-react/pull/1802)
 

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -37,6 +37,10 @@ export default class AppProvider extends React.Component<Props> {
       subscribe: this.subscribe,
       unsubscribe: this.unsubscribe,
     });
+
+    console.warn(
+      'Notice: In v4 polaris will remove some internal types/components that were included in our exports or are not needed anymore as we migrate away from deprecated react features; ThemeProviderProps, ThemeProviderContext, IconProps, WithAppProviderProps, polarisContextTypes, AppProviderContext, createPolarisContext, withAppProvider, createAppProviderContext, WithRef, and WithContext.',
+    );
   }
 
   componentDidMount() {

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -38,6 +38,7 @@ export default class AppProvider extends React.Component<Props> {
       unsubscribe: this.unsubscribe,
     });
 
+    // eslint-disable-next-line no-console
     console.warn(
       'Notice: In v4 polaris will remove some internal types/components that were included in our exports or are not needed anymore as we migrate away from deprecated react features; ThemeProviderProps, ThemeProviderContext, IconProps, WithAppProviderProps, polarisContextTypes, AppProviderContext, createPolarisContext, withAppProvider, createAppProviderContext, WithRef, and WithContext.',
     );


### PR DESCRIPTION
### WHY are these changes introduced?

Some internal types and components are being removed from our export in v4

### WHAT is this pull request doing?

Adding a message to let consumers know
