### PR TITLE
[ContextualSaveBar] Prevent context bar actions from shrinking

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -50,6 +50,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed accessibility labels on `ResourceList.Item` persistent action disclosure icon ([#1973](https://github.com/Shopify/polaris-react/pull/1973))
 - Fixed accessibility issue with `Autocomplete` where keyboard navigation of options was laggy and skipped options([#1887](https://github.com/Shopify/polaris-react/pull/1887))
 - Fixed bug where `Autocomplete` was bubbling up the `Enter` key event unexpectedly ([#1887](https://github.com/Shopify/polaris-react/pull/1887))
+- Fixed `ContextualSaveBar` actions overflowing on small screens ([#1967](https://github.com/Shopify/polaris-react/pull/1967))
 
 ### Documentation
 

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -37,6 +37,7 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   display: flex;
   flex: 1 1 auto;
   align-items: center;
+  justify-content: space-between;
   min-width: 1px;
   max-width: layout-width(primary, max) + layout-width(secondary, max) +
     layout-width(inner-spacing);
@@ -57,7 +58,10 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   @include truncate;
   @include text-style-heading;
   @include text-emphasis-subdued;
-  flex-grow: 1;
+}
+
+.ActionContainer {
+  flex-shrink: 0;
 }
 
 .Action {

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -112,10 +112,12 @@ class ContextualSaveBar extends React.PureComponent<CombinedProps, State> {
           {logoMarkup}
           <div className={styles.Contents}>
             <h2 className={styles.Message}>{message}</h2>
-            <Stack spacing="tight" wrap={false}>
-              {discardActionMarkup}
-              {saveActionMarkup}
-            </Stack>
+            <div className={styles.ActionContainer}>
+              <Stack spacing="tight" wrap={false}>
+                {discardActionMarkup}
+                {saveActionMarkup}
+              </Stack>
+            </div>
           </div>
         </div>
         {discardConfirmationModalMarkup}


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes a bug where the context bar actions are overflowing when the content is too long.

### WHAT is this pull request doing?
Tweaks the styles to prevent the actions from shrinking. Instead forcing the message to shrink further. I think there is a separate issue for the fact that the message gets truncated on smaller screens.

| Before  | After |
| ------------- | ------------- |
| <img width="344" alt="Screen Shot 2019-08-14 at 1 44 53 PM" src="https://user-images.githubusercontent.com/4441303/63043632-9d037000-be9a-11e9-83af-3779390577c3.png"> | <img width="350" alt="Screen Shot 2019-08-14 at 1 43 01 PM" src="https://user-images.githubusercontent.com/4441303/63043725-cd4b0e80-be9a-11e9-943f-1fb440ccedab.png"> |

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

View the contextual save bar component in storybook. Change the content of the actions to make sure that the buttons look good with various content.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
