### PR TITLE
Update examples to use v4.0.0 final

### DIFF
--- a/examples/cdn-styles/README.md
+++ b/examples/cdn-styles/README.md
@@ -11,7 +11,7 @@ The CDN hosted CSS file needs to be included in your HTML document. Replace the 
 ```html
 <link
   rel="stylesheet"
-  href="https://unpkg.com/@shopify/polaris@4.0.0-rc.4/styles.min.css"
+  href="https://unpkg.com/@shopify/polaris@4.0.0/styles.min.css"
 />
 ```
 

--- a/examples/create-react-app-ts-react-testing/package.json
+++ b/examples/create-react-app-ts-react-testing/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@shopify/polaris": "^4.0.0-rc.2",
+    "@shopify/polaris": "^4.0.0",
     "@types/jest": "24.0.15",
     "@types/node": "12.6.5",
     "@types/react": "16.8.23",

--- a/examples/create-react-app-ts-react-testing/yarn.lock
+++ b/examples/create-react-app-ts-react-testing/yarn.lock
@@ -1269,10 +1269,10 @@
   resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.6.0.tgz#1654c83025d80ce803f06329aceaabfb96b5e684"
   integrity sha512-l2AwgZhujgu/C1cchJginWODXWcjhrpqrh+lcI+SM3MSSca6l2zSXa3B5OqCcspk6DIQDeJEn5BvXJgT7AJNPQ==
 
-"@shopify/polaris@^4.0.0-rc.2":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-4.0.0-rc.2.tgz#1d2dff5992201e4cb8a0765ab49513262dd37512"
-  integrity sha512-A72sHRLzbaU3BGnlF5A/gfB0FZxds1oV7a6gslev8+KKQcvYafZAoZB/0fxEZTphZRGpQdUeNPy4NS3aEIGfVQ==
+"@shopify/polaris@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-4.0.0.tgz#1353e388eec6df4e349d9391938697f9118dafa0"
+  integrity sha512-N5c59kX2li52YU1zxo22osjkjNopdOHypyGt2Cep3SPwLpABwyAD9LvR13bBcV77NpFFM3c/4onuEyGPJEjcsQ==
   dependencies:
     "@babel/runtime" "^7.1.6"
     "@material-ui/react-transition-group" "^4.2.0"
@@ -1281,6 +1281,7 @@
     "@shopify/polaris-icons" "^3.3.0"
     "@shopify/polaris-tokens" "^2.6.0"
     "@shopify/useful-types" "^1.2.4"
+    "@types/hoist-non-react-statics" "^3.3.1"
     "@types/react" "^16.8.15"
     "@types/react-dom" "^16.8.4"
     "@types/react-transition-group" "^2.0.7"
@@ -1431,6 +1432,14 @@
   integrity sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==
   dependencies:
     "@babel/types" "^7.3.0"
+
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -11,7 +11,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@shopify/polaris": "^4.0.0-rc.2",
+    "@shopify/polaris": "^4.0.0",
     "@shopify/polaris-icons": "^3.4.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/examples/create-react-app/yarn.lock
+++ b/examples/create-react-app/yarn.lock
@@ -1097,10 +1097,10 @@
   resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.6.0.tgz#1654c83025d80ce803f06329aceaabfb96b5e684"
   integrity sha512-l2AwgZhujgu/C1cchJginWODXWcjhrpqrh+lcI+SM3MSSca6l2zSXa3B5OqCcspk6DIQDeJEn5BvXJgT7AJNPQ==
 
-"@shopify/polaris@^4.0.0-rc.2":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-4.0.0-rc.2.tgz#1d2dff5992201e4cb8a0765ab49513262dd37512"
-  integrity sha512-A72sHRLzbaU3BGnlF5A/gfB0FZxds1oV7a6gslev8+KKQcvYafZAoZB/0fxEZTphZRGpQdUeNPy4NS3aEIGfVQ==
+"@shopify/polaris@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-4.0.0.tgz#1353e388eec6df4e349d9391938697f9118dafa0"
+  integrity sha512-N5c59kX2li52YU1zxo22osjkjNopdOHypyGt2Cep3SPwLpABwyAD9LvR13bBcV77NpFFM3c/4onuEyGPJEjcsQ==
   dependencies:
     "@babel/runtime" "^7.1.6"
     "@material-ui/react-transition-group" "^4.2.0"
@@ -1109,6 +1109,7 @@
     "@shopify/polaris-icons" "^3.3.0"
     "@shopify/polaris-tokens" "^2.6.0"
     "@shopify/useful-types" "^1.2.4"
+    "@types/hoist-non-react-statics" "^3.3.1"
     "@types/react" "^16.8.15"
     "@types/react-dom" "^16.8.4"
     "@types/react-transition-group" "^2.0.7"
