### PR TITLE
[TextField] Fix type for button

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed `type` for clearButton ([#2060](https://github.com/Shopify/polaris-react/pull/2060))
+
 ### Documentation
 
 - Converted `Form`, `Frame`, and `Loading` examples to functional components ([#2130](https://github.com/Shopify/polaris-react/pull/2130))

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -240,6 +240,7 @@ export function TextField({
   const clearButtonMarkup =
     clearButton && normalizedValue !== '' ? (
       <button
+        type="button"
         testID="clearButton"
         className={styles.ClearButton}
         onClick={handleClearButtonPress}


### PR DESCRIPTION
### WHY are these changes introduced?

The default `type` for button is [`submit`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type), which means whenever you click the clearButton, it will fire `submit` event on the form.

Here's an example [on codesandbox](https://codesandbox.io/s/pensive-grass-t45xl).

### WHAT is this pull request doing?

It sets the type to `button` to fix the bug.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)
