### PR TITLE
Remove Modal.Dialog and Tabs.Panel public subcomponents

### DIFF
--- a/UNRELEASED-V4.md
+++ b/UNRELEASED-V4.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Increased peer-dependencies on `react` and `react-dom` to 16.8.6 to enable the use of hooks ([#1525](https://github.com/Shopify/polaris-react/pull/1525))
 - Changed the import method for React to use default imports. Applications consuming Polaris using TypeScript must enable [`esModuleInterop`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#support-for-import-d-from-cjs-from-commonjs-modules-with---esmoduleinterop) in `tsconfig.json`. ([#1523](https://github.com/Shopify/polaris-react/pull/1523))
 - Removed `LinkLikeComponent` type export. Use `AppProviderProps['linkComponent']` instead. ([#1864](https://github.com/Shopify/polaris-react/pull/1864))
+- Removed the `Modal.Dialog` and `Tabs.Panel` subcomponents as they were undocumented parts of our public API meant for internal use only. ([#1899](https://github.com/Shopify/polaris-react/pull/1899)).
 
 ### New components
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -95,7 +95,6 @@ const APP_BRIDGE_PROPS: (keyof Props)[] = [
 ];
 
 class Modal extends React.Component<CombinedProps, State> {
-  static Dialog = Dialog;
   static Section = Section;
   focusReturnPointNode: HTMLElement;
 

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -263,7 +263,7 @@ describe('<Modal>', () => {
         </Modal>,
       );
 
-      expect(modal.find(Modal.Dialog).prop('limitHeight')).toBeTruthy();
+      expect(modal.find(Dialog).prop('limitHeight')).toBeTruthy();
     });
   });
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -42,8 +42,6 @@ export interface State {
 }
 
 class Tabs extends React.PureComponent<CombinedProps, State> {
-  static Panel = Panel;
-
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
     const {disclosureWidth, tabWidths, containerWidth} = prevState;
     const {visibleTabs, hiddenTabs} = getVisibleAndHiddenTabIndices(


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1788 

These components are never used or documented publicly and should be
part of our internal API. These have never been used in the wild in the
Shopify org.

### WHAT is this pull request doing?

Removing the ability to do `<Modal.Dialog>` and `<Tabs.Panel>`

