### PR TITLE
[Filters] Export interface for filters and applied filters

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Exported `AppliedFilterInterface` and `FilterInterface` from `Filters` ([#1924](https://github.com/Shopify/polaris-react/pull/1924))
+
 ### Bug fixes
 
 - Fixed types merge of `ActionMenu` `MenuAction` and `MenuGroup.actions` ([#1895](https://github.com/Shopify/polaris-react/pull/1895))

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -172,7 +172,12 @@ export {default as Link, Props as LinkProps} from './Link';
 
 export {default as List, Props as ListProps} from './List';
 
-export {default as Filters, Props as FiltersProps} from './Filters';
+export {
+  default as Filters,
+  Props as FiltersProps,
+  AppliedFilter as AppliedFilterInterface,
+  Filter as FilterInterface,
+} from './Filters';
 
 export {default as Loading, Props as LoadingProps} from './Loading';
 


### PR DESCRIPTION
### WHY are these changes introduced?

Missed this one and needed for https://github.com/Shopify/web/pull/15425

### WHAT is this pull request doing?

Exporting the interfaces for filters and applied filters so they can be imported by consumers
