### PR TITLE
[Tabs] Fix disclosure a11y

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed accessibility issue with `Autocomplete` where keyboard navigation of options was laggy and skipped options([#1887](https://github.com/Shopify/polaris-react/pull/1887))
 - Fixed bug where `Autocomplete` was bubbling up the `Enter` key event unexpectedly ([#1887](https://github.com/Shopify/polaris-react/pull/1887))
 - Fixed `ContextualSaveBar` actions overflowing on small screens ([#1967](https://github.com/Shopify/polaris-react/pull/1967))
+- Fixed `Tabs` rollup automatically opening from keyboard navigation of tab list ([#1933](https://github.com/Shopify/polaris-react/pull/1933))
 
 ### Documentation
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -208,7 +208,7 @@
       "warningMessage": "Die Farbe {color} sollte nicht für {size} Spinner verwendet werden. Die für große Spinner verfügbaren Farben sind: {colors}"
     },
     "Tabs": {
-      "toggleTabsLabel": "Menü wechseln"
+      "toggleTabsLabel": "Weitere Registerkarten"
     },
     "Tag": {
       "ariaLabel": "{children} entfernen"

--- a/locales/en.json
+++ b/locales/en.json
@@ -236,7 +236,7 @@
     },
 
     "Tabs": {
-      "toggleTabsLabel": "Toggle menu"
+      "toggleTabsLabel": "More tabs"
     },
 
     "Tag": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -208,7 +208,7 @@
       "warningMessage": "El color {color} no está concebido para ser utilizado en spinners {size} Los colores disponibles en los spinners grandes son: {colors}"
     },
     "Tabs": {
-      "toggleTabsLabel": "Activar menú"
+      "toggleTabsLabel": "Más pestañas"
     },
     "Tag": {
       "ariaLabel": "Eliminar {children}"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -208,7 +208,7 @@
       "warningMessage": "La couleur {color} n'est pas destinée à être utilisée sur les boutons fléchés de {size}. Les couleurs disponibles sur les grands boutons fléchés sont : {colors}"
     },
     "Tabs": {
-      "toggleTabsLabel": "Menu toggle"
+      "toggleTabsLabel": "Plus d'onglets"
     },
     "Tag": {
       "ariaLabel": "Supprimer {children}"

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -208,7 +208,7 @@
       "warningMessage": "{color} रंग का उपयोग {size} स्पिनर पर करने के लिए नहीं है. बड़े स्पिनर पर उपलब्ध रंग हैं: {colors}"
     },
     "Tabs": {
-      "toggleTabsLabel": "मेनू टॉगल करें"
+      "toggleTabsLabel": "अधिक टैब"
     },
     "Tag": {
       "ariaLabel": "{children} को निकालें"

--- a/locales/it.json
+++ b/locales/it.json
@@ -208,7 +208,7 @@
       "warningMessage": "Il colore {color} non è pensato per essere usato su spinner {size}. Colori disponibili per grandi spinner: {colors}"
     },
     "Tabs": {
-      "toggleTabsLabel": "Menu di attivazione/disattivazione"
+      "toggleTabsLabel": "Altre schede"
     },
     "Tag": {
       "ariaLabel": "Rimuovi {children}"

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -208,7 +208,7 @@
       "warningMessage": "{color}色は{size}のスピナーでは使用されていません。大きなスピナーで利用可能な色は次のとおりです: {colors}"
     },
     "Tabs": {
-      "toggleTabsLabel": "メニューを切り替える"
+      "toggleTabsLabel": "その他のタブ"
     },
     "Tag": {
       "ariaLabel": "{children}を削除する"

--- a/locales/ms.json
+++ b/locales/ms.json
@@ -208,7 +208,7 @@
       "warningMessage": "Warna {color} tidak dimaksudkan untuk digunakan pada pemintal {size}. Warna-warna yang tersedia pada pemintal besar adalah: {colors}"
     },
     "Tabs": {
-      "toggleTabsLabel": "Togol menu"
+      "toggleTabsLabel": "Lebih banyak tab"
     },
     "Tag": {
       "ariaLabel": "Alih keluar {children}"

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -208,7 +208,7 @@
       "warningMessage": "De kleur {color} is niet bedoeld voor gebruik op {size} spinners. De beschikbare kleuren op grote spinner zijn: {colors}"
     },
     "Tabs": {
-      "toggleTabsLabel": "Schakelen tussen menu's"
+      "toggleTabsLabel": "Meer tabbladen"
     },
     "Tag": {
       "ariaLabel": "{children} verwijderen"

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -208,7 +208,7 @@
       "warningMessage": "A cor {color} não é para ser usada spinners de {size}. As cores disponíveis em grandes spinners são: {colors}"
     },
     "Tabs": {
-      "toggleTabsLabel": "Alternar menu"
+      "toggleTabsLabel": "Mais abas"
     },
     "Tag": {
       "ariaLabel": "Remover {children}"

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -208,7 +208,7 @@
       "warningMessage": "{size} 加载微调器不支持颜色 {color}。大型加载微调器的可用颜色：{colors}"
     },
     "Tabs": {
-      "toggleTabsLabel": "切换菜单"
+      "toggleTabsLabel": "更多标签"
     },
     "Tag": {
       "ariaLabel": "删除 {children}"

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -208,7 +208,7 @@
       "warningMessage": "{color} 這個顏色不能搭配{size}的轉盤。大型轉盤可以使用的顏色為：{colors}"
     },
     "Tabs": {
-      "toggleTabsLabel": "切換選單"
+      "toggleTabsLabel": "更多索引標籤"
     },
     "Tag": {
       "ariaLabel": "移除 {children}"

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -208,18 +208,6 @@ $focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
       border-bottom: border-width(thicker) solid color('indigo', 'light');
     }
   }
-
-  &.Tab-selected {
-    // stylelint-disable-next-line selector-max-class
-    .Title {
-      border-bottom: border-width(thicker) solid color('indigo');
-
-      @media (-ms-high-contrast: active) {
-        background: ms-high-contrast-color('selected-text-background');
-        border-bottom-color: ms-high-contrast-color('selected-text-background');
-      }
-    }
-  }
 }
 
 .TabMeasurer {

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -179,17 +179,45 @@ $focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
   position: relative;
   justify-content: center;
   height: 100%;
+  margin: 1px 1px -1px 0;
   padding: 0 spacing();
   background-color: transparent;
   cursor: pointer;
   border: none;
   outline: none;
   text-align: center;
+
   &:hover {
-    @include recolor-icon(color('ink'));
-    @media (-ms-high-contrast: active) {
-      @include recolor-icon(color('black'));
-      @include state(active, hover);
+    .Title {
+      @include recolor-icon(color('ink'));
+      border-bottom: border-width(thicker) solid color('sky');
+
+      @media (-ms-high-contrast: active) {
+        @include recolor-icon(color('black'));
+        @include state(active, hover);
+        border-bottom-color: ms-high-contrast-color('selected-text-background');
+      }
+    }
+  }
+
+  &:focus {
+    box-shadow: inset 0 0 2px 0 $focus-state-box-shadow-color,
+      0 0 2px 0 $focus-state-box-shadow-color;
+
+    .Title {
+      border-bottom: border-width(thicker) solid color('indigo', 'light');
+    }
+  }
+
+  &.Tab-selected {
+    // stylelint-disable-next-line selector-max-class
+    .Title {
+      border-bottom: border-width(thicker) solid color('indigo');
+
+      @media (-ms-high-contrast: active) {
+        background: ms-high-contrast-color('selected-text-background');
+        border-bottom-color: ms-high-contrast-color('selected-text-background');
+      }
     }
   }
 }

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -120,7 +120,7 @@ class Tabs extends React.PureComponent<CombinedProps, State> {
 
     const activator = (
       <button
-        tabIndex={-1}
+        type="button"
         className={styles.DisclosureActivator}
         onClick={this.handleDisclosureActivatorClick}
         aria-label={intl.translate('Polaris.Tabs.toggleTabsLabel')}
@@ -172,14 +172,17 @@ class Tabs extends React.PureComponent<CombinedProps, State> {
   }
 
   private handleKeyPress = (event: React.KeyboardEvent<HTMLElement>) => {
-    const {tabToFocus, visibleTabs, hiddenTabs} = this.state;
-    const tabsArrayInOrder = visibleTabs.concat(hiddenTabs);
+    const {tabToFocus, visibleTabs, hiddenTabs, showDisclosure} = this.state;
     const key = event.key;
+    const tabsArrayInOrder = showDisclosure
+      ? visibleTabs.concat(hiddenTabs)
+      : [...visibleTabs];
 
     let newFocus = tabsArrayInOrder.indexOf(tabToFocus);
 
     if (key === 'ArrowRight' || key === 'ArrowDown') {
       newFocus += 1;
+
       if (newFocus === tabsArrayInOrder.length) {
         newFocus = 0;
       }
@@ -194,7 +197,6 @@ class Tabs extends React.PureComponent<CombinedProps, State> {
     }
 
     this.setState({
-      showDisclosure: hiddenTabs.indexOf(tabsArrayInOrder[newFocus]) > -1,
       tabToFocus: tabsArrayInOrder[newFocus],
     });
   };
@@ -223,9 +225,9 @@ class Tabs extends React.PureComponent<CombinedProps, State> {
   private handleFocus = (event: React.FocusEvent<HTMLUListElement>) => {
     const {selected, tabs} = this.props;
 
-    // If we are explicitly focusing one of the non-selected tabs, use it
-    // move the focus to it
+    // If we are explicitly focusing a non-selected tab, this focuses it
     const target = event.target as HTMLElement;
+
     if (
       target.classList.contains(styles.Tab) ||
       target.classList.contains(styles.Item)
@@ -258,6 +260,7 @@ class Tabs extends React.PureComponent<CombinedProps, State> {
     }
 
     const relatedTarget = event.relatedTarget as HTMLElement;
+
     if (
       !relatedTarget.classList.contains(styles.Tab) &&
       !relatedTarget.classList.contains(styles.Item) &&

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -306,6 +306,7 @@ class Tabs extends React.PureComponent<CombinedProps, State> {
       containerWidth,
       disclosureWidth,
     } = measurements;
+
     const {visibleTabs, hiddenTabs} = getVisibleAndHiddenTabIndices(
       tabs,
       selected,

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -125,7 +125,9 @@ class Tabs extends React.PureComponent<CombinedProps, State> {
         onClick={this.handleDisclosureActivatorClick}
         aria-label={intl.translate('Polaris.Tabs.toggleTabsLabel')}
       >
-        <Icon source={HorizontalDotsMinor} />
+        <span className={styles.Title}>
+          <Icon source={HorizontalDotsMinor} />
+        </span>
       </button>
     );
 

--- a/src/components/Tabs/components/Item/Item.tsx
+++ b/src/components/Tabs/components/Item/Item.tsx
@@ -64,7 +64,7 @@ export default class Item extends React.PureComponent<Props, never> {
       </button>
     );
 
-    return <li role="presentation">{markup}</li>;
+    return <li>{markup}</li>;
   }
 
   private setFocusedNode = (

--- a/src/components/Tabs/components/Tab/Tab.tsx
+++ b/src/components/Tabs/components/Tab/Tab.tsx
@@ -131,11 +131,7 @@ class Tab extends React.PureComponent<CombinedProps, never> {
     );
 
     return (
-      <li
-        role="presentation"
-        className={styles.TabContainer}
-        ref={this.setNode}
-      >
+      <li className={styles.TabContainer} ref={this.setNode}>
         {markup}
       </li>
     );

--- a/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
+++ b/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
@@ -22,7 +22,7 @@ export interface Props {
 }
 
 export default class TabMeasurer extends React.PureComponent<Props, never> {
-  private containerNode: HTMLElement | null = null;
+  private containerNode: React.RefObject<HTMLDivElement> = React.createRef();
   private animationFrame: number | null = null;
 
   componentDidMount() {
@@ -70,7 +70,7 @@ export default class TabMeasurer extends React.PureComponent<Props, never> {
     const classname = classNames(styles.Tabs, styles.TabMeasurer);
 
     return (
-      <div className={classname} ref={this.setContainerNode}>
+      <div className={classname} ref={this.containerNode}>
         <EventListener event="resize" handler={this.handleMeasurement} />
         {tabsMarkup}
         {activator}
@@ -78,25 +78,20 @@ export default class TabMeasurer extends React.PureComponent<Props, never> {
     );
   }
 
-  private setContainerNode = (node: HTMLElement | null) => {
-    this.containerNode = node;
-  };
-
   private handleMeasurement = () => {
     if (this.animationFrame) {
       cancelAnimationFrame(this.animationFrame);
     }
 
     this.animationFrame = requestAnimationFrame(() => {
-      if (this.containerNode == null) {
+      if (!this.containerNode.current) {
         return;
       }
 
       const {handleMeasurement} = this.props;
-      const containerWidth = this.containerNode.offsetWidth;
-      const hiddenTabNodes =
-        this.containerNode instanceof Element && this.containerNode.children;
-      const hiddenTabNodesArray: HTMLElement[] = [].slice.call(hiddenTabNodes);
+      const containerWidth = this.containerNode.current.offsetWidth;
+      const hiddenTabNodes = this.containerNode.current.children;
+      const hiddenTabNodesArray = Array.from(hiddenTabNodes);
       const hiddenTabWidths = hiddenTabNodesArray.map((node) => {
         return node.getBoundingClientRect().width;
       });

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {ReactWrapper} from 'enzyme';
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
-import {Tab, Panel, TabMeasurer, List} from '../components';
+import {Tab, Panel, TabMeasurer} from '../components';
 import Tabs, {Props} from '../Tabs';
 import {getVisibleAndHiddenTabIndices} from '../utilities';
 import Popover from '../../Popover';
@@ -13,16 +12,10 @@ describe('<Tabs />', () => {
   ];
 
   const mockProps = {
-    selected: 0,
     tabs,
+    selected: 0,
     onSelect: noop,
   };
-
-  function getPopoverContents(tabs: ReactWrapper) {
-    return mountWithAppProvider(
-      <div>{tabs.find(Popover).prop('children')}</div>,
-    );
-  }
 
   afterEach(() => {
     if (document.activeElement) {
@@ -420,13 +413,73 @@ describe('<Tabs />', () => {
           disclosureWidth: 0,
         });
 
-        const popoverContents = getPopoverContents(tabs);
-        async () => {
-          trigger(popoverContents.find(List), 'onKeyPress', {
-            key: 'ArrowRight',
-          });
-          await expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
-        };
+        const popover = tabs.find(Popover);
+        const disclosureActivator = popover.find('.DisclosureActivator');
+
+        trigger(disclosureActivator, 'onClick', {
+          key: 'Enter',
+        });
+
+        trigger(tabs.find('ul'), 'onKeyUp', {
+          key: 'ArrowRight',
+        });
+
+        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
+      });
+
+      it('shifts focus to the first hidden tab when the last visible tab is focused and the disclosure popover is active', () => {
+        const tabs = mountWithAppProvider(<Tabs {...mockProps} />);
+        const tabMeasurer = tabs.find(TabMeasurer);
+        trigger(tabMeasurer, 'handleMeasurement', {
+          hiddenTabWidths: [82, 160, 150, 100, 80, 120],
+          containerWidth: 300,
+          disclosureWidth: 0,
+        });
+        const popover = tabs.find(Popover);
+        const disclosureActivator = popover.find('button');
+
+        disclosureActivator.simulate('click');
+
+        trigger(disclosureActivator, 'onClick', {
+          key: 'Enter',
+        });
+
+        trigger(tabs.find('ul'), 'onKeyUp', {
+          key: 'ArrowRight',
+        });
+
+        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
+
+        trigger(tabs.find('ul'), 'onKeyUp', {
+          key: 'ArrowRight',
+        });
+
+        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(1);
+      });
+
+      it('does not shift focus to the first hidden tab when the last visible tab is focused and the disclosure popover is not active', () => {
+        const tabs = mountWithAppProvider(<Tabs {...mockProps} />);
+        const tabMeasurer = tabs.find(TabMeasurer);
+        trigger(tabMeasurer, 'handleMeasurement', {
+          hiddenTabWidths: [82, 160, 150, 100, 80, 120],
+          containerWidth: 300,
+          disclosureWidth: 0,
+        });
+
+        const popover = tabs.find(Popover);
+        expect(popover.prop('active')).toBe(false);
+
+        trigger(tabs.find('ul'), 'onKeyUp', {
+          key: 'ArrowRight',
+        });
+
+        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
+
+        trigger(tabs.find('ul'), 'onKeyUp', {
+          key: 'Enter',
+        });
+
+        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
       });
     });
   });

--- a/src/components/Tabs/utilities.ts
+++ b/src/components/Tabs/utilities.ts
@@ -8,7 +8,6 @@ export function getVisibleAndHiddenTabIndices(
   containerWidth: number,
 ) {
   const sumTabWidths = tabWidths.reduce((sum, width) => sum + width, 0);
-
   const arrayOfTabIndices = tabs.map((_, index) => {
     return index;
   });
@@ -20,16 +19,20 @@ export function getVisibleAndHiddenTabIndices(
     visibleTabs.push(...arrayOfTabIndices);
   } else {
     visibleTabs.push(selected);
-    let newTabWidth: number = tabWidths[selected];
 
-    arrayOfTabIndices.forEach((index) => {
-      if (index !== selected) {
-        if (newTabWidth + tabWidths[index] > containerWidth - disclosureWidth) {
-          hiddenTabs.push(index);
+    let tabListWidth = tabWidths[selected];
+
+    arrayOfTabIndices.forEach((currentTabIndex) => {
+      if (currentTabIndex !== selected) {
+        const currentTabWidth = tabWidths[currentTabIndex];
+
+        if (tabListWidth + currentTabWidth > containerWidth - disclosureWidth) {
+          hiddenTabs.push(currentTabIndex);
           return;
         }
-        visibleTabs.push(index);
-        newTabWidth += tabWidths[index];
+
+        visibleTabs.push(currentTabIndex);
+        tabListWidth += currentTabWidth;
       }
     });
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/153

### WHAT is this pull request doing?

Implements recommendations two and three, adding a focus state to the tab rollup activator and fixes the tab order.

### Questions

- The `role="presentation"` on the `li` that wraps each `Tab` as well as the disclosure/rollup activator was causing the a11y check to fail [so I 🔥it](https://github.com/Shopify/polaris-react/pull/1933/commits/16424da601af5b0ab5b45ed6a785a0278ca1fb99). Should there be a different `role` here (like `navigation`?), or is it alright that it's been removed?

<img width="982" alt="Screen Shot 2019-08-06 at 7 22 52 PM" src="https://user-images.githubusercontent.com/18447883/62583929-57361e80-b880-11e9-8913-8387d0238cb0.png">


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

- Open the latest Playground deployment 
- Click on any tabs example and resize your window* so that the tabs disclosure/rollup is visible
- Tab to the first tab and navigate the visible tab list with arrow keys
    - it should cycle through the visible tabs
    - it should not activate the disclosure/rollup
- Tab to the disclosure/rollup button and click Enter/Return to activate the popover and click the Tab key
    - the action list items should be next in the tab order
    - if the action list is open, the arrow keys should also be able to navigate the entire list of tabs inclusive of the action list


*Or use Storybook's preview resize menu
![screencapture-localhost-6006-2019-08-06-19_15_39](https://user-images.githubusercontent.com/18447883/62583648-0d006d80-b87f-11e9-9ada-9ea4cc942859.png)



### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
