### PR TITLE
Convert a few simple components to use hooks

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,4 +22,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Code quality
 
+- Migrated `ActionMenu.RollupAction`, `Autocomplete`, `Card`, `EmptySearchResult`, `Form`, `SkeletonPage` and `TopBar` to use hooks instead of withAppProvider ([#2065](https://github.com/Shopify/polaris-react/pull/2065))
+
 ### Deprecations

--- a/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
+++ b/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 
 import {ActionListSection, ActionListItemDescriptor} from '../../../../types';
+import {useI18n} from '../../../../utilities/i18n';
+import {useToggle} from '../../../../utilities/use-toggle';
 
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../../../utilities/with-app-provider';
 import {ActionList} from '../../../ActionList';
 import {Button} from '../../../Button';
 import {Popover} from '../../../Popover';
@@ -20,63 +18,40 @@ export interface RollupActionsProps {
   sections?: ActionListSection[];
 }
 
-type ComposedProps = RollupActionsProps & WithAppProviderProps;
+export function RollupActions({items = [], sections = []}: RollupActionsProps) {
+  const i18n = useI18n();
 
-interface State {
-  rollupOpen: boolean;
-}
+  const [rollupOpen, toggleRollupOpen] = useToggle(false);
 
-class RollupActions extends React.PureComponent<ComposedProps, State> {
-  state: State = {
-    rollupOpen: false,
-  };
-
-  render() {
-    const {
-      items = [],
-      sections = [],
-      polaris: {intl},
-    } = this.props;
-    const {rollupOpen} = this.state;
-
-    if (items.length === 0 && sections.length === 0) {
-      return null;
-    }
-
-    const activatorMarkup = (
-      <div className={styles.RollupActivator}>
-        <Button
-          plain
-          icon={HorizontalDotsMinor}
-          accessibilityLabel={intl.translate(
-            'Polaris.ActionMenu.RollupActions.rollupButton',
-          )}
-          onClick={this.handleRollupToggle}
-        />
-      </div>
-    );
-
-    return (
-      <Popover
-        active={rollupOpen}
-        activator={activatorMarkup}
-        preferredAlignment="right"
-        onClose={this.handleRollupToggle}
-      >
-        <ActionList
-          items={items}
-          sections={sections}
-          onActionAnyItem={this.handleRollupToggle}
-        />
-      </Popover>
-    );
+  if (items.length === 0 && sections.length === 0) {
+    return null;
   }
 
-  private handleRollupToggle = () => {
-    this.setState(({rollupOpen}) => ({rollupOpen: !rollupOpen}));
-  };
-}
+  const activatorMarkup = (
+    <div className={styles.RollupActivator}>
+      <Button
+        plain
+        icon={HorizontalDotsMinor}
+        accessibilityLabel={i18n.translate(
+          'Polaris.ActionMenu.RollupActions.rollupButton',
+        )}
+        onClick={toggleRollupOpen}
+      />
+    </div>
+  );
 
-// Use named export once withAppProvider is refactored away
-// eslint-disable-next-line import/no-default-export
-export default withAppProvider<RollupActionsProps>()(RollupActions);
+  return (
+    <Popover
+      active={rollupOpen}
+      activator={activatorMarkup}
+      preferredAlignment="right"
+      onClose={toggleRollupOpen}
+    >
+      <ActionList
+        items={items}
+        sections={sections}
+        onActionAnyItem={toggleRollupOpen}
+      />
+    </Popover>
+  );
+}

--- a/src/components/ActionMenu/components/RollupActions/index.ts
+++ b/src/components/ActionMenu/components/RollupActions/index.ts
@@ -1,3 +1,1 @@
-import RollupActions, {RollupActionsProps} from './RollupActions';
-
-export {RollupActions, RollupActionsProps};
+export {RollupActions, RollupActionsProps} from './RollupActions';

--- a/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
+++ b/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
@@ -11,7 +11,7 @@ import {
   Section as ActionListSection,
 } from '../../../../ActionList/components';
 
-import RollupActions, {RollupActionsProps} from '../RollupActions';
+import {RollupActions, RollupActionsProps} from '../RollupActions';
 
 type Wrapper = ReactWrapper<RollupActionsProps, any>;
 

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 
+import {useI18n} from '../../utilities/i18n';
 import {ActionListItemDescriptor} from '../../types';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
 import {PreferredPosition} from '../PositionedOverlay';
 import {OptionDescriptor} from '../OptionList';
 import {Spinner} from '../Spinner';
@@ -41,64 +38,55 @@ export interface AutocompleteProps {
   onLoadMoreResults?(): void;
 }
 
-type CombinedProps = AutocompleteProps & WithAppProviderProps;
+export function Autocomplete({
+  id,
+  options,
+  selected,
+  textField,
+  preferredPosition,
+  listTitle,
+  allowMultiple,
+  loading,
+  actionBefore,
+  willLoadMoreResults,
+  emptyState,
+  onSelect,
+  onLoadMoreResults,
+}: AutocompleteProps) {
+  const i18n = useI18n();
 
-class Autocomplete extends React.PureComponent<CombinedProps, never> {
-  static TextField = TextField;
-  static ComboBox = ComboBox;
-
-  render() {
-    const {
-      id,
-      options,
-      selected,
-      textField,
-      preferredPosition,
-      listTitle,
-      allowMultiple,
-      loading,
-      actionBefore,
-      willLoadMoreResults,
-      emptyState,
-      onSelect,
-      onLoadMoreResults,
-      polaris: {intl},
-    } = this.props;
-
-    const spinnerMarkup = loading ? (
-      <div className={styles.Loading}>
-        <Spinner
-          size="small"
-          accessibilityLabel={intl.translate(
-            'Polaris.Autocomplete.spinnerAccessibilityLabel',
-          )}
-        />
-      </div>
-    ) : null;
-
-    const conditionalOptions = loading && !willLoadMoreResults ? [] : options;
-    const conditionalAction =
-      actionBefore && actionBefore !== [] ? [actionBefore] : undefined;
-
-    return (
-      <ComboBox
-        id={id}
-        options={conditionalOptions}
-        selected={selected}
-        textField={textField}
-        preferredPosition={preferredPosition}
-        listTitle={listTitle}
-        allowMultiple={allowMultiple}
-        contentAfter={spinnerMarkup}
-        actionsBefore={conditionalAction}
-        onSelect={onSelect}
-        onEndReached={onLoadMoreResults}
-        emptyState={emptyState}
+  const spinnerMarkup = loading ? (
+    <div className={styles.Loading}>
+      <Spinner
+        size="small"
+        accessibilityLabel={i18n.translate(
+          'Polaris.Autocomplete.spinnerAccessibilityLabel',
+        )}
       />
-    );
-  }
+    </div>
+  ) : null;
+
+  const conditionalOptions = loading && !willLoadMoreResults ? [] : options;
+  const conditionalAction =
+    actionBefore && actionBefore !== [] ? [actionBefore] : undefined;
+
+  return (
+    <ComboBox
+      id={id}
+      options={conditionalOptions}
+      selected={selected}
+      textField={textField}
+      preferredPosition={preferredPosition}
+      listTitle={listTitle}
+      allowMultiple={allowMultiple}
+      contentAfter={spinnerMarkup}
+      actionsBefore={conditionalAction}
+      onSelect={onSelect}
+      onEndReached={onLoadMoreResults}
+      emptyState={emptyState}
+    />
+  );
 }
 
-// Use named export once withAppProvider is refactored away
-// eslint-disable-next-line import/no-default-export
-export default withAppProvider<AutocompleteProps>()(Autocomplete);
+Autocomplete.TextField = TextField;
+Autocomplete.ComboBox = ComboBox;

--- a/src/components/Autocomplete/index.ts
+++ b/src/components/Autocomplete/index.ts
@@ -1,3 +1,1 @@
-import Autocomplete, {AutocompleteProps} from './Autocomplete';
-
-export {Autocomplete, AutocompleteProps};
+export {Autocomplete, AutocompleteProps} from './Autocomplete';

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
+import {useI18n} from '../../utilities/i18n';
 import {classNames} from '../../utilities/css';
-
-import {ButtonGroup} from '../ButtonGroup';
+import {useToggle} from '../../utilities/use-toggle';
 import {WithinContentContext} from '../../utilities/within-content-context';
+import {ButtonGroup} from '../ButtonGroup';
 import {DisableableAction, ComplexAction} from '../../types';
 import {ActionList} from '../ActionList';
 import {Button, buttonFrom} from '../Button';
 import {Popover} from '../Popover';
-
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
 
 import {Header, Section, Subsection} from './components';
 import styles from './Card.scss';
@@ -35,99 +31,79 @@ export interface CardProps {
   secondaryFooterActionsDisclosureText?: string;
 }
 
-export type CombinedProps = CardProps & WithAppProviderProps;
+export function Card({
+  children,
+  title,
+  subdued,
+  sectioned,
+  actions,
+  primaryFooterAction,
+  secondaryFooterActions,
+  secondaryFooterActionsDisclosureText,
+}: CardProps) {
+  const i18n = useI18n();
 
-interface State {
-  secondaryFooterActionsPopoverOpen: boolean;
-}
+  const [
+    secondaryActionsPopoverOpen,
+    toggleSecondaryActionsPopoverOpen,
+  ] = useToggle(false);
 
-class Card extends React.PureComponent<CombinedProps, State> {
-  static Section = Section;
-  static Header = Header;
-  static Subsection = Subsection;
+  const className = classNames(styles.Card, subdued && styles.subdued);
 
-  state: State = {
-    secondaryFooterActionsPopoverOpen: false,
-  };
+  const headerMarkup =
+    title || actions ? <Header actions={actions} title={title} /> : null;
 
-  render() {
-    const {
-      children,
-      title,
-      subdued,
-      sectioned,
-      actions,
-      primaryFooterAction,
-      secondaryFooterActions,
-      secondaryFooterActionsDisclosureText,
-      polaris: {intl},
-    } = this.props;
+  const content = sectioned ? <Section>{children}</Section> : children;
 
-    const className = classNames(styles.Card, subdued && styles.subdued);
+  const primaryFooterActionMarkup = primaryFooterAction
+    ? buttonFrom(primaryFooterAction, {primary: true})
+    : null;
 
-    const headerMarkup =
-      title || actions ? <Header actions={actions} title={title} /> : null;
-
-    const content = sectioned ? <Section>{children}</Section> : children;
-
-    const primaryFooterActionMarkup = primaryFooterAction
-      ? buttonFrom(primaryFooterAction, {primary: true})
-      : null;
-
-    let secondaryFooterActionsMarkup = null;
-    if (secondaryFooterActions && secondaryFooterActions.length) {
-      if (secondaryFooterActions.length === 1) {
-        secondaryFooterActionsMarkup = buttonFrom(secondaryFooterActions[0]);
-      } else {
-        secondaryFooterActionsMarkup = (
-          <React.Fragment>
-            <Popover
-              active={this.state.secondaryFooterActionsPopoverOpen}
-              activator={
-                <Button disclosure onClick={this.toggleSecondaryActionsPopover}>
-                  {secondaryFooterActionsDisclosureText ||
-                    intl.translate('Polaris.Common.more')}
-                </Button>
-              }
-              onClose={this.toggleSecondaryActionsPopover}
-            >
-              <ActionList items={secondaryFooterActions} />
-            </Popover>
-          </React.Fragment>
-        );
-      }
+  let secondaryFooterActionsMarkup = null;
+  if (secondaryFooterActions && secondaryFooterActions.length) {
+    if (secondaryFooterActions.length === 1) {
+      secondaryFooterActionsMarkup = buttonFrom(secondaryFooterActions[0]);
+    } else {
+      secondaryFooterActionsMarkup = (
+        <React.Fragment>
+          <Popover
+            active={secondaryActionsPopoverOpen}
+            activator={
+              <Button disclosure onClick={toggleSecondaryActionsPopoverOpen}>
+                {secondaryFooterActionsDisclosureText ||
+                  i18n.translate('Polaris.Common.more')}
+              </Button>
+            }
+            onClose={toggleSecondaryActionsPopoverOpen}
+          >
+            <ActionList items={secondaryFooterActions} />
+          </Popover>
+        </React.Fragment>
+      );
     }
-
-    const footerMarkup =
-      primaryFooterActionMarkup || secondaryFooterActionsMarkup ? (
-        <div className={styles.Footer}>
-          <ButtonGroup>
-            {secondaryFooterActionsMarkup}
-            {primaryFooterActionMarkup}
-          </ButtonGroup>
-        </div>
-      ) : null;
-
-    return (
-      <WithinContentContext.Provider value>
-        <div className={className}>
-          {headerMarkup}
-          {content}
-          {footerMarkup}
-        </div>
-      </WithinContentContext.Provider>
-    );
   }
 
-  private toggleSecondaryActionsPopover = () => {
-    this.setState(({secondaryFooterActionsPopoverOpen}) => {
-      return {
-        secondaryFooterActionsPopoverOpen: !secondaryFooterActionsPopoverOpen,
-      };
-    });
-  };
+  const footerMarkup =
+    primaryFooterActionMarkup || secondaryFooterActionsMarkup ? (
+      <div className={styles.Footer}>
+        <ButtonGroup>
+          {secondaryFooterActionsMarkup}
+          {primaryFooterActionMarkup}
+        </ButtonGroup>
+      </div>
+    ) : null;
+
+  return (
+    <WithinContentContext.Provider value>
+      <div className={className}>
+        {headerMarkup}
+        {content}
+        {footerMarkup}
+      </div>
+    </WithinContentContext.Provider>
+  );
 }
 
-// Use named export once withAppProvider is refactored away
-// eslint-disable-next-line import/no-default-export
-export default withAppProvider<CardProps>()(Card);
+Card.Section = Section;
+Card.Header = Header;
+Card.Subsection = Subsection;

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,3 +1,1 @@
-import Card, {CardProps} from './Card';
-
-export {Card, CardProps};
+export {Card, CardProps} from './Card';

--- a/src/components/EmptySearchResult/EmptySearchResult.tsx
+++ b/src/components/EmptySearchResult/EmptySearchResult.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
+import {useI18n} from '../../utilities/i18n';
 import {DisplayText} from '../DisplayText';
 import {TextStyle} from '../TextStyle';
 import {Image} from '../Image';
@@ -18,40 +15,30 @@ export interface EmptySearchResultProps {
   withIllustration?: boolean;
 }
 
-type CombinedProps = EmptySearchResultProps & WithAppProviderProps;
+export function EmptySearchResult({
+  title,
+  description,
+  withIllustration,
+}: EmptySearchResultProps) {
+  const i18n = useI18n();
+  const altText = i18n.translate('Polaris.EmptySearchResult.altText');
 
-class EmptySearchResult extends React.PureComponent<CombinedProps, never> {
-  render() {
-    const {
-      title,
-      description,
-      withIllustration,
-      polaris: {intl},
-    } = this.props;
+  const descriptionMarkup = description ? <p>{description}</p> : null;
 
-    const altText = intl.translate('Polaris.EmptySearchResult.altText');
+  const illustrationMarkup = withIllustration ? (
+    <Image
+      alt={altText}
+      source={emptySearch}
+      className={styles.Image}
+      draggable={false}
+    />
+  ) : null;
 
-    const descriptionMarkup = description ? <p>{description}</p> : null;
-
-    const illustrationMarkup = withIllustration ? (
-      <Image
-        alt={altText}
-        source={emptySearch}
-        className={styles.Image}
-        draggable={false}
-      />
-    ) : null;
-
-    return (
-      <Stack alignment="center" vertical>
-        {illustrationMarkup}
-        <DisplayText size="small">{title}</DisplayText>
-        <TextStyle variation="subdued">{descriptionMarkup}</TextStyle>
-      </Stack>
-    );
-  }
+  return (
+    <Stack alignment="center" vertical>
+      {illustrationMarkup}
+      <DisplayText size="small">{title}</DisplayText>
+      <TextStyle variation="subdued">{descriptionMarkup}</TextStyle>
+    </Stack>
+  );
 }
-
-// Use named export once withAppProvider is refactored away
-// eslint-disable-next-line import/no-default-export
-export default withAppProvider<EmptySearchResultProps>()(EmptySearchResult);

--- a/src/components/EmptySearchResult/index.ts
+++ b/src/components/EmptySearchResult/index.ts
@@ -1,3 +1,1 @@
-import EmptySearchResult, {EmptySearchResultProps} from './EmptySearchResult';
-
-export {EmptySearchResult, EmptySearchResultProps};
+export {EmptySearchResult, EmptySearchResultProps} from './EmptySearchResult';

--- a/src/components/EmptySearchResult/tests/EmptySearchResult.test.tsx
+++ b/src/components/EmptySearchResult/tests/EmptySearchResult.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {DisplayText, TextStyle} from 'components';
-import EmptySearchResult from '../EmptySearchResult';
+import {EmptySearchResult} from '../EmptySearchResult';
 import {emptySearch} from '../illustrations';
 
 describe('<EmptySearchResult />', () => {

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,10 +1,7 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 
 import {VisuallyHidden} from '../VisuallyHidden';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
+import {useI18n} from '../../utilities/i18n';
 
 export type Enctype =
   | 'application/x-www-form-urlencoded'
@@ -42,61 +39,60 @@ export interface FormProps {
   onSubmit(event: React.FormEvent<HTMLFormElement>): void;
 }
 
-type CombinedProps = FormProps & WithAppProviderProps;
+export function Form({
+  acceptCharset,
+  action,
+  autoComplete,
+  children,
+  encType,
+  implicitSubmit = true,
+  method = 'post',
+  name,
+  noValidate,
+  preventDefault = true,
+  target,
+  onSubmit,
+}: FormProps) {
+  const i18n = useI18n();
 
-class Form extends React.PureComponent<CombinedProps, never> {
-  render() {
-    const {
-      acceptCharset,
-      action,
-      autoComplete,
-      children,
-      encType,
-      implicitSubmit = true,
-      method = 'post',
-      name,
-      noValidate,
-      target,
-      polaris: {intl},
-    } = this.props;
-    const autoCompleteInputs = normalizeAutoComplete(autoComplete);
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      if (!preventDefault) {
+        return;
+      }
 
-    const submitMarkup = implicitSubmit ? (
-      <VisuallyHidden>
-        <button type="submit" aria-hidden="true">
-          {intl.translate('Polaris.Common.submit')}
-        </button>
-      </VisuallyHidden>
-    ) : null;
+      event.preventDefault();
+      onSubmit(event);
+    },
+    [onSubmit, preventDefault],
+  );
 
-    return (
-      <form
-        acceptCharset={acceptCharset}
-        action={action}
-        autoComplete={autoCompleteInputs}
-        encType={encType}
-        method={method}
-        name={name}
-        noValidate={noValidate}
-        target={target}
-        onSubmit={this.handleSubmit}
-      >
-        {children}
-        {submitMarkup}
-      </form>
-    );
-  }
+  const autoCompleteInputs = normalizeAutoComplete(autoComplete);
 
-  private handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    const {preventDefault = true, onSubmit} = this.props;
+  const submitMarkup = implicitSubmit ? (
+    <VisuallyHidden>
+      <button type="submit" aria-hidden="true">
+        {i18n.translate('Polaris.Common.submit')}
+      </button>
+    </VisuallyHidden>
+  ) : null;
 
-    if (!preventDefault) {
-      return;
-    }
-
-    event.preventDefault();
-    onSubmit(event);
-  };
+  return (
+    <form
+      acceptCharset={acceptCharset}
+      action={action}
+      autoComplete={autoCompleteInputs}
+      encType={encType}
+      method={method}
+      name={name}
+      noValidate={noValidate}
+      target={target}
+      onSubmit={handleSubmit}
+    >
+      {children}
+      {submitMarkup}
+    </form>
+  );
 }
 
 function normalizeAutoComplete(autoComplete?: boolean) {
@@ -106,7 +102,3 @@ function normalizeAutoComplete(autoComplete?: boolean) {
 
   return autoComplete ? 'on' : 'off';
 }
-
-// Use named export once withAppProvider is refactored away
-// eslint-disable-next-line import/no-default-export
-export default withAppProvider<FormProps>()(Form);

--- a/src/components/Form/index.ts
+++ b/src/components/Form/index.ts
@@ -1,3 +1,1 @@
-import Form, {FormProps, Enctype, Method, Target} from './Form';
-
-export {Form, FormProps, Enctype, Method, Target};
+export {Form, FormProps, Enctype, Method, Target} from './Form';

--- a/src/components/Form/tests/Form.test.tsx
+++ b/src/components/Form/tests/Form.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
-import Form from '../Form';
+import {Form} from '../Form';
 
 const name = 'form-name';
 const noValidate = true;

--- a/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/src/components/SkeletonPage/SkeletonPage.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
+import {useAppBridge} from '../../utilities/app-bridge';
 import {classNames} from '../../utilities/css';
+import {useI18n} from '../../utilities/i18n';
 import {DisplayText} from '../DisplayText';
 import {SkeletonDisplayText} from '../SkeletonDisplayText';
 import {SkeletonBodyText} from '../SkeletonBodyText';
 
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
 import styles from './SkeletonPage.scss';
 
 export interface SkeletonPageProps {
@@ -34,83 +32,79 @@ interface DeprecatedProps {
   singleColumn?: boolean;
 }
 
-export type CombinedProps = SkeletonPageProps &
-  DeprecatedProps &
-  WithAppProviderProps;
+export type CombinedProps = SkeletonPageProps & DeprecatedProps;
 
-class SkeletonPage extends React.PureComponent<CombinedProps, never> {
-  render() {
-    const {
-      children,
-      fullWidth,
-      narrowWidth,
-      singleColumn,
-      primaryAction,
-      secondaryActions,
-      title = '',
-      breadcrumbs,
-      polaris: {intl},
-    } = this.props;
-
-    if (singleColumn) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Deprecation: The singleColumn prop has been renamed to narrowWidth to better represents its use and will be removed in v5.0.',
-      );
-    }
-
-    const className = classNames(
-      styles.Page,
-      fullWidth && styles.fullWidth,
-      (narrowWidth || singleColumn) && styles.narrowWidth,
-    );
-
-    const headerClassName = classNames(
-      styles.Header,
-      breadcrumbs && styles['Header-hasBreadcrumbs'],
-      secondaryActions && styles['Header-hasSecondaryActions'],
-    );
-
-    const titleMarkup = title !== null ? renderTitle(title) : null;
-
-    const primaryActionMarkup = primaryAction ? (
-      <div className={styles.PrimaryAction}>
-        <SkeletonDisplayText size="large" />
-      </div>
-    ) : null;
-
-    const secondaryActionsMarkup = secondaryActions
-      ? renderSecondaryActions(secondaryActions)
-      : null;
-
-    const breadcrumbMarkup = breadcrumbs ? (
-      <div className={styles.BreadcrumbAction} style={{width: 60}}>
-        <SkeletonBodyText lines={1} />
-      </div>
-    ) : null;
-
-    const headerMarkup = !this.props.polaris.appBridge ? (
-      <div className={headerClassName}>
-        {breadcrumbMarkup}
-        <div className={styles.TitleAndPrimaryAction}>
-          {titleMarkup}
-          {primaryActionMarkup}
-        </div>
-        {secondaryActionsMarkup}
-      </div>
-    ) : null;
-
-    return (
-      <div
-        className={className}
-        role="status"
-        aria-label={intl.translate('Polaris.SkeletonPage.loadingLabel')}
-      >
-        {headerMarkup}
-        <div className={styles.Content}>{children}</div>
-      </div>
+export function SkeletonPage({
+  children,
+  fullWidth,
+  narrowWidth,
+  singleColumn,
+  primaryAction,
+  secondaryActions,
+  title = '',
+  breadcrumbs,
+}: CombinedProps) {
+  if (singleColumn) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Deprecation: The singleColumn prop has been renamed to narrowWidth to better represents its use and will be removed in v5.0.',
     );
   }
+
+  const i18n = useI18n();
+  const appBridge = useAppBridge();
+
+  const className = classNames(
+    styles.Page,
+    fullWidth && styles.fullWidth,
+    (narrowWidth || singleColumn) && styles.narrowWidth,
+  );
+
+  const headerClassName = classNames(
+    styles.Header,
+    breadcrumbs && styles['Header-hasBreadcrumbs'],
+    secondaryActions && styles['Header-hasSecondaryActions'],
+  );
+
+  const titleMarkup = title !== null ? renderTitle(title) : null;
+
+  const primaryActionMarkup = primaryAction ? (
+    <div className={styles.PrimaryAction}>
+      <SkeletonDisplayText size="large" />
+    </div>
+  ) : null;
+
+  const secondaryActionsMarkup = secondaryActions
+    ? renderSecondaryActions(secondaryActions)
+    : null;
+
+  const breadcrumbMarkup = breadcrumbs ? (
+    <div className={styles.BreadcrumbAction} style={{width: 60}}>
+      <SkeletonBodyText lines={1} />
+    </div>
+  ) : null;
+
+  const headerMarkup = !appBridge ? (
+    <div className={headerClassName}>
+      {breadcrumbMarkup}
+      <div className={styles.TitleAndPrimaryAction}>
+        {titleMarkup}
+        {primaryActionMarkup}
+      </div>
+      {secondaryActionsMarkup}
+    </div>
+  ) : null;
+
+  return (
+    <div
+      className={className}
+      role="status"
+      aria-label={i18n.translate('Polaris.SkeletonPage.loadingLabel')}
+    >
+      {headerMarkup}
+      <div className={styles.Content}>{children}</div>
+    </div>
+  );
 }
 
 function renderSecondaryActions(actionCount: number) {
@@ -137,9 +131,3 @@ function renderTitle(title: string) {
     );
   return <div className={styles.Title}>{titleContent}</div>;
 }
-
-// Use named export once withAppProvider is refactored away
-// eslint-disable-next-line import/no-default-export
-export default withAppProvider<SkeletonPageProps & DeprecatedProps>()(
-  SkeletonPage,
-);

--- a/src/components/SkeletonPage/index.ts
+++ b/src/components/SkeletonPage/index.ts
@@ -1,3 +1,1 @@
-import SkeletonPage, {SkeletonPageProps} from './SkeletonPage';
-
-export {SkeletonPage, SkeletonPageProps};
+export {SkeletonPage, SkeletonPageProps} from './SkeletonPage';

--- a/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
+++ b/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
@@ -7,7 +7,7 @@ import {
   DisplayText,
   SkeletonDisplayText,
 } from 'components';
-import SkeletonPage from '../SkeletonPage';
+import {SkeletonPage} from '../SkeletonPage';
 
 describe('<SkeletonPage />', () => {
   it('renders its children', () => {

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -4,7 +4,7 @@ import {classNames} from '../../utilities/css';
 import {getWidth} from '../../utilities/get-width';
 import {useI18n} from '../../utilities/i18n';
 import {useTheme} from '../../utilities/theme';
-import {useForcableToggle} from '../../utilities/use-toggle';
+import {useForcibleToggle} from '../../utilities/use-toggle';
 import {Icon} from '../Icon';
 import {Image} from '../Image';
 import {UnstyledLink} from '../UnstyledLink';
@@ -50,7 +50,7 @@ export function TopBar({
   const [
     focused,
     {forceTrue: forceTrueFocused, forceFalse: forceFalseFocused},
-  ] = useForcableToggle(false);
+  ] = useForcibleToggle(false);
 
   const className = classNames(
     styles.NavigationIcon,

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import {MobileHamburgerMajorMonotone} from '@shopify/polaris-icons';
 import {classNames} from '../../utilities/css';
-
 import {getWidth} from '../../utilities/get-width';
-import {
-  withAppProvider,
-  WithAppProviderProps,
-} from '../../utilities/with-app-provider';
+import {useI18n} from '../../utilities/i18n';
+import {useTheme} from '../../utilities/theme';
+import {useForcableToggle} from '../../utilities/use-toggle';
 import {Icon} from '../Icon';
 import {Image} from '../Image';
 import {UnstyledLink} from '../UnstyledLink';
@@ -35,122 +33,98 @@ export interface TopBarProps {
   onNavigationToggle?(): void;
 }
 
-export type ComposedProps = TopBarProps & WithAppProviderProps;
+export function TopBar({
+  showNavigationToggle,
+  userMenu,
+  searchResults,
+  searchField,
+  secondaryMenu,
+  searchResultsVisible,
+  onNavigationToggle,
+  onSearchResultsDismiss,
+  contextControl,
+}: TopBarProps) {
+  const i18n = useI18n();
+  const {logo} = useTheme();
 
-interface State {
-  focused: boolean;
-}
+  const [
+    focused,
+    {forceTrue: forceTrueFocused, forceFalse: forceFalseFocused},
+  ] = useForcableToggle(false);
 
-class TopBar extends React.PureComponent<ComposedProps, State> {
-  static UserMenu = UserMenu;
-  static SearchField = SearchField;
-  static Menu = Menu;
+  const className = classNames(
+    styles.NavigationIcon,
+    focused && styles.focused,
+  );
 
-  state: State = {
-    focused: false,
-  };
+  const navigationButtonMarkup = showNavigationToggle ? (
+    <button
+      type="button"
+      className={className}
+      onClick={onNavigationToggle}
+      onFocus={forceTrueFocused}
+      onBlur={forceFalseFocused}
+      aria-label={i18n.translate('Polaris.TopBar.toggleMenuLabel')}
+    >
+      <Icon source={MobileHamburgerMajorMonotone} color="white" />
+    </button>
+  ) : null;
 
-  render() {
-    const {
-      showNavigationToggle,
-      userMenu,
-      searchResults,
-      searchField,
-      secondaryMenu,
-      searchResultsVisible,
-      onNavigationToggle,
-      onSearchResultsDismiss,
-      contextControl,
-      polaris: {intl, theme},
-    } = this.props;
-    const logo = theme && theme.logo;
-    const {focused} = this.state;
+  const width = getWidth(logo, 104);
+  let contextMarkup;
 
-    const className = classNames(
-      styles.NavigationIcon,
-      focused && styles.focused,
+  if (contextControl) {
+    contextMarkup = (
+      <div testID="ContextControl" className={styles.ContextControl}>
+        {contextControl}
+      </div>
     );
-
-    const navigationButtonMarkup = showNavigationToggle ? (
-      <button
-        type="button"
-        className={className}
-        onClick={onNavigationToggle}
-        onFocus={this.handleFocus}
-        onBlur={this.handleBlur}
-        aria-label={intl.translate('Polaris.TopBar.toggleMenuLabel')}
-      >
-        <Icon source={MobileHamburgerMajorMonotone} color="white" />
-      </button>
-    ) : null;
-
-    const width = getWidth(logo, 104);
-    let contextMarkup;
-
-    if (contextControl) {
-      contextMarkup = (
-        <div testID="ContextControl" className={styles.ContextControl}>
-          {contextControl}
-        </div>
-      );
-    } else if (logo) {
-      contextMarkup = (
-        <div className={styles.LogoContainer}>
-          <UnstyledLink
-            url={logo.url || ''}
-            className={styles.LogoLink}
-            style={{width}}
-          >
-            <Image
-              source={logo.topBarSource || ''}
-              alt={logo.accessibilityLabel || ''}
-              className={styles.Logo}
-              style={{width}}
-            />
-          </UnstyledLink>
-        </div>
-      );
-    }
-
-    const searchResultsMarkup =
-      searchResults && searchResultsVisible ? (
-        <Search
-          visible={searchResultsVisible}
-          onDismiss={onSearchResultsDismiss}
+  } else if (logo) {
+    contextMarkup = (
+      <div className={styles.LogoContainer}>
+        <UnstyledLink
+          url={logo.url || ''}
+          className={styles.LogoLink}
+          style={{width}}
         >
-          {searchResults}
-        </Search>
-      ) : null;
-
-    const searchMarkup = searchField ? (
-      <React.Fragment>
-        {searchField}
-        {searchResultsMarkup}
-      </React.Fragment>
-    ) : null;
-
-    return (
-      <div className={styles.TopBar}>
-        {navigationButtonMarkup}
-        {contextMarkup}
-        <div className={styles.Contents}>
-          <div className={styles.SearchField}>{searchMarkup}</div>
-          <div className={styles.SecondaryMenu}>{secondaryMenu}</div>
-          {userMenu}
-        </div>
+          <Image
+            source={logo.topBarSource || ''}
+            alt={logo.accessibilityLabel || ''}
+            className={styles.Logo}
+            style={{width}}
+          />
+        </UnstyledLink>
       </div>
     );
   }
 
-  private handleFocus = () => {
-    this.setState({focused: true});
-  };
+  const searchResultsMarkup =
+    searchResults && searchResultsVisible ? (
+      <Search visible={searchResultsVisible} onDismiss={onSearchResultsDismiss}>
+        {searchResults}
+      </Search>
+    ) : null;
 
-  private handleBlur = () => {
-    this.setState({focused: false});
-  };
+  const searchMarkup = searchField ? (
+    <React.Fragment>
+      {searchField}
+      {searchResultsMarkup}
+    </React.Fragment>
+  ) : null;
+
+  return (
+    <div className={styles.TopBar}>
+      {navigationButtonMarkup}
+      {contextMarkup}
+      <div className={styles.Contents}>
+        <div className={styles.SearchField}>{searchMarkup}</div>
+        <div className={styles.SecondaryMenu}>{secondaryMenu}</div>
+        {userMenu}
+      </div>
+    </div>
+  );
 }
 
-// Use named export once withAppProvider is refactored away
-// eslint-disable-next-line import/no-default-export
-export default withAppProvider<TopBarProps>()(TopBar);
+TopBar.UserMenu = UserMenu;
+TopBar.SearchField = SearchField;
+TopBar.Menu = Menu;

--- a/src/components/TopBar/index.ts
+++ b/src/components/TopBar/index.ts
@@ -1,4 +1,2 @@
-import TopBar, {TopBarProps} from './TopBar';
-
-export {TopBar, TopBarProps};
+export {TopBar, TopBarProps} from './TopBar';
 export {UserMenuProps, SearchFieldProps} from './components';

--- a/src/components/TopBar/tests/TopBar.test.tsx
+++ b/src/components/TopBar/tests/TopBar.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {Image, UnstyledLink} from 'components';
-import TopBar from '../TopBar';
+import {TopBar} from '../TopBar';
 import {Menu, SearchField, UserMenu, Search} from '../components';
 
 const actions = [

--- a/src/utilities/use-toggle.ts
+++ b/src/utilities/use-toggle.ts
@@ -1,0 +1,24 @@
+import {useState, useCallback} from 'react';
+
+export function useToggle(initialState: boolean) {
+  const [state, setState] = useState(initialState);
+  const toggle = useCallback(() => setState((state) => !state), []);
+
+  // cast needed to say this returns a two item array with the items in
+  // their specific positions instead of `(typeof state | typeof toggle)[]`
+  return [state, toggle] as [typeof state, typeof toggle];
+}
+
+export function useForcableToggle(initialState: boolean) {
+  const [state, setState] = useState(initialState);
+
+  const toggles = {
+    toggle: useCallback(() => setState((state) => !state), []),
+    forceTrue: useCallback(() => setState(true), []),
+    forceFalse: useCallback(() => setState(false), []),
+  };
+
+  // cast needed to say this returns a two item array with the items in
+  // their specific positions instead of `(typeof state | typeof toggles)[]`
+  return [state, toggles] as [typeof state, typeof toggles];
+}

--- a/src/utilities/use-toggle.ts
+++ b/src/utilities/use-toggle.ts
@@ -9,7 +9,7 @@ export function useToggle(initialState: boolean) {
   return [state, toggle] as [typeof state, typeof toggle];
 }
 
-export function useForcableToggle(initialState: boolean) {
+export function useForcibleToggle(initialState: boolean) {
   const [state, setState] = useState(initialState);
 
   const toggles = {


### PR DESCRIPTION
*This PR is best viewed if you disable whitespace changes, as the hookification saves a level of indentation, which makes it look like i changed EVERYTHING*

### WHY are these changes introduced?

Starting down the path of removing withAppProvider usage into the new world of hooks.
Part of #1995

### WHAT is this pull request doing?

Remove withAppProvider, and use hooks for the following components:

ActionMenu/RollupAction
Autocomplete
Card
EmptySearchResult
Form
SkeletonPage
TopBar


### How to 🎩

- ActionMeni/RollupAction: Confirm ... popover on with Page with action group example at small screen sizes renders and toggles on click
- Autocomplete: Check interactions on any Autocomplete example
- Card: Confirm secondary actions popover still works on Card
- EmptySearchResult: Check `<EmptySearchResult title="Title" description="Description" withIllustration />` renders in playground
- Form: Check any form example
- SkeletonPage: Check and skeleton page example
- Topbar: check navigation visibility toggling works in Frame example at small screen sizes