### PR TITLE
Add minified styles to npm package

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,6 +7,7 @@ node_modules
 /types
 /index.*
 /styles.css
+/styles.min.css
 /styles.scss
 /styles
 /src/styles/polaris-tokens

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 /types
 /index.*
 /styles.css
+/styles.min.css
 /styles.scss
 /styles
 /sandbox

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@ node_modules
 /types
 /index.*
 /styles.css
+/styles.min.css
 /styles.scss
 /styles
 /src/styles/polaris-tokens

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -6,6 +6,7 @@ node_modules
 /types
 /index.*
 /styles.css
+/styles.min.css
 /styles.scss
 /styles
 /src/styles/polaris-tokens

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
     "esnext/": true,
     "index.*": true,
     "sandbox": true,
-    "styles.{css,scss}": true,
+    "styles.{css,min.css,scss}": true,
     "styles/": true,
     "types/": true
   },
@@ -40,7 +40,7 @@
     "esnext/": true,
     "index.*": true,
     "sandbox": true,
-    "styles.{css,scss}": true,
+    "styles.{css,min.css,scss}": true,
     "styles/": true,
     "types/": true
   },

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "test:ci": "yarn test --coverage",
     "check": "npm-run-all lint type-check test",
     "check:ci": "npm-run-all lint type-check test:ci",
-    "clean": "rimraf build esnext styles types docs \"build-intermediate\" \"index.*\" \"./src/styles/polaris-tokens\" \"styles.{css,scss}\"",
-    "clean:build": "rimraf \"build/!(cache|coverage|storybook)\" esnext styles types docs \"build-intermediate\" \"index.*\" \"./src/styles/polaris-tokens\" \"styles.{css,scss}\"",
+    "clean": "rimraf build esnext styles types docs \"build-intermediate\" \"index.*\" \"./src/styles/polaris-tokens\" \"styles.{css,min.css,scss}\"",
+    "clean:build": "rimraf \"build/!(cache|coverage|storybook)\" esnext styles types docs \"build-intermediate\" \"index.*\" \"./src/styles/polaris-tokens\" \"styles.{css,min.css,scss}\"",
     "optimize": "sewing-kit optimize",
     "prebuild": "npm-run-all clean:build optimize copy-polaris-tokens",
     "build": "node ./scripts/build.js",
@@ -177,6 +177,7 @@
     "index.js",
     "index.es.js",
     "styles.css",
+    "styles.min.css",
     "styles.scss"
   ],
   "dependencies": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -76,6 +76,7 @@ copy(['./src/**/*.{scss,svg,png,jpg,jpeg,json}', intermediateBuild], {up: 1})
       cp('build/polaris.js', './index.js'),
       cp('build/polaris.es.js', './index.es.js'),
       cp('build/polaris.css', './styles.css'),
+      cp('build/polaris.min.css', './styles.min.css'),
       cp('build/styles.scss', './styles.scss'),
       cp('-r', 'build/styles', './styles'),
     ]),

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -24,6 +24,7 @@ describe('build', () => {
     expect(fs.existsSync('./index.js')).toBe(true);
     expect(fs.existsSync('./index.es.js')).toBe(true);
     expect(fs.existsSync('./styles.css')).toBe(true);
+    expect(fs.existsSync('./styles.min.css')).toBe(true);
   });
 
   it('generates a ./styles/foundation dir with spacing.scss', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Maintaining our own CDN distribution of our CSS files is a little annoying as it leads to more complex builds. Let's let unpkg handle our CDN styles.

The first step to that is adding minified styles into npm package - that's this PR.
The second step is ripping out our build config that uploads files to sdks.shopifycdn.com and updates our links to unpkg.com files (that'll be a new PR after we do an RC containing this change)

### WHAT is this pull request doing?

Adds `styles.min.css` to our npm package

### How to 🎩

- Run `yarn run build` and see that `styles.min.css` is generated
- Run `npm pack` then extract the generated tgz and see that styles.min.css is included in the package folder
- See that `styles.min.css` is excluded from git and linting configs
- See that running `yarn run clean` deletes `styles.min.css` 