### PR TITLE
[Autocomplete]Fix keyboard navigation and item selection in Autocomplete combo box.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -48,6 +48,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed accessibility issue with `Tabs` list item presentation role ([#1958](https://github.com/Shopify/polaris-react/pull/1958))
 - Removed `Tooltip` on disabled `Pagination` buttons ([#1963](https://github.com/Shopify/polaris-react/pull/1963))
 - Fixed accessibility labels on `ResourceList.Item` persistent action disclosure icon ([#1973](https://github.com/Shopify/polaris-react/pull/1973))
+- Fixed accessibility issue with `Autocomplete` where keyboard navigation of options was laggy and skipped options([#1887](https://github.com/Shopify/polaris-react/pull/1887))
+- Fixed bug where `Autocomplete` was bubbling up the `Enter` key event unexpectedly ([#1887](https://github.com/Shopify/polaris-react/pull/1887))
 
 ### Documentation
 

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -283,19 +283,21 @@ export default class ComboBox extends React.PureComponent<Props, State> {
   };
 
   private handleEnter = (event: KeyboardEvent) => {
-    if (event.keyCode === Key.Enter) {
-      const {selectedOption} = this.state;
-      if (this.state.popoverActive && selectedOption) {
-        if (isOption(selectedOption)) {
-          event.preventDefault();
-          this.handleSelection(selectedOption.value);
-        } else {
-          selectedOption.onAction && selectedOption.onAction();
-        }
-      }
-
-      this.handlePopoverOpen;
+    if (event.keyCode !== Key.Enter) {
+      return;
     }
+
+    const {selectedOption} = this.state;
+    if (this.state.popoverActive && selectedOption) {
+      if (isOption(selectedOption)) {
+        event.preventDefault();
+        this.handleSelection(selectedOption.value);
+      } else {
+        selectedOption.onAction && selectedOption.onAction();
+      }
+    }
+
+    this.handlePopoverOpen;
   };
 
   private handleFocus = () => {

--- a/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
+++ b/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
@@ -420,8 +420,24 @@ describe('<ComboBox/>', () => {
       );
       comboBox.find(TextField).simulate('click');
       dispatchKeyup(Key.DownArrow);
-      dispatchKeyup(Key.Enter);
+      dispatchKeydown(Key.Enter);
       expect(spy).toHaveBeenCalledWith(['cheese_pizza']);
+    });
+
+    it('does not add to selected options when the down arrow and key other than enter is pressed', () => {
+      const spy = jest.fn();
+      const comboBox = mountWithAppProvider(
+        <ComboBox
+          options={options}
+          selected={[]}
+          textField={renderTextField()}
+          onSelect={spy}
+        />,
+      );
+      comboBox.find(TextField).simulate('click');
+      dispatchKeyup(Key.DownArrow);
+      dispatchKeydown(Key.RightArrow);
+      expect(spy).not.toHaveBeenCalled();
     });
 
     it('activates the popover when the combobox is focused', () => {
@@ -554,4 +570,9 @@ function renderNodeWithId() {
 function dispatchKeyup(key: Key) {
   const event: KeyboardEventInit & {keyCode: Key} = {keyCode: key};
   document.dispatchEvent(new KeyboardEvent('keyup', event));
+}
+
+function dispatchKeydown(key: Key) {
+  const event: KeyboardEventInit & {keyCode: Key} = {keyCode: key};
+  window.dispatchEvent(new KeyboardEvent('keydown', event));
 }

--- a/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
+++ b/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
@@ -408,6 +408,36 @@ describe('<ComboBox/>', () => {
   });
 
   describe('keypress events', () => {
+    it('handles key events when there are no previous options', () => {
+      const spy = jest.fn();
+      const options: {value: string; label: string}[] = [];
+      const comboBox = mountWithAppProvider(
+        <ComboBox
+          options={options}
+          selected={[]}
+          textField={renderTextField()}
+          onSelect={spy}
+        />,
+      );
+      comboBox.find(TextField).simulate('click');
+      dispatchKeyup(Key.DownArrow);
+      dispatchKeydown(Key.Enter);
+      expect(spy).not.toHaveBeenCalled();
+
+      comboBox.setProps({
+        options: [
+          {value: 'cheese_pizza', label: 'Cheese Pizza'},
+          {value: 'macaroni_pizza', label: 'Macaroni Pizza'},
+          {value: 'pepperoni_pizza', label: 'Pepperoni Pizza'},
+        ],
+      });
+      comboBox.update();
+      comboBox.find(TextField).simulate('click');
+      dispatchKeyup(Key.DownArrow);
+      dispatchKeydown(Key.Enter);
+      expect(spy).toHaveBeenCalledWith(['cheese_pizza']);
+    });
+
     it('adds to selected options when the down arrow and enter keys are pressed', () => {
       const spy = jest.fn();
       const comboBox = mountWithAppProvider(

--- a/src/components/Autocomplete/tests/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/tests/Autocomplete.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {CirclePlusMinor} from '@shopify/polaris-icons';
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {Spinner} from 'components';
+import {Key} from '../../../types';
 import Autocomplete from '..';
 import {ComboBox} from '../components';
 
@@ -89,6 +90,29 @@ describe('<Autocomplete/>', () => {
       expect(autocomplete.find(ComboBox).prop('emptyState')).toStrictEqual(
         <EmptyState />,
       );
+    });
+
+    it('`Enter` keypress in <Autocomplete/> does not trigger `onSubmit` when wrapped in a <form>', () => {
+      const spy = jest.fn();
+
+      const autocomplete = mountWithAppProvider(
+        <form style={{height: '225px'}} onSubmit={spy}>
+          <Autocomplete
+            options={options}
+            selected={[]}
+            textField={renderTextField()}
+            onSelect={noop}
+            loading
+          />
+        </form>,
+      );
+
+      autocomplete.find(Autocomplete).simulate('click');
+      autocomplete
+        .find(Autocomplete)
+        .simulate('keyup', {keyCode: Key.DownArrow});
+      autocomplete.find(Autocomplete).simulate('keyDown', {keyCode: Key.Enter});
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Need to fix keyboard navigation and item selection in Autocomplete combo box.
Fixes #1380. Fixes #1346  <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Added an EventListener for the `keydown` event and only use the handler to track the Enter key events. This prevents any `submit` events from being triggered on Enter key press inside the combo box. `stopPropagation()` does not seem to work in this case. 
https://stackoverflow.com/questions/895171/prevent-users-from-submitting-a-form-by-hitting-enter  - `The keydown event is preferred over keyup as the keyup is too late to block form submit`
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

1. Use the keyboard to navigate the options in the combo box. See the visual highlight of the options not skip any options. You can use Storybook in [this deployment](https://polaris-react-pr-1887.herokuapp.com/?path=/story/playground-playground--playground) to test it. 

2. Using the Playground code, Use the Enter key to select an option. Option should be selected without any logs in the console. Console log has been added to the outer `<form>` onSubmit action. Compare to the code [here](https://codesandbox.io/s/oqmom5qrxz) where the current production version logs an event when Enter key is pressed to select an option. 

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {SearchMinor} from '@shopify/polaris-icons';
import {Page, Autocomplete, Icon, TextContainer} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  options = [
    {value: 'rustic', label: 'Rustic'},
    {value: 'antique', label: 'Antique'},
    {value: 'vinyl', label: 'Vinyl'},
    {value: 'vintage', label: 'Vintage'},
    {value: 'refurbished', label: 'Refurbished'},
  ];

  state = {
    selected: [],
    inputText: '',
    options: this.options,
    loading: false,
  };

  render() {
    const textField = (
      <Autocomplete.TextField
        onChange={this.updateText}
        label="Tags"
        value={this.state.inputText}
        prefix={<Icon source={SearchMinor} color="inkLighter" />}
        placeholder="Search"
      />
    );
    const emptyState = (
      <React.Fragment>
        <Icon source={SearchMinor} />
        <div style={{textAlign: 'center'}}>
          <TextContainer>Could not find any results</TextContainer>
        </div>
      </React.Fragment>
    );
    return (
      <Page title="Playground">
        <form
          style={{height: '225px'}}
          onSubmit={(err) => {
            err.preventDefault();
            console.log('Submit event');
          }}
        >
          <Autocomplete
            options={this.state.options}
            selected={this.state.selected}
            onSelect={this.updateSelection}
            emptyState={emptyState}
            loading={this.state.loading}
            textField={textField}
          />
        </form>
      </Page>
    );
  }

  updateText = (newValue) => {
    this.setState({inputText: newValue});
    this.filterAndUpdateOptions(newValue);
  };

  filterAndUpdateOptions = (inputString) => {
    if (!this.state.loading) {
      this.setState({loading: true});
    }

    setTimeout(() => {
      if (inputString === '') {
        this.setState({
          options: this.options,
          loading: false,
        });
        return;
      }
      const filterRegex = new RegExp(inputString, 'i');
      const resultOptions = this.options.filter((option) =>
        option.label.match(filterRegex),
      );
      this.setState({
        options: resultOptions,
        loading: false,
      });
    }, 300);
  };

  updateSelection = (selected) => {
    const selectedText = selected.map((selectedItem) => {
      const matchedOption = this.options.find((option) => {
        return option.value.match(selectedItem);
      });
      return matchedOption && matchedOption.label;
    });
    this.setState({selected, inputText: selectedText});
  };
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