@@ -1261,6 +1262,14 @@
   integrity sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==
   dependencies:
     "@babel/types" "^7.3.0"
+
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"

--- a/examples/next.js/package.json
+++ b/examples/next.js/package.json
@@ -10,7 +10,7 @@
     "server": "next start"
   },
   "dependencies": {
-    "@shopify/polaris": "^4.0.0-rc.2",
+    "@shopify/polaris": "^4.0.0",
     "@shopify/polaris-icons": "^3.4.0",
     "@zeit/next-css": "^1.0.1",
     "next": "^9.0.2",

--- a/examples/next.js/yarn.lock
+++ b/examples/next.js/yarn.lock
@@ -814,10 +814,10 @@
   resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.6.0.tgz#1654c83025d80ce803f06329aceaabfb96b5e684"
   integrity sha512-l2AwgZhujgu/C1cchJginWODXWcjhrpqrh+lcI+SM3MSSca6l2zSXa3B5OqCcspk6DIQDeJEn5BvXJgT7AJNPQ==
 
-"@shopify/polaris@^4.0.0-rc.2":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-4.0.0-rc.2.tgz#1d2dff5992201e4cb8a0765ab49513262dd37512"
-  integrity sha512-A72sHRLzbaU3BGnlF5A/gfB0FZxds1oV7a6gslev8+KKQcvYafZAoZB/0fxEZTphZRGpQdUeNPy4NS3aEIGfVQ==
+"@shopify/polaris@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-4.0.0.tgz#1353e388eec6df4e349d9391938697f9118dafa0"
+  integrity sha512-N5c59kX2li52YU1zxo22osjkjNopdOHypyGt2Cep3SPwLpABwyAD9LvR13bBcV77NpFFM3c/4onuEyGPJEjcsQ==
   dependencies:
     "@babel/runtime" "^7.1.6"
     "@material-ui/react-transition-group" "^4.2.0"
@@ -826,6 +826,7 @@
     "@shopify/polaris-icons" "^3.3.0"
     "@shopify/polaris-tokens" "^2.6.0"
     "@shopify/useful-types" "^1.2.4"
+    "@types/hoist-non-react-statics" "^3.3.1"
     "@types/react" "^16.8.15"
     "@types/react-dom" "^16.8.4"
     "@types/react-transition-group" "^2.0.7"
@@ -840,6 +841,14 @@
   dependencies:
     "@types/react" ">=16.4.0"
     tslib "^1.9.3"
+
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/lodash@^4.14.65":
   version "4.14.136"

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -10,7 +10,7 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@shopify/polaris": "^4.0.0-rc.2",
+    "@shopify/polaris": "^4.0.0",
     "@shopify/polaris-icons": "^3.4.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/examples/webpack/yarn.lock
+++ b/examples/webpack/yarn.lock
@@ -745,10 +745,10 @@
   resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.6.0.tgz#1654c83025d80ce803f06329aceaabfb96b5e684"
   integrity sha512-l2AwgZhujgu/C1cchJginWODXWcjhrpqrh+lcI+SM3MSSca6l2zSXa3B5OqCcspk6DIQDeJEn5BvXJgT7AJNPQ==
 
-"@shopify/polaris@^4.0.0-rc.2":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-4.0.0-rc.2.tgz#1d2dff5992201e4cb8a0765ab49513262dd37512"
-  integrity sha512-A72sHRLzbaU3BGnlF5A/gfB0FZxds1oV7a6gslev8+KKQcvYafZAoZB/0fxEZTphZRGpQdUeNPy4NS3aEIGfVQ==
+"@shopify/polaris@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-4.0.0.tgz#1353e388eec6df4e349d9391938697f9118dafa0"
+  integrity sha512-N5c59kX2li52YU1zxo22osjkjNopdOHypyGt2Cep3SPwLpABwyAD9LvR13bBcV77NpFFM3c/4onuEyGPJEjcsQ==
   dependencies:
     "@babel/runtime" "^7.1.6"
     "@material-ui/react-transition-group" "^4.2.0"
@@ -757,6 +757,7 @@
     "@shopify/polaris-icons" "^3.3.0"
     "@shopify/polaris-tokens" "^2.6.0"
     "@shopify/useful-types" "^1.2.4"
+    "@types/hoist-non-react-statics" "^3.3.1"
     "@types/react" "^16.8.15"
     "@types/react-dom" "^16.8.4"
     "@types/react-transition-group" "^2.0.7"
@@ -785,6 +786,14 @@
     "@types/events" "*"
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/lodash@^4.14.65":
   version "4.14.123"


### PR DESCRIPTION
Updates examples to use `@shopify/polaris` v4.0.0 instead of pre-releases