### PR TITLE
[Avatar] Hookify component

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -52,6 +52,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Migrated `ContextualSaveBar` to use hooks instead of `withAppProvider` ([#2091](https://github.com/Shopify/polaris-react/pull/2091))
 - Migrated `RangeSlider`, `ScrollLock` and `TopBar.SearchField` to use hooks instead of withAppProvider ([#2083](https://github.com/Shopify/polaris-react/pull/2083))
 - Updated `ResourceItem` to no longer rely on withAppProvider ([#2094](https://github.com/Shopify/polaris-react/pull/2094))
-- Migrated `TextField` and `Resizer` to use hooks ([#1997](https://github.com/Shopify/polaris-react/pull/1997));
+- Migrated `TextField` and `Resizer` to use hooks ([#1997](https://github.com/Shopify/polaris-react/pull/1997))
+- Migrated `Avatar` to use hooks instead of withAppProvider ([#2067](https://github.com/Shopify/polaris-react/pull/2067))
 
 ### Deprecations

--- a/src/components/Avatar/index.ts
+++ b/src/components/Avatar/index.ts
@@ -1,3 +1,1 @@
-import Avatar, {AvatarProps} from './Avatar';
-
-export {Avatar, AvatarProps};
+export {Avatar, AvatarProps} from './Avatar';

--- a/src/components/Avatar/tests/Avatar-ssr.test.tsx
+++ b/src/components/Avatar/tests/Avatar-ssr.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
-import {Image} from 'components';
-import Avatar from '../Avatar';
+import {Avatar, Image} from 'components';
 
 jest.mock('../../../utilities/target', () => ({
   get isServer() {

--- a/src/components/Avatar/tests/Avatar.test.tsx
+++ b/src/components/Avatar/tests/Avatar.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
-import {Image} from 'components';
-import Avatar from '../Avatar';
+import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
+import {Avatar, Image} from 'components';
 
 describe('<Avatar />', () => {
   describe('intials', () => {
@@ -45,36 +45,44 @@ describe('<Avatar />', () => {
 
   describe('on Error with Initials', () => {
     it('renders initials if the Image onError prop is triggered and the Intials are provided', () => {
-      const src = 'image/path/';
-      const avatar = mountWithAppProvider(
-        <Avatar size="large" initials="DL" source={src} />,
+      const avatar = mountWithApp(
+        <Avatar size="large" initials="DL" source="image/path/" />,
       );
-      expect(avatar.find('span[role="img"] span svg')).toHaveLength(0);
-      trigger(avatar.find(Image), 'onError');
-      expect(avatar.find('span[role="img"] span svg')).toHaveLength(1);
+
+      expect(avatar).toContainReactComponent(Image);
+      expect(avatar).not.toContainReactComponent('span', {
+        className: 'Initials',
+      });
+
+      avatar.find(Image)!.trigger('onError');
+
+      expect(avatar).not.toContainReactComponent(Image);
+      expect(avatar).toContainReactComponent('span', {
+        className: 'Initials',
+      });
     });
   });
 
   describe('on Error with changed props', () => {
     it('re-renders the image if a the source prop is changed after an error', () => {
-      const src = 'image/path/';
       const workingSrc = 'image/goodPath/';
-      const avatar = mountWithAppProvider(
-        <Avatar size="large" initials="DL" source={src} />,
+      const avatar = mountWithApp(
+        <Avatar size="large" initials="DL" source="image/path/" />,
       );
-      trigger(avatar.find(Image), 'onError');
-      expect(avatar.find(Image)).toHaveLength(0);
+      avatar.find(Image)!.trigger('onError');
+
+      expect(avatar).not.toContainReactComponent(Image);
+
       avatar.setProps({source: workingSrc});
-      const image = avatar.find(Image);
-      expect(image).toHaveLength(1);
+      expect(avatar).toContainReactComponent(Image);
     });
   });
 
   describe('on Load', () => {
     it('safely triggers onLoad', () => {
-      const avatar = mountWithAppProvider(<Avatar source="image/path/" />);
+      const avatar = mountWithApp(<Avatar source="image/path/" />);
       expect(() => {
-        trigger(avatar.find(Image), 'onLoad');
+        avatar.find(Image)!.trigger('onLoad');
       }).not.toThrow();
     });
   });

--- a/tests/build.test.js
+++ b/tests/build.test.js
@@ -134,7 +134,7 @@ describe('build', () => {
         'esnext/components/Avatar/index.js',
         'utf8',
       );
-      expect(contents).toMatch("import Avatar from './Avatar'");
+      expect(contents).toMatch("export { Avatar } from './Avatar'");
     });
 
     it('preserves ES scss imports', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Starting down the path of removing withAppProvider usage into the new world of hooks.
Part of #1995

### WHAT is this pull request doing?

Converts Avatar to use hooks.
Reworks the logic for how we handle falling back to using initials if an image fails to load so it relies on a single `status` state that can be either "pending, errored or loading" rather than two `hasError` and `hasLoading` states.

Use react-testing in some Avatar tests as Enzyme doesn't seem to accurately reflect props chagnes for functional components.

### How to 🎩

Play with the following to investigate how the onError fallback to initials logic behaves:

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';
import {Page, Button, Avatar} from '../src';

export function Playground() {
  const [isUsingValidSource, setIsUsingValidSource] = useState(true);
  const toggle = useCallback(() => {
    setIsUsingValidSource((state) => !state);
  }, []);

  const avatarSource = isUsingValidSource
    ? 'http://placekitten.com/40/40'
    : 'nope';

  return (
    <Page title="Playground">
      <Button onClick={toggle}>Toggle Source</Button>
      <hr />
      <Avatar size="large" initials="DL" source={avatarSource} />
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
