### PR TITLE
[RangeSlider] Fix range slider focus state

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,12 @@
 ### Bug fixes
 
 - Fixed issue with `Filters` component displaying an undesired margin top and bottom on the button element on Safari ([#2292](https://github.com/Shopify/polaris-react/pull/2292))
+- Doesn't render `MenuActions` if no actions are passed to an `actionGroups` item inside `Page` ([#2266](https://github.com/Shopify/polaris-react/pull/2266))
+- Fixed `PositionedOverlay` incorrectly calculating `Topbar.UserMenu` `Popover` width ([#1692](https://github.com/Shopify/polaris-react/pull/1692))
+- Fixed `recolor-icon` Sass mixin to properly scope `$secondary-color` to the child `svg` ([#2298](https://github.com/Shopify/polaris-react/pull/2298))
+- Fixed a regression with the positioning of the `Popover` component ([#2305](https://github.com/Shopify/polaris-react/pull/2305))
+- Fixed Stack Item proportion when shrinking ([#2319](https://github.com/Shopify/polaris-react/pull/2319))
+- Fixed `RangeSlider` focus state style issues ([#1926](https://github.com/Shopify/polaris-react/pull/1926))
 
 ### Documentation
 

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -14,6 +14,7 @@ $range-thumb-border-error: rem(2px) solid color('red');
 $range-thumb-shadow: (0 0 0 rem(1px) rgba(black, 0.2), shadow(faint));
 $range-thumb-shadow-hover: (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint));
 $range-thumb-shadow-error: 0 0 0 rem(1px) color('red');
+$range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
 
 .Wrapper {
   position: relative;
@@ -94,20 +95,25 @@ $range-thumb-shadow-error: 0 0 0 rem(1px) color('red');
     border-color: color('sky', 'dark');
   }
 
-  .error & {
-    border-color: color('red');
-    box-shadow: $range-thumb-shadow-error;
-
-    &:hover,
-    &:focus {
-      border-color: color('red');
-      box-shadow: $range-thumb-shadow-error;
-    }
-  }
-
   &:hover {
     background: linear-gradient(color('sky', 'lighter'), color('sky', 'light'));
     box-shadow: $range-thumb-shadow-hover;
+  }
+
+  .error & {
+    border-color: color('red');
+    box-shadow: $range-thumb-shadow-error;
+  }
+
+  &:focus {
+    outline: 0;
+    background: linear-gradient(color('sky', 'lighter'), color('sky', 'light'));
+    border-color: color('indigo');
+    box-shadow: $range-thumb-shadow-focus;
+
+    @media (-ms-high-contrast: active) {
+      outline: 1px solid ms-high-contrast-color('text');
+    }
   }
 }
 

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -260,6 +260,7 @@ export class DualThumb extends React.Component<DualThumbProps, State> {
                 onMouseDown={this.handleMouseDownThumbLower}
                 onTouchStart={this.handleTouchStartThumbLower}
                 ref={this.thumbLower}
+                disabled={disabled}
               />
               {outputMarkupLower}
               <button
@@ -282,6 +283,7 @@ export class DualThumb extends React.Component<DualThumbProps, State> {
                 onMouseDown={this.handleMouseDownThumbUpper}
                 onTouchStart={this.handleTouchStartThumbUpper}
                 ref={this.thumbUpper}
+                disabled={disabled}
               />
               {outputMarkupUpper}
             </div>

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -82,36 +82,40 @@ describe('<DualThumb />', () => {
   });
 
   describe('disabled', () => {
-    it('sets aria-disabled to false by default on the lower thumb', () => {
+    it('sets aria-disabled and disabled to false by default on the lower thumb', () => {
       const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
 
       const thumbLower = findThumbLower(dualThumb);
       expect(thumbLower.prop('aria-disabled')).toBe(false);
+      expect(thumbLower.prop('disabled')).toBe(false);
     });
 
-    it('sets aria-disabled to false by default on the upper thumb', () => {
+    it('sets aria-disabled and disabled to false by default on the upper thumb', () => {
       const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
 
       const thumbUpper = findThumbUpper(dualThumb);
       expect(thumbUpper.prop('aria-disabled')).toBe(false);
+      expect(thumbUpper.prop('disabled')).toBe(false);
     });
 
-    it('sets aria-disabled to true on the lower thumb', () => {
+    it('sets aria-disabled and disabled to true on the lower thumb', () => {
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} disabled />,
       );
 
       const thumbLower = findThumbLower(dualThumb);
       expect(thumbLower.prop('aria-disabled')).toBe(true);
+      expect(thumbLower.prop('disabled')).toBe(true);
     });
 
-    it('sets aria-disabled to true on the upper thumb', () => {
+    it('sets aria-disabled and disabled to true on the upper thumb', () => {
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} disabled />,
       );
 
       const thumbUpper = findThumbUpper(dualThumb);
       expect(thumbUpper.prop('aria-disabled')).toBe(true);
+      expect(thumbUpper.prop('disabled')).toBe(true);
     });
   });
 

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -143,11 +143,7 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
     }
   }
 
-  // match `error` specificity for interaction styles
-  .RangeSlider &:focus {
-    // repeated so that `focus` can override `error`
-    --progress-lower: #{color('indigo')};
-
+  &:focus {
     @include range-track-selectors {
       background-color: color('sky', 'dark');
     }
@@ -159,6 +155,10 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
       );
       border-color: color('indigo');
       box-shadow: $range-thumb-shadow-focus;
+    }
+
+    @media (-ms-high-contrast: active) {
+      outline: 1px solid ms-high-contrast-color('text');
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?
* The range slider currently doesn't have a visible focus state, which is especially noticeable when it is used without the numeric output bubble 

### WHAT is this pull request doing?
* Removed a class selector from the `SingleThumb` styles which was preventing the focus styles from being applied to the input
  * The `.RangeSlider` selector was never used anywhere in the component, and was left over from the before the `DualThumb` component existed
* Added an outline to the entire `SingleThumb` input when focused in high contrast mode
* Updated the `SingleThumb` styles to prevent focus from taking over the error track colour
  * This should improve consistency across other input components (e.g. checkbox, select), where it will maintain some error styles but the focused area will receive an indigo outline
* Copied over the focus styles to the `DualThumb` scss to apply consistent focus styles across both components
* Added an outline to the `DualThumb` thumb button when focused in high contrast mode
* Disabled the `DualThumb` buttons to prevent them from receiving focus when the component is disabled
  * The single thumb range slider cannot receive focus in a disabled state, so this improves consistency across range sliders 


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

General case: 
* Tab into the input, and verify the slider receives an indigo border
* Use the mouse to move the slider, and verify it receives the focus state

Error state:
* Update component to be in an error state by adding `error="error"` as a prop
* Verify that focus states will not change the track colour, but the slider will receive an indigo border

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';
import {Page, Card, RangeSlider} from '../src';

export function Playground() {
  const initialValue = [700, 1000];
  const prefix = '$';
  const min = 0;
  const max = 2000;
  const step = 10;

  const [doubleRangeValue, setDoubleRangeValue] = useState(initialValue);
  const [rangeValue, setRangeValue] = useState(32);

  const handleDoubleRangeSliderChange = useCallback((value) => {
    setDoubleRangeValue(value);
  }, []);

  const handleRangeSliderChange = useCallback(
    (value) => setRangeValue(value),
    [],
  );

  return (
    <Page title="Playground">
      <Card sectioned title="Background color">
        <RangeSlider
          label="Opacity percentage"
          value={rangeValue}
          onChange={handleRangeSliderChange}
          output
        />
      </Card>
      <Card sectioned title="Minimum requirements">
        <RangeSlider
          output
          label="Money spent is between"
          value={doubleRangeValue}
          prefix={prefix}
          min={min}
          max={max}
          step={step}
          onChange={handleDoubleRangeSliderChange}
        />
      </Card>
    </Page>
  );
}
```

</details>

**Mac Chrome:**
Single without focus: 
![image](https://user-images.githubusercontent.com/12417232/67047680-c17d0200-f100-11e9-9051-3fe32d096d42.png)
Single with focus: 
![image](https://user-images.githubusercontent.com/12417232/67047705-ccd02d80-f100-11e9-957a-6cf7b32c1332.png)
Single error without focus:
![image](https://user-images.githubusercontent.com/12417232/67047800-086af780-f101-11e9-9d9b-37f4c2ed3d94.png)
Single error with focus:
![image](https://user-images.githubusercontent.com/12417232/67047822-10c33280-f101-11e9-961f-1b24015182d3.png)

Double without focus:
![image](https://user-images.githubusercontent.com/12417232/67047737-dce80d00-f100-11e9-9d34-253e018773ec.png)
Double with focus:
![image](https://user-images.githubusercontent.com/12417232/67047742-e4a7b180-f100-11e9-8057-663bc1b18ef1.png)
Double error without focus:
![image](https://user-images.githubusercontent.com/12417232/67047848-1caef480-f101-11e9-96e2-0ea4b79cf2c0.png)
Double error with focus:
![image](https://user-images.githubusercontent.com/12417232/67047888-2f292e00-f101-11e9-867a-5e8e15545cdb.png)

**Edge:**
Single without focus: 
![image](https://user-images.githubusercontent.com/12417232/67048679-a14e4280-f102-11e9-828c-1ac2b7d60254.png)
Single with focus: 
![image](https://user-images.githubusercontent.com/12417232/67048729-bb882080-f102-11e9-87d8-5e273b0cad54.png)
Single error without focus:
![image](https://user-images.githubusercontent.com/12417232/67048896-0e61d800-f103-11e9-80e5-dcf73ba8422e.png)
Single error with focus:
![image](https://user-images.githubusercontent.com/12417232/67048935-1f124e00-f103-11e9-95d0-3e28d9df1c5b.png)

Double without focus:
![image](https://user-images.githubusercontent.com/12417232/67048699-aad7aa80-f102-11e9-8cd6-5c36dcdcb952.png)
Double with focus:
![image](https://user-images.githubusercontent.com/12417232/67048759-c773e280-f102-11e9-972b-70a610f74302.png)
Double error without focus:
![image](https://user-images.githubusercontent.com/12417232/67048910-13bf2280-f103-11e9-9a0b-810c7b9c9fa1.png)
Double error with focus:
![image](https://user-images.githubusercontent.com/12417232/67048966-2afe1000-f103-11e9-9297-5a66d4f0ff6f.png)


**High contrast mode:**
Single without focus: 
![image](https://user-images.githubusercontent.com/12417232/67098379-17e25300-f18a-11e9-96e5-9507daeb28ef.png)
Single with focus: 
![image](https://user-images.githubusercontent.com/12417232/67098409-292b5f80-f18a-11e9-9447-e494793082e2.png)
Single error without focus:
![image](https://user-images.githubusercontent.com/12417232/67098002-4dd30780-f189-11e9-911e-6f10a47e9a3f.png)
Single error with focus:
![image](https://user-images.githubusercontent.com/12417232/67098036-693e1280-f189-11e9-98c8-4f38123e0a1e.png)

Double without focus:
![image](https://user-images.githubusercontent.com/12417232/67098392-1fa1f780-f18a-11e9-8657-a181b224d6c4.png)
Double with focus:
![image](https://user-images.githubusercontent.com/12417232/67098428-31839a80-f18a-11e9-9bcf-7b5e919f6343.png)
Double error without focus:
![image](https://user-images.githubusercontent.com/12417232/67098054-72c77a80-f189-11e9-9f40-6c55384f2ad2.png)
Double error with focus:
![image](https://user-images.githubusercontent.com/12417232/67098223-c5089b80-f189-11e9-8985-dcab86f8399a.png)


### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
