### PR TITLE
[Text field] Allow min and max to accept a string

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed animation for Modal when being rendered asynchronously ([#2076](https://github.com/Shopify/polaris-react/pull/2076))
+- Updated `TextField` `min` and `max` type from `number` to `number | string` to allow min/max dates ([#1991](https://github.com/Shopify/polaris-react/pull/1991))
 
 ### Documentation
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -432,7 +432,10 @@ class TextField extends React.PureComponent<CombinedProps, State> {
     // step / value has.
     const decimalPlaces = Math.max(dpl(numericValue), dpl(step));
 
-    const newValue = Math.min(max, Math.max(numericValue + steps * step, min));
+    const newValue = Math.min(
+      Number(max),
+      Math.max(numericValue + steps * step, Number(min)),
+    );
     onChange(String(newValue.toFixed(decimalPlaces)), this.state.id);
   };
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -87,12 +87,12 @@ export interface BaseProps {
   step?: number;
   /** Enable automatic completion by the browser */
   autoComplete?: boolean | string;
-  /** Mimics the behavior of the native HTML attribute, limiting how high the spinner can increment the value */
-  max?: number;
+  /** Mimics the behavior of the native HTML attribute, limiting the maximum value */
+  max?: number | string;
   /** Maximum character length for an input */
   maxLength?: number;
-  /** Mimics the behavior of the native HTML attribute, limiting how low the spinner can decrement the value */
-  min?: number;
+  /** Mimics the behavior of the native HTML attribute, limiting the minimum value */
+  min?: number | string;
   /** Minimum character length for an input */
   minLength?: number;
   /** A regular expression to check the value against */


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1988 

### WHAT is this pull request doing?

Allows `number | string`, updates the prop description

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';
import {Page, TextField} from '../src';

export default function Playground() {
  const [value, setValue] = useState('2008-07-22');

  return (
    <Page title="Playground">
      <TextField
        label="Any time this decade 🙄"
        value={value}
        onChange={setValue}
        type="date"
        min="2010-01-01"
        max="2019-12-31"
      />
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
