### PR TITLE
[Resource list] Hide inline label on small screen

### DIFF
--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -40,6 +40,7 @@ interface State {
   selectMode: boolean;
   loadingPosition: number;
   lastSelected: number | null;
+  smallScreen: boolean;
 }
 
 export interface Props {
@@ -94,15 +95,20 @@ class ResourceList extends React.Component<CombinedProps, State> {
 
   private handleResize = debounce(() => {
     const {selectedItems} = this.props;
-    const {selectMode} = this.state;
+    const {selectMode, smallScreen} = this.state;
+    const newSmallScreen = isSmallScreen();
 
     if (
       selectedItems &&
       selectedItems.length === 0 &&
       selectMode &&
-      !isSmallScreen()
+      !newSmallScreen
     ) {
       this.handleSelectMode(false);
+    }
+
+    if (smallScreen !== newSmallScreen) {
+      this.setState({smallScreen: newSmallScreen});
     }
   }, 50);
 
@@ -124,6 +130,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
       selectMode: Boolean(selectedItems && selectedItems.length > 0),
       loadingPosition: 0,
       lastSelected: null,
+      smallScreen: isSmallScreen(),
     };
   }
 
@@ -361,7 +368,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
       onSortChange,
       polaris: {intl},
     } = this.props;
-    const {selectMode, loadingPosition} = this.state;
+    const {selectMode, loadingPosition, smallScreen} = this.state;
 
     const filterControlMarkup = filterControl ? (
       <div className={styles.FiltersWrapper}>{filterControl}</div>
@@ -391,7 +398,8 @@ class ResourceList extends React.Component<CombinedProps, State> {
         <div className={styles.SortWrapper}>
           <Select
             label={intl.translate('Polaris.ResourceList.sortingLabel')}
-            labelInline
+            labelInline={!smallScreen}
+            labelHidden={smallScreen}
             options={sortOptions}
             onChange={onSortChange}
             value={sortValue}

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -479,6 +479,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
               );
               return (
                 <div className={headerClassName} testID="ResourceList-Header">
+                  <EventListener event="resize" handler={this.handleResize} />
                   {headerWrapperOverlay}
                   <div className={styles.HeaderContentWrapper}>
                     {headerTitleMarkup}
@@ -492,7 +493,6 @@ class ResourceList extends React.Component<CombinedProps, State> {
               );
             }}
           </Sticky>
-          <EventListener event="resize" handler={this.handleResize} />
         </div>
       );
 

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -93,24 +93,28 @@ class ResourceList extends React.Component<CombinedProps, State> {
   private defaultResourceName: {singular: string; plural: string};
   private listRef: React.RefObject<HTMLUListElement> = React.createRef();
 
-  private handleResize = debounce(() => {
-    const {selectedItems} = this.props;
-    const {selectMode, smallScreen} = this.state;
-    const newSmallScreen = isSmallScreen();
+  private handleResize = debounce(
+    () => {
+      const {selectedItems} = this.props;
+      const {selectMode, smallScreen} = this.state;
+      const newSmallScreen = isSmallScreen();
 
-    if (
-      selectedItems &&
-      selectedItems.length === 0 &&
-      selectMode &&
-      !newSmallScreen
-    ) {
-      this.handleSelectMode(false);
-    }
+      if (
+        selectedItems &&
+        selectedItems.length === 0 &&
+        selectMode &&
+        !newSmallScreen
+      ) {
+        this.handleSelectMode(false);
+      }
 
-    if (smallScreen !== newSmallScreen) {
-      this.setState({smallScreen: newSmallScreen});
-    }
-  }, 50);
+      if (smallScreen !== newSmallScreen) {
+        this.setState({smallScreen: newSmallScreen});
+      }
+    },
+    50,
+    {leading: true, trailing: true, maxWait: 50},
+  );
 
   constructor(props: CombinedProps) {
     super(props);
@@ -389,7 +393,6 @@ class ResourceList extends React.Component<CombinedProps, State> {
           actions={bulkActions}
           disabled={loading}
         />
-        <EventListener event="resize" handler={this.handleResize} />
       </div>
     ) : null;
 
@@ -489,6 +492,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
               );
             }}
           </Sticky>
