### PR TITLE
Update to latest Prettier and reformat

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Dependency upgrades
 
+- Updated Prettier to v1.18.2 ([#2070](https://github.com/Shopify/polaris-react/pull/2070))
+
 ### Code quality
 
 ### Deprecations

--- a/scripts/readme-update-version.js
+++ b/scripts/readme-update-version.js
@@ -9,12 +9,14 @@ const {semverRegExp, readmes} = require('./utilities');
 const root = resolve(__dirname, '..');
 
 console.log(`🆕 Updating version in ${readmes.join(', ')}...`);
-readmes.map((readme) => resolve(root, readme)).forEach((file) => {
-  writeFileSync(
-    file,
-    readFileSync(file, 'utf8').replace(semverRegExp, newVersion),
-  );
-});
+readmes
+  .map((readme) => resolve(root, readme))
+  .forEach((file) => {
+    writeFileSync(
+      file,
+      readFileSync(file, 'utf8').replace(semverRegExp, newVersion),
+    );
+  });
 
 console.log(`🏃‍♂️ Running \`git add -A ${readmes.join(' ')}\`...`);
 const execOpts = {stdio: 'inherit'};

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -184,15 +184,13 @@ export class ComboBox extends React.PureComponent<ComboBoxProps, State> {
     } = this.props;
     const {comboBoxId, navigableOptions, selectedOptions} = this.state;
 
-    const actionsBeforeMarkup = actionsBefore &&
-      actionsBefore.length > 0 && (
-        <ActionList actionRole="option" items={actionsBefore} />
-      );
+    const actionsBeforeMarkup = actionsBefore && actionsBefore.length > 0 && (
+      <ActionList actionRole="option" items={actionsBefore} />
+    );
 
-    const actionsAfterMarkup = actionsAfter &&
-      actionsAfter.length > 0 && (
-        <ActionList actionRole="option" items={actionsAfter} />
-      );
+    const actionsAfterMarkup = actionsAfter && actionsAfter.length > 0 && (
+      <ActionList actionRole="option" items={actionsAfter} />
+    );
 
     const optionsMarkup = options.length > 0 && (
       <OptionList

--- a/src/components/Choice/Choice.tsx
+++ b/src/components/Choice/Choice.tsx
@@ -54,12 +54,11 @@ export function Choice({
     </div>
   ) : null;
 
-  const errorMarkup = error &&
-    typeof error !== 'boolean' && (
-      <div className={styles.Error}>
-        <InlineError message={error} fieldID={id} />
-      </div>
-    );
+  const errorMarkup = error && typeof error !== 'boolean' && (
+    <div className={styles.Error}>
+      <InlineError message={error} fieldID={id} />
+    </div>
+  );
 
   const descriptionMarkup =
     helpTextMarkup || errorMarkup ? (

--- a/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -18,30 +18,24 @@ export const ContextualSaveBar = React.memo(function ContextualSaveBar({
 }: ContextualSaveBarProps) {
   const {setContextualSaveBar, removeContextualSaveBar} = useFrame();
 
-  React.useEffect(
-    () => {
-      setContextualSaveBar({
-        message,
-        saveAction,
-        discardAction,
-        alignContentFlush,
-      });
-    },
-    [
+  React.useEffect(() => {
+    setContextualSaveBar({
       message,
       saveAction,
       discardAction,
       alignContentFlush,
-      setContextualSaveBar,
-    ],
-  );
+    });
+  }, [
+    message,
+    saveAction,
+    discardAction,
+    alignContentFlush,
+    setContextualSaveBar,
+  ]);
 
-  React.useEffect(
-    () => {
-      return removeContextualSaveBar;
-    },
-    [removeContextualSaveBar],
-  );
+  React.useEffect(() => {
+    return removeContextualSaveBar;
+  }, [removeContextualSaveBar]);
 
   return null;
 });

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -178,9 +178,7 @@ class DropZoneExample extends React.Component {
         <List type="bullet">
           {rejectedFiles.map((file, index) => (
             <List.Item key={index}>
-              {`"${
-                file.name
-              }" is not supported. File type must be .gif, .jpg, .png or .svg.`}
+              {`"${file.name}" is not supported. File type must be .gif, .jpg, .png or .svg.`}
             </List.Item>
           ))}
         </List>

--- a/src/components/Frame/components/CSSAnimation/CSSAnimation.tsx
+++ b/src/components/Frame/components/CSSAnimation/CSSAnimation.tsx
@@ -33,23 +33,17 @@ export function CSSAnimation({
   const isMounted = useRef(false);
   const node = useRef<HTMLDivElement>(null);
 
-  useEffect(
-    () => {
-      if (!isMounted.current) return;
-      transitionStatus === TransitionStatus.Entering &&
-        changeTransitionStatus(TransitionStatus.Entered);
-    },
-    [transitionStatus],
-  );
+  useEffect(() => {
+    if (!isMounted.current) return;
+    transitionStatus === TransitionStatus.Entering &&
+      changeTransitionStatus(TransitionStatus.Entered);
+  }, [transitionStatus]);
 
-  useEffect(
-    () => {
-      if (!isMounted.current) return;
-      inProp && changeTransitionStatus(TransitionStatus.Entering);
-      !inProp && changeTransitionStatus(TransitionStatus.Exiting);
-    },
-    [inProp],
-  );
+  useEffect(() => {
+    if (!isMounted.current) return;
+    inProp && changeTransitionStatus(TransitionStatus.Entering);
+    !inProp && changeTransitionStatus(TransitionStatus.Exiting);
+  }, [inProp]);
 
   useEffect(() => {
     isMounted.current = true;

--- a/src/components/Frame/components/ToastManager/ToastManager.tsx
+++ b/src/components/Frame/components/ToastManager/ToastManager.tsx
@@ -25,32 +25,26 @@ export const ToastManager = memo(function ToastManager({
 }: ToastManagerProps) {
   const toastNodes: React.RefObject<HTMLDivElement>[] = [];
 
-  const updateToasts = useDeepCallback(
-    () => {
-      let targetInPos = 0;
-      toastMessages.forEach((_, index) => {
-        const currentToast = toastNodes[index];
-        if (!currentToast.current) return;
-        targetInPos += currentToast.current.clientHeight;
-        currentToast.current.style.setProperty(
-          '--toast-translate-y-in',
-          `-${targetInPos}px`,
-        );
-        currentToast.current.style.setProperty(
-          '--toast-translate-y-out',
-          `${-targetInPos + 150}px`,
-        );
-      });
-    },
-    [toastMessages, toastNodes],
-  );
+  const updateToasts = useDeepCallback(() => {
+    let targetInPos = 0;
+    toastMessages.forEach((_, index) => {
+      const currentToast = toastNodes[index];
+      if (!currentToast.current) return;
+      targetInPos += currentToast.current.clientHeight;
+      currentToast.current.style.setProperty(
+        '--toast-translate-y-in',
+        `-${targetInPos}px`,
+      );
+      currentToast.current.style.setProperty(
+        '--toast-translate-y-out',
+        `${-targetInPos + 150}px`,
+      );
+    });
+  }, [toastMessages, toastNodes]);
 
-  useDeepEffect(
-    () => {
-      updateToasts();
-    },
-    [toastMessages],
-  );
+  useDeepEffect(() => {
+    updateToasts();
+  }, [toastMessages]);
 
   const toastsMarkup = toastMessages.map((toast, index) => {
     const toastNode = createRef<HTMLDivElement>();

--- a/src/components/Labelled/Labelled.tsx
+++ b/src/components/Labelled/Labelled.tsx
@@ -50,12 +50,11 @@ export function Labelled({
     </div>
   ) : null;
 
-  const errorMarkup = error &&
-    typeof error !== 'boolean' && (
-      <div className={styles.Error}>
-        <InlineError message={error} fieldID={id} />
-      </div>
-    );
+  const errorMarkup = error && typeof error !== 'boolean' && (
+    <div className={styles.Error}>
+      <InlineError message={error} fieldID={id} />
+    </div>
+  );
 
   const labelMarkup = label ? (
     <div className={styles.LabelWrapper}>

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -13,31 +13,28 @@ export const Loading = React.memo(function Loading() {
   const appBridge = useAppBridge();
   const {startLoading, stopLoading} = useFrame();
 
-  useEffect(
-    () => {
+  useEffect(() => {
+    if (appBridge == null) {
+      startLoading();
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Deprecation: Using `Loading` in an embedded app is deprecated and will be removed in v5.0. Use `Loading` from `@shopify/app-bridge-react` instead: https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components/loading',
+      );
+
+      appBridgeLoading.current = AppBridgeLoading.create(appBridge);
+      appBridgeLoading.current.dispatch(AppBridgeLoading.Action.START);
+    }
+
+    return () => {
       if (appBridge == null) {
-        startLoading();
+        stopLoading();
       } else {
-        // eslint-disable-next-line no-console
-        console.warn(
-          'Deprecation: Using `Loading` in an embedded app is deprecated and will be removed in v5.0. Use `Loading` from `@shopify/app-bridge-react` instead: https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components/loading',
-        );
-
-        appBridgeLoading.current = AppBridgeLoading.create(appBridge);
-        appBridgeLoading.current.dispatch(AppBridgeLoading.Action.START);
+        appBridgeLoading.current &&
+          appBridgeLoading.current.dispatch(AppBridgeLoading.Action.STOP);
       }
-
-      return () => {
-        if (appBridge == null) {
-          stopLoading();
-        } else {
-          appBridgeLoading.current &&
-            appBridgeLoading.current.dispatch(AppBridgeLoading.Action.STOP);
-        }
-      };
-    },
-    [appBridge, startLoading, stopLoading],
-  );
+    };
+  }, [appBridge, startLoading, stopLoading]);
 
   return null;
 });

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -88,24 +88,18 @@ export function Item({
   const {location, onNavigationDismiss} = useContext(NavigationContext);
   const [expanded, setExpanded] = useState(false);
 
-  const handleResize = useCallback(
-    () => {
-      if (!navigationBarCollapsed().matches && expanded) {
-        setExpanded(false);
-      }
-    },
-    [expanded],
-  );
+  const handleResize = useCallback(() => {
+    if (!navigationBarCollapsed().matches && expanded) {
+      setExpanded(false);
+    }
+  }, [expanded]);
 
-  useEffect(
-    () => {
-      navigationBarCollapsed().addListener(handleResize);
-      return () => {
-        navigationBarCollapsed().removeListener(handleResize);
-      };
-    },
-    [handleResize],
-  );
+  useEffect(() => {
+    navigationBarCollapsed().addListener(handleResize);
+    return () => {
+      navigationBarCollapsed().removeListener(handleResize);
+    };
+  }, [handleResize]);
 
   const tabIndex = disabled ? -1 : 0;
 

--- a/src/components/Navigation/components/Section/Section.tsx
+++ b/src/components/Navigation/components/Section/Section.tsx
@@ -97,22 +97,21 @@ export class Section extends React.Component<SectionProps, State> {
     const toggleClassName = classNames(styles.Item, styles.RollupToggle);
     const ariaLabel = rollup && (expanded ? rollup.hide : rollup.view);
 
-    const toggleRollup = rollup &&
-      items.length > rollup.after && (
-        <div className={styles.ListItem} key="List Item">
-          <button
-            type="button"
-            className={toggleClassName}
-            onClick={this.toggleViewAll}
-            aria-label={ariaLabel}
-            testID="ToggleViewAll"
-          >
-            <span className={styles.Icon}>
-              <Icon source={HorizontalDotsMinor} />
-            </span>
-          </button>
-        </div>
-      );
+    const toggleRollup = rollup && items.length > rollup.after && (
+      <div className={styles.ListItem} key="List Item">
+        <button
+          type="button"
+          className={toggleClassName}
+          onClick={this.toggleViewAll}
+          aria-label={ariaLabel}
+          testID="ToggleViewAll"
+        >
+          <span className={styles.Icon}>
+            <Icon source={HorizontalDotsMinor} />
+          </span>
+        </button>
+      </div>
+    );
 
     const activeItemIndex = items.findIndex((item: ItemProps) => {
       if (!rollup) {
@@ -148,15 +147,14 @@ export class Section extends React.Component<SectionProps, State> {
 
     const additionalItemsId = createAdditionalItemsId();
 
-    const activeItemsMarkup = rollup &&
-      additionalItems.length > 0 && (
-        <li className={styles.RollupSection}>
-          <Collapsible id={additionalItemsId} open={expanded}>
-            <ul className={styles.List}>{additionalItems}</ul>
-          </Collapsible>
-          {toggleRollup}
-        </li>
-      );
+    const activeItemsMarkup = rollup && additionalItems.length > 0 && (
+      <li className={styles.RollupSection}>
+        <Collapsible id={additionalItemsId} open={expanded}>
+          <ul className={styles.List}>{additionalItems}</ul>
+        </Collapsible>
+        {toggleRollup}
+      </li>
+    );
 
     return (
       <ul className={className}>

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
@@ -61,14 +61,13 @@ export function SingleThumb(props: SingleThumbProps) {
     [`${CSS_VAR_PREFIX}output-factor`]: `${outputFactor}`,
   };
 
-  const outputMarkup = !disabled &&
-    output && (
-      <output htmlFor={id} className={styles.Output}>
-        <div className={styles.OutputBubble}>
-          <span className={styles.OutputText}>{clampedValue}</span>
-        </div>
-      </output>
-    );
+  const outputMarkup = !disabled && output && (
+    <output htmlFor={id} className={styles.Output}>
+      <div className={styles.OutputBubble}>
+        <span className={styles.OutputText}>{clampedValue}</span>
+      </div>
+    </output>
+  );
 
   const prefixMarkup = prefix && <div className={styles.Prefix}>{prefix}</div>;
 

--- a/src/components/ResourceList/components/FilterControl/FilterControl.tsx
+++ b/src/components/ResourceList/components/FilterControl/FilterControl.tsx
@@ -206,11 +206,10 @@ export function FilterControl({
     const {value: appliedFilterValue} = appliedFilter;
 
     if (filter.type === FilterType.Select) {
-      const foundFilterOption = filter.options.find(
-        (option) =>
-          typeof option === 'string'
-            ? option === appliedFilterValue
-            : option.value === appliedFilterValue,
+      const foundFilterOption = filter.options.find((option) =>
+        typeof option === 'string'
+          ? option === appliedFilterValue
+          : option.value === appliedFilterValue,
       );
 
       if (foundFilterOption) {
@@ -222,9 +221,7 @@ export function FilterControl({
 
     if (filter.type === FilterType.DateSelector) {
       if (filter.key === appliedFilter.key) {
-        const filterLabelKey = `Polaris.ResourceList.DateSelector.FilterLabelForValue.${
-          appliedFilter.value
-        }`;
+        const filterLabelKey = `Polaris.ResourceList.DateSelector.FilterLabelForValue.${appliedFilter.value}`;
 
         return intl.translationKeyExists(filterLabelKey)
           ? intl.translate(filterLabelKey)

--- a/src/components/Scrollable/components/ScrollTo/ScrollTo.tsx
+++ b/src/components/Scrollable/components/ScrollTo/ScrollTo.tsx
@@ -6,16 +6,13 @@ export function ScrollTo() {
   const anchorNode = useRef<HTMLAnchorElement>(null);
   const scrollToPosition = useContext(ScrollableContext);
 
-  useEffect(
-    () => {
-      if (!scrollToPosition || !anchorNode.current) {
-        return;
-      }
+  useEffect(() => {
+    if (!scrollToPosition || !anchorNode.current) {
+      return;
+    }
 
-      scrollToPosition(anchorNode.current.offsetTop);
-    },
-    [scrollToPosition],
-  );
+    scrollToPosition(anchorNode.current.offsetTop);
+  }, [scrollToPosition]);
 
   const getUniqueId = createUniqueIDFactory(`ScrollTo`);
   // eslint-disable-next-line jsx-a11y/anchor-is-valid

--- a/src/components/Sheet/Sheet.tsx
+++ b/src/components/Sheet/Sheet.tsx
@@ -70,13 +70,11 @@ export function Sheet({
     [mobile],
   );
 
-  useEffect(
-    () => {
-      handleResize();
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
-  );
+  // eslint-disable react-hooks/exhaustive-deps
+  useEffect(() => {
+    handleResize();
+  }, [handleResize]);
+  // eslint-enable react-hooks/exhaustive-deps
 
   return (
     <Portal idPrefix="sheet">

--- a/src/components/Sheet/Sheet.tsx
+++ b/src/components/Sheet/Sheet.tsx
@@ -70,11 +70,10 @@ export function Sheet({
     [mobile],
   );
 
-  // eslint-disable react-hooks/exhaustive-deps
   useEffect(() => {
     handleResize();
-  }, [handleResize]);
-  // eslint-enable react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Portal idPrefix="sheet">

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,8 +318,8 @@ export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends Array<infer U>
     ? Array<DeepPartial<U>>
     : T[P] extends ReadonlyArray<infer U>
-      ? ReadonlyArray<DeepPartial<U>>
-      : DeepPartial<T[P]>
+    ? ReadonlyArray<DeepPartial<U>>
+    : DeepPartial<T[P]>;
 };
 
 export type Discard<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;

--- a/src/utilities/components.tsx
+++ b/src/utilities/components.tsx
@@ -56,7 +56,7 @@ export function isElementOfType<P>(
 // filtered by passing `predicate`.
 export function elementChildren<T extends React.ReactElement<{}>>(
   children: React.ReactNode,
-  predicate: ((element: T) => boolean) = () => true,
+  predicate: (element: T) => boolean = () => true,
 ): T[] {
   return React.Children.toArray(children).filter(
     (child) => React.isValidElement(child) && predicate(child as T),

--- a/src/utilities/with-app-provider.tsx
+++ b/src/utilities/with-app-provider.tsx
@@ -32,7 +32,7 @@ export function withAppProvider<OwnProps>() {
         appBridge: useAppBridge(),
       };
 
-      return <WrappedComponent {...props as any} polaris={polaris} />;
+      return <WrappedComponent {...(props as any)} polaris={polaris} />;
     };
 
     const FinalComponent = hoistStatics(WithProvider, WrappedComponent);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13936,9 +13936,9 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 prettier@^1.14.3:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
-  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-error@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
### WHY are these changes introduced?

This version of prettier formats hooks a bit more cleanly which is handy
as we're going to be using them a lot


### WHAT is this pull request doing?

Updates to latest prettier, and runs `yarn run format` over the content.
One manual fix to Sheet.tsx had to be applied as prettier's formatting and ignoring the exhaustive-deps check didn't play nice.

## Tophatting

- Check lint/tests pass
- Review code while supressing whitespace-only changes to make it easier to review (a bit over half of this PR is whitespace changes)