### PR TITLE
Remove unused spread operator

### DIFF
--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -143,11 +143,11 @@ describe('<Header />', () => {
     const mockActionGroups: Props['actionGroups'] = [
       {
         title: 'First group',
-        actions: [...mockSecondaryActions],
+        actions: mockSecondaryActions,
       },
       {
         title: 'Second group',
-        actions: [...mockSecondaryActions],
+        actions: mockSecondaryActions,
       },
     ];
 


### PR DESCRIPTION
### WHY are these changes introduced?

Rerun Percy without pushing to master (v4 master 😛)
