### PR TITLE
Fixed getDerivedStateFromProp type with cast

### DIFF
--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -36,6 +36,7 @@ const ParentCollapsibleExpandingContext = createContext(false);
 
 class Collapsible extends React.Component<Props, State> {
   static contextType = ParentCollapsibleExpandingContext;
+
   static getDerivedStateFromProps(
     {open: willOpen}: Props,
     {open, animationState: prevAnimationState}: State,
@@ -51,6 +52,8 @@ class Collapsible extends React.Component<Props, State> {
     };
   }
 
+  context!: React.ContextType<typeof ParentCollapsibleExpandingContext>;
+
   state: State = {
     height: null,
     animationState: 'idle',
@@ -63,7 +66,7 @@ class Collapsible extends React.Component<Props, State> {
 
   componentDidUpdate({open: wasOpen}: Props) {
     const {animationState} = this.state;
-    const {parentCollapsibleExpanding} = this.context;
+    const parentCollapsibleExpanding = this.context;
 
     if (parentCollapsibleExpanding && animationState !== 'idle') {
       // eslint-disable-next-line react/no-did-update-set-state

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -1,4 +1,9 @@
-import React, {createContext, createRef, TransitionEvent} from 'react';
+import React, {
+  createContext,
+  createRef,
+  TransitionEvent,
+  ComponentClass,
+} from 'react';
 import {read} from '@shopify/javascript-utilities/fastdom';
 import {classNames} from '../../utilities/css';
 
@@ -157,4 +162,4 @@ function collapsibleHeight(
   return `${height || 0}px`;
 }
 
-export default Collapsible;
+export default Collapsible as ComponentClass<Props> & typeof Collapsible;


### PR DESCRIPTION
### Error

<img width="984" alt="Screen Shot 2019-08-14 at 11 00 31 AM" src="https://user-images.githubusercontent.com/24610840/63031932-e47e0200-be82-11e9-9d8b-5a176010b4d7.png">

It turns out all of the types may be broken on components that use `getDerivedStateFromProps` however they've all been using `withAppProvider` which is forcing a correct type. Whether it's a web issue or a `@types` issue, this will solve it short term.
