### PR TITLE
Ignore deprecation noisy deprecation warnings in tests

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -12,6 +12,15 @@ const IGNORE_ERROR_REGEXES = [
   /React\.createClass is deprecated and will be removed in version 16/,
 ];
 
+const IGNORE_WARN_REGEXES = [
+  /Deprecation: Using `apiKey` and `shopOrigin` on `AppProvider` to initialize the Shopify App Bridge is deprecated. Support for this will be removed in v5\.0\./,
+  /Deprecation: Using `Loading` in an embedded app is deprecated and will be removed in v5\.0\./,
+  /Deprecation: Using `Modal` in an embedded app is deprecated and will be removed in v5\.0\./,
+  /Deprecation: Using `Page` to render an embedded app title bar is deprecated and will be removed in v5\.0\./,
+  /Deprecation: Using `Toast` in an embedded app is deprecated and will be removed in v5\.0\./,
+  /Deprecation: `ResourcePicker` is deprecated and will be removed in v5\.0\./,
+];
+
 // eslint-disable-next-line no-console
 const originalConsoleError = console.error.bind(console);
 // eslint-disable-next-line no-console
@@ -25,4 +34,19 @@ console.error = (...args: any[]) => {
   }
 
   originalConsoleError(...args);
+};
+
+// eslint-disable-next-line no-console
+const originalConsoleWarn = console.warn.bind(console);
+// eslint-disable-next-line no-console
+console.warn = (...args: any[]) => {
+  const [firstArgument] = args;
+  if (
+    typeof firstArgument === 'string' &&
+    IGNORE_WARN_REGEXES.some((regex) => regex.test(firstArgument))
+  ) {
+    return;
+  }
+
+  originalConsoleWarn(...args);
 };


### PR DESCRIPTION
### WHY are these changes introduced?

AppBridge related deprecation warnings are super noisy and make test
output hard to scroll through. Silence them so they don't get in the
way.

### WHAT is this pull request doing?

Overrides `console.warn` with a version that ignores AppBridge related deprecation warnings.

### To test

Check the console output for a `yarn build` and see that it's not full of warnings. (there are still some there, but all the AppBridge related noise is quietened.