### PR TITLE
[ActionMenu] Toggle activeMenuGroup when clicking secondary action trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@ The format is based on [these versioning and changelog guidelines](https://git.i
 - Fixed `tabIndex` on `main` element causing event delegation issues ([#1821](https://github.com/Shopify/polaris-react/pull/1821))
 - Fixed icon color for destructive ActionList items ([#1836](https://github.com/Shopify/polaris-react/pull/1836))
 - Fixed not being able to explictly set `autoComplete` prop on`Autocomplete.TextField` ([#1839](https://github.com/Shopify/polaris-react/pull/1839))
-- Fixed not being able to close popover in secondary actions by clicking trigger [#1905](https://github.com/Shopify/polaris-react/pull/1905)
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [these versioning and changelog guidelines](https://git.i
 - Fixed `tabIndex` on `main` element causing event delegation issues ([#1821](https://github.com/Shopify/polaris-react/pull/1821))
 - Fixed icon color for destructive ActionList items ([#1836](https://github.com/Shopify/polaris-react/pull/1836))
 - Fixed not being able to explictly set `autoComplete` prop on`Autocomplete.TextField` ([#1839](https://github.com/Shopify/polaris-react/pull/1839))
+- Fixed not being able to close popover in secondary actions by clicking trigger [#1905](https://github.com/Shopify/polaris-react/pull/1905)
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed types merge of `ActionMenu` `MenuAction` and `MenuGroup.actions` ([#1895](https://github.com/Shopify/polaris-react/pull/1895))
+- Fixed the activator buttons of `Page` `actionGroups` not toggling the `Popover` `active` state on click [#1905](https://github.com/Shopify/polaris-react/pull/1905)
 
 ### Documentation
 

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -90,7 +90,9 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
   };
 
   private handleMenuGroupToggle = (group: string) => {
-    this.setState(({activeMenuGroup}) => ({activeMenuGroup: activeMenuGroup ? undefined : group}));
+    this.setState(({activeMenuGroup}) => ({
+      activeMenuGroup: activeMenuGroup ? undefined : group,
+    }));
   };
 
   private handleMenuGroupClose = () => {

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -75,7 +75,7 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
             title={title}
             active={title === activeMenuGroup}
             {...rest}
-            onOpen={this.handleMenuGroupToggle.bind(this)}
+            onOpen={this.handleMenuGroupToggle}
             onClose={this.handleMenuGroupClose}
           />
         ))

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -90,7 +90,7 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
   };
 
   private handleMenuGroupToggle = (group: string) => {
-    this.setState({activeMenuGroup: activeMenuGroup ? undefined : group});
+    this.setState(({activeMenuGroup}) => ({activeMenuGroup: activeMenuGroup ? undefined : group}));
   };
 
   private handleMenuGroupClose = () => {

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -75,7 +75,7 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
             title={title}
             active={title === activeMenuGroup}
             {...rest}
-            onOpen={this.handleMenuGroupOpen}
+            onOpen={this.handleMenuGroupToggle.bind(this)}
             onClose={this.handleMenuGroupClose}
           />
         ))
@@ -89,8 +89,9 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
     ) : null;
   };
 
-  private handleMenuGroupOpen = (group: string) => {
-    this.setState({activeMenuGroup: group});
+  private handleMenuGroupToggle = (group: string) => {
+    const {activeMenuGroup} = this.state;
+    this.setState({activeMenuGroup: activeMenuGroup ? undefined : group});
   };
 
   private handleMenuGroupClose = () => {

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -90,7 +90,6 @@ export default class ActionMenu extends React.PureComponent<Props, State> {
   };
 
   private handleMenuGroupToggle = (group: string) => {
-    const {activeMenuGroup} = this.state;
     this.setState({activeMenuGroup: activeMenuGroup ? undefined : group});
   };
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1849

### WHAT is this pull request doing?

This PR toggles the `activeMenuGroup` in the `ActionMenu` when clicking the secondary action trigger. This allows an open `Popover` to be closed when clicking the secondary action trigger while it is open.

Here are some videos to illustate:

#### Before:

![https://screenshot.click/31-02-leeig-eieau.gif](https://screenshot.click/31-02-leeig-eieau.gif)

#### After:

![https://screenshot.click/31-00-h2vuj-wv5ju.gif](https://screenshot.click/31-00-h2vuj-wv5ju.gif)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Badge, Page} from '../src';

export default class App extends React.Component {
  render() {
    return (
      <Page
        breadcrumbs={[{content: 'Products', url: '/products'}]}
        title="Jar With Lock-Lid"
        titleMetadata={<Badge>Draft</Badge>}
        primaryAction={{content: 'Save', disabled: true}}
        secondaryActions={[
          {
            content: 'Duplicate',
            accessibilityLabel: 'Secondary action label',
          },
          {content: 'View on your store'},
        ]}
        actionGroups={[
          {
            title: 'Promote',
            accessibilityLabel: 'Action group label',
            actions: [
              {
                content: 'Share on Facebook',
                accessibilityLabel: 'Individual action label',
                onAction: () => {},
              },
            ],
          },
        ]}
        pagination={{
          hasPrevious: true,
          hasNext: true,
        }}
        separator
      >
        <p>Page content</p>
      </Page>
    );
  }
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide