### PR TITLE
[Page] Add thumbnail and subtitle to Page

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added a `subtitle` and `thumbnail` prop to `Page` ([#1880](https://github.com/Shopify/polaris-react/pull/1880))
+
 ### Bug fixes
 
 - Fixed accessibility issue with ChoiceList errors not being correctly connected to the inputs ([#1824](https://github.com/Shopify/polaris-react/pull/1824));

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -185,8 +185,15 @@ Use for detail pages, which should have pagination and breadcrumbs, and also oft
 ```jsx
 <Page
   breadcrumbs={[{content: 'Products', url: '/products'}]}
-  title="Jar With Lock-Lid"
-  titleMetadata={<Badge>Draft</Badge>}
+  title="3/4 inch Leather pet collar"
+  titleMetadata={<Badge status="success">Paid</Badge>}
+  subtitle="Perfect for any pet"
+  thumbnail={
+    <Thumbnail
+      source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+      alt="Black leather pet collar"
+    />
+  }
   primaryAction={{content: 'Save', disabled: true}}
   secondaryActions={[
     {
@@ -268,6 +275,69 @@ Use when a primary action functions better as part of the page content instead o
       <Button primary>Continue</Button>
     </Stack>
   </Card>
+</Page>
+```
+
+### Page with subtitle
+
+<!-- example-for: web -->
+
+Use when the page title benefits from secondary content.
+
+```jsx
+<Page
+  breadcrumbs={[{content: 'Products', url: '/products'}]}
+  title="Invoice"
+  subtitle="Statement period: May 3, 2019 to June 2, 2019"
+  secondaryActions={[{content: 'Download', icon: ArrowDownMinor}]}
+>
+  <p>Page content</p>
+</Page>
+```
+
+### Page with title thumbnail
+
+<!-- example-for: web -->
+
+Use when an image will help merchants identify the purpose of the page.
+
+```jsx
+<Page
+  breadcrumbs={[{content: 'Products', url: '/products/31'}]}
+  title="3/4 inch Leather pet collar"
+  titleMetadata={<Badge status="success">Paid</Badge>}
+  thumbnail={
+    <Thumbnail
+      source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+      alt="Black leather pet collar"
+    />
+  }
+  secondaryActions={[
+    {
+      content: 'Duplicate',
+      icon: DuplicateMinor,
+    },
+    {
+      content: 'View',
+      icon: ViewMinor,
+    },
+  ]}
+  actionGroups={[
+    {
+      title: 'Promote',
+      actions: [{content: 'Share on Facebook'}],
+    },
+    {
+      title: 'More actions',
+      actions: [{content: 'Embed on a website'}],
+    },
+  ]}
+  pagination={{
+    hasPrevious: true,
+    hasNext: true,
+  }}
+>
+  <p>Page content</p>
 </Page>
 ```
 

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -66,10 +66,6 @@ $action-menu-rollup-computed-width: icon-size() + (spacing(tight) * 2);
   }
 }
 
-.Title {
-  @include page-title-layout;
-}
-
 .PrimaryActionWrapper {
   .mobileView & {
     margin-top: spacing();

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -10,18 +10,15 @@ import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 import EventListener from '../../../EventListener';
 import {buttonsFrom} from '../../../Button';
 import Breadcrumbs, {Props as BreadcrumbsProps} from '../../../Breadcrumbs';
-import DisplayText from '../../../DisplayText';
+
 import Pagination, {PaginationDescriptor} from '../../../Pagination';
 import ActionMenu, {hasGroupsWithActions} from '../../../ActionMenu';
 
 import {HeaderPrimaryAction} from '../../types';
+import {Title, TitleProps} from './components';
 import styles from './Header.scss';
 
-export interface Props {
-  /** Page title, in large type */
-  title: string;
-  /** Important and non-interactive status information shown immediately after the title. (stand-alone app use only) */
-  titleMetadata?: React.ReactNode;
+export interface Props extends TitleProps {
   /** Visually hide the title (stand-alone app use only) */
   titleHidden?: boolean;
   /**
@@ -83,7 +80,9 @@ class Header extends React.PureComponent<ComposedProps, State> {
   render() {
     const {
       title,
+      subtitle,
       titleMetadata,
+      thumbnail,
       titleHidden = false,
       icon,
       separator,
@@ -94,6 +93,7 @@ class Header extends React.PureComponent<ComposedProps, State> {
       actionGroups = [],
       polaris: {intl},
     } = this.props;
+
     const {mobileView} = this.state;
 
     if (icon) {
@@ -123,18 +123,13 @@ class Header extends React.PureComponent<ComposedProps, State> {
         </div>
       ) : null;
 
-    const titleMarkup = (
-      <div className={styles.Title}>
-        <div className={styles.DisplayTextWrapper}>
-          <DisplayText size="large" element="h1">
-            {title}
-          </DisplayText>
-        </div>
-
-        {titleMetadata && (
-          <div className={styles.TitleMetadataWrapper}>{titleMetadata}</div>
-        )}
-      </div>
+    const pageTitleMarkup = (
+      <Title
+        title={title}
+        subtitle={subtitle}
+        titleMetadata={titleMetadata}
+        thumbnail={thumbnail}
+      />
     );
 
     const primaryActionMarkup = primaryAction ? (
@@ -171,7 +166,7 @@ class Header extends React.PureComponent<ComposedProps, State> {
 
         <div className={styles.MainContent}>
           <div className={styles.TitleActionMenuWrapper}>
-            {titleMarkup}
+            {pageTitleMarkup}
             {actionMenuMarkup}
           </div>
 

--- a/src/components/Page/components/Header/components/Title/Title.scss
+++ b/src/components/Page/components/Header/components/Title/Title.scss
@@ -1,0 +1,38 @@
+@import '../../../../../../styles/common';
+
+.Title {
+  @include text-breakword;
+}
+
+.SubTitle {
+  margin-top: spacing(tight);
+}
+
+.hasThumbnail {
+  display: grid;
+  grid-gap: spacing();
+  grid-template-columns: auto 1fr;
+
+  .TitleAndSubtitleWrapper {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+}
+
+.TitleWithMetadataWrapper {
+  .Title {
+    display: inline;
+    margin-right: spacing(tight);
+
+    // stylelint-disable-next-line selector-max-combinators
+    > * {
+      display: inline;
+    }
+  }
+
+  .TitleMetadata {
+    margin-top: spacing(tight);
+    display: inline-block;
+  }
+}

--- a/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/src/components/Page/components/Header/components/Title/Title.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import {classNames} from '@shopify/css-utilities';
+import {Props as AvatarProps} from '../../../../../Avatar';
+import {Props as ThumbnailProps} from '../../../../../Thumbnail';
+import DisplayText from '../../../../../DisplayText';
+
+import styles from './Title.scss';
+
+export interface Props {
+  /** Page title, in large type */
+  title: string;
+  /** Page subtitle, in regular type*/
+  subtitle?: string;
+  /** Important and non-interactive status information shown immediately after the title. (stand-alone app use only) */
+  titleMetadata?: React.ReactNode;
+  /** thumbnail that precedes the title */
+  thumbnail?:
+    | React.ReactElement<AvatarProps | ThumbnailProps>
+    | React.SFC<React.SVGProps<SVGSVGElement>>;
+}
+
+export default function Title({
+  title,
+  subtitle,
+  titleMetadata,
+  thumbnail,
+}: Props) {
+  const titleMarkup = (
+    <div className={styles.Title}>
+      <DisplayText size="large" element="h1">
+        {title}
+      </DisplayText>
+    </div>
+  );
+
+  const titleMetadataMarkup = titleMetadata ? (
+    <div className={styles.TitleMetadata}>{titleMetadata}</div>
+  ) : null;
+
+  const wrappedTitleMarkup = titleMetadata ? (
+    <div className={styles.TitleWithMetadataWrapper}>
+      {titleMarkup}
+      {titleMetadataMarkup}
+    </div>
+  ) : (
+    titleMarkup
+  );
+
+  const subtitleMarkup = subtitle ? (
+    <div className={styles.SubTitle}>
+      <p>{subtitle}</p>
+    </div>
+  ) : null;
+
+  const thumbnailMarkup = thumbnail ? <div>{thumbnail}</div> : null;
+
+  const pageTitleClassName = thumbnail
+    ? classNames(styles.hasThumbnail)
+    : undefined;
+
+  return (
+    <div className={pageTitleClassName}>
+      {thumbnailMarkup}
+      <div className={styles.TitleAndSubtitleWrapper}>
+        {wrappedTitleMarkup}
+        {subtitleMarkup}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Page/components/Header/components/Title/index.ts
+++ b/src/components/Page/components/Header/components/Title/index.ts
@@ -1,0 +1,4 @@
+import Title from './Title';
+
+export {Props} from './Title';
+export default Title;

--- a/src/components/Page/components/Header/components/Title/tests/PageTitle.test.tsx
+++ b/src/components/Page/components/Header/components/Title/tests/PageTitle.test.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import {mountWithAppProvider} from 'test-utilities';
+import {Badge, DisplayText, Avatar} from 'components';
+import Title from '..';
+
+describe('<Title />', () => {
+  const mockProps = {
+    title: 'Test',
+  };
+
+  describe('title', () => {
+    it('renders a DisplayText with the title', () => {
+      const pageTitle = mountWithAppProvider(<Title {...mockProps} />);
+      expect(pageTitle.find(DisplayText).text()).toBe(mockProps.title);
+    });
+  });
+
+  describe('subtitle', () => {
+    const propsWithSubtitle = {
+      ...mockProps,
+      subtitle: 'Subtitle',
+    };
+
+    it('renders a paragaph when defined', () => {
+      const pageTitle = mountWithAppProvider(<Title {...propsWithSubtitle} />);
+      expect(pageTitle.find('p').text()).toBe(propsWithSubtitle.subtitle);
+    });
+
+    it('does not render a paragraph when not defined', () => {
+      const pageTitle = mountWithAppProvider(<Title {...mockProps} />);
+      expect(pageTitle.find('p').exists()).toBe(false);
+    });
+  });
+
+  describe('titleMetadata', () => {
+    const propsWithMetadata = {
+      ...mockProps,
+      titleMetadata: <Badge>Sold</Badge>,
+    };
+    it('renders the titleMetadata when defined', () => {
+      const pageTitle = mountWithAppProvider(<Title {...propsWithMetadata} />);
+      expect(pageTitle.find(Badge).exists()).toBe(true);
+    });
+  });
+
+  describe('thumbail', () => {
+    const propsWithThumbail = {
+      ...mockProps,
+      thumbnail: <Avatar customer />,
+    };
+
+    it('renders the thumbnail when defined', () => {
+      const pageTitle = mountWithAppProvider(<Title {...propsWithThumbail} />);
+      expect(pageTitle.find(Avatar).exists()).toBe(true);
+    });
+  });
+});

--- a/src/components/Page/components/Header/components/index.ts
+++ b/src/components/Page/components/Header/components/index.ts
@@ -1,0 +1,1 @@
+export {default as Title, Props as TitleProps} from './Title';

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {mountWithAppProvider} from 'test-utilities';
+import Title from '..';
 
 import {
   ActionMenu,
@@ -8,6 +9,8 @@ import {
   buttonsFrom,
   EventListener,
   Pagination,
+  Badge,
+  Avatar,
 } from 'components';
 
 import {HeaderPrimaryAction} from '../../../types';
@@ -37,21 +40,34 @@ describe('<Header />', () => {
     expect(resizeEventListener).toHaveLength(1);
   });
 
-  describe('title', () => {
-    it('is displayed in the header', () => {
-      const mockTitle = 'mock title';
-      const header = mountWithAppProvider(<Header title={mockTitle} />);
-      expect(header.text()).toContain(mockTitle);
-    });
-  });
+  describe('Title', () => {
+    const mockProps = {
+      title: 'title',
+      subtitle: 'subtitle',
+      titleMetadata: <Badge>Sold</Badge>,
+      thumbnail: <Avatar customer />,
+    };
 
-  describe('titleMetadata', () => {
-    it('is displayed in the header', () => {
-      const metaData = <div />;
-      const header = mountWithAppProvider(
-        <Header {...mockProps} titleMetadata={metaData} />,
+    it('sets the title on the Title', () => {
+      const header = mountWithAppProvider(<Header {...mockProps} />);
+      expect(header.find(Title).prop('title')).toBe(mockProps.title);
+    });
+
+    it('sets the subtitle on the Title', () => {
+      const header = mountWithAppProvider(<Header {...mockProps} />);
+      expect(header.find(Title).prop('subtitle')).toBe(mockProps.subtitle);
+    });
+
+    it('sets the thumbnail on the Title', () => {
+      const header = mountWithAppProvider(<Header {...mockProps} />);
+      expect(header.find(Title).prop('thumbnail')).toBe(mockProps.thumbnail);
+    });
+
+    it('sets the titleMetadata on the Title', () => {
+      const header = mountWithAppProvider(<Header {...mockProps} />);
+      expect(header.find(Title).prop('titleMetadata')).toBe(
+        mockProps.titleMetadata,
       );
-      expect(header.contains(metaData)).toBeTruthy();
     });
   });
 

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -6,7 +6,7 @@ import {
 import {animationFrame} from '@shopify/jest-dom-mocks';
 import {shallowWithAppProvider, mountWithAppProvider} from 'test-utilities';
 
-import {Card} from 'components';
+import {Card, Badge, Avatar} from 'components';
 import {Header} from '../components';
 import {LinkAction} from '../../../types';
 
@@ -100,6 +100,36 @@ describe('<Page />', () => {
       const title = 'Products';
       const page = mountWithAppProvider(<Page {...mockProps} title={title} />);
       expect(page.find(Header).prop('title')).toBe(title);
+    });
+  });
+
+  describe('subtitle', () => {
+    it('gets passed into the <Header />', () => {
+      const subtitle = 'Subtitle';
+      const page = mountWithAppProvider(
+        <Page {...mockProps} subtitle={subtitle} />,
+      );
+      expect(page.find(Header).prop('subtitle')).toBe(subtitle);
+    });
+  });
+
+  describe('titleMetadata', () => {
+    it('gets passed into the <Header />', () => {
+      const titleMetadata = <Badge>Sold</Badge>;
+      const page = mountWithAppProvider(
+        <Page {...mockProps} titleMetadata={titleMetadata} />,
+      );
+      expect(page.find(Header).prop('titleMetadata')).toBe(titleMetadata);
+    });
+  });
+
+  describe('thumbnail', () => {
+    it('gets passed into the <Header />', () => {
+      const thumbnail = <Avatar customer />;
+      const page = mountWithAppProvider(
+        <Page {...mockProps} thumbnail={thumbnail} />,
+      );
+      expect(page.find(Header).prop('thumbnail')).toBe(thumbnail);
     });
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1711 and adds a subtitle prop

### WHAT is this pull request doing?

Add 2 props to page: Thumbnail and Subtitle.

We opted with props for now until we get time to investigate the best approach to have more composable components.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {PageDownMajorMonotone} from '@shopify/polaris-icons';
import {Page, Badge, Avatar} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page
        breadcrumbs={[{content: 'Bills', url: '/settings/billing'}]}
        title="Invoice, but this page could have a longer title"
        subtitle="Statement period: May 3, 2019 to June 2, 2019"
        titleMetadata={<Badge status="success">Paid</Badge>}
        thumbnail={<Avatar customer />}
        secondaryActions={[{content: 'Download', icon: PageDownMajorMonotone}]}
        primaryAction={{content: 'Save', disabled: true}}
        actionGroups={[
          {
            title: 'Promote',
            actions: [
              {
                content: 'Share on Facebook',
                accessibilityLabel: 'Individual action label',
                onAction: () => {},
              },
            ],
          },
        ]}
        pagination={{
          hasPrevious: true,
          hasNext: true,
        }}
        separator
      >
        <p>Page content</p>
      </Page>
    );
  }
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