+          <EventListener event="resize" handler={this.handleResize} />
         </div>
       );
 

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -39,6 +39,7 @@ const sortOptions = [
 ];
 
 const alternateTool = <div id="AlternateTool">Alternate Tool</div>;
+const defaultWindowWidth = window.innerWidth;
 
 describe('<ResourceList />', () => {
   describe('renderItem', () => {
@@ -870,14 +871,8 @@ describe('<ResourceList />', () => {
   });
 
   describe('Resizing', () => {
-    const defaultWindowWidth = window.innerWidth;
-
     afterEach(() => {
-      Object.defineProperty(window, 'innerWidth', {
-        configurable: true,
-        writable: true,
-        value: defaultWindowWidth,
-      });
+      setDefaultScreen();
     });
 
     it('an inline label is hidden on small screen', () => {
@@ -890,12 +885,7 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      Object.defineProperty(window, 'innerWidth', {
-        configurable: true,
-        writable: true,
-        value: 458,
-      });
-
+      setSmallScreen();
       trigger(resourceList.find(EventListener), 'handler');
 
       expect(
@@ -904,6 +894,21 @@ describe('<ResourceList />', () => {
           .first()
           .prop('labelInline'),
       ).toBe(false);
+    });
+
+    it('select mode is turned off on large screen when no items are selected', () => {
+      const resourceList = mountWithAppProvider(
+        <ResourceList
+          items={singleItemWithID}
+          renderItem={renderItem}
+          bulkActions={bulkActions}
+          selectedItems={[]}
+        />,
+      );
+
+      trigger(resourceList.find(BulkActions), 'onSelectModeToggle', true);
+      trigger(resourceList.find(EventListener).first(), 'handler');
+      expect(resourceList.find(BulkActions).prop('selectMode')).toBe(false);
     });
   });
 });
@@ -930,4 +935,20 @@ function renderItem(item: any, id: any, index: number) {
       <div>{item.title}</div>
     </ResourceList.Item>
   );
+}
+
+function setSmallScreen() {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: 458,
+  });
+}
+
+function setDefaultScreen() {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: defaultWindowWidth,
+  });
 }

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -5,6 +5,7 @@ import {
   Spinner,
   EmptySearchResult,
   ResourceItem,
+  EventListener,
 } from 'components';
 import {
   findByTestID,
@@ -865,6 +866,44 @@ describe('<ResourceList />', () => {
       });
 
       expect(onSelectionChange).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('Resizing', () => {
+    const defaultWindowWidth = window.innerWidth;
+
+    afterEach(() => {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        writable: true,
+        value: defaultWindowWidth,
+      });
+    });
+
+    it('an inline label is hidden on small screen', () => {
+      const resourceList = mountWithAppProvider(
+        <ResourceList
+          items={itemsWithID}
+          sortOptions={sortOptions}
+          onSortChange={noop}
+          renderItem={renderItem}
+        />,
+      );
+
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        writable: true,
+        value: 458,
+      });
+
+      trigger(resourceList.find(EventListener), 'handler');
+
+      expect(
+        resourceList
+          .find(Select)
+          .first()
+          .prop('labelInline'),
+      ).toBe(false);
     });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

I switched the sort select to use an inline label in #1774, but did not hide the label on small screen.

|Before|After|
|---|---|
|<img width="431" alt="Screen Shot 2019-08-18 at 3 07 38 PM" src="https://user-images.githubusercontent.com/344839/63231119-c3dbe200-c1cb-11e9-8980-3944f5c1440a.png">|<img width="422" alt="Screen Shot 2019-08-18 at 3 07 43 PM" src="https://user-images.githubusercontent.com/344839/63231121-cdfde080-c1cb-11e9-807f-614278a9e480.png">|

### WHAT is this pull request doing?

Tracking `smallScreen` in state and using the existing resize handler to set it. If `smallScreen` is true then hide the inline label. Not adding a changelog entry as the inline label change has not yet been released.

Bonus: bumps the test coverage by 3% for resource list.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
