### PR TITLE
[Collapsible] Fixed nested Collapsible animation

### DIFF
--- a/src/components/Collapsible/Collapsible.scss
+++ b/src/components/Collapsible/Collapsible.scss
@@ -7,13 +7,15 @@
   padding-bottom: 0;
   opacity: 0;
   will-change: opacity, height;
+}
+
+.animating {
   transition-property: opacity, height;
   transition-duration: duration(slow);
   transition-timing-function: easing(out);
 }
 
 .open {
-  height: var(--polaris-collapsible-height);
   opacity: 1;
 }
 

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -27,10 +27,10 @@ export interface State {
   open: boolean;
 }
 
-const CollapsibleContext = createContext(false);
+const ParentCollapsibleExpandingContext = createContext(false);
 
 class Collapsible extends React.Component<Props, State> {
-  static contextType = CollapsibleContext;
+  static contextType = ParentCollapsibleExpandingContext;
   static getDerivedStateFromProps(
     {open: willOpen}: Props,
     {open, animationState: prevAnimationState}: State,
@@ -114,7 +114,7 @@ class Collapsible extends React.Component<Props, State> {
     const content = animating || open ? children : null;
 
     return (
-      <CollapsibleContext.Provider
+      <ParentCollapsibleExpandingContext.Provider
         value={
           parentCollapsibleExpanding || (open && animationState !== 'idle')
         }
@@ -129,7 +129,7 @@ class Collapsible extends React.Component<Props, State> {
         >
           <div ref={this.heightNode}>{content}</div>
         </div>
-      </CollapsibleContext.Provider>
+      </ParentCollapsibleExpandingContext.Provider>
     );
   }
 

--- a/src/components/Collapsible/tests/Collapsible.test.tsx
+++ b/src/components/Collapsible/tests/Collapsible.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
-import {mountWithApp} from 'test-utilities';
 import Collapsible from '../Collapsible';
 
 describe('<Collapsible />', () => {
@@ -32,15 +31,16 @@ describe('<Collapsible />', () => {
   it('does not render its children when going from open to closed', () => {
     const Child = () => null;
 
-    const collapsible = mountWithApp(
+    const collapsible = mountWithAppProvider(
       <Collapsible id="test-collapsible" open>
         <Child />
       </Collapsible>,
     );
 
-    expect(collapsible).toContainReactComponent(Child);
+    expect(collapsible.find(Child)).toHaveLength(1);
     collapsible.setProps({open: false});
-    expect(collapsible).not.toContainReactComponent(Child);
+    collapsible.simulate('transitionEnd');
+    expect(collapsible.find(Child)).toHaveLength(0);
   });
 
   it('renders its children and does not render aria-hidden when open', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1950

### WHAT is this pull request doing?

* Using our old style of collapsing content to manage nested animations

### Gif

[link](https://cl.ly/6a78aec92904)

### How to 🎩

Playground with nested collapsible's below

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';
import {Page, Collapsible, Button} from '../src';

function Playground() {
  const [open, setOpen] = useState(false);
  const [openChild, setOpenChild] = useState(false);

  const divStyle = {
    backgroundColor: 'red',
  };
  const parentStyle = {
    backgroundColor: 'blue',
  };
  return (
    <Page title="Playground">
      <Collapsible id="parent" open={open}>
        <div style={parentStyle}>
          Lorem Ipsum is simply dummy text of the printing and typesetting
          industry. Lorem Ipsum has been the industry's standard dummy text ever
          since the 1500s, when an unknown printer took a galley of type and
          scrambled it to make a type specimen book. It has survived not only
          five centuries, but also the leap into electronic typesetting,
          remaining essentially unchanged. It was popularised in the 1960s with
          the release of Letraset sheets containing Lorem Ipsum passages, and
          more recently with desktop publishing software like Aldus PageMaker
          including versions of Lorem Ipsum Lorem Ipsum is simply dummy text of
          the printing and typesetting industry. Lorem Ipsum has been the
          industry's standard dummy text ever since the 1500s, when an unknown
          printer took a galley of type and scrambled it to make a type specimen
          book. It has survived not only five centuries, but also the leap into
          electronic typesetting, remaining essentially unchanged. It was
          popularised in the 1960s with the release of Letraset sheets
          containing Lorem Ipsum passages, and more recently with desktop
          publishing software like Aldus PageMaker including versions of Lorem
          Ipsum Lorem Ipsum is simply dummy text of the printing and typesetting
          industry. Lorem Ipsum has been the industry's standard dummy text ever
          since the 1500s, when an unknown printer took a galley of type and
        </div>
        <Collapsible id="child" open={openChild}>
          <div style={divStyle}>
            scrambled it to make a type specimen book. It has survived not only
            five centuries, but also the leap into electronic typesetting,
            remaining essentially unchanged. It was popularised in the 1960s
            with the release of Letraset sheets containing Lorem Ipsum passages,
            and more recently with desktop publishing software like Aldus
            PageMaker including versions of Lorem Ipsum Lorem Ipsum is simply
            dummy text of the printing and typesetting industry. Lorem Ipsum has
            been the industry's standard dummy text ever since the 1500s, when
            an unknown printer took a galley of type and scrambled it to make a
            type specimen book. It has survived not only five centuries, but
            also the leap into electronic typesetting, remaining essentially
            unchanged. It was popularised in the 1960s with the release of
            Letraset sheets containing Lorem Ipsum passages, and more recently
            with desktop publishing software like Aldus PageMaker including
            versions of Lorem Ipsum Lorem Ipsum is simply dummy text of the
            printing and typesetting industry. Lorem Ipsum has been the
            industry's standard dummy text ever since the 1500s, when an unknown
            printer took a galley of type and scrambled it to make a type
            specimen book. It has survived not only five centuries, but also the
            leap into electronic typesetting, remaining essentially unchanged.
            It was popularised in the 1960s with the release of Letraset sheets
            containing Lorem Ipsum passages, and more recently with desktop
            publishing software like Aldus PageMaker including versions of Lorem
            Ipsum
          </div>
        </Collapsible>
      </Collapsible>
      <Button onClick={() => setOpen(!open)}>Open/close parent</Button>
      <Button onClick={() => setOpenChild(!openChild)}>Open/close child</Button>
    </Page>
  );
}

export default Playground;

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
