### PR TITLE
[Tabs] remove presentation role from list item

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -46,6 +46,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `BulkActionButton` from throwing an error in `componentDidMount` ([#1913](https://github.com/Shopify/polaris-react/pull/1913))
 - Fixed `ToastManager` from not working correctly in `React.StrictMode` ([#1741](https://github.com/Shopify/polaris-react/pull/1741))
 - Updated translation.yml with the new locales path ([#1649](https://github.com/Shopify/polaris-react/pull/1649))
+- Fixed accessibility issue with `Tabs` list item presentation role ([A#1958](https://github.com/Shopify/polaris-react/pull/1958))
 
 ### Documentation
 

--- a/a11y_shitlist.json
+++ b/a11y_shitlist.json
@@ -130,25 +130,5 @@
       "typeCode": 1,
       "selector": "#256 > div:nth-child(4) > div > button"
     }
-  ],
-  "all-components-tabs--fitted-tabs": [
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F92,ARIA4",
-      "context": "<li role=\"presentation\" class=\"Tabs-DisclosureTab_1_TJd\"><div><button tabindex=\"-1\" clas...</li>",
-      "message": "This element's role is \"presentation\" but contains child elements with semantic meaning.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#root > div > div > div > div > ul > li:nth-child(3)"
-    }
-  ],
-  "all-components-tabs--default-tabs": [
-    {
-      "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F92,ARIA4",
-      "context": "<li role=\"presentation\" class=\"Tabs-DisclosureTab_1_TJd\"><div><button tabindex=\"-1\" clas...</li>",
-      "message": "This element's role is \"presentation\" but contains child elements with semantic meaning.",
-      "type": "error",
-      "typeCode": 1,
-      "selector": "#root > div > div > div > div > ul > li:nth-child(5)"
-    }
   ]
 }

--- a/src/components/Tabs/README.md
+++ b/src/components/Tabs/README.md
@@ -154,15 +154,15 @@ class FittedTabsExample extends React.Component {
 
     const tabs = [
       {
-        id: 'all-customers',
+        id: 'all-customers-fitted',
         content: 'All',
         accessibilityLabel: 'All customers',
-        panelID: 'all-customers-content',
+        panelID: 'all-customers-fitted-content',
       },
       {
-        id: 'accepts-marketing',
+        id: 'accepts-marketing-fitted',
         content: 'Accepts marketing',
-        panelID: 'accepts-marketing-content',
+        panelID: 'accepts-marketing-fitted-Ccontent',
       },
     ];
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -140,7 +140,7 @@ class Tabs extends React.PureComponent<CombinedProps, State> {
           onKeyUp={this.handleKeyPress}
         >
           {tabsMarkup}
-          <li role="presentation" className={disclosureTabClassName}>
+          <li className={disclosureTabClassName}>
             <Popover
               preferredPosition="below"
               activator={activator}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1577

This issue was missed the original pr. Our tab component uses list items with buttons for the tabs but the role of presentation on them was causing a11y issue because the child element had semantic meaning.

### WHAT is this pull request doing?

This PR removed the presentation role and removes the rule from the shitlist.

### How to 🎩

If a11y tests then ✅ 


### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
