### PR TITLE
[Filters] Add onQueryFocused callback

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -36,6 +36,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Exported `AppliedFilterInterface` and `FilterInterface` from `Filters` ([#1924](https://github.com/Shopify/polaris-react/pull/1924))
 - Improved color contrast of links inside `Banner` ([#1651](https://github.com/Shopify/polaris-react/pull/1651))
 - Add underline to Links and Plain button on hover, so it doesn't rely on color alone for accessibility ([#1885](https://github.com/Shopify/polaris-react/pull/1885))
+- Add `onQueryFocus` callback prop to the `Filters` component ([#1948](https://github.com/Shopify/polaris-react/pull/1948))
 
 ### Bug fixes
 

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -74,6 +74,8 @@ export interface Props {
   onClearAll(): void;
   /** Callback when the query field is blurred */
   onQueryBlur?(): void;
+  /** Callback when the query field is focused */
+  onQueryFocus?(): void;
   /** The content to display inline with the controls */
   children?: React.ReactNode;
 }
@@ -133,6 +135,7 @@ class Filters extends React.Component<ComposedProps, State> {
       queryValue,
       onQueryBlur,
       onQueryChange,
+      onQueryFocus,
       focused,
       onClearAll,
       appliedFilters,
@@ -236,6 +239,7 @@ class Filters extends React.Component<ComposedProps, State> {
           }
           onChange={onQueryChange}
           onBlur={onQueryBlur}
+          onFocus={onQueryFocus}
           value={queryValue}
           focused={focused}
           label={

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {matchMedia} from '@shopify/jest-dom-mocks';
-import {Button, Popover, Sheet, Tag} from 'components';
+import {Button, Popover, Sheet, Tag, TextField} from 'components';
 
 import {
   mountWithAppProvider,
@@ -48,6 +48,17 @@ describe('<Filters />', () => {
 
   afterEach(() => {
     matchMedia.restore();
+  });
+
+  it('calls the onQueryFocus callback when the query field is focused', () => {
+    const onQueryFocus = jest.fn();
+    const filters = mountWithAppProvider(
+      <Filters {...mockProps} onQueryFocus={onQueryFocus} />,
+    );
+
+    trigger(filters.find(TextField), 'onFocus');
+
+    expect(onQueryFocus).toHaveBeenCalledTimes(1);
   });
 
   describe('toggleFilters()', () => {


### PR DESCRIPTION
### WHY are these changes introduced?
Current functionality in web relies on an `onQueryFocus` callback on the ListFilters component in polaris-next. This is used to instrument the search behaviour, where a focus event on the query field indicates the beginning of the users intent to search.

Tim's excellent PR to replace the polaris-next ListFilters with the proper Filter component from Polaris means we can no longer do this. (see https://github.com/Shopify/web/pull/15425#discussion_r311870970)

### WHAT is this pull request doing?

Adding a callback to the Filters component to be triggered when the query field is focused.
### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
