### PR TITLE
Add request to hide autoplaying gifs in details

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE.md
@@ -26,6 +26,14 @@ What do you think should happen?
 What actually happens?
 
 Tip: include an error message (in a `<details></details>` tag) if your issue is related to an error while running Polaris.
+
+If you include an animated gif showing your issue, wrapping it in a details tag is also recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:
+
+    <details>
+      <summary>Summary of your gif(s)</summary>
+      <img src="..." alt="Description of what the gif shows">
+    </details>
+
 -->
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,15 @@ Fixes #0000 <!-- link to issue if one exists -->
 
 <!--
   Summary of the changes committed.
-  Before / after screenshots appreciated for UI changes.
+
+  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.
+
+  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:
+
+    <details>
+      <summary>Summary of your gif(s)</summary>
+      <img src="..." alt="Description of what the gif shows">
+    </details>
 -->
 
 ## <!-- ℹ️ Delete the following for small / trivial changes -->


### PR DESCRIPTION
### WHY are these changes introduced?

Gifs are a helpful way for contributors to show behavior in issues and PRs. However, gifs autoplay in GitHub threads and in unfurled Slack messages, which can cause accessibility issues for members of the community who have vestibular, motion, sensory, or attention issues.  This PR adds guidances for contributors to wrap gifs in a `<details>` container with a `<summary>`, so autoplaying gifs are hidden on page load.

### WHAT is this pull request doing?

Edits the following files:

- [X] Adds a comment with contributor guidance to `PULL_REQUEST_TEMPLATE.md`
- [X] Adds a comment with contributor guidance to `ISSUE.md`
- [ ] Updates `UNRELEASED.md` with an entry about documentation