### PR TITLE
Improve tsconfig

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -44,6 +44,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Added support for React hooks in Storybook ([#1665](https://github.com/Shopify/polaris-react/pull/1665))
 - Created `toBeDisabled`, `mountWithContext` and added custom testing matchers ([#1596](https://github.com/Shopify/polaris-react/pull/1596))
+- Enabled strict mode in TypeScript ([#1883](https://github.com/Shopify/polaris-react/pull/1883))
 
 ### Dependency upgrades
 

--- a/src/components/Autocomplete/tests/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/tests/Autocomplete.test.tsx
@@ -134,7 +134,7 @@ describe('<Autocomplete/>', () => {
     return <Autocomplete.TextField label="" onChange={noop} />;
   }
 
-  function handleOnSelect(updatedSelection: string[]) {
+  function handleOnSelect(this: any, updatedSelection: string[]) {
     const selectedText = updatedSelection.map((selectedItem: string) => {
       const matchedOption = this.options.filter((option: any) => {
         return option.value.match(selectedItem);

--- a/src/utilities/app-bridge/tests/app-bridge.test.ts
+++ b/src/utilities/app-bridge/tests/app-bridge.test.ts
@@ -63,7 +63,8 @@ describe('createAppBridge()', () => {
     const next = jest.fn((args) => args);
     const baseAction = {type: 'actionType'};
 
-    expect(setClientInterfaceHook.call({}, next)(baseAction)).toStrictEqual({
+    const hookResult = setClientInterfaceHook.call({}, next) as any;
+    expect(hookResult(baseAction)).toStrictEqual({
       type: 'actionType',
       clientInterface: {
         name: '@shopify/polaris',

--- a/src/utilities/tests/app-bridge-transformers.test.ts
+++ b/src/utilities/tests/app-bridge-transformers.test.ts
@@ -20,7 +20,7 @@ describe('app bridge transformers', () => {
 
     it('action is APP by default', () => {
       const callback = generateRedirect(appBridge, '/path');
-      callback!.call(this);
+      callback!();
 
       expect(dispatch).toHaveBeenCalledTimes(1);
       expect(dispatch).toHaveBeenCalledWith(Redirect.Action.APP, '/path');
@@ -28,7 +28,7 @@ describe('app bridge transformers', () => {
 
     it('action is APP when target is APP', () => {
       const callback = generateRedirect(appBridge, '/path', 'APP');
-      callback!.call(this);
+      callback!();
 
       expect(dispatch).toHaveBeenCalledTimes(1);
       expect(dispatch).toHaveBeenCalledWith(Redirect.Action.APP, '/path');
@@ -36,7 +36,7 @@ describe('app bridge transformers', () => {
 
     it('action is REMOTE with newContext when external is true', () => {
       const callback = generateRedirect(appBridge, '/path', undefined, true);
-      callback!.call(this);
+      callback!();
 
       expect(dispatch).toHaveBeenCalledTimes(1);
       expect(dispatch).toHaveBeenCalledWith(Redirect.Action.REMOTE, {
@@ -47,7 +47,7 @@ describe('app bridge transformers', () => {
 
     it('action is REMOTE when target is REMOTE', () => {
       const callback = generateRedirect(appBridge, '/path', 'REMOTE');
-      callback!.call(this);
+      callback!();
 
       expect(dispatch).toHaveBeenCalledTimes(1);
       expect(dispatch).toHaveBeenCalledWith(Redirect.Action.REMOTE, '/path');
@@ -55,7 +55,7 @@ describe('app bridge transformers', () => {
 
     it('action is ADMIN_PATH when target is ADMIN_PATH', () => {
       const callback = generateRedirect(appBridge, '/path', 'ADMIN_PATH');
-      callback!.call(this);
+      callback!();
 
       expect(dispatch).toHaveBeenCalledTimes(1);
       expect(dispatch).toHaveBeenCalledWith(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,15 +3,13 @@
   "compilerOptions": {
     "baseUrl": "./src",
     "rootDir": "./",
-    "module": "es2015",
     "declarationDir": "types",
     "declarationMap": false,
     "jsx": "react-native",
-    "strict": false,
-    "strictNullChecks": true,
-    "noImplicitAny": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
+    // strictFunctionTypes & strictPropertyInitialization are implictly
+    // enabled by strict mode but we're not yet compliant, so disable for now
+    "strictFunctionTypes": false,
+    "strictPropertyInitialization": false,
     "importHelpers": true,
     "skipLibCheck": false
   },


### PR DESCRIPTION
### WHY are these changes introduced?

Tightening up our TS config

Fixes #1881

### WHAT is this pull request doing?

- Enables esModuleInterop (it's enabled in the base config, and allowSyntheticDefaultImports can be removed as that is implied to be true if esModuleInterop is set)
- Enables strict mode (its enabled in the base config). We still have quite a lot of violations for strictFunctionTypes and strictPropertyInitialization and the fixes aren't as trivial as the others in this PR so I've disabled those for now and we can tidy them up later. I expect most of the strictPropertyInitialization issues to go away as we migrate to hooks
- Changes module type to be the default (which is esnext, but that only allows for `import()` functions which recently hit stage 4 so it's stable anyway)

### How to 🎩

Check type-check and tests pass. Ensure the output of the esnext folder is the same as on master.

 - `git checkout master && yarn && yarn run build && mv esnext master-esnext`
- `git checkout ts-updates && yarn && yarn run build`
- `diff -ru master-esnext esnext`
