### PR TITLE
[Page] Add subtitle prop to Header

### DIFF
--- a/.storybook/polaris-readme-loader.js
+++ b/.storybook/polaris-readme-loader.js
@@ -115,6 +115,7 @@ import {
   NotificationMajorMonotone,
   OnlineStoreMajorTwotone,
   OrdersMajorTwotone,
+  PageDownMajorMonotone,
   PrintMinor,
   ProductsMajorTwotone,
   ProfileMinor,

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added a `subtitle` prop to `Page` ([#1851](https://github.com/Shopify/polaris-react/pull/1851))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -271,6 +271,23 @@ Use when a primary action functions better as part of the page content instead o
 </Page>
 ```
 
+### Page with subtitle
+
+<!-- example-for: web -->
+
+Use when the page title benefits from secondary content.
+
+```jsx
+<Page
+  breadcrumbs={[{content: 'Products', url: '/products'}]}
+  title="Invoice"
+  subtitle="Statement period: May 3, 2019 to June 2, 2019"
+  secondaryActions={[{content: 'Download', icon: PageDownMajorMonotone}]}
+>
+  <p>Page content</p>
+</Page>
+```
+
 ### Page with external link
 
 <!-- example-for: web -->

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -70,6 +70,16 @@ $action-menu-rollup-computed-width: icon-size() + (spacing(tight) * 2);
   @include page-title-layout;
 }
 
+.hasSubtitle {
+  flex-direction: column;
+}
+
+.TitleSecondaryContent {
+  @include page-title-layout;
+  margin-top: 0;
+  margin-left: 0;
+}
+
 .PrimaryActionWrapper {
   .mobileView & {
     margin-top: spacing();

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -11,6 +11,7 @@ import EventListener from '../../../EventListener';
 import {buttonsFrom} from '../../../Button';
 import Breadcrumbs, {Props as BreadcrumbsProps} from '../../../Breadcrumbs';
 import DisplayText from '../../../DisplayText';
+import Heading from '../../../Heading';
 import Pagination, {PaginationDescriptor} from '../../../Pagination';
 import ActionMenu, {hasGroupsWithActions} from '../../../ActionMenu';
 
@@ -20,6 +21,8 @@ import styles from './Header.scss';
 export interface Props {
   /** Page title, in large type */
   title: string;
+  /** Page subtitle, in medium type (stand-alone app use only) */
+  subtitle?: string;
   /** Important and non-interactive status information shown immediately after the title. (stand-alone app use only) */
   titleMetadata?: React.ReactNode;
   /** Visually hide the title (stand-alone app use only) */
@@ -83,6 +86,7 @@ class Header extends React.PureComponent<ComposedProps, State> {
   render() {
     const {
       title,
+      subtitle,
       titleMetadata,
       titleHidden = false,
       icon,
@@ -94,6 +98,7 @@ class Header extends React.PureComponent<ComposedProps, State> {
       actionGroups = [],
       polaris: {intl},
     } = this.props;
+
     const {mobileView} = this.state;
 
     if (icon) {
@@ -123,17 +128,33 @@ class Header extends React.PureComponent<ComposedProps, State> {
         </div>
       ) : null;
 
-    const titleMarkup = (
-      <div className={styles.Title}>
-        <div className={styles.DisplayTextWrapper}>
-          <DisplayText size="large" element="h1">
-            {title}
-          </DisplayText>
-        </div>
+    const titleMetadataMarkup = titleMetadata ? (
+      <div className={styles.TitleMetadata}>{titleMetadata}</div>
+    ) : null;
 
-        {titleMetadata && (
-          <div className={styles.TitleMetadataWrapper}>{titleMetadata}</div>
-        )}
+    const subtitleMarkup = subtitle ? (
+      <Heading element="h2">{subtitle}</Heading>
+    ) : null;
+
+    const titleSecondaryContent =
+      subtitle || titleMetadata ? (
+        <div className={styles.TitleSecondaryContent}>
+          {subtitleMarkup}
+          {titleMetadataMarkup}
+        </div>
+      ) : null;
+
+    const titleClassName = classNames(
+      styles.Title,
+      subtitle && styles.hasSubtitle,
+    );
+
+    const titleMarkup = (
+      <div className={titleClassName}>
+        <DisplayText size="large" element="h1">
+          {title}
+        </DisplayText>
+        {titleSecondaryContent}
       </div>
     );
 

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -45,6 +45,16 @@ describe('<Header />', () => {
     });
   });
 
+  describe('subtitle', () => {
+    it('is displayed in the header', () => {
+      const mockSubtitle = 'mock subtitle';
+      const header = mountWithAppProvider(
+        <Header title="title" subtitle={mockSubtitle} />,
+      );
+      expect(header.text()).toContain(mockSubtitle);
+    });
+  });
+
   describe('titleMetadata', () => {
     it('is displayed in the header', () => {
       const metaData = <div />;


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, the only support for secondary content in the `Page` `Header` is the `titleMetadata` prop. In use cases that benefit from a subtitle, that prop is not sufficient since the title lays out its children inline. 

### WHAT is this pull request doing?

This PR adds an optional `subtitle` prop to the `Page`, which accepts a string and renders below the `title` in the `Header`. 

This came out of a pairing session that followed a [Slack discussion](https://shopify.slack.com/archives/C4Y8N30KD/p1563212872385900) around the Billing team's [use case](https://docs.google.com/presentation/d/143hAb4HYvsoSGFjT11-h6CVdCJKsUiY-4XbfssG3Suk/edit#slide=id.g5b180fc265_0_86).

|  Large screen | Small screen  |
|---|---|
|<img width="998" alt="Screen Shot 2019-07-16 at 6 18 32 PM" src="https://user-images.githubusercontent.com/18447883/61333873-50266e00-a7f6-11e9-8f7d-1d92b2a961a3.png">|<img width="316" alt="Screen Shot 2019-07-16 at 6 18 47 PM" src="https://user-images.githubusercontent.com/18447883/61333893-5f0d2080-a7f6-11e9-8f88-9f67c3eb4e24.png">|

### Input needed

@mirualves @sarahill I'm seeking design input for the `subtitle` styling and placement. 

- I've chosen to implement this as an `h2` using the `Heading` component, as using `medium` `DisplayText` doesn't seem to give the appropriate visual hierarchy.

<details>
<summary>Click to see collapsed screenshot example</summary>

<img width="626" alt="Screen Shot 2019-07-16 at 3 57 57 PM" src="https://user-images.githubusercontent.com/18447883/61325342-80fca800-a7e2-11e9-9d7c-813711f93c4e.png">

</details>

- I'm currently working on how best to handle `titleMetadata` layout since `subtitle` placement needs to break the placement of the metadata. I'm thinking the layout should update to place and space `titleMetadata` inline with the `subtitle` instead of the title when present.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {PageDownMajorMonotone} from '@shopify/polaris-icons';
import {Page, Badge} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page
        breadcrumbs={[{content: 'Bills', url: '/settings/billing'}]}
        title="Invoice, but this page could have a longer title"
        subtitle="Statement period: May 3, 2019 to June 2, 2019"
        titleMetadata={<Badge status="success">Paid</Badge>}
        secondaryActions={[{content: 'Download', icon: PageDownMajorMonotone}]}
        primaryAction={{content: 'Save', disabled: true}}
        actionGroups={[
          {
            title: 'Promote',
            actions: [
              {
                content: 'Share on Facebook',
                accessibilityLabel: 'Individual action label',
                onAction: () => {},
              },
            ],
          },
        ]}
        pagination={{
          hasPrevious: true,
          hasNext: true,
        }}
        separator
      >
        <p>Page content</p>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
