### PR TITLE
[ContextualSaveBar] Changed useEffect to useDeepEffect

### DIFF
--- a/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {ContextualSaveBarProps, useFrame} from '../../utilities/frame';
+import {useDeepEffect} from '../../utilities/use-deep-effect';
 
 // The script in the styleguide that generates the Props Explorer data expects
 // a component's props to be found in the Props interface. This silly workaround
@@ -15,7 +16,7 @@ function ContextualSaveBar({
 }: Props) {
   const {setContextualSaveBar, removeContextualSaveBar} = useFrame();
 
-  React.useEffect(
+  useDeepEffect(
     () => {
       setContextualSaveBar({
         message,


### PR DESCRIPTION
### WHY are these changes introduced?

Save action and discard action are compared by reference and could fail an object is comparison so this will reduce unnecessary renders 