### PR TITLE
[Dropzone] fix various accessibility issues

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed animation for Modal when being rendered asynchronously ([#2076](https://github.com/Shopify/polaris-react/pull/2076))
 - Updated `TextField` `min` and `max` type from `number` to `number | string` to allow min/max dates ([#1991](https://github.com/Shopify/polaris-react/pull/1991))
 - Fixed item content from overflowing past the container in `Stack` ([#2071](https://github.com/Shopify/polaris-react/pull/2071))
+- Fixed `Dropzone` hover, disabled and focus states ([#1994](https://github.com/Shopify/polaris-react/pull/1994))
 
 ### Documentation
 

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -3,8 +3,8 @@
 $dropzone-padding: rem(15px);
 $dropzone-border-style: dashed;
 $dropzone-border-color: color('sky');
-$dropzone-background: color('white');
 $dropzone-border-radius: border-radius();
+$dropzone-background: color('white');
 $dropzone-min-height-extra-large: rem(205px);
 $dropzone-min-height-large: rem(160px);
 $dropzone-min-height-medium: rem(100px);
@@ -16,6 +16,10 @@ $dropzone-overlay-border-color: color('indigo');
 $dropzone-overlay-border-color-error: color('red');
 $dropzone-overlay-background: color('indigo', 'lighter');
 $dropzone-overlay-background-error: color('red', 'lighter');
+$dropzone-stacking-order: (
+  outline: 29,
+  overlay: 30,
+);
 
 .DropZone {
   position: relative;
@@ -23,15 +27,65 @@ $dropzone-overlay-background-error: color('red', 'lighter');
   justify-content: center;
   background-color: $dropzone-background;
   border-radius: $dropzone-border-radius;
+
+  &::after {
+    content: '';
+    position: absolute;
+    z-index: z-index(outline, $dropzone-stacking-order);
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border: border-width(thick) $dropzone-border-style transparent;
+    border-radius: $dropzone-border-radius;
+    pointer-events: none;
+  }
 }
 
 .hasOutline {
-  border: border-width(thick) $dropzone-border-style $dropzone-border-color;
+  padding: border-width(thick);
+
+  &::after {
+    border-color: $dropzone-border-color;
+  }
+
+  &:not(.isDisabled) {
+    &:hover {
+      cursor: pointer;
+      background-color: $dropzone-overlay-background;
+    }
+
+    // stylelint-disable-next-line selector-max-specificity
+    &:hover::after {
+      border-color: $dropzone-overlay-border-color;
+    }
+  }
+}
+
+.focused {
+  &:not(.isDisabled) {
+    background-color: $dropzone-overlay-background;
+
+    &::after {
+      border: border-width(thick) $dropzone-border-style
+        $dropzone-overlay-border-color;
+
+      @media (-ms-high-contrast: active) {
+        border-style: solid;
+        border-color: ms-high-contrast-color('selected-text-background');
+      }
+    }
+  }
 }
 
 .isDragging {
-  border-color: $dropzone-overlay-border-color;
-  background-color: $dropzone-overlay-background;
+  &:not(.isDisabled) {
+    background-color: $dropzone-overlay-background;
+
+    &::after {
+      border-color: $dropzone-overlay-border-color;
+    }
+  }
 }
 
 .isDisabled {
@@ -63,7 +117,7 @@ $dropzone-overlay-background-error: color('red', 'lighter');
 
 .Overlay {
   position: absolute;
-  z-index: 30;
+  z-index: z-index(overlay, $dropzone-stacking-order);
   top: 0;
   right: 0;
   bottom: 0;
@@ -77,13 +131,6 @@ $dropzone-overlay-background-error: color('red', 'lighter');
   text-align: center;
   color: $dropzone-overlay-color;
   background-color: $dropzone-overlay-background;
-
-  .hasOutline & {
-    top: -(border-width(thick));
-    right: -(border-width(thick));
-    bottom: -(border-width(thick));
-    left: -(border-width(thick));
-  }
 
   .hasError & {
     border-color: $dropzone-overlay-border-color-error;

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -34,13 +34,14 @@ export type Type = 'file' | 'image';
 
 interface State {
   id: string;
+  dragging: boolean;
+  error?: boolean;
+  errorOverlayText?: string;
+  focused: boolean;
+  numFiles: number;
+  overlayText?: string;
   size: string;
   type?: string;
-  error?: boolean;
-  dragging: boolean;
-  overlayText?: string;
-  errorOverlayText?: string;
-  numFiles: number;
 }
 
 export interface DropZoneProps {
@@ -196,14 +197,15 @@ class DropZone extends React.Component<CombinedProps, State> {
 
     // eslint-disable-next-line react/state-in-constructor
     this.state = {
-      type,
       id: props.id || getUniqueID(),
-      size: 'extraLarge',
       dragging: false,
       error: false,
-      overlayText: translate(`Polaris.DropZone.overlayText${suffix}`),
       errorOverlayText: translate(`Polaris.DropZone.errorOverlayText${suffix}`),
+      focused: false,
       numFiles: 0,
+      overlayText: translate(`Polaris.DropZone.overlayText${suffix}`),
+      size: 'extraLarge',
+      type,
     };
   }
 
@@ -215,6 +217,7 @@ class DropZone extends React.Component<CombinedProps, State> {
     const {
       id,
       dragging,
+      focused,
       error,
       size,
       type,
@@ -226,7 +229,7 @@ class DropZone extends React.Component<CombinedProps, State> {
       labelAction,
       labelHidden,
       children,
-      disabled,
+      disabled = false,
       outline,
       accept,
       active,
@@ -244,12 +247,16 @@ class DropZone extends React.Component<CombinedProps, State> {
       ref: this.fileInputNode,
       onChange: this.handleDrop,
       autoComplete: 'off',
+      onFocus: this.handleFocus,
+      onBlur: this.handleBlur,
     };
 
     const classes = classNames(
       styles.DropZone,
       outline && styles.hasOutline,
+      focused && styles.focused,
       (active || dragging) && styles.isDragging,
+      disabled && styles.isDisabled,
       error && styles.hasError,
       size && size === 'extraLarge' && styles.sizeExtraLarge,
       size && size === 'large' && styles.sizeLarge,
@@ -297,6 +304,8 @@ class DropZone extends React.Component<CombinedProps, State> {
     const labelHiddenValue = label ? labelHidden : true;
 
     const context = {
+      disabled,
+      focused,
       size,
       type: type || 'file',
     };
@@ -422,6 +431,14 @@ class DropZone extends React.Component<CombinedProps, State> {
     }
 
     return onClick ? onClick(event) : this.open();
+  };
+
+  private handleFocus = () => {
+    this.setState({focused: true});
+  };
+
+  private handleBlur = () => {
+    this.setState({focused: false});
   };
 
   private handleDrop = (event: DragEvent) => {

--- a/src/components/DropZone/components/FileUpload/FileUpload.scss
+++ b/src/components/DropZone/components/FileUpload/FileUpload.scss
@@ -1,10 +1,59 @@
 @import '../../../../styles/common';
 
 $fileupload-padding: rem(15px);
+$slim-min-height: rem(30px);
+$slim-vertical-padding: ($slim-min-height - line-height(body) - rem(2px)) / 2;
 
 .FileUpload {
   padding: $fileupload-padding;
   text-align: center;
+}
+
+.Button {
+  @include button-base;
+
+  &.disabled {
+    @include base-button-disabled;
+    cursor: not-allowed;
+    box-shadow: none;
+  }
+
+  &.focused {
+    border-color: color('indigo');
+    outline: 0;
+    box-shadow: 0 0 0 1px color('indigo');
+
+    @include high-contrast-button-outline;
+  }
+
+  .sizeSlim {
+    min-height: $slim-min-height;
+    padding: $slim-vertical-padding spacing(base-tight);
+  }
+}
+
+.ActionTitle {
+  color: color('blue');
+  text-decoration: none;
+
+  &:not(.ActionTitle-disabled) {
+    cursor: pointer;
+
+    &:hover,
+    &:active {
+      color: color('blue', 'dark');
+      text-decoration: underline;
+    }
+  }
+}
+
+.ActionTitle-focused {
+  color: color('blue', 'dark');
+  text-decoration: underline;
+}
+
+.ActionTitle-disabled {
+  color: color('ink', 'lightest');
 }
 
 .Image {

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -3,11 +3,8 @@ import {DragDropMajorMonotone} from '@shopify/polaris-icons';
 
 import {classNames} from '../../../../utilities/css';
 import {capitalize} from '../../../../utilities/capitalize';
-
-import {Link} from '../../../Link';
 import {Icon} from '../../../Icon';
 import {Stack} from '../../../Stack';
-import {Button} from '../../../Button';
 import {Caption} from '../../../Caption';
 import {TextStyle} from '../../../TextStyle';
 
@@ -25,17 +22,35 @@ export interface FileUploadProps {
 
 export function FileUpload(props: FileUploadProps) {
   const {translate} = useI18n();
-  const {size, type} = useContext(DropZoneContext);
+  const {size, type, focused, disabled} = useContext(DropZoneContext);
   const suffix = capitalize(type);
   const {
     actionTitle = translate(`Polaris.DropZone.FileUpload.actionTitle${suffix}`),
     actionHint = translate(`Polaris.DropZone.FileUpload.actionHint${suffix}`),
   } = props;
+
   const imageClasses = classNames(
     styles.Image,
     size && size === 'extraLarge' && styles.sizeExtraLarge,
     size && size === 'large' && styles.sizeLarge,
   );
+
+  const buttonStyles =
+    size === 'extraLarge' || size === 'large'
+      ? classNames(
+          styles.Button,
+          size && size !== 'extraLarge' && styles.slim,
+          focused && styles.focused,
+          disabled && styles.disabled,
+        )
+      : null;
+
+  const buttonMarkup =
+    (size === 'extraLarge' || size === 'large') && buttonStyles ? (
+      <div testID="Button" className={buttonStyles}>
+        {actionTitle}
+      </div>
+    ) : null;
 
   const extraLargeView =
     size === 'extraLarge' ? (
@@ -46,7 +61,7 @@ export function FileUpload(props: FileUploadProps) {
         {type === 'image' && (
           <img className={imageClasses} src={imageUpload} alt="" />
         )}
-        <Button>{actionTitle}</Button>
+        {buttonMarkup}
         <TextStyle variation="subdued">{actionHint}</TextStyle>
       </Stack>
     ) : null;
@@ -60,17 +75,29 @@ export function FileUpload(props: FileUploadProps) {
         {type === 'image' && (
           <img className={imageClasses} src={imageUpload} alt="" />
         )}
-        <Button size="slim">{actionTitle}</Button>
+        {buttonMarkup}
         <Caption>
           <TextStyle variation="subdued">{actionHint}</TextStyle>
         </Caption>
       </Stack>
     ) : null;
 
+  const actionTitleClassName = classNames(
+    styles.ActionTitle,
+    focused && !disabled && styles['ActionTitle-focused'],
+    disabled && styles['ActionTitle-disabled'],
+  );
+
+  const actionTitleMarkup = (
+    <div testID="Link" className={actionTitleClassName}>
+      {actionTitle}
+    </div>
+  );
+
   const mediumView =
     size === 'medium' ? (
       <Stack vertical spacing="tight">
-        <Link>{actionTitle}</Link>
+        {actionTitleMarkup}
         <Caption>
           <TextStyle variation="subdued">{actionHint}</TextStyle>
         </Caption>

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -1,33 +1,46 @@
 import React from 'react';
-import {Link, Icon, Button, Caption, TextStyle} from 'components';
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {Icon, Caption, TextStyle} from 'components';
+import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {DropZoneContext} from '../../../context';
 import {FileUpload} from '../FileUpload';
 import {fileUpload as fileUploadImage, imageUpload} from '../../../images';
 
 describe('<FileUpload />', () => {
+  const defaultStates = {
+    hover: false,
+    focused: false,
+    disabled: false,
+  };
   describe('extraLarge', () => {
     it('renders extra large view for type file', () => {
       const fileUpload = mountWithAppProvider(
-        <DropZoneContext.Provider value={{size: 'extraLarge', type: 'file'}}>
+        <DropZoneContext.Provider
+          value={{
+            size: 'extraLarge',
+            type: 'file',
+            ...defaultStates,
+          }}
+        >
           <FileUpload />
         </DropZoneContext.Provider>,
       );
 
       expect(fileUpload.find('img').prop('src')).toBe(fileUploadImage);
-      expect(fileUpload.find(Button)).toHaveLength(1);
+      expect(findByTestID(fileUpload, 'Button')).toHaveLength(1);
       expect(fileUpload.find(TextStyle)).toHaveLength(1);
     });
 
     it('renders extra large view for type image', () => {
       const fileUpload = mountWithAppProvider(
-        <DropZoneContext.Provider value={{size: 'extraLarge', type: 'image'}}>
+        <DropZoneContext.Provider
+          value={{size: 'extraLarge', type: 'image', ...defaultStates}}
+        >
           <FileUpload />
         </DropZoneContext.Provider>,
       );
 
       expect(fileUpload.find('img').prop('src')).toBe(imageUpload);
-      expect(fileUpload.find(Button)).toHaveLength(1);
+      expect(findByTestID(fileUpload, 'Button')).toHaveLength(1);
       expect(fileUpload.find(TextStyle)).toHaveLength(1);
     });
   });
@@ -35,26 +48,30 @@ describe('<FileUpload />', () => {
   describe('large', () => {
     it('renders large view for type file', () => {
       const fileUpload = mountWithAppProvider(
-        <DropZoneContext.Provider value={{size: 'large', type: 'file'}}>
+        <DropZoneContext.Provider
+          value={{size: 'large', type: 'file', ...defaultStates}}
+        >
           <FileUpload />
         </DropZoneContext.Provider>,
       );
 
       expect(fileUpload.find('img').prop('src')).toBe(fileUploadImage);
-      expect(fileUpload.find(Button)).toHaveLength(1);
+      expect(findByTestID(fileUpload, 'Button')).toHaveLength(1);
       expect(fileUpload.find(TextStyle)).toHaveLength(1);
       expect(fileUpload.find(Caption)).toHaveLength(1);
     });
 
     it('renders large view for type image', () => {
       const fileUpload = mountWithAppProvider(
-        <DropZoneContext.Provider value={{size: 'large', type: 'image'}}>
+        <DropZoneContext.Provider
+          value={{size: 'large', type: 'image', ...defaultStates}}
+        >
           <FileUpload />
         </DropZoneContext.Provider>,
       );
 
       expect(fileUpload.find('img').prop('src')).toBe(imageUpload);
-      expect(fileUpload.find(Button)).toHaveLength(1);
+      expect(findByTestID(fileUpload, 'Button')).toHaveLength(1);
       expect(fileUpload.find(TextStyle)).toHaveLength(1);
       expect(fileUpload.find(Caption)).toHaveLength(1);
     });
@@ -62,18 +79,22 @@ describe('<FileUpload />', () => {
 
   it('renders medium view', () => {
     const fileUpload = mountWithAppProvider(
-      <DropZoneContext.Provider value={{size: 'medium', type: 'file'}}>
+      <DropZoneContext.Provider
+        value={{size: 'medium', type: 'file', ...defaultStates}}
+      >
         <FileUpload />
       </DropZoneContext.Provider>,
     );
 
-    expect(fileUpload.find(Link)).toHaveLength(1);
+    expect(findByTestID(fileUpload, 'Link')).toHaveLength(1);
     expect(fileUpload.find(Caption)).toHaveLength(1);
   });
 
   it('renders small view', () => {
     const fileUpload = mountWithAppProvider(
-      <DropZoneContext.Provider value={{size: 'small', type: 'file'}}>
+      <DropZoneContext.Provider
+        value={{size: 'small', type: 'file', ...defaultStates}}
+      >
         <FileUpload />
       </DropZoneContext.Provider>,
     );
@@ -83,18 +104,22 @@ describe('<FileUpload />', () => {
 
   it('sets a default actionTitle if the prop is provided then removed', () => {
     const fileUpload = mountWithAppProvider(
-      <DropZoneContext.Provider value={{size: 'large', type: 'file'}}>
+      <DropZoneContext.Provider
+        value={{size: 'large', type: 'file', ...defaultStates}}
+      >
         <FileUpload actionTitle="Title" />
       </DropZoneContext.Provider>,
     );
 
     fileUpload.setProps({children: <FileUpload />});
-    expect(fileUpload.find(Button).text()).toBe('Add file');
+    expect(findByTestID(fileUpload, 'Button').text()).toBe('Add file');
   });
 
   it('sets a default actionHint if the prop is provided then removed', () => {
     const fileUpload = mountWithAppProvider(
-      <DropZoneContext.Provider value={{size: 'large', type: 'file'}}>
+      <DropZoneContext.Provider
+        value={{size: 'large', type: 'file', ...defaultStates}}
+      >
         <FileUpload actionHint="Hint" />
       </DropZoneContext.Provider>,
     );

--- a/src/components/DropZone/context.tsx
+++ b/src/components/DropZone/context.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 
 interface DropZoneContextType {
+  disabled: boolean;
+  focused: boolean;
   size: string;
   type: string;
 }
 
 export const DropZoneContext = React.createContext<DropZoneContextType>({
+  disabled: false,
+  focused: false,
   size: 'extraLarge',
   type: 'file',
 });

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -195,6 +195,45 @@ describe('<DropZone />', () => {
     expect(input.prop('id')).toStrictEqual(id);
   });
 
+  it('renders a disabled input when the disabled prop is true', () => {
+    const dropZone = mountWithAppProvider(<DropZone disabled />);
+    expect(dropZone.find('input[type="file"]').prop('disabled')).toBe(true);
+  });
+
+  describe('onClick', () => {
+    it('calls the onClick when clicking the dropzone if one is provided', () => {
+      const spy = jest.fn();
+      const dropZone = mountWithAppProvider(
+        <DropZone label="My DropZone label" onClick={spy} />,
+      );
+
+      dropZone
+        .find('div')
+        .at(4)
+        .simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('triggers the file input click event if no onClick is provided', () => {
+      const dropZone = mountWithAppProvider(
+        <DropZone label="My DropZone label" />,
+      );
+
+      const fileInput = dropZone
+        .find('input[type="file"]')
+        .getDOMNode() as HTMLInputElement;
+
+      const spy = jest.spyOn(fileInput, 'click');
+
+      dropZone
+        .find('div')
+        .at(4)
+        .simulate('click');
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
   describe('labelAction', () => {
     it("passes 'labelAction' to the Labelled options", () => {
       const callbackDropZone = {
@@ -310,7 +349,9 @@ describe('<DropZone />', () => {
       const displayText = dropZone.find(DisplayText);
       expect(displayText.contains(errorOverlayText)).toBe(true);
     });
+  });
 
+  describe('context', () => {
     it('sets type from props on context', () => {
       const type = 'image';
 
@@ -329,6 +370,64 @@ describe('<DropZone />', () => {
 
       const component = mountWithApp(<Component />);
       expect(component).toContainReactComponent('div');
+    });
+
+    it('sets focused to true when the input file is focused', () => {
+      const dropZone = mountWithAppProvider(
+        <DropZone>
+          <DropZoneContext.Consumer>
+            {({focused}) => {
+              return focused ? <div id="focused" /> : null;
+            }}
+          </DropZoneContext.Consumer>
+        </DropZone>,
+      );
+      const fileInput = dropZone.find(`input[type="file"]`);
+      fileInput.simulate('focus');
+      expect(dropZone.find('#focused')).toHaveLength(1);
+    });
+
+    it('sets focused to false when the input file is blur', () => {
+      const dropZone = mountWithAppProvider(
+        <DropZone>
+          <DropZoneContext.Consumer>
+            {({focused}) => {
+              return focused ? null : <div id="blurred" />;
+            }}
+          </DropZoneContext.Consumer>
+        </DropZone>,
+      );
+      const fileInput = dropZone.find(`input[type="file"]`);
+      fileInput.simulate('blur');
+      expect(dropZone.find('#blurred')).toHaveLength(1);
+    });
+
+    it('sets disabled to true when the dropzone is disabled', () => {
+      const dropZone = mountWithAppProvider(
+        <DropZone disabled>
+          <DropZoneContext.Consumer>
+            {({disabled}) => {
+              return disabled ? <div id="disabled" /> : null;
+            }}
+          </DropZoneContext.Consumer>
+        </DropZone>,
+      );
+
+      expect(dropZone.find('#disabled')).toHaveLength(1);
+    });
+
+    it('sets the default type to file if not specified', () => {
+      const dropZone = mountWithAppProvider(
+        <DropZone>
+          <DropZoneContext.Consumer>
+            {({type}) => {
+              return type === 'file' ? <div id="file" /> : null;
+            }}
+          </DropZoneContext.Consumer>
+        </DropZone>,
+      );
+
+      expect(dropZone.find('#file')).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/762

### WHAT is this pull request doing?

1. The focus issue is revolved by allowing users to focus the `file input` and turning the button into a simple div. Visually it looks like a button but cannot be tabbed to focused to via keyboard.

2. The dropzone keeps tracks of being focused via its state and communicates it to the fileUpload component via context. The same has been done for hovering and disabling of the dropzone. 

3. We explored adding a hover state to the dropzone. This was challenging because in many cases (like the web image card), once images are uploaded, the outline prop is changed to false to accommodate the design. Having a hover isn't ideal. So this PR only adds a hover state when outline is set to true. (once this is finalized a UX issue will be opened to outline various accessibility issue that may require design changes in the admin.)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

1. Build the playground with the code below
2. Test hover state at all 4 sizes of the drop zone (with and without the outline prop).
3. Test focus state at all 4 sizes as well (with and without the outline prop). 

<!--
  Give as much information as needed to experiment with the component in the playground.
-->

<details>
<summary><code>Playground code</code>:</summary>

```jsx
import React from 'react';
import {Page, Stack, DropZone, Banner, List, Caption, Thumbnail} from '../src';

export default function Playground() {
  return (
    <Page title="Playground">
      <DropZoneExample />
    </Page>
  );
}

class DropZoneExample extends React.Component {
  state = {
    files: [],
    rejectedFiles: [],
    hasError: false,
  };

  render() {
    const {files, hasError, rejectedFiles} = this.state;

    const fileUpload = !files.length && <DropZone.FileUpload />;
    const uploadedFiles = files.length > 0 && (
      <Stack vertical>
        {files.map((file, index) => (
          <Stack alignment="center" key={index}>
            <Thumbnail
              size="small"
              alt={file.name}
              source={window.URL.createObjectURL(file)}
            />
            <div>
              {file.name} <Caption>{file.size} bytes</Caption>
            </div>
          </Stack>
        ))}
      </Stack>
    );

    const errorMessage = hasError && (
      <Banner
        title="The following images couldn’t be uploaded:"
        status="critical"
      >
        <List type="bullet">
          {rejectedFiles.map((file, index) => (
            <List.Item key={index}>
              {`"${
                file.name
              }" is not supported. File type must be .gif, .jpg, .png or .svg.`}
            </List.Item>
          ))}
        </List>
      </Banner>
    );

    return (
      <Stack vertical>
        {errorMessage}
        <DropZone
          accept="image/*"
          type="image"
          outline={false}
          onDrop={(files, acceptedFiles, rejectedFiles) => {
            this.setState({
              files: [...this.state.files, ...acceptedFiles],
              rejectedFiles,
              hasError: rejectedFiles.length > 0,
            });
          }}
        >
          {uploadedFiles}
          {fileUpload}
        </DropZone>
      </Stack>
    );
  }
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
