### PR TITLE
Rename export from use-deep-effect to be useDeepEffect

### DIFF
--- a/src/components/Frame/components/ToastManager/ToastManager.tsx
+++ b/src/components/Frame/components/ToastManager/ToastManager.tsx
@@ -8,7 +8,7 @@ import EventListener from '../../../EventListener';
 import Portal from '../../../Portal';
 import {ToastPropsWithID} from '../../../../utilities/frame';
 import Toast from '../Toast';
-import {useDeepCompare} from '../../../../utilities/use-deep-effect';
+import {useDeepEffect} from '../../../../utilities/use-deep-effect';
 import {useDeepCallback} from '../../../../utilities/use-deep-callback';
 
 import styles from './ToastManager.scss';
@@ -40,7 +40,7 @@ function ToastManager({toastMessages}: Props) {
     [toastMessages, toastNodes],
   );
 
-  useDeepCompare(
+  useDeepEffect(
     () => {
       updateToasts();
     },

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -5,7 +5,7 @@ import {arraysAreEqual} from '../../utilities/arrays';
 import {IconProps} from '../../types';
 import {Props as AvatarProps} from '../Avatar';
 import {Props as ThumbnailProps} from '../Thumbnail';
-import {useDeepCompare} from '../../utilities/use-deep-effect';
+import {useDeepEffect} from '../../utilities/use-deep-effect';
 
 import {Option} from './components';
 import styles from './OptionList.scss';
@@ -81,7 +81,7 @@ export default function OptionList({
     id.current = propId || id.current;
   }
 
-  useDeepCompare(
+  useDeepEffect(
     () => {
       setNormalizedOptions(
         createNormalizedOptions(options || [], sections || [], title),

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -4,7 +4,7 @@ import {Toast as AppBridgeToast} from '@shopify/app-bridge/actions';
 
 import {DEFAULT_TOAST_DURATION} from '../Frame';
 import {ToastProps, useFrame} from '../../utilities/frame';
-import {useDeepCompare} from '../../utilities/use-deep-effect';
+import {useDeepEffect} from '../../utilities/use-deep-effect';
 import {useAppBridge} from '../../utilities/app-bridge';
 
 const createId = createUniqueIDFactory('Toast');
@@ -21,7 +21,7 @@ function Toast(props: Props) {
   const {showToast, hideToast} = useFrame();
   const appBridge = useAppBridge();
 
-  useDeepCompare(
+  useDeepEffect(
     () => {
       const {
         error,

--- a/src/utilities/use-deep-effect.tsx
+++ b/src/utilities/use-deep-effect.tsx
@@ -2,7 +2,7 @@ import {useEffect} from 'react';
 import {EffectCallback, DependencyList, Comparator} from '../types';
 import {useDeepCompareRef} from './use-deep-compare-ref';
 
-export function useDeepCompare(
+export function useDeepEffect(
   callback: EffectCallback,
   dependencies: DependencyList,
   customCompare?: Comparator,


### PR DESCRIPTION
### WHY are these changes introduced?
Follow up to #1938.

That PR renamed the files but didn't rename the exported function

### WHAT is this pull request doing?
Renames `useDeepCompare` to `useDeepEffect` to match the filename
