### PR TITLE
[v4] Further test and context tidying

### DIFF
--- a/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -18,7 +18,7 @@ describe('<ContextualSaveBar />', () => {
     });
 
     mountWithAppProvider(<ContextualSaveBar {...props} />, {
-      context: {frame: mockFrameContext},
+      frame: mockFrameContext,
     });
     expect(mockFrameContext.setContextualSaveBar).toHaveBeenCalledWith({
       ...props,
@@ -32,7 +32,7 @@ describe('<ContextualSaveBar />', () => {
     });
 
     const frame = mountWithAppProvider(<ContextualSaveBar {...props} />, {
-      context: {frame: mockFrameContext},
+      frame: mockFrameContext,
     });
     expect(mockFrameContext.removeContextualSaveBar).not.toHaveBeenCalled();
     frame.unmount();
@@ -46,7 +46,7 @@ describe('<ContextualSaveBar />', () => {
     });
 
     const frame = mountWithAppProvider(<ContextualSaveBar {...props} />, {
-      context: {frame: mockFrameContext},
+      frame: mockFrameContext,
     });
     const newProps = {
       saveAction: {content: 'Save', onAction: noop, loading: true},
@@ -69,7 +69,7 @@ describe('<ContextualSaveBar />', () => {
     });
 
     const frame = mountWithAppProvider(<ContextualSaveBar {...props} />, {
-      context: {frame: mockFrameContext},
+      frame: mockFrameContext,
     });
 
     expect(mockFrameContext.setContextualSaveBar).toHaveBeenCalledTimes(1);

--- a/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {Button, Image, Modal} from 'components';
 import ContextualSaveBar from '../ContextualSaveBar';
-import {ThemeProviderContextType} from '../../../../../utilities/theme';
-import {merge} from '../../../../../utilities/merge';
 
 describe('<ContextualSaveBar />', () => {
   describe('discardAction', () => {
@@ -116,30 +114,28 @@ describe('<ContextualSaveBar />', () => {
 
   describe('logo', () => {
     it('will render an image with the contextual save bar source', () => {
-      const contextualSaveBar = mountWithAppProvider(
-        <ContextualSaveBar />,
-        mergeThemeProviderContext({
+      const contextualSaveBar = mountWithAppProvider(<ContextualSaveBar />, {
+        themeProvider: {
           logo: {
             width: 200,
             contextualSaveBarSource: './assets/monochrome_shopify.svg',
           },
-        }),
-      );
+        },
+      });
       expect(contextualSaveBar.find(Image).prop('source')).toBe(
         './assets/monochrome_shopify.svg',
       );
     });
 
     it('will render an image with the width provided', () => {
-      const contextualSaveBar = mountWithAppProvider(
-        <ContextualSaveBar />,
-        mergeThemeProviderContext({
+      const contextualSaveBar = mountWithAppProvider(<ContextualSaveBar />, {
+        themeProvider: {
           logo: {
             width: 200,
             contextualSaveBarSource: './assets/monochrome_shopify.svg',
           },
-        }),
-      );
+        },
+      });
       expect(contextualSaveBar.find(Image).get(0).props.style).toHaveProperty(
         'width',
         '200px',
@@ -147,15 +143,14 @@ describe('<ContextualSaveBar />', () => {
     });
 
     it('will render the image with a default width if 0 is provided', () => {
-      const contextualSaveBar = mountWithAppProvider(
-        <ContextualSaveBar />,
-        mergeThemeProviderContext({
+      const contextualSaveBar = mountWithAppProvider(<ContextualSaveBar />, {
+        themeProvider: {
           logo: {
             contextualSaveBarSource: './assets/monochrome_shopify.svg',
             width: 0,
           },
-        }),
-      );
+        },
+      });
       expect(contextualSaveBar.find(Image).get(0).props.style).toHaveProperty(
         'width',
         '104px',
@@ -165,23 +160,17 @@ describe('<ContextualSaveBar />', () => {
     it('will not render the logo when content is aligned flush left', () => {
       const contextualSaveBar = mountWithAppProvider(
         <ContextualSaveBar alignContentFlush />,
-        mergeThemeProviderContext({
-          logo: {
-            contextualSaveBarSource: './assets/monochrome_shopify.svg',
-            width: 200,
+        {
+          themeProvider: {
+            logo: {
+              contextualSaveBarSource: './assets/monochrome_shopify.svg',
+              width: 200,
+            },
           },
-        }),
+        },
       );
 
       expect(contextualSaveBar.find(Image).exists()).toBeFalsy();
     });
   });
 });
-
-function mergeThemeProviderContext(
-  providedThemeContext: ThemeProviderContextType,
-) {
-  return {
-    themeProvider: merge({logo: null}, providedThemeContext),
-  };
-}

--- a/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -182,8 +182,6 @@ function mergeThemeProviderContext(
   providedThemeContext: ThemeProviderContextType,
 ) {
   return {
-    context: {
-      themeProvider: merge({logo: null}, providedThemeContext),
-    },
+    themeProvider: merge({logo: null}, providedThemeContext),
   };
 }

--- a/src/components/Loading/tests/Loading.test.tsx
+++ b/src/components/Loading/tests/Loading.test.tsx
@@ -15,7 +15,7 @@ describe('<Loading />', () => {
       startLoading: jest.fn(),
     });
 
-    mountWithAppProvider(<Loading />, {context: {frame: mockFrameContext}});
+    mountWithAppProvider(<Loading />, {frame: mockFrameContext});
     expect(mockFrameContext.startLoading).toHaveBeenCalled();
   });
 
@@ -23,9 +23,7 @@ describe('<Loading />', () => {
     const mockFrameContext = createFrameContext({
       stopLoading: jest.fn(),
     });
-    const frame = mountWithAppProvider(<Loading />, {
-      context: {frame: mockFrameContext},
-    });
+    const frame = mountWithAppProvider(<Loading />, {frame: mockFrameContext});
     expect(mockFrameContext.stopLoading).not.toHaveBeenCalled();
 
     frame.unmount();
@@ -71,7 +69,8 @@ describe('<Loading />', () => {
 function mountWithAppBridge(element: React.ReactElement<any>) {
   const appBridge = {};
   const loading = mountWithAppProvider(element, {
-    context: {frame: {}, appBridge},
+    frame: {},
+    appBridge,
   });
 
   return {loading, appBridge};

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -487,9 +487,7 @@ describe('<Modal>', () => {
 
 function mountWithAppBridge(element: React.ReactElement<any>) {
   const appBridge = {};
-  const modal = mountWithAppProvider(element, {
-    context: {appBridge},
-  });
+  const modal = mountWithAppProvider(element, {appBridge});
 
   return {modal, appBridge};
 }

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -424,8 +424,6 @@ function noop() {}
 
 function mountWithAppBridge(element: React.ReactElement<any>) {
   const appBridge = {};
-  const page = mountWithAppProvider(element, {
-    context: {appBridge},
-  });
+  const page = mountWithAppProvider(element, {appBridge});
   return {page, appBridge};
 }

--- a/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
+++ b/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
@@ -229,9 +229,7 @@ function noop() {}
 
 function mountWithAppBridge(element: React.ReactElement<any>) {
   const appBridge = {};
-  const resourcePicker = mountWithAppProvider(element, {
-    context: {appBridge},
-  });
+  const resourcePicker = mountWithAppProvider(element, {appBridge});
 
   return {resourcePicker, appBridge};
 }

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import isEqual from 'lodash/isEqual';
-import {ThemeProviderContext} from '../../utilities/theme';
+import {ThemeContext} from '../../utilities/theme';
 import {Theme} from '../../utilities/theme/types';
 import {setColors} from '../../utilities/theme/utils';
 
@@ -48,15 +48,15 @@ export default class ThemeProvider extends React.Component<Props, State> {
     const {children} = this.props;
     const styles = this.createStyles() || defaultTheme;
 
-    const context = {
+    const theme = {
       ...rest,
       logo,
     };
 
     return (
-      <ThemeProviderContext.Provider value={context}>
+      <ThemeContext.Provider value={theme}>
         <div style={styles}>{React.Children.only(children)}</div>
-      </ThemeProviderContext.Provider>
+      </ThemeContext.Provider>
     );
   }
 

--- a/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import ThemeProvider from '../ThemeProvider';
-import {ThemeProviderContext} from '../../../utilities/theme';
+import {ThemeContext} from '../../../utilities/theme';
 
 describe('<ThemeProvider />', () => {
   it('mounts', () => {
@@ -16,12 +16,12 @@ describe('<ThemeProvider />', () => {
   it('passes context', () => {
     const Child: React.SFC<{}> = (_props) => {
       return (
-        <ThemeProviderContext.Consumer>
+        <ThemeContext.Consumer>
           {(polarisTheme) => {
             // eslint-disable-next-line shopify/jest/no-if
             return polarisTheme && polarisTheme.logo ? <div /> : null;
           }}
-        </ThemeProviderContext.Consumer>
+        </ThemeContext.Consumer>
       );
     };
 

--- a/src/components/Toast/tests/Toast.test.tsx
+++ b/src/components/Toast/tests/Toast.test.tsx
@@ -16,7 +16,7 @@ describe('<Toast />', () => {
 
     const props = {content: 'Image uploaded', onDismiss: noop};
     mountWithAppProvider(<Toast {...props} />, {
-      context: {frame: mockFrameContext},
+      frame: mockFrameContext,
     });
 
     expect(mockFrameContext.showToast).toHaveBeenCalledWith(
@@ -31,7 +31,7 @@ describe('<Toast />', () => {
 
     const frame = mountWithAppProvider(
       <Toast content="Message sent" onDismiss={noop} />,
-      {context: {frame: mockFrameContext}},
+      {frame: mockFrameContext},
     );
 
     expect(mockFrameContext.hideToast).not.toHaveBeenCalled();
@@ -113,7 +113,8 @@ function noop() {}
 function mountWithAppBridge(element: React.ReactElement<any>) {
   const appBridge = {};
   const toast = mountWithAppProvider(element, {
-    context: {frame: {}, appBridge},
+    frame: {},
+    appBridge,
   });
 
   return {toast, appBridge};

--- a/src/components/TopBar/tests/TopBar.test.tsx
+++ b/src/components/TopBar/tests/TopBar.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {Image, UnstyledLink} from 'components';
-import {ThemeProviderContextType} from '../../../utilities/theme';
 import TopBar from '../TopBar';
 import {Menu, SearchField, UserMenu, Search} from '../components';
-import {merge} from '../../../utilities/merge';
 
 const actions = [
   {
@@ -143,52 +141,47 @@ describe('<TopBar />', () => {
 
   describe('logo', () => {
     it('will render an image with the logo top bar source', () => {
-      const topBar = mountWithAppProvider(
-        <TopBar />,
-        mergeThemeProviderContext({
+      const topBar = mountWithAppProvider(<TopBar />, {
+        themeProvider: {
           logo: {
             topBarSource: './assets/shopify.svg',
           },
-        }),
-      );
+        },
+      });
       expect(topBar.find(Image).prop('source')).toBe('./assets/shopify.svg');
     });
 
     it('will render an image with the logo accessibility label', () => {
-      const topBar = mountWithAppProvider(
-        <TopBar />,
-        mergeThemeProviderContext({
+      const topBar = mountWithAppProvider(<TopBar />, {
+        themeProvider: {
           logo: {
             accessibilityLabel: 'Shopify',
           },
-        }),
-      );
+        },
+      });
       expect(topBar.find(Image).prop('alt')).toBe('Shopify');
     });
 
     it('will render an unstyled link with the logo URL', () => {
-      const topBar = mountWithAppProvider(
-        <TopBar />,
-        mergeThemeProviderContext({logo: {url: 'https://shopify.com'}}),
-      );
+      const topBar = mountWithAppProvider(<TopBar />, {
+        themeProvider: {logo: {url: 'https://shopify.com'}},
+      });
       expect(topBar.find(UnstyledLink).prop('url')).toBe('https://shopify.com');
     });
 
     it('will render an unstyled link with the logo width', () => {
-      const topBar = mountWithAppProvider(
-        <TopBar />,
-        mergeThemeProviderContext({logo: {width: 124}}),
-      );
+      const topBar = mountWithAppProvider(<TopBar />, {
+        themeProvider: {logo: {width: 124}},
+      });
       expect(topBar.find(UnstyledLink).prop('style')).toStrictEqual({
         width: '124px',
       });
     });
 
     it('will render an unstyled link with a default width', () => {
-      const topBar = mountWithAppProvider(
-        <TopBar />,
-        mergeThemeProviderContext({logo: {}}),
-      );
+      const topBar = mountWithAppProvider(<TopBar />, {
+        themeProvider: {logo: {}},
+      });
       expect(topBar.find(UnstyledLink).prop('style')).toStrictEqual({
         width: '104px',
       });
@@ -217,11 +210,11 @@ describe('<TopBar />', () => {
     it('doesn’t render a logo when defined', () => {
       const topBar = mountWithAppProvider(
         <TopBar contextControl={mockContextControl} />,
-        mergeThemeProviderContext({
-          logo: {
-            topBarSource: './assets/shopify.svg',
+        {
+          themeProvider: {
+            logo: {topBarSource: './assets/shopify.svg'},
           },
-        }),
+        },
       );
       expect(topBar.find(Image).exists()).toBe(false);
     });
@@ -234,11 +227,3 @@ describe('<TopBar />', () => {
 });
 
 function noop() {}
-
-function mergeThemeProviderContext(
-  providedThemeContext: ThemeProviderContextType,
-) {
-  return {
-    themeProvider: merge({logo: null}, providedThemeContext),
-  };
-}

--- a/src/components/TopBar/tests/TopBar.test.tsx
+++ b/src/components/TopBar/tests/TopBar.test.tsx
@@ -239,8 +239,6 @@ function mergeThemeProviderContext(
   providedThemeContext: ThemeProviderContextType,
 ) {
   return {
-    context: {
-      themeProvider: merge({logo: null}, providedThemeContext),
-    },
+    themeProvider: merge({logo: null}, providedThemeContext),
   };
 }

--- a/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
+++ b/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
@@ -6,10 +6,9 @@ describe('<UnstyledLink />', () => {
   describe('custom link component', () => {
     it('uses a custom link component instead of an anchor', () => {
       const CustomLinkComponent = () => <div />;
-      const mockContext = {context: {link: CustomLinkComponent}};
       const anchorElement = mountWithAppProvider(
         <UnstyledLink external url="https://shopify.com" />,
-        mockContext,
+        {link: CustomLinkComponent},
       ).find(CustomLinkComponent);
 
       expect(anchorElement).toHaveLength(1);
@@ -17,10 +16,9 @@ describe('<UnstyledLink />', () => {
 
     it('doesn’t have polaris prop', () => {
       const CustomLinkComponent = () => <div />;
-      const mockContext = {context: {link: CustomLinkComponent}};
       const anchorElement = mountWithAppProvider(
         <UnstyledLink external url="https://shopify.com" />,
-        mockContext,
+        {link: CustomLinkComponent},
       ).find(CustomLinkComponent);
 
       expect(anchorElement.prop('polaris')).not.toBeDefined();

--- a/src/test-utilities/PolarisTestProvider.tsx
+++ b/src/test-utilities/PolarisTestProvider.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 // eslint-disable-next-line shopify/strict-component-boundaries
 import {FrameContext} from '../components/Frame';
-import {createThemeContext, ThemeProviderContext} from '../utilities/theme';
+import {createThemeContext, ThemeContext} from '../utilities/theme';
 import {
   ScrollLockManager,
   ScrollLockManagerContext,
@@ -49,7 +49,7 @@ export function PolarisTestProvider({
       <I18nContext.Provider value={intl}>
         <ScrollLockManagerContext.Provider value={scrollLockManager}>
           <StickyManagerContext.Provider value={stickyManager}>
-            <ThemeProviderContext.Provider value={themeProvider}>
+            <ThemeContext.Provider value={themeProvider}>
               <AppBridgeContext.Provider value={appBridge}>
                 <LinkContext.Provider value={link}>
                   <FrameContext.Provider value={frame}>
@@ -57,7 +57,7 @@ export function PolarisTestProvider({
                   </FrameContext.Provider>
                 </LinkContext.Provider>
               </AppBridgeContext.Provider>
-            </ThemeProviderContext.Provider>
+            </ThemeContext.Provider>
           </StickyManagerContext.Provider>
         </ScrollLockManagerContext.Provider>
       </I18nContext.Provider>

--- a/src/test-utilities/PolarisTestProvider.tsx
+++ b/src/test-utilities/PolarisTestProvider.tsx
@@ -11,9 +11,9 @@ import {AppBridgeContext} from '../utilities/app-bridge';
 import {I18n, I18nContext} from '../utilities/i18n';
 import translations from '../../locales/en.json';
 import {Link, LinkContext} from '../utilities/link';
-import {ReturnedContext} from './types';
+import {WithProvidersContext} from './types';
 
-export interface Props extends Partial<ReturnedContext> {
+export interface Props extends Partial<WithProvidersContext> {
   children: React.ReactElement<any>;
   strict?: boolean;
 }

--- a/src/test-utilities/legacy.tsx
+++ b/src/test-utilities/legacy.tsx
@@ -91,23 +91,19 @@ interface AppContextOptions {
 }
 
 interface MountWithAppProviderOptions {
-  context?: {
-    themeProvider?: DeepPartial<ThemeProviderContextType>;
-    frame?: DeepPartial<FrameContextType>;
-    intl?: TranslationDictionary | TranslationDictionary[];
-    scrollLockManager?: ScrollLockManager;
-    stickyManager?: StickyManager;
-    appBridge?: ClientApplication<{}> | {};
-    link?: LinkLikeComponent;
-  };
+  themeProvider?: DeepPartial<ThemeProviderContextType>;
+  frame?: DeepPartial<FrameContextType>;
+  intl?: TranslationDictionary | TranslationDictionary[];
+  scrollLockManager?: ScrollLockManager;
+  stickyManager?: StickyManager;
+  appBridge?: ClientApplication<{}> | {};
+  link?: LinkLikeComponent;
 }
 
 export function mountWithAppProvider<P>(
   node: React.ReactElement<P>,
-  options: MountWithAppProviderOptions = {},
+  ctx: MountWithAppProviderOptions = {},
 ): PolarisContextReactWrapper<P, any> {
-  const {context: ctx = {}} = options;
-
   const intlTranslations =
     (ctx.intl && merge(translations, ctx.intl)) || translations;
   const intl = new I18n(intlTranslations);

--- a/src/test-utilities/legacy.tsx
+++ b/src/test-utilities/legacy.tsx
@@ -10,7 +10,7 @@ import translations from '../../locales/en.json';
 
 // eslint-disable-next-line shopify/strict-component-boundaries
 import {FrameContextType} from '../components/Frame';
-import {createThemeContext, ThemeProviderContextType} from '../utilities/theme';
+import {createThemeContext} from '../utilities/theme';
 import {ScrollLockManager} from '../utilities/scroll-lock-manager';
 import {StickyManager} from '../utilities/sticky-manager';
 import {Link, LinkLikeComponent} from '../utilities/link';
@@ -81,7 +81,7 @@ type AppContext = {
   scrollLockManager: ScrollLockManager;
   stickyManager: StickyManager;
   appBridge: ClientApplication<{}> | {} | null;
-  themeProvider: ThemeProviderContextType;
+  themeProvider: ReturnType<typeof createThemeContext>;
   frame: FrameContextType;
   link: Link;
 };
@@ -90,8 +90,8 @@ interface AppContextOptions {
   app: AppContext;
 }
 
-interface MountWithAppProviderOptions {
-  themeProvider?: DeepPartial<ThemeProviderContextType>;
+interface MountWithAppProviderContext {
+  themeProvider?: DeepPartial<ReturnType<typeof createThemeContext>>;
   frame?: DeepPartial<FrameContextType>;
   intl?: TranslationDictionary | TranslationDictionary[];
   scrollLockManager?: ScrollLockManager;
@@ -102,7 +102,7 @@ interface MountWithAppProviderOptions {
 
 export function mountWithAppProvider<P>(
   node: React.ReactElement<P>,
-  ctx: MountWithAppProviderOptions = {},
+  ctx: MountWithAppProviderContext = {},
 ): PolarisContextReactWrapper<P, any> {
   const intlTranslations =
     (ctx.intl && merge(translations, ctx.intl)) || translations;

--- a/src/test-utilities/legacy.tsx
+++ b/src/test-utilities/legacy.tsx
@@ -1,20 +1,17 @@
 import {ReactWrapper, CommonWrapper, mount} from 'enzyme';
 import React from 'react';
 import {noop} from '@shopify/javascript-utilities/other';
-import {ClientApplication} from '@shopify/app-bridge';
-import {I18n, TranslationDictionary} from '../utilities/i18n';
+import {I18n} from '../utilities/i18n';
 import {get} from '../utilities/get';
 import {merge} from '../utilities/merge';
-import {DeepPartial} from '../types';
 import translations from '../../locales/en.json';
 
-// eslint-disable-next-line shopify/strict-component-boundaries
-import {FrameContextType} from '../components/Frame';
 import {createThemeContext} from '../utilities/theme';
 import {ScrollLockManager} from '../utilities/scroll-lock-manager';
 import {StickyManager} from '../utilities/sticky-manager';
-import {Link, LinkLikeComponent} from '../utilities/link';
+import {Link} from '../utilities/link';
 import {PolarisTestProvider} from './PolarisTestProvider';
+import {WithProvidersContext, WithProvidersOptions} from './types';
 
 export type AnyWrapper = ReactWrapper<any, any> | CommonWrapper<any, any>;
 
@@ -76,34 +73,10 @@ function updateRoot(wrapper: AnyWrapper) {
   (wrapper as any).root().update();
 }
 
-type AppContext = {
-  intl: I18n;
-  scrollLockManager: ScrollLockManager;
-  stickyManager: StickyManager;
-  appBridge: ClientApplication<{}> | {} | null;
-  themeProvider: ReturnType<typeof createThemeContext>;
-  frame: FrameContextType;
-  link: Link;
-};
-
-interface AppContextOptions {
-  app: AppContext;
-}
-
-interface MountWithAppProviderContext {
-  themeProvider?: DeepPartial<ReturnType<typeof createThemeContext>>;
-  frame?: DeepPartial<FrameContextType>;
-  intl?: TranslationDictionary | TranslationDictionary[];
-  scrollLockManager?: ScrollLockManager;
-  stickyManager?: StickyManager;
-  appBridge?: ClientApplication<{}> | {};
-  link?: LinkLikeComponent;
-}
-
 export function mountWithAppProvider<P>(
   node: React.ReactElement<P>,
-  ctx: MountWithAppProviderContext = {},
-): PolarisContextReactWrapper<P, any> {
+  ctx: WithProvidersOptions = {},
+) {
   const intlTranslations =
     (ctx.intl && merge(translations, ctx.intl)) || translations;
   const intl = new I18n(intlTranslations);
@@ -129,9 +102,10 @@ export function mountWithAppProvider<P>(
 
   const link = new Link(ctx.link);
 
-  const appBridge = ctx.appBridge || null;
+  // Yes this is bad typing, we'll fix it later
+  const appBridge: any = ctx.appBridge;
 
-  const context: AppContext = {
+  const context: WithProvidersContext = {
     themeProvider,
     frame,
     intl,
@@ -141,26 +115,7 @@ export function mountWithAppProvider<P>(
     link,
   };
 
-  const wrapper = polarisContextReactWrapper(node, {
-    app: context,
-  });
-
-  return wrapper;
-}
-
-type PolarisContextReactWrapper<P, S> = ReactWrapper<P, S> & AppContextOptions;
-
-export function polarisContextReactWrapper<P, S>(
-  element: React.ReactElement<P>,
-  {app}: AppContextOptions,
-): PolarisContextReactWrapper<P, S> {
-  const appBridge: any = app.appBridge;
-
-  const wrapper = mount<P, S>(
-    <PolarisTestProvider {...app} appBridge={appBridge}>
-      {element}
-    </PolarisTestProvider>,
+  return mount<P>(
+    <PolarisTestProvider {...context}>{node}</PolarisTestProvider>,
   );
-
-  return wrapper as PolarisContextReactWrapper<P, S>;
 }

--- a/src/test-utilities/react-testing.tsx
+++ b/src/test-utilities/react-testing.tsx
@@ -6,16 +6,15 @@ import {StickyManager} from '../utilities/sticky-manager';
 import {createAppBridge} from '../utilities/app-bridge';
 import {I18n} from '../utilities/i18n';
 import translations from '../../locales/en.json';
-import {DeepPartial} from '../types';
 import {merge} from '../utilities/merge';
 import {Link} from '../utilities/link';
 import {PolarisTestProvider} from './PolarisTestProvider';
-import {ComplexProviders, SimpleProviders, ReturnedContext} from './types';
+import {WithProvidersOptions, WithProvidersContext} from './types';
 
-type Options = DeepPartial<ComplexProviders> & Partial<SimpleProviders>;
-type Context = ReturnedContext;
-
-export const mountWithContext = createMount<Options, Context>({
+export const mountWithContext = createMount<
+  WithProvidersOptions,
+  WithProvidersContext
+>({
   context({
     themeProvider,
     frame,

--- a/src/test-utilities/types.ts
+++ b/src/test-utilities/types.ts
@@ -1,7 +1,7 @@
 import {ClientApplication} from '@shopify/app-bridge';
 // eslint-disable-next-line shopify/strict-component-boundaries
 import {FrameContextType} from '../components/Frame';
-import {ThemeProviderContext} from '../utilities/theme';
+import {ThemeContext} from '../utilities/theme';
 import {ScrollLockManager} from '../utilities/scroll-lock-manager';
 import {StickyManager} from '../utilities/sticky-manager';
 import {AppBridgeOptions} from '../utilities/app-bridge';
@@ -9,7 +9,7 @@ import {I18n, TranslationDictionary} from '../utilities/i18n';
 import {Link, LinkLikeComponent} from '../utilities/link';
 
 export interface ComplexProviders {
-  themeProvider: React.ContextType<typeof ThemeProviderContext>;
+  themeProvider: React.ContextType<typeof ThemeContext>;
   frame: FrameContextType;
 }
 

--- a/src/test-utilities/types.ts
+++ b/src/test-utilities/types.ts
@@ -7,27 +7,34 @@ import {StickyManager} from '../utilities/sticky-manager';
 import {AppBridgeOptions} from '../utilities/app-bridge';
 import {I18n, TranslationDictionary} from '../utilities/i18n';
 import {Link, LinkLikeComponent} from '../utilities/link';
+import {DeepPartial} from '../types';
 
-export interface ComplexProviders {
-  themeProvider: React.ContextType<typeof ThemeContext>;
-  frame: FrameContextType;
-}
-
-export interface SimpleProvidersWithSameReturn {
+/**
+ * Options a user will pass into a mountWithX() function
+ */
+export type WithProvidersOptions = Partial<{
+  // Values for contexts provided by AppProvider
+  intl: TranslationDictionary | TranslationDictionary[];
   scrollLockManager: ScrollLockManager;
   stickyManager: StickyManager;
-}
-export interface SimpleProvidersWithAltReturn {
-  intl: TranslationDictionary | TranslationDictionary[];
+  themeProvider: DeepPartial<React.ContextType<typeof ThemeContext>>;
   appBridge: AppBridgeOptions;
   link: LinkLikeComponent;
-}
-export type SimpleProviders = SimpleProvidersWithSameReturn &
-  SimpleProvidersWithAltReturn;
+  // Values for contexts provided by Frame
+  frame: DeepPartial<FrameContextType>;
+}>;
 
-export type ReturnedContext = ComplexProviders &
-  SimpleProvidersWithSameReturn & {
-    intl: I18n;
-    appBridge: ClientApplication<{}> | undefined;
-    link: Link;
-  };
+/**
+ * The mountWithX() function willl take the above values and return them into these
+ */
+export type WithProvidersContext = {
+  // Contexts provided by AppProvider
+  intl: I18n;
+  scrollLockManager: ScrollLockManager;
+  stickyManager: StickyManager;
+  appBridge: ClientApplication<{}> | undefined;
+  themeProvider: React.ContextType<typeof ThemeContext>;
+  link: Link;
+  // Contets provided by Frame
+  frame: FrameContextType;
+};

--- a/src/test-utilities/types.ts
+++ b/src/test-utilities/types.ts
@@ -1,7 +1,7 @@
 import {ClientApplication} from '@shopify/app-bridge';
 // eslint-disable-next-line shopify/strict-component-boundaries
 import {FrameContextType} from '../components/Frame';
-import {ThemeProviderContextType} from '../utilities/theme';
+import {ThemeProviderContext} from '../utilities/theme';
 import {ScrollLockManager} from '../utilities/scroll-lock-manager';
 import {StickyManager} from '../utilities/sticky-manager';
 import {AppBridgeOptions} from '../utilities/app-bridge';
@@ -9,7 +9,7 @@ import {I18n, TranslationDictionary} from '../utilities/i18n';
 import {Link, LinkLikeComponent} from '../utilities/link';
 
 export interface ComplexProviders {
-  themeProvider: ThemeProviderContextType;
+  themeProvider: React.ContextType<typeof ThemeProviderContext>;
   frame: FrameContextType;
 }
 

--- a/src/utilities/theme/context.tsx
+++ b/src/utilities/theme/context.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import {Theme} from './types';
 
-export interface ThemeProviderContextType {
+export interface ThemeContextType {
   logo: Theme['logo'] | null;
 }
 
-export const ThemeProviderContext = React.createContext<
-  ThemeProviderContextType
->({
+export const ThemeProviderContext = React.createContext<ThemeContextType>({
   logo: null,
 });

--- a/src/utilities/theme/context.tsx
+++ b/src/utilities/theme/context.tsx
@@ -5,6 +5,6 @@ export interface ThemeContextType {
   logo: Theme['logo'] | null;
 }
 
-export const ThemeProviderContext = React.createContext<ThemeContextType>({
+export const ThemeContext = React.createContext<ThemeContextType>({
   logo: null,
 });

--- a/src/utilities/theme/hooks.tsx
+++ b/src/utilities/theme/hooks.tsx
@@ -1,6 +1,6 @@
 import {useContext} from 'react';
-import {ThemeProviderContext} from './context';
+import {ThemeContext} from './context';
 
 export function useTheme() {
-  return useContext(ThemeProviderContext);
+  return useContext(ThemeContext);
 }

--- a/src/utilities/theme/index.ts
+++ b/src/utilities/theme/index.ts
@@ -1,4 +1,4 @@
-export {ThemeProviderContext} from './context';
+export {ThemeContext} from './context';
 export {useTheme} from './hooks';
 export {Theme} from './types';
 export {createThemeContext} from './utils';

--- a/src/utilities/theme/index.ts
+++ b/src/utilities/theme/index.ts
@@ -1,4 +1,4 @@
-export {ThemeProviderContext, ThemeProviderContextType} from './context';
+export {ThemeProviderContext} from './context';
 export {useTheme} from './hooks';
 export {Theme} from './types';
 export {createThemeContext} from './utils';

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -7,7 +7,7 @@ import {createLightColor} from '../color-manipulation';
 import {compose} from '../compose';
 
 import {Theme, ColorsToParse, ThemeVariant, ThemeColors} from './types';
-import {ThemeProviderContextType} from './context';
+import {ThemeContextType} from './context';
 import {needsVariantList} from './config';
 
 export function setColors(theme: Theme | undefined): string[][] | undefined {
@@ -115,9 +115,7 @@ function parseColors([baseName, colors]: [string, ColorsToParse]): string[][] {
   return colorPairs;
 }
 
-export function createThemeContext(
-  theme?: ThemeProviderContextType,
-): ThemeProviderContextType {
+export function createThemeContext(theme?: ThemeContextType): ThemeContextType {
   if (!theme) {
     return {logo: null};
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Tweaking some of our test and context config to make it a bit less verbose, so you have half a chance of understanding what is happening.

### WHAT is this pull request doing?

- Simplify args of mountWithAppProvider in legacy tests - There's no need to nest the context values inside another object. This API matches the modern testing API for custom mounts.
-  Stop exporting the Theme context type from utilities/theme - Consuming sites should use `React.contextType<typeof ThemeProviderContext>` like the calling sites of all other contexts we provide
- Rename ThemeProviderContext to ThemeContext  - All our other provided contexts don't have Provider in their name, neither should this
- Make legacy withAppProvider use the modern types - Have a single suite of types for our mounting functions in enzyme and react-testing instead of duplicating them

### How to 🎩

Ensure tests and typechecks pass