### PR TITLE
Add images for Single ChoiceList error state

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Added mobile example images error state of Single Choice List ([#2007](https://github.com/Shopify/polaris-react/pull/2007))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/ChoiceList/README.md
+++ b/src/components/ChoiceList/README.md
@@ -252,6 +252,18 @@ class ChoiceListExample extends React.Component {
 }
 ```
 
+<!-- content-for: android -->
+
+![Single choice list with error for Android](/public_images/components/ChoiceList/android/single-choice-error@2x.png)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+![Single choice list with error for iOS](/public_images/components/ChoiceList/ios/single-choice-error@2x.png)
+
+<!-- /content-for -->
+
 ### Multi-choice list
 
 Allows merchants to select multiple options from a list.


### PR DESCRIPTION

### WHY are these changes introduced?

Fixes #1943 

### WHAT is this pull request doing?

Adds references to single choice list error state images (added in https://github.com/Shopify/polaris-styleguide/pull/2928)
