### PR TITLE
[Modal] Removed inconsistent padding of modal section

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed inconsistent padding of sections in `Modal` ([#2072](https://github.com/Shopify/polaris-react/pull/2072))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Modal/components/Section/Section.scss
+++ b/src/components/Modal/components/Section/Section.scss
@@ -2,11 +2,7 @@
 
 .Section {
   flex: 0 0 auto;
-  padding: spacing() spacing(loose);
-
-  &:first-of-type {
-    padding-top: spacing(loose);
-  }
+  padding: spacing(loose);
 
   &:not(:last-of-type) {
     border-bottom: border();


### PR DESCRIPTION
### Why are these changes introduced?

Fixes #2061 

### What issue is this PR addressing?

The [Modal](https://polaris.shopify.com/components/overlays/modal) component currently has an inconsistent top and bottom spacing in the _section_ subcomponent.

### What is this pull request doing?

This very simple change removes a repeated function call that made the top padding set to the _base_ Polaris token value rather than the correct _loose_ one. Now the top and bottom padding for the section is set to _loose_.

### Before
![image](https://user-images.githubusercontent.com/42747959/64209125-b4b48f80-ce6d-11e9-9e9f-d757a91a9871.png)
![image](https://user-images.githubusercontent.com/42747959/64209226-ecbbd280-ce6d-11e9-8499-0c8e72578fde.png)


### After
![image](https://user-images.githubusercontent.com/42747959/64209153-c5fd9c00-ce6d-11e9-8544-9963df18f3d8.png)
![image](https://user-images.githubusercontent.com/42747959/64209200-de6db680-ce6d-11e9-8ac7-89a5fdc266a6.png)