### PR TITLE
[v4] Fix "Function components do not support contextType" error in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@storybook/theming": "^5.1.9",
     "@types/enzyme": "^3.9.3",
     "@types/enzyme-adapter-react-16": "^1.0.5",
+    "@types/hoist-non-react-statics": "^3.3.1",
     "@types/lodash": "^4.14.108",
     "@types/node": "^11.13.8",
     "archiver": "^3.0.0",
@@ -189,7 +190,7 @@
     "@types/react": "^16.8.15",
     "@types/react-dom": "^16.8.4",
     "@types/react-transition-group": "^2.0.7",
-    "hoist-non-react-statics": "^2.5.0",
+    "hoist-non-react-statics": "^3.3.0",
     "lodash": "^4.17.4",
     "tslib": "^1.9.3"
   }

--- a/src/utilities/with-app-provider.tsx
+++ b/src/utilities/with-app-provider.tsx
@@ -74,7 +74,6 @@ export function withAppProvider<OwnProps>({withinScrollable}: Options = {}) {
 
       return <WrappedComponent {...props as any} polaris={polaris} />;
     };
-    WithProvider.contextTypes = WrappedComponent.contextTypes;
 
     let WithScrollable: React.ComponentClass<any> | undefined;
     if (withinScrollable) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2260,6 +2260,14 @@
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.2.0.tgz#74e1da5f2a4a744ac6eb3ed57b48242ea9367202"
   integrity sha512-lELg5m6eBOmATWyCZl8qULEOvnPIUG6B443yXKj930glXIgwQirIBPp5rthP2amJW0YSzUg2s5sfgba4mRRCNw==
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"


### PR DESCRIPTION
### WHY are these changes introduced?

Filters.test.tsx caused the above error due to us using an old version
of hoist-non-react-statics

[Example of a build containing this error](https://circleci.com/gh/Shopify/polaris-react/23684?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

### WHAT is this pull request doing?

Update the version of hoist-non-react-statics we use.
Remove a pointless reassign of contextTypes - I'm pretty sure we won't ever need this.

### How to 🎩

Check the test output, see there is no "Function components do not support contextType" error