### PR TITLE
[ToastManager] Move aria-live to containing div for a11y using NVDA

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixed accessibility issue with ChoiceList errors not being correctly connected to the inputs ([#1824](https://github.com/Shopify/polaris-react/pull/1824));
 - Fixed `Tab` `aria-controls` pointing to a non-existent `Panel` `id` ([#1869](https://github.com/Shopify/polaris-react/pull/1869))
+- Fixed `Toast` accessibility issue by moving `aria-live` prop to `ToastManager` ([#1873](https://github.com/Shopify/polaris-react/pull/1873))
 
 ### Documentation
 

--- a/src/components/Frame/components/ToastManager/ToastManager.tsx
+++ b/src/components/Frame/components/ToastManager/ToastManager.tsx
@@ -31,7 +31,7 @@ export default class ToastManager extends React.PureComponent<Props, never> {
           timeout={{enter: 0, exit: 400}}
           classNames={toastClasses}
         >
-          <div ref={this.toastNodes[index]} aria-live="polite">
+          <div ref={this.toastNodes[index]}>
             <Toast {...toast} />
           </div>
         </CSSTransition>
@@ -41,7 +41,7 @@ export default class ToastManager extends React.PureComponent<Props, never> {
     return (
       <Portal idPrefix="toast-manager">
         <EventListener event="resize" handler={this.updateToasts} />
-        <div className={styles.ToastManager}>
+        <div className={styles.ToastManager} aria-live="polite">
           <TransitionGroup component={null}>{toastsMarkup}</TransitionGroup>
         </div>
       </Portal>

--- a/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
+++ b/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
@@ -29,6 +29,21 @@ describe('<ToastManager />', () => {
       });
     }).not.toThrow();
   });
+
+  it('has and aria-live attribute of polite', () => {
+    const toastManager = mountWithAppProvider(
+      <ToastManager
+        toastMessages={[{id: '1', content: 'Hello', onDismiss: noop}]}
+      />,
+    );
+
+    expect(
+      toastManager
+        .find('div')
+        .at(0)
+        .prop('aria-live'),
+    ).toBe('polite');
+  });
 });
 
 describe('<Toast />', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1215

### WHAT is this pull request doing?

In order to announce the Toast using the aria-live attribut, NVDA require the element with the aria-live prop to be on screen when the content changes.

Our Toasts are wrapped in a Toast manager. This pr moves the aria-live attribute from the Toast to the Toast Manager    

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Using NVDA (on windows) navigate to:

http://localhost:6006/?path=/story/all-components-toast--basic-toast

and ensure that the Toast messages are being announced.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {Page} from '@shopify/polaris';

interface State {}

export default class Playground extends React.Component<never, State> {
  render() {
    return (
      <Page title="Playground">
        {/* Add the code you want to test here */}
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
