### PR TITLE
Removed mocks that are no longer needed

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -72,6 +72,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Code quality
 
+- Removed mocks in various tests suites that are now redundant ([#1978](https://github.com/Shopify/polaris-react/pull/1978))
 - Bumped test coverage in `Collapsible` ([#1929](https://github.com/Shopify/polaris-react/pull/1929))
 - Bumped test coverage in `DropZone`, `Frame`, `Icon`, and `Loading` ([#1927](https://github.com/Shopify/polaris-react/pull/1927))
 - Removed unused type definitions ([#1862](https://github.com/Shopify/polaris-react/pull/1862))

--- a/src/components/Collapsible/tests/Collapsible.test.tsx
+++ b/src/components/Collapsible/tests/Collapsible.test.tsx
@@ -4,17 +4,6 @@ import Collapsible from '../Collapsible';
 
 describe('<Collapsible />', () => {
   const ariaHiddenSelector = '[aria-hidden=true]';
-  let setTimeoutMock: jest.SpyInstance;
-
-  beforeEach(() => {
-    setTimeoutMock = jest
-      .spyOn(window, 'setTimeout')
-      .mockImplementation((cb: Function) => cb());
-  });
-
-  afterEach(() => {
-    setTimeoutMock.mockRestore();
-  });
 
   it('does not render its children and indicates hidden with aria-hidden', () => {
     const collapsible = mountWithAppProvider(

--- a/src/components/Focus/tests/Focus.test.tsx
+++ b/src/components/Focus/tests/Focus.test.tsx
@@ -4,17 +4,6 @@ import Focus, {Props} from '../Focus';
 import {Discard} from '../../../types';
 
 describe('<Focus />', () => {
-  let requestAnimationFrameSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    requestAnimationFrameSpy = jest.spyOn(window, 'requestAnimationFrame');
-    requestAnimationFrameSpy.mockImplementation((cb) => cb());
-  });
-
-  afterEach(() => {
-    requestAnimationFrameSpy.mockRestore();
-  });
-
   it('mounts', () => {
     const focus = mountWithAppProvider(<FocusTestWrapper />);
 

--- a/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
+++ b/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
@@ -5,17 +5,6 @@ import Tab from '../../Tab';
 import Item from '../../Item';
 
 describe('<TabMeasurer />', () => {
-  let requestAnimationFrameSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    requestAnimationFrameSpy = jest.spyOn(window, 'requestAnimationFrame');
-    requestAnimationFrameSpy.mockImplementation((cb) => cb());
-  });
-
-  afterEach(() => {
-    requestAnimationFrameSpy.mockRestore();
-  });
-
   const mockProps = {
     tabToFocus: 0,
     activator: <Item id="id" focused />,

--- a/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -10,16 +10,8 @@ import {
 import TrapFocus from '../TrapFocus';
 
 describe('<TrapFocus />', () => {
-  let requestAnimationFrameSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    requestAnimationFrameSpy = jest.spyOn(window, 'requestAnimationFrame');
-    requestAnimationFrameSpy.mockImplementation((cb) => cb());
-  });
-
   afterEach(() => {
     (document.activeElement as HTMLElement).blur();
-    requestAnimationFrameSpy.mockRestore();
   });
 
   it('mounts', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

At some point, these mocks became redundant, lets strip away this extra code