### PR TITLE
[v4] Override StickyManager context in Scrollable

### DIFF
--- a/src/components/Scrollable/Scrollable.tsx
+++ b/src/components/Scrollable/Scrollable.tsx
@@ -13,7 +13,7 @@ import {
 import {scrollable} from '../shared';
 
 import {ScrollTo} from './components';
-import ScrollableContext from './context';
+import {ScrollableContext} from './context';
 
 import styles from './Scrollable.scss';
 
@@ -125,12 +125,8 @@ export default class Scrollable extends React.Component<Props, State> {
       bottomShadow && styles.hasBottomShadow,
     );
 
-    const scrollableContext = {
-      scrollToPosition: this.scrollToPosition,
-    };
-
     return (
-      <ScrollableContext.Provider value={scrollableContext}>
+      <ScrollableContext.Provider value={this.scrollToPosition}>
         <StickyManagerContext.Provider value={this.stickyManager}>
           <div
             className={finalClassName}

--- a/src/components/Scrollable/components/ScrollTo/ScrollTo.tsx
+++ b/src/components/Scrollable/components/ScrollTo/ScrollTo.tsx
@@ -1,10 +1,10 @@
 import React, {useContext, useEffect, useRef} from 'react';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
-import ScrollableContext from '../../context';
+import {ScrollableContext} from '../../context';
 
 export default function ScrollTo() {
   const anchorNode = useRef<HTMLAnchorElement>(null);
-  const {scrollToPosition} = useContext(ScrollableContext);
+  const scrollToPosition = useContext(ScrollableContext);
 
   useEffect(
     () => {

--- a/src/components/Scrollable/components/ScrollTo/tests/ScrollTo.test.tsx
+++ b/src/components/Scrollable/components/ScrollTo/tests/ScrollTo.test.tsx
@@ -1,17 +1,14 @@
 import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import ScrollTo from '../ScrollTo';
-import ScrollableContext from '../../../context';
+import {ScrollableContext} from '../../../context';
 
 describe('<Scrollable.ScrollTo />', () => {
   it('calls scrollToPosition on mount', () => {
     const spy = jest.fn();
-    const mockContext = {
-      scrollToPosition: spy,
-    };
 
     mountWithAppProvider(
-      <ScrollableContext.Provider value={mockContext}>
+      <ScrollableContext.Provider value={spy}>
         <ScrollTo />
       </ScrollableContext.Provider>,
     );
@@ -20,13 +17,9 @@ describe('<Scrollable.ScrollTo />', () => {
   });
 
   it("does not call scrollToPosition when it's undefined", () => {
-    const mockContext = {
-      scrollToPosition: undefined,
-    };
-
     function fn() {
       mountWithAppProvider(
-        <ScrollableContext.Provider value={mockContext}>
+        <ScrollableContext.Provider value={undefined}>
           <ScrollTo />
         </ScrollableContext.Provider>,
       );

--- a/src/components/Scrollable/context.ts
+++ b/src/components/Scrollable/context.ts
@@ -1,9 +1,7 @@
 import React from 'react';
 
-export interface ScrollableContextType {
-  scrollToPosition?(scrollY: number): void;
-}
+type ScrollToPositionFn = (scrollY: number) => void;
 
-const ScrollableContext = React.createContext<ScrollableContextType>({});
-
-export default ScrollableContext;
+export const ScrollableContext = React.createContext<
+  ScrollToPositionFn | undefined
+>(undefined);

--- a/src/components/Scrollable/tests/Scrollable.test.tsx
+++ b/src/components/Scrollable/tests/Scrollable.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import Scrollable from '../Scrollable';
-import ScrollableContext from '../context';
+import {ScrollableContext} from '../context';
 
 describe('<Scrollable />', () => {
   it('mounts', () => {
@@ -32,7 +32,7 @@ describe('<Scrollable />', () => {
   it('provides scrollToPosition callback to children', () => {
     const Child: React.SFC<{}> = (_) => (
       <ScrollableContext.Consumer>
-        {({scrollToPosition}) => {
+        {(scrollToPosition) => {
           // eslint-disable-next-line shopify/jest/no-if
           return scrollToPosition ? <div /> : null;
         }}
@@ -40,7 +40,7 @@ describe('<Scrollable />', () => {
     );
 
     const scrollableContainer = mountWithAppProvider(
-      <ScrollableContext.Provider value={{scrollToPosition: () => {}}}>
+      <ScrollableContext.Provider value={() => {}}>
         <Scrollable>
           <Child />
         </Scrollable>

--- a/src/utilities/with-app-provider.tsx
+++ b/src/utilities/with-app-provider.tsx
@@ -4,14 +4,8 @@ import {useI18n} from './i18n';
 import {useLink} from './link';
 import {useScrollLockManager} from './scroll-lock-manager';
 import {useTheme} from './theme';
-import {
-  StickyManager,
-  StickyManagerContext,
-  useStickyManager,
-} from './sticky-manager';
+import {useStickyManager} from './sticky-manager';
 import {useAppBridge} from './app-bridge';
-
-type ReactComponent<P, C> = React.ComponentType<P> & C;
 
 export interface WithAppProviderProps {
   polaris: {
@@ -24,61 +18,24 @@ export interface WithAppProviderProps {
   };
 }
 
-export interface Options {
-  withinScrollable?: boolean;
-}
-
-function withScrollable<P, T>(WrappedComponent: ReactComponent<P, T>) {
-  class WithScrollable extends React.Component {
-    static contextTypes = WrappedComponent.contextTypes;
-    private stickyManager: StickyManager = new StickyManager();
-
-    render() {
-      return (
-        <StickyManagerContext.Provider value={this.stickyManager}>
-          <WrappedComponent {...this.props as any} />
-        </StickyManagerContext.Provider>
-      );
-    }
-  }
-
-  return WithScrollable;
-}
-
-export function withAppProvider<OwnProps>({withinScrollable}: Options = {}) {
+export function withAppProvider<OwnProps>() {
   return function addProvider<C>(
-    WrappedComponent: ReactComponent<OwnProps & WithAppProviderProps, C>,
-  ): React.ComponentClass<OwnProps> & C {
-    const WithProvider: React.FunctionComponent = (props: OwnProps) => {
-      const link = useLink();
-      const theme = useTheme();
-      const intl = useI18n();
-      const scrollLockManager = useScrollLockManager();
-      const stickyManager = useStickyManager();
-      const appBridge = useAppBridge();
-
+    WrappedComponent: React.ComponentType<OwnProps & WithAppProviderProps> & C,
+  ) {
+    const WithProvider: React.FunctionComponent<OwnProps> = (props) => {
       const polaris: WithAppProviderProps['polaris'] = {
-        link,
-        theme,
-        intl,
-        scrollLockManager,
-        stickyManager,
-        appBridge,
+        link: useLink(),
+        theme: useTheme(),
+        intl: useI18n(),
+        scrollLockManager: useScrollLockManager(),
+        stickyManager: useStickyManager(),
+        appBridge: useAppBridge(),
       };
 
       return <WrappedComponent {...props as any} polaris={polaris} />;
     };
 
-    let WithScrollable: React.ComponentClass<any> | undefined;
-    if (withinScrollable) {
-      WithScrollable = withScrollable(WithProvider);
-    }
-
-    const FinalComponent = hoistStatics(
-      WithScrollable || WithProvider,
-      WrappedComponent as React.ComponentClass<any>,
-    );
-
-    return FinalComponent as React.ComponentClass<OwnProps> & C;
+    const FinalComponent = hoistStatics(WithProvider, WrappedComponent);
+    return FinalComponent;
   };
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This removes the need for the WithScrollable HoC in withAppProvider,
leading to a drastically simpler withAppProvider implementation.

### WHAT is this pull request doing?

Moves the responsibility for creating a new StickyManager into Scrollable

Simplify SrollableContext - It's a single value so there is no value to nesting it in an object.
Also use a named export for the context as we're moving towards that for everything

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Add the following to the playground, scroll up and down and see that the sticky paragraph sticks to the top of the scrollable area

Ensure that the Scrollable -> ScrollTo example still works by jumping to the mid point scroll position
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Scrollable, Sticky} from '../src';

function LoremIpsum({repeat}) {
  const text = (
    <p>
      Lorem ipsum dolor sit, amet consectetur adipisicing elit. Doloremque quis
      accusamus perferendis et voluptatibus corporis eos repudiandae, possimus
      omnis velit magnam, pariatur temporibus natus saepe? Maxime commodi quo
      veritatis consectetur?
    </p>
  );

  return <React.Fragment>{Array(repeat).fill(text)}</React.Fragment>;
}

export default function Playground() {
  return (
    <Page title="Playground">
      <Scrollable shadow style={{height: '200px'}}>
        <LoremIpsum repeat={2} />

        <Sticky>
          <p>
            <strong>
              I am some sticky content. I am some sticky content. I am some
              sticky content
            </strong>
          </p>
        </Sticky>

        <LoremIpsum repeat={10} />
      </Scrollable>
    </Page>
  );
}
```

</details>
