### PR TITLE
[v4][Collapsible] Fix collapsible regression

### DIFF
--- a/src/components/Collapsible/Collapsible.scss
+++ b/src/components/Collapsible/Collapsible.scss
@@ -16,3 +16,7 @@
   height: var(--polaris-collapsible-height);
   opacity: 1;
 }
+
+.fullyOpen {
+  overflow: visible;
+}

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -98,7 +98,11 @@ export default function Collapsible({id, open, children}: Props) {
     isMounted.current = true;
   }, []);
 
-  const wrapperClassName = classNames(styles.Collapsible, open && styles.open);
+  const wrapperClassName = classNames(
+    styles.Collapsible,
+    open && styles.open,
+    transitionStatus === TransitionStatus.Entered && styles.fullyOpen,
+  );
 
   const content =
     transitionStatus === TransitionStatus.Exited && !open ? null : children;


### PR DESCRIPTION
### WHY are these changes introduced?

Overflow content remains hidden

### WHAT is this pull request doing?

Applying overflow visible like was [previously done](https://github.com/Shopify/polaris-react/pull/902/files#diff-2ebd5f6d700a607bf58b3c27882b28f5L23)

### How to 🎩

* Open filters example
* Open sheet
* Open money spent filter
* Do the "tooltips" show?
