### PR TITLE
[ActionMenu] Add support for explicit item order

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,15 +6,6 @@
 
 - Added a split variant to `Button` ([#2329](https://github.com/Shopify/polaris-react/pull/2329))
 - Allow DataTable headers to be React Elements ([#2635](https://github.com/Shopify/polaris-react/pull/2635))
-- Added `hideTags` prop to `Filters` ([#2573](https://github.com/Shopify/polaris-react/pull/2573))
-- Added `searchResultsOverlayVisible` prop to `TopBar` which adds a translucent background to the search dismissal overlay when results are displayed ([#2440](https://github.com/Shopify/polaris-react/pull/2440))
-- Added `external` prop to `ResourceList` ([#2408](https://github.com/Shopify/polaris-react/pull/2408))
-- Added `onMouseEnter` and `onTouchStart` props to `Button` ([#2409](https://github.com/Shopify/polaris-react/pull/2409))
-- Added `ariaHaspopup` prop to `Popover` ([#2248](https://github.com/Shopify/polaris-react/pull/2248))
-- Updated `OptionList` section title to match `ActionList` section title ([#2300](https://github.com/Shopify/polaris-react/pull/2300))
-- Added `pressed` state to `Button` ([#2148](https://github.com/Shopify/polaris-react/pull/2148))
-- Added CSS custom properties to `Portal` container ([#2306](https://github.com/Shopify/polaris-react/pull/2306))
-- Updated the type of the `label` prop in `ChoiceList` (nested prop of `choices`) from `string` to `ReactNode` ([#2325](https://github.com/Shopify/polaris-react/pull/2325)).
 - Added support for explicit order of items in `ActionMenu` ([2057](https://github.com/Shopify/polaris-react/pull/2057))
 
 ### Bug fixes

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,16 @@
 
 - Added a split variant to `Button` ([#2329](https://github.com/Shopify/polaris-react/pull/2329))
 - Allow DataTable headers to be React Elements ([#2635](https://github.com/Shopify/polaris-react/pull/2635))
+- Added `hideTags` prop to `Filters` ([#2573](https://github.com/Shopify/polaris-react/pull/2573))
+- Added `searchResultsOverlayVisible` prop to `TopBar` which adds a translucent background to the search dismissal overlay when results are displayed ([#2440](https://github.com/Shopify/polaris-react/pull/2440))
+- Added `external` prop to `ResourceList` ([#2408](https://github.com/Shopify/polaris-react/pull/2408))
+- Added `onMouseEnter` and `onTouchStart` props to `Button` ([#2409](https://github.com/Shopify/polaris-react/pull/2409))
+- Added `ariaHaspopup` prop to `Popover` ([#2248](https://github.com/Shopify/polaris-react/pull/2248))
+- Updated `OptionList` section title to match `ActionList` section title ([#2300](https://github.com/Shopify/polaris-react/pull/2300))
+- Added `pressed` state to `Button` ([#2148](https://github.com/Shopify/polaris-react/pull/2148))
+- Added CSS custom properties to `Portal` container ([#2306](https://github.com/Shopify/polaris-react/pull/2306))
+- Updated the type of the `label` prop in `ChoiceList` (nested prop of `choices`) from `string` to `ReactNode` ([#2325](https://github.com/Shopify/polaris-react/pull/2325)).
+- Added support for explicit order of items in `ActionMenu` ([2057](https://github.com/Shopify/polaris-react/pull/2057))
 
 ### Bug fixes
 

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -57,14 +57,13 @@ export class ActionMenu extends React.PureComponent<ActionMenuProps, State> {
   private renderActions = () => {
     const {actions = [], groups = []} = this.props;
     const {activeMenuGroup} = this.state;
-    const overriddenActions = sortAndOverrideActionOrder([
-      ...actions,
-      ...groups,
-    ]);
+    const menuActions = [...actions, ...groups];
 
-    if (overriddenActions.length === 0) {
+    if (menuActions.length === 0) {
       return null;
     }
+
+    const overriddenActions = sortAndOverrideActionOrder(menuActions);
 
     const actionMarkup = overriddenActions.map((action, index) => {
       if ('title' in action) {
@@ -72,7 +71,7 @@ export class ActionMenu extends React.PureComponent<ActionMenuProps, State> {
 
         return actions.length > 0 ? (
           <MenuGroup
-            key={`MenuGroup-${title || index}`}
+            key={`MenuGroup-${index}`}
             title={title}
             active={title === activeMenuGroup}
             actions={actions}
@@ -85,17 +84,11 @@ export class ActionMenu extends React.PureComponent<ActionMenuProps, State> {
 
       const {content, ...rest} = action;
       return (
-        <MenuAction
-          key={`MenuAction-${content || index}`}
-          content={content}
-          {...rest}
-        />
+        <MenuAction key={`MenuAction-${index}`} content={content} {...rest} />
       );
     });
 
-    return actionMarkup.length > 0 ? (
-      <div className={styles.ActionsLayout}>{actionMarkup}</div>
-    ) : null;
+    return <div className={styles.ActionsLayout}>{actionMarkup}</div>;
   };
 
   private handleMenuGroupToggle = (group: string) => {

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -59,10 +59,6 @@ export class ActionMenu extends React.PureComponent<ActionMenuProps, State> {
     const {activeMenuGroup} = this.state;
     const menuActions = [...actions, ...groups];
 
-    if (menuActions.length === 0) {
-      return null;
-    }
-
     const overriddenActions = sortAndOverrideActionOrder(menuActions);
 
     const actionMarkup = overriddenActions.map((action, index) => {

--- a/src/components/ActionMenu/tests/ActionMenu.test.tsx
+++ b/src/components/ActionMenu/tests/ActionMenu.test.tsx
@@ -15,7 +15,8 @@ describe('<ActionMenu />', () => {
 
   it('does not render when there are no `actions` or `groups`', () => {
     const wrapper = mountWithAppProvider(<ActionMenu {...mockProps} />);
-    expect(wrapper.find('div').exists()).toBe(false);
+    expect(wrapper.find(MenuAction)).toHaveLength(0);
+    expect(wrapper.find(MenuGroup)).toHaveLength(0);
   });
 
   describe('actions', () => {
@@ -42,7 +43,7 @@ describe('<ActionMenu />', () => {
       );
     });
 
-    it('renders actions in their overridden order when their index set', () => {
+    it('renders an action in its overridden order when index is set', () => {
       const overrideIndex = 1;
       const actionWithIndex = {
         content: 'mock content 1',
@@ -64,22 +65,64 @@ describe('<ActionMenu />', () => {
       ).toBe(actionWithIndex.content);
     });
 
-    it('renders actions in their initial order when their index is not set', () => {
-      const overrideIndex = 1;
-      const actionWithIndex = {
-        content: 'mock content 1',
-        index: overrideIndex,
-      };
+    it('renders all actions in their overridden order when multiple indexes are set', () => {
+      const actionsBeforeOverride: ActionMenuProps['actions'] = [
+        {content: 'mock content 4', index: 3},
+        {content: 'mock content 1', index: 0},
+        {content: 'mock content 2'},
+        {content: 'mock content 5', index: 4},
+        {content: 'mock content 3'},
+      ];
 
+      const expectedOrderAfterOverride = [
+        {content: 'mock content 1', index: 0},
+        {content: 'mock content 2'},
+        {content: 'mock content 3'},
+        {content: 'mock content 4', index: 3},
+        {content: 'mock content 5', index: 4},
+      ];
+
+      const wrapper = mountWithAppProvider(
+        <ActionMenu actions={actionsBeforeOverride} />,
+      );
+
+      wrapper.find(MenuAction).forEach((action, index) => {
+        expect(action.props()).toMatchObject(expectedOrderAfterOverride[index]);
+      });
+    });
+
+    it('renders actions with the same set index consecutively, in order from highest initial index to lowest', () => {
+      const actionsBeforeOverride: ActionMenuProps['actions'] = [
+        {content: 'mock content 3', index: 0},
+        {content: 'mock content 2', index: 0},
+        {content: 'mock content 1', index: 0},
+      ];
+
+      const expectedOrderAfterOverride = [
+        {content: 'mock content 1', index: 0},
+        {content: 'mock content 2', index: 0},
+        {content: 'mock content 3', index: 0},
+      ];
+
+      const wrapper = mountWithAppProvider(
+        <ActionMenu actions={actionsBeforeOverride} />,
+      );
+
+      wrapper.find(MenuAction).forEach((action, index) => {
+        expect(action.props()).toMatchObject(expectedOrderAfterOverride[index]);
+      });
+    });
+
+    it('renders actions in their initial order when no indexes are set', () => {
       const actionsBeforeOverriddenOrder: ActionMenuProps['actions'] = [
-        actionWithIndex,
         {content: 'mock content 0'},
+        {content: 'mock content 1'},
         {content: 'mock content 2'},
       ];
 
       const expectedOrderAfterOverride = [
         {content: 'mock content 0'},
-        actionWithIndex,
+        {content: 'mock content 1'},
         {content: 'mock content 2'},
       ];
 
@@ -98,6 +141,7 @@ describe('<ActionMenu />', () => {
       {content: 'mock content 1'},
       {content: 'mock content 2'},
     ];
+
     const mockGroups: ActionMenuProps['groups'] = [
       {
         title: 'First group',
@@ -130,7 +174,7 @@ describe('<ActionMenu />', () => {
       );
     });
 
-    it('renders groups at their overriden order when their index is set', () => {
+    it('renders a group at its overriden order when index is set', () => {
       const overrideIndex = 1;
       const groupWithIndex = {
         title: 'group with explicit order in menu',
@@ -149,28 +193,101 @@ describe('<ActionMenu />', () => {
       ).toBe(groupWithIndex.title);
     });
 
-    it('renders groups in their initial order when their index is not set', () => {
-      const overrideIndex = 1;
-      const groupWithIndex = {
-        title: 'group with explicit order in menu',
-        actions: [{content: 'mock content 1'}],
-        index: overrideIndex,
+    it('renders all groups in their overridden order when multiple indexes are set', () => {
+      const overrideIndexZero = {
+        title: 'Mock group 1',
+        actions: [{content: 'mock content'}],
+        index: 0,
       };
 
-      const groupsBeforeOverriddenOrder = [...mockGroups, groupWithIndex];
+      const overrideIndexTwo = {
+        title: 'Mock group 3',
+        actions: [{content: 'mock content'}],
+        index: 2,
+      };
+
+      const overrideIndexThree = {
+        title: 'Mock group 4',
+        actions: [{content: 'mock content'}],
+        index: 3,
+      };
+
+      const groupsWithIndexes = [
+        overrideIndexZero,
+        overrideIndexThree,
+        overrideIndexTwo,
+      ];
+
+      const groups = [...mockGroups, ...groupsWithIndexes];
       const expectedOrderAfterOverride = [
+        overrideIndexZero,
         mockGroups[0],
-        groupWithIndex,
+        overrideIndexTwo,
+        overrideIndexThree,
         mockGroups[1],
       ];
 
-      const wrapper = mountWithAppProvider(
-        <ActionMenu groups={groupsBeforeOverriddenOrder} />,
-      );
+      const wrapper = mountWithAppProvider(<ActionMenu groups={groups} />);
 
       wrapper.find(MenuGroup).forEach((group, index) => {
         expect(group.props()).toMatchObject(expectedOrderAfterOverride[index]);
       });
+    });
+
+    it('renders groups with the same set index consecutively, in order from highest initial index to lowest', () => {
+      const groupsWithIndexes = [
+        {
+          title: 'Mock group 3',
+          actions: [{content: 'mock content'}],
+          index: 0,
+        },
+        {
+          title: 'Mock group 2',
+          actions: [{content: 'mock content'}],
+          index: 0,
+        },
+        {
+          title: 'Mock group 1',
+          actions: [{content: 'mock content'}],
+          index: 0,
+        },
+      ];
+
+      const groups = [...mockGroups, ...groupsWithIndexes];
+      const expectedOrderAfterOverride = [
+        groupsWithIndexes[2],
+        groupsWithIndexes[1],
+        groupsWithIndexes[0],
+        mockGroups[0],
+        mockGroups[1],
+      ];
+
+      const wrapper = mountWithAppProvider(<ActionMenu groups={groups} />);
+
+      wrapper.find(MenuGroup).forEach((group, index) => {
+        expect(group.props()).toMatchObject(expectedOrderAfterOverride[index]);
+      });
+    });
+
+    it('renders groups in their initial order when no indexes are set', () => {
+      const wrapper = mountWithAppProvider(<ActionMenu groups={mockGroups} />);
+
+      wrapper.find(MenuGroup).forEach((group, index) => {
+        expect(group.props()).toMatchObject(mockGroups[index]);
+      });
+    });
+
+    it('only renders a group when it has one or more actions', () => {
+      const groups: MenuGroupDescriptor[] = [
+        {
+          title: 'Mock group 2',
+          actions: [],
+        },
+      ];
+
+      const wrapper = mountWithAppProvider(<ActionMenu groups={groups} />);
+
+      expect(wrapper.find(MenuGroup)).toHaveLength(0);
     });
   });
 

--- a/src/components/ActionMenu/tests/ActionMenu.test.tsx
+++ b/src/components/ActionMenu/tests/ActionMenu.test.tsx
@@ -41,6 +41,56 @@ describe('<ActionMenu />', () => {
         mockActions,
       );
     });
+
+    it('renders actions in their overridden order when their index set', () => {
+      const overrideIndex = 1;
+      const actionWithIndex = {
+        content: 'mock content 1',
+        index: overrideIndex,
+      };
+
+      const actions: ActionMenuProps['actions'] = [
+        actionWithIndex,
+        {content: 'mock content 0'},
+      ];
+
+      const wrapper = mountWithAppProvider(<ActionMenu actions={actions} />);
+
+      expect(
+        wrapper
+          .find(MenuAction)
+          .at(overrideIndex)
+          .prop('content'),
+      ).toBe(actionWithIndex.content);
+    });
+
+    it('renders actions in their initial order when their index is not set', () => {
+      const overrideIndex = 1;
+      const actionWithIndex = {
+        content: 'mock content 1',
+        index: overrideIndex,
+      };
+
+      const actionsBeforeOverriddenOrder: ActionMenuProps['actions'] = [
+        actionWithIndex,
+        {content: 'mock content 0'},
+        {content: 'mock content 2'},
+      ];
+
+      const expectedOrderAfterOverride = [
+        {content: 'mock content 0'},
+        actionWithIndex,
+        {content: 'mock content 2'},
+      ];
+
+      const wrapper = mountWithAppProvider(
+        <ActionMenu actions={actionsBeforeOverriddenOrder} />,
+      );
+
+      wrapper.find(MenuAction).forEach((action, index) => {
+        expect(action.props()).toMatchObject(expectedOrderAfterOverride[index]);
+      });
+    });
   });
 
   describe('groups', () => {
@@ -78,6 +128,49 @@ describe('<ActionMenu />', () => {
       expect(wrapper.find(RollupActions).prop('sections')).toStrictEqual(
         convertedSections,
       );
+    });
+
+    it('renders groups at their overriden order when their index is set', () => {
+      const overrideIndex = 1;
+      const groupWithIndex = {
+        title: 'group with explicit order in menu',
+        actions: [{content: 'mock content 1'}],
+        index: overrideIndex,
+      };
+
+      const groups = [...mockGroups, groupWithIndex];
+      const wrapper = mountWithAppProvider(<ActionMenu groups={groups} />);
+
+      expect(
+        wrapper
+          .find(MenuGroup)
+          .at(overrideIndex)
+          .prop('title'),
+      ).toBe(groupWithIndex.title);
+    });
+
+    it('renders groups in their initial order when their index is not set', () => {
+      const overrideIndex = 1;
+      const groupWithIndex = {
+        title: 'group with explicit order in menu',
+        actions: [{content: 'mock content 1'}],
+        index: overrideIndex,
+      };
+
+      const groupsBeforeOverriddenOrder = [...mockGroups, groupWithIndex];
+      const expectedOrderAfterOverride = [
+        mockGroups[0],
+        groupWithIndex,
+        mockGroups[1],
+      ];
+
+      const wrapper = mountWithAppProvider(
+        <ActionMenu groups={groupsBeforeOverriddenOrder} />,
+      );
+
+      wrapper.find(MenuGroup).forEach((group, index) => {
+        expect(group.props()).toMatchObject(expectedOrderAfterOverride[index]);
+      });
     });
   });
 
@@ -121,7 +214,7 @@ describe('<ActionMenu />', () => {
         },
       ];
       const wrapper = mountWithAppProvider(
-        <ActionMenu {...mockProps} groups={mockGroupsWithoutActions} />,
+        <ActionMenu groups={mockGroupsWithoutActions} />,
       );
 
       expect(wrapper.find(MenuGroup)).toHaveLength(0);

--- a/src/components/ActionMenu/tests/utilities.test.ts
+++ b/src/components/ActionMenu/tests/utilities.test.ts
@@ -1,0 +1,119 @@
+import {sortAndOverrideActionOrder} from '../utilities';
+
+describe('sortAndOverrideActionOrder', () => {
+  it('returns the original actions when no indexes are set', () => {
+    const actions = [
+      {content: 'Duplicate'},
+      {content: 'View on your store'},
+      {
+        title: 'Print',
+        actions: [
+          {content: 'Print shipping label'},
+          {content: 'Add to print queue'},
+        ],
+      },
+      {
+        title: 'Promote',
+        actions: [{content: 'Share on Facebook'}],
+      },
+    ];
+
+    expect(sortAndOverrideActionOrder(actions)).toBe(actions);
+  });
+
+  it('sorts actions with indexes from lowest to highest index', () => {
+    const actions = [
+      {content: 'Duplicate'},
+      {index: 1, content: 'View on your store'},
+      {
+        index: 0,
+        title: 'Print',
+        actions: [
+          {content: 'Print shipping label'},
+          {content: 'Add to print queue'},
+        ],
+      },
+      {
+        title: 'Promote',
+        actions: [{content: 'Share on Facebook'}],
+      },
+    ];
+
+    const expectedActionOrder = [
+      {
+        index: 0,
+        title: 'Print',
+        actions: [
+          {content: 'Print shipping label'},
+          {content: 'Add to print queue'},
+        ],
+      },
+      {index: 1, content: 'View on your store'},
+      {content: 'Duplicate'},
+      {
+        title: 'Promote',
+        actions: [{content: 'Share on Facebook'}],
+      },
+    ];
+
+    sortAndOverrideActionOrder(actions).forEach((action, index) => {
+      expect(action).toMatchObject(expectedActionOrder[index]);
+    });
+  });
+
+  it('returns an action in its overridden order when index is set', () => {
+    const overrideIndex = 1;
+    const actionWithIndex = {
+      content: 'mock content 1',
+      index: overrideIndex,
+    };
+
+    const actions = [actionWithIndex, {content: 'mock content 0'}];
+
+    const expectedActionOrder = [{content: 'mock content 0'}, actionWithIndex];
+
+    sortAndOverrideActionOrder(actions).forEach((action, index) => {
+      expect(action).toMatchObject(expectedActionOrder[index]);
+    });
+  });
+
+  it('returns all actions in their overridden order when multiple indexes are set', () => {
+    const actions = [
+      {content: 'mock content 4', index: 3},
+      {content: 'mock content 1', index: 0},
+      {content: 'mock content 2'},
+      {content: 'mock content 5', index: 4},
+      {content: 'mock content 3'},
+    ];
+
+    const expectedActionOrder = [
+      {content: 'mock content 1', index: 0},
+      {content: 'mock content 2'},
+      {content: 'mock content 3'},
+      {content: 'mock content 4', index: 3},
+      {content: 'mock content 5', index: 4},
+    ];
+
+    sortAndOverrideActionOrder(actions).forEach((action, index) => {
+      expect(action).toMatchObject(expectedActionOrder[index]);
+    });
+  });
+
+  it('returns actions with the same set index consecutively, in order from highest initial index to lowest', () => {
+    const actions = [
+      {content: 'mock content 3', index: 0},
+      {content: 'mock content 2', index: 0},
+      {content: 'mock content 1', index: 0},
+    ];
+
+    const expectedActionOrder = [
+      {content: 'mock content 1', index: 0},
+      {content: 'mock content 2', index: 0},
+      {content: 'mock content 3', index: 0},
+    ];
+
+    sortAndOverrideActionOrder(actions).forEach((action, index) => {
+      expect(action).toMatchObject(expectedActionOrder[index]);
+    });
+  });
+});

--- a/src/components/ActionMenu/utilities.ts
+++ b/src/components/ActionMenu/utilities.ts
@@ -1,0 +1,23 @@
+import {MenuActionDescriptor, MenuGroupDescriptor} from '../../types';
+
+export function sortAndOverrideActionOrder(
+  actions: (MenuActionDescriptor | MenuGroupDescriptor)[],
+) {
+  const sortedActionsWithOverrides = actions
+    .filter((action) => action.index !== undefined)
+    .sort(({index: indexA = 0}, {index: indexB = 0}) => {
+      return indexA - indexB;
+    });
+
+  const overriddenActions: (
+    | MenuActionDescriptor
+    | MenuGroupDescriptor)[] = actions.filter(
+    (action) => action.index === undefined,
+  );
+
+  sortedActionsWithOverrides.forEach((action) => {
+    action.index && overriddenActions.splice(action.index, 0, action);
+  });
+
+  return overriddenActions;
+}

--- a/src/components/ActionMenu/utilities.ts
+++ b/src/components/ActionMenu/utilities.ts
@@ -3,20 +3,32 @@ import {MenuActionDescriptor, MenuGroupDescriptor} from '../../types';
 export function sortAndOverrideActionOrder(
   actions: (MenuActionDescriptor | MenuGroupDescriptor)[],
 ) {
-  const sortedActionsWithOverrides = actions
-    .filter((action) => action.index !== undefined)
-    .sort(({index: indexA = 0}, {index: indexB = 0}) => {
-      return indexA - indexB;
-    });
+  const actionsWithOverrides = actions.filter(
+    (action) => action.index !== undefined,
+  );
 
-  const overriddenActions: (
-    | MenuActionDescriptor
-    | MenuGroupDescriptor)[] = actions.filter(
+  if (actionsWithOverrides.length === 0) {
+    return actions;
+  }
+
+  const sortedActionsWithOverrides = actionsWithOverrides.sort(
+    ({index: indexA = 0}, {index: indexB = 0}) => {
+      return indexA - indexB;
+    },
+  );
+
+  const actionsWithoutOverrides = actions.filter(
     (action) => action.index === undefined,
   );
 
+  const overriddenActions: (MenuActionDescriptor | MenuGroupDescriptor)[] = [
+    ...actionsWithoutOverrides,
+  ];
+
   sortedActionsWithOverrides.forEach((action) => {
-    action.index && overriddenActions.splice(action.index, 0, action);
+    if (action.index !== undefined) {
+      overriddenActions.splice(action.index, 0, action);
+    }
   });
 
   return overriddenActions;

--- a/src/components/ActionMenu/utilities.ts
+++ b/src/components/ActionMenu/utilities.ts
@@ -1,18 +1,22 @@
 import {MenuActionDescriptor, MenuGroupDescriptor} from '../../types';
 
+type MenuDescriptorWithIndex = (MenuActionDescriptor | MenuGroupDescriptor) & {
+  index: number;
+};
+
 export function sortAndOverrideActionOrder(
   actions: (MenuActionDescriptor | MenuGroupDescriptor)[],
 ) {
   const actionsWithOverrides = actions.filter(
     (action) => action.index !== undefined,
-  );
+  ) as MenuDescriptorWithIndex[];
 
   if (actionsWithOverrides.length === 0) {
     return actions;
   }
 
   const sortedActionsWithOverrides = actionsWithOverrides.sort(
-    ({index: indexA = 0}, {index: indexB = 0}) => {
+    ({index: indexA}, {index: indexB}) => {
       return indexA - indexB;
     },
   );
@@ -26,9 +30,7 @@ export function sortAndOverrideActionOrder(
   ];
 
   sortedActionsWithOverrides.forEach((action) => {
-    if (action.index !== undefined) {
-      overriddenActions.splice(action.index, 0, action);
-    }
+    overriddenActions.splice(action.index, 0, action);
   });
 
   return overriddenActions;

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -3,8 +3,8 @@ import {classNames} from '../../../../utilities/css';
 import {buttonsFrom} from '../../../Button';
 import {useMediaQuery} from '../../../../utilities/media-query';
 import {
-  ComplexAction,
   MenuGroupDescriptor,
+  MenuActionDescriptor,
   AppBridgeAction,
   DestructableAction,
   DisableableAction,
@@ -38,7 +38,7 @@ export interface HeaderProps extends TitleProps {
   /** Collection of breadcrumbs */
   breadcrumbs?: BreadcrumbsProps['breadcrumbs'];
   /** Collection of secondary page-level actions */
-  secondaryActions?: ComplexAction[];
+  secondaryActions?: MenuActionDescriptor[];
   /** Collection of page-level groups of secondary actions */
   actionGroups?: MenuGroupDescriptor[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,6 +189,11 @@ export interface ComplexAction
     IconableAction,
     LoadableAction {}
 
+export interface MenuActionDescriptor extends ComplexAction {
+  /** Zero-indexed numerical position. Overrides the menu item order */
+  index?: number;
+}
+
 export interface MenuGroupDescriptor extends BadgeAction {
   /** Menu group title */
   title: string;
@@ -198,6 +203,8 @@ export interface MenuGroupDescriptor extends BadgeAction {
   icon?: IconableAction['icon'];
   /** Action details */
   details?: React.ReactNode;
+  /** Zero-indexed position override of the group's order in the menu */
+  index?: number;
   /** Callback when any action takes place */
   onActionAnyItem?: ActionListItemDescriptor['onAction'];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,7 +190,7 @@ export interface ComplexAction
     LoadableAction {}
 
 export interface MenuActionDescriptor extends ComplexAction {
-  /** Zero-indexed numerical position. Overrides the menu item order */
+  /** Zero-indexed numerical position. Overrides the action's order in the menu */
   index?: number;
 }
 
@@ -203,7 +203,7 @@ export interface MenuGroupDescriptor extends BadgeAction {
   icon?: IconableAction['icon'];
   /** Action details */
   details?: React.ReactNode;
-  /** Zero-indexed position override of the group's order in the menu */
+  /** Zero-indexed numerical position. Overrides the group's order in the menu. */
   index?: number;
   /** Callback when any action takes place */
   onActionAnyItem?: ActionListItemDescriptor['onAction'];


### PR DESCRIPTION
### WHY are these changes introduced?

The Orders team needs to be able to specify the order of their `Page` actions because one of their actions varies from being a `secondaryAction` or an `actionGroup` depending on the status of the order.

### WHAT is this pull request doing?

Adds support for overriding the order of actions in the action menu. 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Thumbnail, Badge} from '../src';

export function Playground() {
  return (
    <Page
      breadcrumbs={[{content: 'Products', url: '/products'}]}
      title="3/4 inch Leather pet collar"
      titleMetadata={<Badge status="success">Paid</Badge>}
      subtitle="Perfect for any pet"
      thumbnail={
        <Thumbnail
          source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
          alt="Black leather pet collar"
        />
      }
      primaryAction={{content: 'Save', disabled: true}}
      secondaryActions={[
        {
          content: 'Duplicate',
          accessibilityLabel: 'Secondary action label',
        },
        {content: 'View on your store'},
      ]}
      actionGroups={[
        {
          index: 0,
          title: 'Promote',
          actions: [
            {
              content: 'Share on Facebook',
              accessibilityLabel: 'Individual action label',
              onAction: () => {},
            },
          ],
        },
      ]}
      pagination={{
        hasPrevious: true,
        hasNext: true,
      }}
      separator
    >
      <p>Page content</p>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
