### PR TITLE
Stop exporting State interfaces

### DIFF
--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -12,7 +12,7 @@ import styles from './ComboBox.scss';
 
 const getUniqueId = createUniqueIDFactory('ComboBox');
 
-export interface State {
+interface State {
   comboBoxId: string;
   selectedOption?: OptionDescriptor | ActionListItemDescriptor | undefined;
   selectedIndex: number;

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -38,7 +38,7 @@ export interface Props {
   accessibilityLabel?: string;
 }
 
-export interface State {
+interface State {
   hasError: boolean;
   hasLoaded: boolean;
   prevSource?: string;

--- a/src/components/ButtonGroup/components/Item/Item.tsx
+++ b/src/components/ButtonGroup/components/Item/Item.tsx
@@ -9,7 +9,7 @@ export interface Props {
   button: React.ReactElement<ButtonProps>;
 }
 
-export interface State {
+interface State {
   focused: boolean;
 }
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -37,7 +37,7 @@ export interface Props {
 
 export type CombinedProps = Props & WithAppProviderProps;
 
-export interface State {
+interface State {
   secondaryFooterActionsPopoverOpen: boolean;
 }
 

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -26,7 +26,7 @@ export type AnimationState =
   | 'openingStart'
   | 'opening';
 
-export interface State {
+interface State {
   height?: number | null;
   animationState: AnimationState;
   open: boolean;

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -6,7 +6,7 @@ import {HSBColor, HSBAColor} from '../../utilities/color-types';
 import {AlphaPicker, HuePicker, Slidable, Position} from './components';
 import styles from './ColorPicker.scss';
 
-export interface State {
+interface State {
   pickerSize: number;
 }
 

--- a/src/components/ColorPicker/components/AlphaPicker/AlphaPicker.tsx
+++ b/src/components/ColorPicker/components/AlphaPicker/AlphaPicker.tsx
@@ -5,7 +5,7 @@ import {hsbToRgb} from '../../../../utilities/color-transformers';
 import styles from '../../ColorPicker.scss';
 import {calculateDraggerY, alphaForDraggerY} from './utilities';
 
-export interface State {
+interface State {
   sliderHeight: number;
   draggerHeight: number;
 }

--- a/src/components/ColorPicker/components/HuePicker/HuePicker.tsx
+++ b/src/components/ColorPicker/components/HuePicker/HuePicker.tsx
@@ -3,7 +3,7 @@ import Slidable, {Position} from '../Slidable';
 import styles from '../../ColorPicker.scss';
 import {calculateDraggerY, hueForDraggerY} from './utilities';
 
-export interface State {
+interface State {
   sliderHeight: number;
   draggerHeight: number;
 }

--- a/src/components/ColorPicker/components/Slidable/Slidable.tsx
+++ b/src/components/ColorPicker/components/Slidable/Slidable.tsx
@@ -9,7 +9,7 @@ export interface Position {
   y: number;
 }
 
-export interface State {
+interface State {
   dragging: boolean;
 }
 

--- a/src/components/Connected/Connected.tsx
+++ b/src/components/Connected/Connected.tsx
@@ -12,10 +12,6 @@ export interface Props {
   children?: React.ReactNode;
 }
 
-export interface State {
-  focused?: ItemPosition | null;
-}
-
 export default function Connected({children, left, right}: Props) {
   if (left == null && right == null) {
     return <React.Fragment>{children}</React.Fragment>;

--- a/src/components/Connected/components/Item/Item.tsx
+++ b/src/components/Connected/components/Item/Item.tsx
@@ -15,7 +15,7 @@ export interface Props {
   children?: React.ReactNode;
 }
 
-export interface State {
+interface State {
   focused: boolean;
 }
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -54,7 +54,7 @@ export interface BaseProps {
 export interface Props extends BaseProps {}
 type CombinedProps = Props & WithAppProviderProps;
 
-export interface State {
+interface State {
   hoverDate?: Date;
   focusDate?: Date;
 }

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -32,7 +32,7 @@ import styles from './DropZone.scss';
 
 export type Type = 'file' | 'image';
 
-export interface State {
+interface State {
   id: string;
   size: string;
   type?: string;

--- a/src/components/Filters/components/ConnectedFilterControl/components/Item/Item.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/components/Item/Item.tsx
@@ -6,7 +6,7 @@ export interface Props {
   children?: React.ReactNode;
 }
 
-export interface State {
+interface State {
   focused: boolean;
 }
 

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -47,7 +47,7 @@ export interface Props {
   onNavigationDismiss?(): void;
 }
 
-export interface State {
+interface State {
   mobileView?: boolean;
   skipFocused?: boolean;
   globalRibbonHeight: number;

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -17,7 +17,7 @@ import styles from './ContextualSaveBar.scss';
 
 type CombinedProps = Props & WithAppProviderProps;
 
-export interface State {
+interface State {
   discardConfirmationModalVisible: boolean;
 }
 

--- a/src/components/Frame/components/Loading/Loading.tsx
+++ b/src/components/Frame/components/Loading/Loading.tsx
@@ -4,7 +4,7 @@ import styles from './Loading.scss';
 
 export interface Props {}
 
-export interface State {
+interface State {
   progress: number;
   step: number;
   animation: number | null;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -79,7 +79,7 @@ export interface Props extends FooterProps {
 }
 type CombinedProps = Props & WithAppProviderProps;
 
-export interface State {
+interface State {
   iframeHeight: number;
 }
 

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -57,10 +57,6 @@ export interface Props {
   onChange(selected: string[]): void;
 }
 
-export interface State {
-  normalizedOptions: SectionDescriptor[];
-}
-
 export default function OptionList({
   options,
   sections,

--- a/src/components/OptionList/components/Option/Option.tsx
+++ b/src/components/OptionList/components/Option/Option.tsx
@@ -24,7 +24,7 @@ export interface Props {
   onClick(section: number, option: number): void;
 }
 
-export interface State {
+interface State {
   focused: boolean;
 }
 

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -41,7 +41,7 @@ export interface Props {
   onClose(source: CloseSource): void;
 }
 
-export interface State {
+interface State {
   activatorNode: HTMLElement | null;
 }
 

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -8,7 +8,7 @@ export interface Props {
   onPortalCreated?(): void;
 }
 
-export interface State {
+interface State {
   isMounted: boolean;
 }
 

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -40,7 +40,7 @@ export interface Props {
   onScrollOut?(): void;
 }
 
-export interface State {
+interface State {
   measuring: boolean;
   activatorRect: Rect;
   left: number;

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -14,7 +14,7 @@ import {Key} from '../../../../types';
 
 import styles from './DualThumb.scss';
 
-export interface State {
+interface State {
   value: DualValue;
   trackWidth: number;
   trackLeft: number;

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -35,7 +35,7 @@ const LARGE_SPINNER_HEIGHT = 45;
 
 export type Items = any[];
 
-export interface State {
+interface State {
   selectMode: boolean;
   loadingPosition: number;
   lastSelected: number | null;

--- a/src/components/ResourceList/components/BulkActions/BulkActions.tsx
+++ b/src/components/ResourceList/components/BulkActions/BulkActions.tsx
@@ -48,7 +48,7 @@ export interface Props {
   onSelectModeToggle?(selectMode: boolean): void;
 }
 
-export interface State {
+interface State {
   smallScreenPopoverVisible: boolean;
   largeScreenPopoverVisible: boolean;
   containerWidth: number;

--- a/src/components/ResourceList/components/FilterControl/components/FilterCreator/FilterCreator.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterCreator/FilterCreator.tsx
@@ -24,7 +24,7 @@ export interface Props {
 
 type CombinedProps = Props & WithAppProviderProps;
 
-export interface State {
+interface State {
   popoverActive: boolean;
   selectedFilter?: Filter;
   selectedFilterKey?: AppliedFilter['key'];

--- a/src/components/ResourceList/components/Item/Item.tsx
+++ b/src/components/ResourceList/components/Item/Item.tsx
@@ -57,7 +57,7 @@ export interface PropsWithClick extends BaseProps {
 
 export type Props = PropsWithUrl | PropsWithClick;
 
-export interface State {
+interface State {
   actionsMenuVisible: boolean;
   focused: boolean;
   focusedInner: boolean;

--- a/src/components/Scrollable/Scrollable.tsx
+++ b/src/components/Scrollable/Scrollable.tsx
@@ -38,7 +38,7 @@ export interface Props extends React.HTMLProps<HTMLDivElement> {
   onScrolledToBottom?(): void;
 }
 
-export interface State {
+interface State {
   topShadow: boolean;
   bottomShadow: boolean;
   scrollPosition: number;

--- a/src/components/Sheet/Sheet.tsx
+++ b/src/components/Sheet/Sheet.tsx
@@ -43,10 +43,6 @@ export interface Props {
   onExit?(): void;
 }
 
-export interface State {
-  mobile: boolean;
-}
-
 export default function Sheet({
   children,
   open,

--- a/src/components/Sticky/Sticky.tsx
+++ b/src/components/Sticky/Sticky.tsx
@@ -5,7 +5,7 @@ import {
   withAppProvider,
 } from '../../utilities/with-app-provider';
 
-export interface State {
+interface State {
   isSticky: boolean;
   style: Object;
 }

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -31,7 +31,7 @@ export interface Props {
 
 type CombinedProps = Props & WithAppProviderProps;
 
-export interface State {
+interface State {
   disclosureWidth: number;
   tabWidths: number[];
   visibleTabs: number[];

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -34,7 +34,7 @@ export type Type =
 
 export type Alignment = 'left' | 'center' | 'right';
 
-export interface State {
+interface State {
   height?: number | null;
   focus: boolean;
   id: string;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -28,7 +28,7 @@ export interface Props {
   activatorWrapper?: string;
 }
 
-export interface State {
+interface State {
   active: boolean;
   activatorNode: HTMLElement | null;
 }

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -37,7 +37,7 @@ export interface Props {
 
 export type ComposedProps = Props & WithAppProviderProps;
 
-export interface State {
+interface State {
   focused: boolean;
 }
 

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -14,7 +14,7 @@ export interface Props {
   children?: React.ReactNode;
 }
 
-export interface State {
+interface State {
   shouldFocusSelf: boolean | undefined;
 }
 


### PR DESCRIPTION


### WHY are these changes introduced?

If you see an export you have to wonder where else it is used. To reduce congnitive load stop exporting `State` interfaces that are never used outside the current file - which is all of them

### WHAT is this pull request doing?

Stop exporting State interfaces.

In three cases this highlighted when the state was no longer used even
inside the component file so the state could be straight-up deleted.

### How to 🎩

Confirm `yarn run type-check` passes