### PR TITLE
[TextField] Converting TextField and Resizer to functional components using React Hooks

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -48,5 +48,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Migrated `ContextualSaveBar` to use hooks instead of `withAppProvider` ([#2091](https://github.com/Shopify/polaris-react/pull/2091))
 - Migrated `RangeSlider`, `ScrollLock` and `TopBar.SearchField` to use hooks instead of withAppProvider ([#2083](https://github.com/Shopify/polaris-react/pull/2083))
 - Updated `ResourceItem` to no longer rely on withAppProvider ([#2094](https://github.com/Shopify/polaris-react/pull/2094))
+- Migrated `TextField` and `Resizer` to use hooks ([#1997](https://github.com/Shopify/polaris-react/pull/1997));
 
 ### Deprecations

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -177,12 +177,9 @@ export function TextField({
   }, []);
 
   useEffect(() => {
-    if (!inputRef.current) return;
-    if (focused) {
-      inputRef.current.focus();
-    } else if (focused === false) {
-      inputRef.current.blur();
-    }
+    const input = inputRef.current;
+    if (!input || focused === undefined) return;
+    focused ? input.focus() : input.blur();
   }, [focused]);
 
   const normalizedValue = value != null ? value : '';

--- a/src/components/TextField/index.ts
+++ b/src/components/TextField/index.ts
@@ -1,3 +1,1 @@
-import TextField, {TextFieldProps, Type} from './TextField';
-
-export {TextField, TextFieldProps, Type};
+export {TextField, TextFieldProps, Type} from './TextField';

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {InlineError, Labelled, Connected, Select} from 'components';
 import {mountWithApp} from 'test-utilities';
 import {Resizer, Spinner} from '../components';
@@ -874,21 +875,16 @@ describe('<TextField />', () => {
     });
 
     it('renders a resizer with `minimumLines` set to 1 if `multiline` is true', () => {
-      const textField = mountWithAppProvider(
+      const textField = mountWithApp(
         <TextField label="TextField" id="MyField" onChange={noop} multiline />,
       );
-
-      expect(
-        textField
-          .findWhere(
-            (wrap) => wrap.is(Resizer) && wrap.prop('minimumLines') === 1,
-          )
-          .exists(),
-      ).toBe(true);
+      expect(textField).toContainReactComponentTimes(Resizer, 1, {
+        minimumLines: 1,
+      });
     });
 
     it('renders a resizer with `minimumLines` set to the `multiline` numeric value', () => {
-      const textField = mountWithAppProvider(
+      const textField = mountWithApp(
         <TextField
           label="TextField"
           id="MyField"
@@ -897,18 +893,14 @@ describe('<TextField />', () => {
         />,
       );
 
-      expect(
-        textField
-          .findWhere(
-            (wrap) => wrap.is(Resizer) && wrap.prop('minimumLines') === 5,
-          )
-          .exists(),
-      ).toBe(true);
+      expect(textField).toContainReactComponentTimes(Resizer, 1, {
+        minimumLines: 5,
+      });
     });
 
     it('passes the `placeholder` to the resizer `contents` prop', () => {
       const placeholderText = 'placeholder text';
-      const textField = mountWithAppProvider(
+      const textField = mountWithApp(
         <TextField
           label="TextField"
           id="MyField"
@@ -918,14 +910,9 @@ describe('<TextField />', () => {
         />,
       );
 
-      expect(
-        textField
-          .findWhere(
-            (wrap) =>
-              wrap.is(Resizer) && wrap.prop('contents') === placeholderText,
-          )
-          .exists(),
-      ).toBe(true);
+      expect(textField).toContainReactComponentTimes(Resizer, 1, {
+        contents: placeholderText,
+      });
     });
   });
 

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {InlineError, Labelled, Connected, Select} from 'components';
+import {mountWithApp} from 'test-utilities';
 import {Resizer, Spinner} from '../components';
-import TextField from '../TextField';
+import {TextField} from '../TextField';
 
 describe('<TextField />', () => {
   it('allows specific props to pass through properties on the input', () => {
@@ -473,15 +474,14 @@ describe('<TextField />', () => {
         />,
       );
 
-      expect(
-        textField.find('#MyFieldCharacterCounter').prop<string>('aria-live'),
-      ).toBe('off');
+      expect(textField.find('#MyFieldCharacterCounter').prop('aria-live')).toBe(
+        'off',
+      );
 
       textField.find('input').simulate('focus');
-
-      expect(
-        textField.find('#MyFieldCharacterCounter').prop<string>('aria-live'),
-      ).toBe('polite');
+      expect(textField.find('#MyFieldCharacterCounter').prop('aria-live')).toBe(
+        'polite',
+      );
     });
   });
 
@@ -530,6 +530,27 @@ describe('<TextField />', () => {
           .last()
           .simulate('click');
         expect(spy).toHaveBeenCalledWith('2', 'MyTextField');
+      });
+
+      it('does not call the onChange if the value is not a number', () => {
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField
+            id="MyTextField"
+            label="TextField"
+            type="number"
+            value="not a number"
+            onChange={spy}
+          />,
+        );
+
+        element!
+          .find('div', {
+            role: 'button',
+          })!
+          .trigger('onClick');
+
+        expect(spy).not.toHaveBeenCalled();
       });
 
       it('handles incrementing from no value', () => {
@@ -840,7 +861,7 @@ describe('<TextField />', () => {
   });
 
   describe('multiline', () => {
-    it('does not render a resizer if multiline is false', () => {
+    it('does not render a resizer if `multiline` is false', () => {
       const textField = mountWithAppProvider(
         <TextField
           label="TextField"
@@ -850,6 +871,61 @@ describe('<TextField />', () => {
         />,
       );
       expect(textField.find(Resizer).exists()).toBe(false);
+    });
+
+    it('renders a resizer with `minimumLines` set to 1 if `multiline` is true', () => {
+      const textField = mountWithAppProvider(
+        <TextField label="TextField" id="MyField" onChange={noop} multiline />,
+      );
+
+      expect(
+        textField
+          .findWhere(
+            (wrap) => wrap.is(Resizer) && wrap.prop('minimumLines') === 1,
+          )
+          .exists(),
+      ).toBe(true);
+    });
+
+    it('renders a resizer with `minimumLines` set to the `multiline` numeric value', () => {
+      const textField = mountWithAppProvider(
+        <TextField
+          label="TextField"
+          id="MyField"
+          onChange={noop}
+          multiline={5}
+        />,
+      );
+
+      expect(
+        textField
+          .findWhere(
+            (wrap) => wrap.is(Resizer) && wrap.prop('minimumLines') === 5,
+          )
+          .exists(),
+      ).toBe(true);
+    });
+
+    it('passes the `placeholder` to the resizer `contents` prop', () => {
+      const placeholderText = 'placeholder text';
+      const textField = mountWithAppProvider(
+        <TextField
+          label="TextField"
+          id="MyField"
+          onChange={noop}
+          placeholder={placeholderText}
+          multiline={5}
+        />,
+      );
+
+      expect(
+        textField
+          .findWhere(
+            (wrap) =>
+              wrap.is(Resizer) && wrap.prop('contents') === placeholderText,
+          )
+          .exists(),
+      ).toBe(true);
     });
   });
 

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
-import {mountWithApp} from 'test-utilities';
 import {InlineError, Labelled, Connected, Select} from 'components';
 import {mountWithApp} from 'test-utilities';
 import {Resizer, Spinner} from '../components';


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-react/issues/1995

### WHAT is this pull request doing?

change `TextField` and `Resizer`  to use react hooks

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

- Loading the Textfield examples in the playground and ensuring they all behave as expected should be sufficient.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export default function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
