### PR TITLE
[Badge] Fix progress pip high contrast color

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixed types merge of `ActionMenu` `MenuAction` and `MenuGroup.actions` ([#1895](https://github.com/Shopify/polaris-react/pull/1895))
 - Fixed the activator buttons of `Page` `actionGroups` not toggling the `Popover` `active` state on click [#1905](https://github.com/Shopify/polaris-react/pull/1905)
+- Fixed Windows high contrast support of `Badge` `progress` ([#1928](https://github.com/Shopify/polaris-react/pull/1928))
 
 ### Documentation
 

--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -62,28 +62,39 @@ $pip-spacing: ($height - $pip-size) / 2;
   border: none;
 }
 
-.progressIncomplete .Pip {
-  background: transparent;
-}
-
-.progressPartiallyComplete .Pip {
-  background: linear-gradient(
-    to top,
-    currentColor,
-    currentColor 50%,
-    transparent 50%,
-    transparent
-  );
-}
-
-.progressComplete .Pip {
-  background: currentColor;
-}
-
 .Pip {
   height: $pip-size;
   width: $pip-size;
   margin: 0 spacing(extra-tight) 0 ($pip-spacing - $horizontal-padding);
   border: border-width(thick) solid currentColor;
   border-radius: 50%;
+}
+
+.progressIncomplete {
+  .Pip {
+    background: transparent;
+  }
+}
+
+.progressPartiallyComplete {
+  .Pip {
+    background: linear-gradient(
+      to top,
+      currentColor,
+      currentColor 50%,
+      transparent 50%,
+      transparent
+    );
+  }
+}
+
+.progressComplete {
+  .Pip {
+    background: linear-gradient(
+      to top,
+      currentColor,
+      currentColor 50%,
+      currentColor 50%
+    );
+  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1749 

### WHAT is this pull request doing?

Uses a linear gradient for the fulfilled badge pip instead of a background color (currentColor doesn't work on backgrounds in Edge, only text and images, so linear gradient works since they are processed by Edge as images).

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

- [x] Check that the pip is filled as expected in Windows high contrast mode
- [x] Check that the pip is filled as expected in standard browsers

### 🎩 checklist

* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

