### PR TITLE
[Stack] Fix stack item content from overflowing past the container

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixed animation for Modal when being rendered asynchronously ([#2076](https://github.com/Shopify/polaris-react/pull/2076))
 - Updated `TextField` `min` and `max` type from `number` to `number | string` to allow min/max dates ([#1991](https://github.com/Shopify/polaris-react/pull/1991))
+- Fixed item content from overflowing past the container in `Stack` ([#2071](https://github.com/Shopify/polaris-react/pull/2071))
 
 ### Documentation
 

--- a/src/components/Stack/Stack.scss
+++ b/src/components/Stack/Stack.scss
@@ -104,8 +104,7 @@
 }
 
 .Item {
-  flex: 0 0 auto;
-  min-width: 0;
+  flex: 0 1 auto;
 }
 
 .Item-fill {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1707

Content inside a Stack item is overflowing past the container.

![image](https://user-images.githubusercontent.com/22782157/64200460-909b8300-ce5a-11e9-8769-07b0b72e7c24.png)

### WHAT is this pull request doing?

This PR removes the `Item` class.

![image](https://user-images.githubusercontent.com/22782157/64200801-3e0e9680-ce5b-11e9-9cc1-ddeb6ab9bb34.png)

I also tried using `calc(100% - #{spacing($spacing)})` which fixed this specific issue, but according to https://github.com/Shopify/polaris-react/commit/ab23144519d5793e41f0a4933d75f077d972fdae, would reintroduce a bug with Safari.

Another possible solution was to set the `flex shrink` value to 1 (without changing the `min width`), but with multiple items and a smaller container, this caused some overlap:

![image](https://user-images.githubusercontent.com/22782157/64268340-e6793500-cf05-11e9-8aa2-0c5c169ee4a3.png)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Layout, Card, Stack, Button} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Layout>
        <Layout.Section>
          <Card title="Title">
            <Card.Section>
              <Stack wrap={false}>
                <img src="https://s3.amazonaws.com/pix.iemoji.com/images/emoji/apple/ios-12/256/snow-capped-mountain.png" />
                <Stack>
                  <p>Short sentence.</p>
                  <p>
                    Long sentence 1. Long sentence 2. Long sentence 3. Long
                    sentence 4. Long sentence 5. Long sentence 6. Long sentence
                    7. Long sentence 8.
                  </p>
                  <Button>Button</Button>
                </Stack>
              </Stack>
            </Card.Section>
          </Card>
        </Layout.Section>
      </Layout>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers) (Checked Chrome, Safari, Firefox)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
