### PR TITLE
[PopoverOverlay] Fix regression introduced by removal of `CSSTransition` 

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -52,6 +52,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed bug where `Autocomplete` was bubbling up the `Enter` key event unexpectedly ([#1887](https://github.com/Shopify/polaris-react/pull/1887))
 - Fixed `ContextualSaveBar` actions overflowing on small screens ([#1967](https://github.com/Shopify/polaris-react/pull/1967))
 - Fixed cross-origin error being thrown in `Modal` when loading an external app ([#1992](https://github.com/Shopify/polaris-react/pull/1992))
+- Fixed regression in `PopoverOverlay` causing `onClose` to be fired when Popover is opening and trigger was not the activator ([#2000](https://github.com/Shopify/polaris-react/pull/2000))
 
 ### Documentation
 

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -62,6 +62,8 @@ export default class PopoverOverlay extends React.PureComponent<Props, State> {
   };
 
   private contentNode = createRef<HTMLDivElement>();
+  private enteringTimer?: number;
+  private exitingTimer?: number;
 
   changeTransitionStatus(transitionStatus: TransitionStatus, cb?: () => void) {
     this.setState({transitionStatus}, cb);
@@ -81,17 +83,24 @@ export default class PopoverOverlay extends React.PureComponent<Props, State> {
   componentDidUpdate(oldProps: Props) {
     if (this.props.active && !oldProps.active) {
       this.focusContent();
-
-      this.changeTransitionStatus(TransitionStatus.Entered);
+      this.changeTransitionStatus(TransitionStatus.Entering, () => {
+        this.enteringTimer = window.setTimeout(() => {
+          this.setState({transitionStatus: TransitionStatus.Entered});
+        }, durationBase);
+      });
     }
 
     if (!this.props.active && oldProps.active) {
       this.changeTransitionStatus(TransitionStatus.Exiting, () => {
-        setTimeout(() => {
+        this.exitingTimer = window.setTimeout(() => {
           this.setState({transitionStatus: TransitionStatus.Exited});
         }, durationBase);
       });
     }
+  }
+
+  componentWillUnmount() {
+    this.clearTransitionTimeout();
   }
 
   render() {
@@ -128,6 +137,16 @@ export default class PopoverOverlay extends React.PureComponent<Props, State> {
         classNames={className}
       />
     );
+  }
+
+  private clearTransitionTimeout() {
+    if (this.enteringTimer) {
+      window.clearTimeout(this.enteringTimer);
+    }
+
+    if (this.exitingTimer) {
+      window.clearTimeout(this.exitingTimer);
+    }
   }
 
   private focusContent() {

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -147,4 +147,39 @@ describe('<Popover />', () => {
     window.dispatchEvent(evt);
     expect(spy).toHaveBeenCalled();
   });
+
+  it('does not call onClose when Popover is opening and trigger was not the activator', () => {
+    class PopoverWithDisconnectedActivator extends React.Component {
+      state = {
+        active: false,
+      };
+
+      handleActivatorClick = () => this.setState({active: true});
+
+      render() {
+        return (
+          <React.Fragment>
+            <button onClick={this.handleActivatorClick}>Activator</button>
+            <Popover
+              active={this.state.active}
+              activator={<div />}
+              onClose={onCloseSpy}
+            />
+          </React.Fragment>
+        );
+      }
+    }
+
+    const onCloseSpy = jest.fn();
+
+    const popoverWithDisconnectedActivator = mountWithAppProvider(
+      <PopoverWithDisconnectedActivator />,
+    );
+
+    popoverWithDisconnectedActivator.find('button').simulate('click');
+    const evt = new CustomEvent('click');
+    window.dispatchEvent(evt);
+
+    expect(onCloseSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

This PR fixes a regression in `PopoverOverlay` introduced by https://github.com/Shopify/polaris-react/pull/1756

The `onClose` prop was fired when clicking or touching the element activating the `Popover` when that element was not the `activator` received as a prop. 

In this case, the `Popover` would close right away.

It feels like a weird use case but that's how the `ImageEditor` in web is using `Popover`. The `activator` prop is just an empty `div`. The real Popover triggers are rendered higher up in the DOM tree.

<img width="842" alt="Screen Shot 2019-08-21 at 4 31 58 PM" src="https://user-images.githubusercontent.com/3925905/63466658-ba53b380-c431-11e9-9b17-3be6d3f658f9.png">

### WHAT is this pull request doing?

This PR fixes the regression.

In `handleClick`, we prevent `onClose` to be called when the source of the click is a descendant of the `Popover` or the `Popover` is being opened (this one was not working as expected).

We are now properly setting the transition status to `Entering` instead of `Entered` when the `Popover` is opened. It prevents clicks that are not coming from descendants to fire `onClose` while the `Popover` is opening.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

Test the Playground code **with and without the changes**.

Before: `closePopover` is fired when opening the `Popover`.
**After: `closePopover` won't be fired when opening the `Popover` (fix)**

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {ActionList, Button, Popover} from '@shopify/polaris';

export default class PopoverContentExample extends React.Component {
  state = {
    active: false,
  };

  openPopover = () => {
    console.log('openPopover called');
    this.setState({active: true});
  };

  closePopover = () => {
    console.log('closePopover called');
    this.setState({active: false});
  };

  render() {
    return (
      <div>
        <Button onClick={this.openPopover}>Toggle `Popover`</Button>
        <div style={{height: '250px'}}>
          <Popover
            active={this.state.active}
            activator={<div />}
            onClose={this.closePopover}
          >
            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae
            orci tellus. Pellentesque non elementum ipsum, at feugiat libero.
            Nulla id mollis nisi. Nam ut ligula mollis, commodo felis ut,
            consequat orci. In in sagittis magna, vitae rutrum mi. Ut facilisis,
            quam eu pulvinar elementum, lorem mauris lobortis leo, a posuere
            erat tortor in ante. Nunc fermentum nulla posuere, tincidunt velit
            id, pharetra velit. Ut congue varius semper. Nullam cursus
            ullamcorper sem, cursus euismod diam mollis id. Nullam sodales nibh
            libero, id auctor lectus condimentum eu. Curabitur dui velit, ornare
            sed vestibulum at, egestas at ante. Proin feugiat eros metus.
            Integer lacinia urna a orci accumsan, eget dignissim turpis pretium.
            Cras feugiat, mi convallis facilisis venenatis, odio lectus
            hendrerit velit, in sollicitudin magna nisi quis lacus. Proin purus
            nunc, posuere eu leo ultrices, hendrerit interdum massa. In non
            felis id justo egestas cursus. Pellentesque euismod quis sem in
            luctus. Nullam ultrices consequat nibh ac cursus. Morbi blandit
            finibus velit, ac scelerisque diam viverra vitae. In a orci orci.
          </Popover>
        </div>
      </div>
    );
  }
}


```

</details>

🎩 In `web`:
- Start the `web` server
- Clone `polaris-react` and checkout `popover-overlay-fix`
- `yarn` then build a consumer for web `yarn run build-consumer web` (still in `polaris-react`)
- Open a Product details page (React) with an image (or upload one)
- Edit the image but do not save it
- Click the `<` (back) button in the left panel, the `X` of the Modal or the 'Undo all' button
- Make sure the leave confirmation is rendered and works as expected. You should also be able to close it.

Web issue for context: https://github.com/Shopify/web/issues/17477

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
