### PR TITLE
[Tabs] Fix Tabs accessibility issue

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed accessibility issue with ChoiceList errors not being correctly connected to the inputs ([#1824](https://github.com/Shopify/polaris-react/pull/1824));
+- Fixed `Tab` `aria-controls` pointing to a non-existent `Panel` `id` ([#1869](https://github.com/Shopify/polaris-react/pull/1869))
 
 ### Documentation
 

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -116,6 +116,10 @@ $focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
   }
 }
 
+.Panel-hidden {
+  display: none;
+}
+
 .List {
   list-style: none;
   margin: 0;

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -79,14 +79,26 @@ class Tabs extends React.PureComponent<CombinedProps, State> {
     const {tabToFocus, visibleTabs, hiddenTabs, showDisclosure} = this.state;
     const disclosureTabs = hiddenTabs.map((tabIndex) => tabs[tabIndex]);
 
-    const panelMarkup = children ? (
-      <Panel
-        id={tabs[selected].panelID || `${tabs[selected].id}-panel`}
-        tabID={tabs[selected].id}
-      >
-        {children}
-      </Panel>
-    ) : null;
+    const panelMarkup = children
+      ? tabs.map((_tab, index) => {
+          return selected === index ? (
+            <Panel
+              id={tabs[index].panelID || `${tabs[index].id}-panel`}
+              tabID={tabs[index].id}
+              key={tabs[index].id}
+            >
+              {children}
+            </Panel>
+          ) : (
+            <Panel
+              id={tabs[index].panelID || `${tabs[index].id}-panel`}
+              tabID={tabs[index].id}
+              key={tabs[index].id}
+              hidden
+            />
+          );
+        })
+      : null;
 
     const tabsMarkup = visibleTabs
       .sort((tabA, tabB) => tabA - tabB)

--- a/src/components/Tabs/components/Panel/Panel.tsx
+++ b/src/components/Tabs/components/Panel/Panel.tsx
@@ -1,16 +1,19 @@
 import * as React from 'react';
+import {classNames} from '@shopify/css-utilities';
 import styles from '../../Tabs.scss';
 
 export interface Props {
+  hidden?: boolean;
   id: string;
   tabID: string;
   children?: React.ReactNode;
 }
 
-export default function Panel({id, tabID, children}: Props) {
+export default function Panel({hidden, id, tabID, children}: Props) {
+  const className = classNames(styles.Panel, hidden && styles['Panel-hidden']);
   return (
     <div
-      className={styles.Panel}
+      className={className}
       id={id}
       role="tabpanel"
       aria-labelledby={tabID}

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -168,7 +168,26 @@ describe('<Tabs />', () => {
     });
   });
 
-  describe('children', () => {
+  describe('panel', () => {
+    it('renders a Panel for each of the Tabs', () => {
+      const content = <p>Tab content</p>;
+      const wrapper = mountWithAppProvider(
+        <Tabs {...mockProps}>{content}</Tabs>,
+      );
+      const panel = wrapper.find(Panel);
+      expect(panel).toHaveLength(2);
+    });
+
+    it('renders a Panel with a hidden prop for the non selected tabs', () => {
+      const content = <p>Tab content</p>;
+      const wrapper = mountWithAppProvider(
+        <Tabs {...mockProps}>{content}</Tabs>,
+      );
+
+      const nonSelectedPanel = wrapper.find(Panel).at(1);
+      expect(nonSelectedPanel.prop('hidden')).toBe(true);
+    });
+
     it('wraps the children in a Panel with matching aria attributes to the tab', () => {
       const content = <p>Tab content</p>;
       const wrapper = mountWithAppProvider(
@@ -176,7 +195,7 @@ describe('<Tabs />', () => {
       );
 
       const selectedTab = wrapper.find(Tab).at(0);
-      const panel = wrapper.find(Panel);
+      const panel = wrapper.find(Panel).at(0);
       expect(panel.exists()).toBe(true);
       expect(panel.contains(content)).toBe(true);
       expect(panel.prop('id')).toBeTruthy();
@@ -195,7 +214,7 @@ describe('<Tabs />', () => {
         </Tabs>,
       );
 
-      const panel = wrapper.find(Panel);
+      const panel = wrapper.find(Panel).at(0);
       const selectedTab = wrapper.find(Tab).at(0);
       expect(panel.prop('id')).toBe(selectedTab.prop('panelID'));
     });


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1577

### WHAT is this pull request doing?

Our tabs generate an aria-control that points to tab panels that don't exist because only render the selected tab.

This generates all Panel and adds a `display: none` on the tabs that aren't selected.


### How to 🎩

To top hat, simply go to the Tab example in the playground and ensure that the value of the `aria-controls` prop of each tab (on buttons) matches the corresponding id of the panel content.


<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        {/* Add the code you want to test here */}
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
