### PR TITLE
[Collapsible] animate collapsible max-height property

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `recolor-icon` Sass mixin to properly scope `$secondary-color` to the child `svg` ([#2298](https://github.com/Shopify/polaris-react/pull/2298))
 - Fixed a regression with the positioning of the `Popover` component ([#2305](https://github.com/Shopify/polaris-react/pull/2305))
 - Fixed Stack Item proportion when shrinking ([#2319](https://github.com/Shopify/polaris-react/pull/2319))
+- Fixed animation of `Collapsible` with children having margins ([#1980](https://github.com/Shopify/polaris-react/pull/1980))
 
 ### Documentation
 

--- a/src/components/Collapsible/Collapsible.scss
+++ b/src/components/Collapsible/Collapsible.scss
@@ -2,15 +2,15 @@
 
 .Collapsible {
   overflow: hidden;
-  height: 0;
+  max-height: 0;
   padding-top: 0;
   padding-bottom: 0;
   opacity: 0;
-  will-change: opacity, height;
+  will-change: opacity, max-height;
 }
 
 .animating {
-  transition-property: opacity, height;
+  transition-property: opacity, max-height;
   transition-duration: duration(slow);
   transition-timing-function: easing(out);
 }

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -130,7 +130,7 @@ class Collapsible extends React.Component<CollapsibleProps, State> {
         <div
           id={id}
           aria-hidden={!open}
-          style={{height: displayHeight}}
+          style={{maxHeight: displayHeight}}
           className={wrapperClassName}
           ref={this.node}
           onTransitionEnd={this.handleTransitionEnd}
@@ -155,11 +155,11 @@ function collapsibleHeight(
   height?: number | null,
 ) {
   if (animationState === 'idle' && open) {
-    return open ? 'auto' : undefined;
+    return open ? 'none' : undefined;
   }
 
   if (animationState === 'measuring') {
-    return open ? undefined : 'auto';
+    return open ? undefined : 'none';
   }
 
   return `${height || 0}px`;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1133

I believe the issue is caused by [collapsing margins](https://www.w3.org/TR/CSS22/box.html#collapsing-margins). Height of element with `overflow: hidden` includes margins of children, while margins of children of `overflow: visible` element spills through the parent and are not included in parent's height.

### WHAT is this pull request doing?

- changes collapsible animation property from height to max-height