### PR TITLE
[Modal] Set default iframe height when src on different domains 

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -51,6 +51,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed accessibility issue with `Autocomplete` where keyboard navigation of options was laggy and skipped options([#1887](https://github.com/Shopify/polaris-react/pull/1887))
 - Fixed bug where `Autocomplete` was bubbling up the `Enter` key event unexpectedly ([#1887](https://github.com/Shopify/polaris-react/pull/1887))
 - Fixed `ContextualSaveBar` actions overflowing on small screens ([#1967](https://github.com/Shopify/polaris-react/pull/1967))
+- Fixed cross-origin error being thrown in `Modal` when loading an external app ([#1992](https://github.com/Shopify/polaris-react/pull/1992))
 
 ### Documentation
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -31,6 +31,7 @@ import {
 import styles from './Modal.scss';
 
 const IFRAME_LOADING_HEIGHT = 200;
+const DEFAULT_IFRAME_CONTENT_HEIGHT = 400;
 
 export type Size = 'Small' | 'Medium' | 'Large' | 'Full';
 
@@ -335,9 +336,15 @@ class Modal extends React.Component<CombinedProps, State> {
   private handleIFrameLoad = (evt: React.SyntheticEvent<HTMLIFrameElement>) => {
     const iframe = evt.target as HTMLIFrameElement;
     if (iframe && iframe.contentWindow) {
-      this.setState({
-        iframeHeight: iframe.contentWindow.document.body.scrollHeight,
-      });
+      try {
+        this.setState({
+          iframeHeight: iframe.contentWindow.document.body.scrollHeight,
+        });
+      } catch {
+        this.setState({
+          iframeHeight: DEFAULT_IFRAME_CONTENT_HEIGHT,
+        });
+      }
     }
 
     const {onIFrameLoad} = this.props;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1985

We are getting cross-origin errors in the modal because the modal assumed the src of the frame was on the same domain and try to get the height of the content.

This only occurs when an admin modal tries to open a standalone app.  

### WHAT is this pull request doing?

This pull request simply does a try/catch and sets a default height in the catch block. The default height is the same default height used in the embedded app: https://github.com/Shopify/web/blob/1617c9b80602a410347f6512a5ebbb068791bd1c/app/sections/Apps/EmbeddedApp/components/Modal/Modal.tsx#L10

![modal-height](https://user-images.githubusercontent.com/1229901/63350076-bc7f1a80-c32a-11e9-8b4d-f6a4c53ff13c.gif)


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

**In Polaris-react:**

1. Tophat the change in polaris react with the playground below. Ensure that there are no cross-origin error in the console when the modal launches

**In Web**

In order to tophat in web you need to install the Buy-Button app https://github.com/Shopify/buy-button

1. From polaris-react run `yarn build-consumer web`
2. `dev clone buy-button`
3. Follow the instruction the `buy-button` README.md
4. Once web is running with internal routes enabled, go to a product details page, and launch the "Buy button" app from the page actions.
5. Ensure no CORS errors are thrown.
 
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Modal, TextContainer, Button} from '../src';

export default function Playground() {
  return (
    <Page title="Playground">
      <ModalExample />
    </Page>
  );
}

class ModalExample extends React.Component {
  state = {
    active: true,
  };

  render() {
    const {active} = this.state;
    return (
      <div style={{height: '500px'}}>
        <Button onClick={this.handleChange}>Open</Button>
        <Modal
          open={active}
          onClose={this.handleChange}
          title="Reach more shoppers with Instagram product tags"
          primaryAction={{
            content: 'Add Instagram',
            onAction: this.handleChange,
          }}
          secondaryActions={[
            {
              content: 'Learn more',
              onAction: this.handleChange,
            },
          ]}
          src="https://alexpage.com.au/"
        />
      </div>
    );
  }

  handleChange = () => {
    this.setState(({active}) => ({active: !active}));
  };
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
