### PR TITLE
Move PolarisTestProvider into components

### DIFF
--- a/src/components/PolarisTestProvider/PolarisTestProvider.tsx
+++ b/src/components/PolarisTestProvider/PolarisTestProvider.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
-// eslint-disable-next-line shopify/strict-component-boundaries
-import {FrameContext, FrameContextType} from '../components/Frame';
-import {Theme, ThemeContext} from '../utilities/theme';
+import {FrameContext, FrameContextType} from '../Frame';
+import {Theme, ThemeContext} from '../../utilities/theme';
 import {
   ScrollLockManager,
   ScrollLockManagerContext,
-} from '../utilities/scroll-lock-manager';
-import {StickyManager, StickyManagerContext} from '../utilities/sticky-manager';
-import {AppBridgeContext, AppBridgeOptions} from '../utilities/app-bridge';
-import {I18n, I18nContext, TranslationDictionary} from '../utilities/i18n';
-import {LinkContext, LinkLikeComponent} from '../utilities/link';
+} from '../../utilities/scroll-lock-manager';
+import {
+  StickyManager,
+  StickyManagerContext,
+} from '../../utilities/sticky-manager';
+import {AppBridgeContext, AppBridgeOptions} from '../../utilities/app-bridge';
+import {I18n, I18nContext, TranslationDictionary} from '../../utilities/i18n';
+import {LinkContext, LinkLikeComponent} from '../../utilities/link';
 
 /**
  * When writing a custom mounting function `mountWithAppContext(node, options)`
@@ -31,7 +33,7 @@ export interface Props extends WithPolarisTestProviderOptions {
   strict?: boolean;
 }
 
-export function PolarisTestProvider({
+export default function PolarisTestProvider({
   strict,
   children,
   i18n,

--- a/src/components/PolarisTestProvider/index.ts
+++ b/src/components/PolarisTestProvider/index.ts
@@ -1,0 +1,5 @@
+export {
+  default,
+  Props,
+  WithPolarisTestProviderOptions,
+} from './PolarisTestProvider';

--- a/src/components/PolarisTestProvider/tests/PolarisTestProvider.test.tsx
+++ b/src/components/PolarisTestProvider/tests/PolarisTestProvider.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
-import {PolarisTestProvider} from '../PolarisTestProvider';
+import {PolarisTestProvider} from '../..';
 
 describe('PolarisTestProvider', () => {
   it("doesn't render in strict mode by default", () => {

--- a/src/components/PolarisTestProvider/tests/PolarisTestProvider.test.tsx
+++ b/src/components/PolarisTestProvider/tests/PolarisTestProvider.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mount} from '@shopify/react-testing';
-import {PolarisTestProvider} from '../..';
+import PolarisTestProvider from '../PolarisTestProvider';
 
 describe('PolarisTestProvider', () => {
   it("doesn't render in strict mode by default", () => {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -187,6 +187,11 @@ export {default as PageActions, Props as PageActionsProps} from './PageActions';
 export {default as Pagination, Props as PaginationProps} from './Pagination';
 
 export {
+  default as PolarisTestProvider,
+  WithPolarisTestProviderOptions,
+} from './PolarisTestProvider';
+
+export {
   default as Popover,
   Props as PopoverProps,
   CloseSource as PopoverCloseSource,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,5 +11,3 @@ export {
   WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT,
 } from './utilities/within-content-context';
 export {AppBridgeContext} from './utilities/app-bridge';
-
-export {PolarisTestProvider} from './test-utilities/PolarisTestProvider';

--- a/src/test-utilities/legacy.tsx
+++ b/src/test-utilities/legacy.tsx
@@ -7,7 +7,7 @@ import translations from '../../locales/en.json';
 import {
   PolarisTestProvider,
   WithPolarisTestProviderOptions,
-} from './PolarisTestProvider';
+} from '../components';
 
 export {act};
 

--- a/src/test-utilities/react-testing.tsx
+++ b/src/test-utilities/react-testing.tsx
@@ -5,7 +5,7 @@ import translations from '../../locales/en.json';
 import {
   PolarisTestProvider,
   WithPolarisTestProviderOptions,
-} from './PolarisTestProvider';
+} from '../components';
 
 export {mount};
 


### PR DESCRIPTION
### WHY are these changes introduced?

Our `test-utilities` folder is being [deleted in `web`](https://github.com/Shopify/web/blob/68750baa3c14bf7390045d260430309d37cdde12/scripts/builder/delete-test-files.sh#L6). I'm temporarily moving `PolarisTestProvider` into `src/components` until node_modules are ignored.