### PR TITLE
Remove duplicated example for navigation with separator

### DIFF
--- a/src/components/Navigation/README.md
+++ b/src/components/Navigation/README.md
@@ -307,7 +307,7 @@ Use to show a limited number of items in a section with an option to expand the 
 
 ### Navigation with section separator
 
-Use to add a horizontal line below each section.
+Use to add a horizontal line below the section.
 
 ```jsx
 <Navigation location="/">

--- a/src/components/Navigation/README.md
+++ b/src/components/Navigation/README.md
@@ -307,7 +307,7 @@ Use to show a limited number of items in a section with an option to expand the 
 
 ### Navigation with section separator
 
-Use to add a horizontal line between sections.
+Use to add a horizontal line below each section.
 
 ```jsx
 <Navigation location="/">

--- a/src/components/Navigation/README.md
+++ b/src/components/Navigation/README.md
@@ -195,43 +195,6 @@ Use to present a navigation menu in the [frame](/components/structure/frame).
 </Navigation>
 ```
 
-### Navigation with sections and a separator
-
-Use to divide groups of items with a horizontal divider.
-
-```jsx
-<Navigation location="/">
-  <Navigation.Section
-    items={[
-      {
-        url: '/path/to/place',
-        label: 'Home',
-        icon: HomeMajorMonotone,
-      },
-      {
-        url: '/path/to/place',
-        label: 'Orders',
-        icon: OrdersMajorTwotone,
-      },
-      {
-        url: '/path/to/place',
-        label: 'Products',
-        icon: ProductsMajorTwotone,
-      },
-    ]}
-  />
-  <Navigation.Section
-    items={[
-      {
-        url: '/path/to/place',
-        label: 'Online Store',
-        icon: OnlineStoreMajorTwotone,
-      },
-    ]}
-    separator
-  />
-</Navigation>
-```
 
 ### Navigation with a secondary action for a section and a section title
 

--- a/src/components/Navigation/README.md
+++ b/src/components/Navigation/README.md
@@ -195,7 +195,6 @@ Use to present a navigation menu in the [frame](/components/structure/frame).
 </Navigation>
 ```
 
-
 ### Navigation with a secondary action for a section and a section title
 
 Use to present a secondary action, related to a section and to title the section.


### PR DESCRIPTION
### WHY are these changes introduced?

We have two duplicated documentation of navigation with separator:
<img width="736" alt="Screen Shot 2019-08-08 at 10 44 39 AM" src="https://user-images.githubusercontent.com/19199063/62712802-8e641700-b9c9-11e9-855d-98f6314b17d5.png">

> Navigation with sections and separator

> Navigation with section separator


### WHAT is this pull request doing?

Removing duplicated examples