### PR TITLE
Update Card README to not used deprecated prop

### DIFF
--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -357,7 +357,7 @@ Use when a card action will delete merchant data or be otherwise difficult to re
 ```jsx
 <Card
   title="Shipment 1234"
-  secondaryFooterAction={{content: 'Cancel shipment', destructive: true}}
+  secondaryFooterActions={[{content: 'Cancel shipment', destructive: true}]}
   primaryFooterAction={{content: 'Add tracking number'}}
 >
   <Card.Section title="Items">


### PR DESCRIPTION
### WHY are these changes introduced?

Card's `secondaryFooterAction` prop is deprecated, let's not use it in our readmes

### WHAT is this pull request doing?

Use `secondaryFooterActions` instead of `secondaryFooterAction`

### How to 🎩

Check `Card => Card with destructive footer action` example renders the same as before and no longer throws a deprecation notice