### PR TITLE
[ActionMenu] Fix type sharing between MenuAction and MenuGroup.actions

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed types merge of `ActionMenu` `MenuAction` and `MenuGroup.actions` ([#1895](https://github.com/Shopify/polaris-react/pull/1895))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -3,7 +3,7 @@ import {classNames} from '@shopify/css-utilities';
 
 import {
   ActionListSection,
-  MenuActionDescriptor,
+  ComplexAction,
   MenuGroupDescriptor,
 } from '../../types';
 
@@ -12,9 +12,9 @@ import {MenuAction, MenuGroup, RollupActions} from './components';
 import styles from './ActionMenu.scss';
 
 export interface Props {
-  /** Collection of page-level actions */
-  actions?: MenuActionDescriptor[];
-  /** Collection of page-level groups of secondary actions */
+  /** Collection of page-level secondary actions */
+  actions?: ComplexAction[];
+  /** Collection of page-level action groups */
   groups?: MenuGroupDescriptor[];
   /** Roll up all actions into a Popover > ActionList */
   rollup?: boolean;

--- a/src/components/ActionMenu/components/MenuAction/MenuAction.tsx
+++ b/src/components/ActionMenu/components/MenuAction/MenuAction.tsx
@@ -3,14 +3,17 @@ import classNames from 'classnames';
 import {CaretDownMinor} from '@shopify/polaris-icons';
 
 import {handleMouseUpByBlurring} from '../../../../utilities/focus';
-import {MenuActionDescriptor} from '../../../../types';
+import {ComplexAction} from '../../../../types';
 
 import Icon from '../../../Icon';
 import UnstyledLink from '../../../UnstyledLink';
 
 import styles from './MenuAction.scss';
 
-export interface Props extends MenuActionDescriptor {}
+export interface Props extends ComplexAction {
+  /** Whether or not the action discloses a menu group */
+  disclosure?: boolean;
+}
 
 export default function MenuAction({
   content,

--- a/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
+++ b/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
@@ -9,14 +9,14 @@ import MenuAction from '../MenuAction';
 import styles from './MenuGroup.scss';
 
 export interface Props extends MenuGroupDescriptor {
-  /** Visually hidden text for screen readers */
+  /** Visually hidden menu description for screen readers */
   accessibilityLabel?: string;
-  /** Show or hide the MenuGroup */
+  /** Whether or not the menu is open */
   active?: boolean;
   /** Callback for opening the MenuGroup by title */
   onOpen(title: string): void;
   /** Callback for closing the MenuGroup by title */
-  onClose(): void;
+  onClose(title: string): void;
 }
 
 export default class MenuGroup extends React.Component<Props, never> {
@@ -32,10 +32,10 @@ export default class MenuGroup extends React.Component<Props, never> {
 
     const popoverActivator = (
       <MenuAction
+        disclosure
         content={title}
         icon={icon}
         accessibilityLabel={accessibilityLabel}
-        disclosure
         onAction={this.handleOpen}
       />
     );
@@ -48,15 +48,14 @@ export default class MenuGroup extends React.Component<Props, never> {
         onClose={this.handleClose}
       >
         <ActionList items={actions} onActionAnyItem={this.handleClose} />
-
         {details && <div className={styles.Details}>{details}</div>}
       </Popover>
     );
   }
 
   private handleClose = () => {
-    const {onClose} = this.props;
-    onClose();
+    const {title, onClose} = this.props;
+    onClose(title);
   };
 
   private handleOpen = () => {

--- a/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
+++ b/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 
-import {MenuActionDescriptor, ActionListSection} from '../../../../types';
+import {ActionListSection, ActionListItemDescriptor} from '../../../../types';
 
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 import ActionList from '../../../ActionList';
@@ -12,7 +12,7 @@ import styles from './RollupActions.scss';
 
 export interface Props {
   /** Collection of actions for the list */
-  items?: MenuActionDescriptor[];
+  items?: ActionListItemDescriptor[];
   /** Collection of sectioned action items */
   sections?: ActionListSection[];
 }

--- a/src/components/ActionMenu/tests/ActionMenu.test.tsx
+++ b/src/components/ActionMenu/tests/ActionMenu.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {mountWithAppProvider, trigger} from 'test-utilities';
 
-import {MenuActionDescriptor, MenuGroupDescriptor} from '../../../types';
+import {MenuGroupDescriptor, ActionListItemDescriptor} from '../../../types';
 import {MenuAction, MenuGroup, RollupActions} from '../components';
 import ActionMenu, {Props, convertGroupToSection} from '../ActionMenu';
 
@@ -163,7 +163,7 @@ describe('<ActionMenu />', () => {
 });
 
 function fillMenuGroup(partialMenuGroup?: Partial<MenuGroupDescriptor>) {
-  const mockAction: MenuActionDescriptor = {
+  const mockAction: ActionListItemDescriptor = {
     content: 'mock content',
     url: 'https://shopify.ca',
     target: 'REMOTE',

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -4,7 +4,7 @@ import debounce from 'lodash/debounce';
 
 import {navigationBarCollapsed} from '../../../../utilities/breakpoints';
 
-import {MenuActionDescriptor, MenuGroupDescriptor} from '../../../../types';
+import {ComplexAction, MenuGroupDescriptor} from '../../../../types';
 
 import {withAppProvider, WithAppProviderProps} from '../../../AppProvider';
 import EventListener from '../../../EventListener';
@@ -35,7 +35,7 @@ export interface Props extends TitleProps {
   /** Collection of breadcrumbs */
   breadcrumbs?: BreadcrumbsProps['breadcrumbs'];
   /** Collection of secondary page-level actions */
-  secondaryActions?: MenuActionDescriptor[];
+  secondaryActions?: ComplexAction[];
   /** Collection of page-level groups of secondary actions */
   actionGroups?: MenuGroupDescriptor[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,16 +135,11 @@ export interface ComplexAction
     IconableAction,
     LoadableAction {}
 
-export interface MenuActionDescriptor extends ActionListItemDescriptor {
-  /** Displays the button with a disclosure icon */
-  disclosure?: boolean;
-}
-
 export interface MenuGroupDescriptor extends BadgeAction {
   /** Menu group title */
   title: string;
   /** List of actions */
-  actions: MenuActionDescriptor[];
+  actions: ActionListItemDescriptor[];
   /** Icon to display */
   icon?: IconableAction['icon'];
   /** Action details */


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1889

When the actions from `Page` `Header` were extracted into a separate component called `ActionMenu`, the types of `Page.secondaryActions` and `Page.actionGroups.actions` were accidentally combined into a single type called `MenuActionDescriptor`. Properties like `badge` and `helpText` are only supported in the items of action lists (which `actionGroups` render as).

### WHAT is this pull request doing?

Fixing the types for `MenuAction` and `MenuGroup` to align with `Page.secondaryActions` and `Page.actionGroups` again.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

- Tests are all ✅?
- Playground and Page examples working as expected?

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import * as React from 'react';
import {DuplicateMinor, ViewMinor} from '@shopify/polaris-icons';
import {Page} from '../src';

interface State {}

export default class Playground extends React.Component<{}, State> {
  render() {
    return (
      <Page
        breadcrumbs={[{content: 'Products', url: '/products'}]}
        title="Jar With Lock-Lid"
        secondaryActions={[
          {
            icon: DuplicateMinor,
            content: 'Duplicate',
          },
          {icon: ViewMinor, content: 'View on your store'},
        ]}
        actionGroups={[
          {
            title: 'Promote',
            actions: [
              {
                badge: {content: 'New', status: 'new'},
                helpText: 'Something informative about this new action',
                content: 'New action',
                onAction: () => {},
              },
            ],
          },
        ]}
      />
    );
  }
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
