### PR TITLE
[v4] Use named exports for contexts and utilities

### DIFF
--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -6,7 +6,7 @@ import Popover from '../../../Popover';
 import {PreferredPosition} from '../../../PositionedOverlay';
 import {ActionListItemDescriptor, Key} from '../../../../types';
 import KeypressListener from '../../../KeypressListener';
-import ComboBoxContext from './context';
+import {ComboBoxContext} from './context';
 
 import styles from './ComboBox.scss';
 

--- a/src/components/Autocomplete/components/ComboBox/context.tsx
+++ b/src/components/Autocomplete/components/ComboBox/context.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 
-export interface ComboBoxContextType {
+interface ComboBoxContextType {
   comboBoxId?: string;
   selectedOptionId?: string;
 }
 
-const ComboBoxContext = React.createContext<ComboBoxContextType>({});
-
-export default ComboBoxContext;
+export const ComboBoxContext = React.createContext<ComboBoxContextType>({});

--- a/src/components/Autocomplete/components/TextField/TextField.tsx
+++ b/src/components/Autocomplete/components/TextField/TextField.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 // eslint-disable-next-line shopify/strict-component-boundaries
-import ComboBoxContext from '../ComboBox/context';
+import {ComboBoxContext} from '../ComboBox/context';
 import BaseTextField, {Props as TextFieldProps} from '../../../TextField';
 
 export default function TextField(props: TextFieldProps) {

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../utilities/with-app-provider';
 
 import {FileUpload} from './components';
-import DropZoneContext from './context';
+import {DropZoneContext} from './context';
 
 import {fileAccepted, getDataTransferFiles} from './utils';
 

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -13,7 +13,7 @@ import TextStyle from '../../../TextStyle';
 
 import {fileUpload, imageUpload} from '../../images';
 
-import DropZoneContext from '../../context';
+import {DropZoneContext} from '../../context';
 import {useI18n} from '../../../../utilities/i18n';
 
 import styles from './FileUpload.scss';

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Link, Icon, Button, Caption, TextStyle} from 'components';
 import {mountWithAppProvider} from 'test-utilities/legacy';
-import DropZoneContext from '../../../context';
+import {DropZoneContext} from '../../../context';
 import FileUpload from '../FileUpload';
 import {fileUpload as fileUploadImage, imageUpload} from '../../../images';
 

--- a/src/components/DropZone/context.tsx
+++ b/src/components/DropZone/context.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 
-export interface DropZoneContextType {
+interface DropZoneContextType {
   size: string;
   type: string;
 }
 
-const DropZoneContext = React.createContext<DropZoneContextType>({
+export const DropZoneContext = React.createContext<DropZoneContextType>({
   size: 'extraLarge',
   type: 'file',
 });
-
-export default DropZoneContext;

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -12,7 +12,7 @@ import {
   withAppProvider,
   WithAppProviderProps,
 } from '../../utilities/with-app-provider';
-import {ResourceListContext, ResourceListContextType} from '../ResourceList';
+import {ResourceListContext} from '../ResourceList';
 import Button from '../Button';
 import DisplayText from '../DisplayText';
 import Collapsible from '../Collapsible';
@@ -27,7 +27,7 @@ import Badge from '../Badge';
 import Focus from '../Focus';
 import Sheet from '../Sheet';
 import Stack from '../Stack';
-import {Key, WithContextTypes} from '../../types';
+import {Key} from '../../types';
 
 import {navigationBarCollapsed} from '../../utilities/breakpoints';
 import KeypressListener from '../KeypressListener';
@@ -78,9 +78,7 @@ export interface Props {
   children?: React.ReactNode;
 }
 
-type ComposedProps = Props &
-  WithAppProviderProps &
-  WithContextTypes<ResourceListContextType>;
+type ComposedProps = Props & WithAppProviderProps;
 
 interface State {
   open: boolean;

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Scrollable from '../Scrollable';
 
 import {WithinContentContext} from '../../utilities/within-content-context';
-import NavigationContext from './context';
+import {NavigationContext} from './context';
 import {Section, Item} from './components';
 import {SectionType} from './types';
 

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -11,7 +11,7 @@ import React, {
 import {classNames} from '../../../../utilities/css';
 import {navigationBarCollapsed} from '../../../../utilities/breakpoints';
 
-import NavigationContext from '../../context';
+import {NavigationContext} from '../../context';
 import Badge from '../../../Badge';
 import Icon from '../../../Icon';
 import {IconProps} from '../../../../types';

--- a/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -3,7 +3,7 @@ import {PlusMinor} from '@shopify/polaris-icons';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {Icon, UnstyledLink, Indicator, Badge} from 'components';
 import {act, trigger, mountWithAppProvider} from 'test-utilities/legacy';
-import NavigationContext, {NavigationContextType} from '../../../context';
+import {NavigationContext} from '../../../context';
 
 import Item, {Props as ItemProps} from '../Item';
 import {Secondary} from '../components';
@@ -466,7 +466,7 @@ function itemForLocation(location: string, overrides: Partial<ItemProps> = {}) {
 
 function mountWithNavigationProvider(
   node: React.ReactElement<any>,
-  context: NavigationContextType = {location: ''},
+  context: React.ContextType<typeof NavigationContext> = {location: ''},
 ) {
   return mountWithAppProvider(
     <NavigationContext.Provider value={context}>

--- a/src/components/Navigation/components/Section/tests/Section.test.tsx
+++ b/src/components/Navigation/components/Section/tests/Section.test.tsx
@@ -8,14 +8,14 @@ import {
 } from 'test-utilities/legacy';
 
 import Collapsible from '../../../../Collapsible';
-import NavigationContext, {NavigationContextType} from '../../../context';
+import {NavigationContext} from '../../../context';
 import Item from '../../Item';
 import Section from '../Section';
 
 import channelResults from './fixtures/AdminNavQuery/multiple-channels.json';
 
 describe('<Navigation.Section />', () => {
-  let context: NavigationContextType;
+  let context: React.ContextType<typeof NavigationContext>;
 
   beforeEach(() => {
     matchMedia.mock();
@@ -258,7 +258,7 @@ describe('<Navigation.Section />', () => {
 
 function mountWithNavigationProvider(
   node: React.ReactElement<any>,
-  context: NavigationContextType = {location: ''},
+  context: React.ContextType<typeof NavigationContext> = {location: ''},
 ) {
   return mountWithAppProvider(
     <NavigationContext.Provider value={context}>

--- a/src/components/Navigation/context.tsx
+++ b/src/components/Navigation/context.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 
-export interface NavigationContextType {
+interface NavigationContextType {
   location: string;
   onNavigationDismiss?(): void;
   withinContentContainer?: boolean;
 }
 
-const NavigationContext = React.createContext<NavigationContextType>({
+export const NavigationContext = React.createContext<NavigationContextType>({
   location: '',
 });
-
-export default NavigationContext;

--- a/src/components/Navigation/tests/Navigation.test.tsx
+++ b/src/components/Navigation/tests/Navigation.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import Navigation from '../Navigation';
-import NavigationContext from '../context';
+import {NavigationContext} from '../context';
 import {WithinContentContext} from '../../../utilities/within-content-context';
 
 describe('<Navigation />', () => {

--- a/src/components/RangeSlider/utilities/index.ts
+++ b/src/components/RangeSlider/utilities/index.ts
@@ -4,4 +4,4 @@ export enum RangeSliderDefault {
   Max = 100,
   Step = 1,
 }
-export {default as invertNumber} from './invertNumber';
+export {invertNumber} from './invertNumber';

--- a/src/components/RangeSlider/utilities/invertNumber.ts
+++ b/src/components/RangeSlider/utilities/invertNumber.ts
@@ -1,4 +1,4 @@
-export default function invertNumber(number: number) {
+export function invertNumber(number: number) {
   if (Math.sign(number) === 1) {
     return -Math.abs(number);
   } else if (Math.sign(number) === -1) {

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -23,7 +23,7 @@ import {
   FilterControl,
   Item,
 } from './components';
-import ResourceListContext from './context';
+import {ResourceListContext} from './context';
 
 import {SelectedItems, SELECT_ALL_ITEMS} from './types';
 

--- a/src/components/ResourceList/components/FilterControl/FilterControl.tsx
+++ b/src/components/ResourceList/components/FilterControl/FilterControl.tsx
@@ -7,7 +7,7 @@ import FormLayout from '../../../FormLayout';
 import TextField from '../../../TextField';
 import Tag from '../../../Tag';
 import {useI18n} from '../../../../utilities/i18n';
-import ResourceListContext from '../../context';
+import {ResourceListContext} from '../../context';
 
 import {FilterCreator} from './components';
 import {AppliedFilter, Filter, FilterType, Operator} from './types';

--- a/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {trigger, mountWithAppProvider} from 'test-utilities/legacy';
 import {TextField, Tag, Button} from 'components';
-import ResourceListContext from '../../../context';
+import {ResourceListContext} from '../../../context';
 import {
   Filter,
   FilterType,

--- a/src/components/ResourceList/components/Item/Item.tsx
+++ b/src/components/ResourceList/components/Item/Item.tsx
@@ -3,7 +3,7 @@ import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 import {classNames} from '../../../../utilities/css';
 import {isObjectsEqual} from '../../../../utilities/is-objects-equal';
-import {DisableableAction, WithContextTypes} from '../../../../types';
+import {DisableableAction} from '../../../../types';
 import ActionList from '../../../ActionList';
 import Popover from '../../../Popover';
 import {Props as AvatarProps} from '../../../Avatar';
@@ -18,12 +18,16 @@ import {
 } from '../../../../utilities/with-app-provider';
 
 import {SELECT_ALL_ITEMS, SelectedItems} from '../../types';
-import ResourceListContext, {ResourceListContextType} from '../../context';
+import {ResourceListContext} from '../../context';
 import styles from './Item.scss';
 
 export type ExceptionStatus = 'neutral' | 'warning' | 'critical';
 export type MediaSize = 'small' | 'medium' | 'large';
 export type MediaType = 'avatar' | 'thumbnail';
+
+interface WithContextTypes<IJ> {
+  context: IJ;
+}
 
 export interface BaseProps {
   /** Visually hidden text for screen readers */
@@ -63,10 +67,10 @@ export interface State {
 export type CombinedProps =
   | PropsWithUrl &
       WithAppProviderProps &
-      WithContextTypes<ResourceListContextType>
+      WithContextTypes<React.ContextType<typeof ResourceListContext>>
   | PropsWithClick &
       WithAppProviderProps &
-      WithContextTypes<ResourceListContextType>;
+      WithContextTypes<React.ContextType<typeof ResourceListContext>>;
 
 const getUniqueCheckboxID = createUniqueIDFactory('ResourceListItemCheckbox');
 const getUniqueOverlayID = createUniqueIDFactory('ResourceListItemOverlay');

--- a/src/components/ResourceList/components/Item/tests/Item.test.tsx
+++ b/src/components/ResourceList/components/Item/tests/Item.test.tsx
@@ -11,7 +11,7 @@ import {
   Thumbnail,
   UnstyledLink,
 } from 'components';
-import ResourceListContext from '../../../context';
+import {ResourceListContext} from '../../../context';
 import Item from '../Item';
 
 describe('<Item />', () => {

--- a/src/components/ResourceList/context.tsx
+++ b/src/components/ResourceList/context.tsx
@@ -18,6 +18,6 @@ export interface ResourceListContextType {
   ): void;
 }
 
-const ResourceListContext = React.createContext<ResourceListContextType>({});
-
-export default ResourceListContext;
+export const ResourceListContext = React.createContext<ResourceListContextType>(
+  {},
+);

--- a/src/components/ResourceList/index.ts
+++ b/src/components/ResourceList/index.ts
@@ -1,9 +1,6 @@
 import ResourceList from './ResourceList';
 
-export {
-  default as ResourceListContext,
-  ResourceListContextType,
-} from './context';
+export {ResourceListContext} from './context';
 export * from './components/FilterControl/types';
 export {Props as FilterControlProps} from './components/FilterControl';
 export {Props} from './ResourceList';

--- a/src/types.ts
+++ b/src/types.ts
@@ -304,10 +304,6 @@ export enum Key {
   SingleQuote = 222,
 }
 
-export interface WithContextTypes<IJ> {
-  context: IJ;
-}
-
 export enum TypeOf {
   Undefined = 'undefined',
   Object = 'object',


### PR DESCRIPTION
### WHY are these changes introduced?

Default exports are low-key annoying as you need to name something
every time you import it instead of using the existing name.

Let's name our things once, and make sure all our contexts follow that same pattern

After this PR the only files that continue to use named exports shall be:
- Component files (e.g. src/components/Button/Button.tsx)
- Component file indexes (e.g. src/components/Button/index.ts) (I've got a plan for removing default exports in these but that should wait till after we get v4 merged)
- src/components/Scrollable/context.ts - This will be converted to use named exports only in #1908
- src/components/Frame/context.tsx - This will be converted to use named exports only in #1906

### WHAT is this pull request doing?

Use named exports for context (oh and that one utility that was still using a default export).

Infer context types where possible instead of exporting the types.

Stop publicly exporting WithContextTypes (it still exists within ResourceList.Item as refactoring that away fully isn't worth it right now)

### How to 🎩

tests & typecheck pass