### PR TITLE
[Frame] Skip to content target / ref

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added skipToContentTarget prop to Frame component ([#2080](https://github.com/Shopify/polaris-react/pull/2080))
+
 ### Bug fixes
 
 - Fixed animation for Modal when being rendered asynchronously ([#2076](https://github.com/Shopify/polaris-react/pull/2076))

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -43,6 +43,8 @@ export interface FrameProps {
    * @default false
    */
   showMobileNavigation?: boolean;
+  /** Accepts a ref to the html anchor element you wish to focus when clicking the skip to content link */
+  skipToContentTarget?: React.RefObject<HTMLAnchorElement>;
   /** A callback function to handle clicking the mobile navigation dismiss button */
   onNavigationDismiss?(): void;
 }
@@ -81,7 +83,8 @@ class Frame extends React.PureComponent<CombinedProps, State> {
   private contextualSaveBar: ContextualSaveBarProps | null;
   private globalRibbonContainer: HTMLDivElement | null = null;
   private navigationNode = createRef<HTMLDivElement>();
-  private skipToMainContentTargetNode = React.createRef<HTMLAnchorElement>();
+  private skipToMainContentTargetNode =
+    this.props.skipToContentTarget || React.createRef<HTMLAnchorElement>();
 
   componentDidMount() {
     this.handleResize();
@@ -112,6 +115,7 @@ class Frame extends React.PureComponent<CombinedProps, State> {
       globalRibbon,
       showMobileNavigation = false,
       polaris: {intl},
+      skipToContentTarget,
     } = this.props;
 
     const navClassName = classNames(
@@ -203,10 +207,14 @@ class Frame extends React.PureComponent<CombinedProps, State> {
       skipFocused && styles.focused,
     );
 
+    const skipTarget = skipToContentTarget
+      ? (skipToContentTarget.current && skipToContentTarget.current.id) || ''
+      : APP_FRAME_MAIN_ANCHOR_TARGET;
+
     const skipMarkup = (
       <div className={skipClassName}>
         <a
-          href={`#${APP_FRAME_MAIN_ANCHOR_TARGET}`}
+          href={`#${skipTarget}`}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           onClick={this.handleClick}
@@ -238,7 +246,7 @@ class Frame extends React.PureComponent<CombinedProps, State> {
         />
       ) : null;
 
-    const skipToMainContentTarget = (
+    const skipToMainContentTarget = skipToContentTarget ? null : (
       // eslint-disable-next-line jsx-a11y/anchor-is-valid
       <a
         id={APP_FRAME_MAIN_ANCHOR_TARGET}

--- a/src/components/Frame/README.md
+++ b/src/components/Frame/README.md
@@ -65,6 +65,8 @@ class FrameExample extends React.Component {
     supportMessage: '',
   };
 
+  skipToContentRef = React.createRef();
+
   render() {
     const {
       showToast,
@@ -183,9 +185,14 @@ class FrameExample extends React.Component {
 
     const loadingMarkup = isLoading ? <Loading /> : null;
 
+    const skipToContentTarget = (
+      <a id="SkipToContentTarget" ref={this.skipToContentRef} tabIndex={-1} />
+    );
+
     const actualPageMarkup = (
       <Page title="Account">
         <Layout>
+          {skipToContentTarget}
           <Layout.AnnotatedSection
             title="Account details"
             description="Jaded Pixel will use this as your account information."
@@ -314,6 +321,7 @@ class FrameExample extends React.Component {
             navigation={navigationMarkup}
             showMobileNavigation={showMobileNavigation}
             onNavigationDismiss={this.toggleState('showMobileNavigation')}
+            skipToContentTarget={this.skipToContentRef}
           >
             {contextualSaveBarMarkup}
             {loadingMarkup}

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -155,6 +155,30 @@ describe('<Frame />', () => {
     expect(mainAnchor.getDOMNode()).toBe(document.activeElement);
   });
 
+  it('sets focus to target element when the skip to content link is clicked', () => {
+    const targetId = 'SkipToContentTarget';
+    const targetRef = React.createRef<HTMLAnchorElement>();
+
+    const skipToContentTarget = (
+      // eslint-disable-next-line jsx-a11y/anchor-is-valid
+      <a id={targetId} ref={targetRef} tabIndex={-1} href="" />
+    );
+
+    const frame = mountWithAppProvider(
+      <Frame skipToContentTarget={targetRef}>{skipToContentTarget}</Frame>,
+    );
+
+    const triggerAnchor = frame.find('a').at(0);
+    const targetAnchor = frame.find(`#${targetId}`);
+    trigger(triggerAnchor, 'onFocus');
+    trigger(triggerAnchor, 'onClick');
+
+    expect(triggerAnchor.getDOMNode().getAttribute('href')).toBe(
+      `#${targetId}`,
+    );
+    expect(targetAnchor.getDOMNode()).toBe(document.activeElement);
+  });
+
   it('renders with a has nav data attribute when nav is passed', () => {
     const navigation = <div />;
     const frame = mountWithAppProvider(<Frame navigation={navigation} />);


### PR DESCRIPTION
### WHY are these changes introduced?

I discovered a problem working on a project for experts.shopify.com. 

We were planning on using a `<Toast />` component for some user feedback but the `<Toast />` component relies on the `<Frame />` component to function. 

The `<Frame />` component adds a skip to content link for a11y purposes that is not configurable and does not work the way we need it to work. 

We already have a skip to content link of our own that places the user past our main navigation to the top of the content area. When we add the frame component to the app we end up with 2 skip to content links (ours that does the thing we want and the one created by the frame that does not function correctly).

Making the skip to content link configurable will allow us to use the Polaris components that rely on the frame component while still providing an accessible skip to content link.

### WHAT is this pull request doing?

Adds a new prop to the `<Frame />` component.

```typescript
/** The RefObject you wish to be focused when clicking the skip to content link */
skipToContentTarget?: React.RefObject<HTMLAnchorElement>;
```

We add a `RefObject` so that on click we can focus the provided `RefObject` and focus the user in the correct place.


<details>
   <summary>[GIF] Skipping to the target element</summary>
   <img src="https://user-images.githubusercontent.com/2581810/64350878-63b8ae80-cfc7-11e9-8368-b364cf07c25b.gif" alt="Description of what the gif shows" />
</details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```tsx
import React from 'react';
import {Page, Frame} from '../src';

export function Playground() {
  const targetId = 'SkipToContentTarget';
  const targetRef = React.createRef<HTMLAnchorElement>();

  const skipToMainContentTarget = (
    // eslint-disable-next-line jsx-a11y/anchor-is-valid
    <a id={targetId} ref={targetRef} tabIndex={-1}>
      Focus target
    </a>
  );

  return (
    <Page title="Playground">
      <Frame skipToContentTargetId={targetId} skipToContentTarget={targetRef}>
        {skipToMainContentTarget}
      </Frame>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
