### PR TITLE
Use act in Navigation Item test to fix warning

### DIFF
--- a/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {PlusMinor} from '@shopify/polaris-icons';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {Icon, UnstyledLink, Indicator, Badge} from 'components';
-import {trigger, mountWithAppProvider} from 'test-utilities/legacy';
+import {act, trigger, mountWithAppProvider} from 'test-utilities/legacy';
 import NavigationContext, {NavigationContextType} from '../../../context';
 
 import Item, {Props as ItemProps} from '../Item';
@@ -61,12 +61,13 @@ describe('<Nav.Item />', () => {
     const item = itemForLocation('/admin/orders');
 
     matchMedia.setMedia(() => ({matches: true}));
-    // Likely cause for error - https://github.com/airbnb/enzyme/issues/2073
-    trigger(item.find(UnstyledLink).first(), 'onClick', {
-      preventDefault: jest.fn(),
-      currentTarget: {
-        getAttribute: () => '/admin/orders',
-      },
+    act(() => {
+      trigger(item.find(UnstyledLink).first(), 'onClick', {
+        preventDefault: jest.fn(),
+        currentTarget: {
+          getAttribute: () => '/admin/orders',
+        },
+      });
     });
 
     expect(item.find(Secondary).prop('expanded')).toBe(true);

--- a/src/test-utilities/legacy.tsx
+++ b/src/test-utilities/legacy.tsx
@@ -1,5 +1,6 @@
 import {ReactWrapper, CommonWrapper, mount} from 'enzyme';
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 import {get} from '../utilities/get';
 import translations from '../../locales/en.json';
 
@@ -7,6 +8,8 @@ import {
   PolarisTestProvider,
   WithPolarisTestProviderOptions,
 } from './PolarisTestProvider';
+
+export {act};
 
 export type AnyWrapper = ReactWrapper<any, any> | CommonWrapper<any, any>;
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes one of the two warnings in #1898

### WHAT is this pull request doing?

Wraps a trigger in act.

Migrating this whole file to use modern testing looked like it'd take a while so here's a stopgap.

### How to 🎩

Check Navigation Item test no longer emits the warning detailed in #1898