### PR TITLE
[ResourceList.FilterControl] Add placeholder to prop list

### DIFF
--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -1407,6 +1407,7 @@ Filter control showing a state with applied filters and an additional action (op
 | appliedFilters  | AppliedFilter[]                                 | Collection of currently applied filters         |
 | focused         | boolean                                         | Whether the search term field is focused        |
 | filters         | Filter[]                                        | Available filters                               |
+| placeholder     | string                                          | Placeholder text for the search input           |
 | onSearchBlur    | function(): void                                | Callback when the search term field is blurred  |
 | onSearchChange  | function(searchvalue: string, id: string): void | Callback when the search term field is changed  |
 | onFiltersChange | function(appliedFilters: AppliedFilter[]): void | Callback when the applied filters are changed   |


### PR DESCRIPTION
### WHY are these changes introduced?

A `placeholder` prop was added to `FilterControl` in #1257, but is missing from the prop list in the docs.

### WHAT is this pull request doing?

Adds `placeholder` to the `FilterControl` prop list.

<img width="931" alt="Screen Shot 2019-08-06 at 10 46 18 AM" src="https://user-images.githubusercontent.com/18447883/62550625-8cb71980-b838-11e9-9eb0-1232d7ae5757.png">

## <!-- ℹ️ Delete the following for small / trivial changes -->

### 🎩 checklist

* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide