### PR TITLE
[v4] Styles build: combine all components into one file

### DIFF
--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -26,10 +26,6 @@ describe('build', () => {
     expect(fs.existsSync('./styles.css')).toBe(true);
   });
 
-  it('generates a ./styles/components dir with Icon.scss', () => {
-    expect(fs.existsSync('./styles/components/Icon/Icon.scss')).toBe(true);
-  });
-
   it('generates a ./styles/foundation dir with spacing.scss', () => {
     expect(fs.existsSync('./styles/foundation/_spacing.scss')).toBe(true);
   });
@@ -45,27 +41,16 @@ describe('build', () => {
     expect(fs.existsSync('./styles.scss')).toBe(true);
   });
 
-  it('copies over subcomponent stylesheets', () => {
-    expect(
-      fs.existsSync(
-        './styles/components/ResourceList/components/BulkActions/BulkActions.scss',
-      ),
-    ).toBe(true);
-  });
-
   it('generates fully namespaced CSS for root components', () => {
-    expect(
-      fs.readFileSync('./styles/components/Button/Button.scss', 'utf8'),
-    ).toMatch('.Polaris-Button{');
+    expect(fs.readFileSync('./styles/components.scss', 'utf8')).toMatch(
+      '.Polaris-Button{',
+    );
   });
 
   it('generates fully namespaced CSS for nested components', () => {
-    expect(
-      fs.readFileSync(
-        './styles/components/ResourceList/components/Item/Item.scss',
-        'utf8',
-      ),
-    ).toMatch('.Polaris-ResourceList-Item{');
+    expect(fs.readFileSync('./styles/components.scss', 'utf8')).toMatch(
+      '.Polaris-ResourceList-Item{',
+    );
   });
 
   it('generates a zip of ./build/sass', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

There is no value in having individual files per component in the styles
folder. It is unneeded overhead and people shouldn't be digging into
that folder trying to include a single component's styles in the first place.

### WHAT is this pull request doing?

Where styles/components.scss previously was a list imports to
per-component files, instead inline the contents of the per-component scss
into styles/components.scss. The listing of the contents is preserved so
the computed css out the other end will be idential.

At this point global.scss and components.scss both contain pure css.
They are only distributed as scss files for the sake of convinience and
ease of @importing (I have future plans to potentially simplify this further but that's a story for another day).

### How to 🎩

Run `yarn run build` and see the `styles/components` folder is no longer generated. See that `styles/components.scss` now includes the contents of  each components' and sub-components' css, with the classnames being the long ones generated using css-modules (note they all start with `Polaris-`.

Check that this works in web's development mode by doing `yarn run build-consumer web` then starting up the web server and browsing arround seeing that the css is still rendered.