### PR TITLE
[Content] Update links to headings content guidelines

### DIFF
--- a/src/components/Heading/README.md
+++ b/src/components/Heading/README.md
@@ -48,7 +48,7 @@ Headings should be:
 - Concise and scannable:
   - Use simple, clear language that can be read at a glance
   - Keep headings to single sentence and avoid using punctuation such as periods, commas, or semicolons
-  - Avoid articles (the, a, an) in [microcopy headings](/content/grammar-and-mechanics#headings-and-subheadings) to keep content short and actionable
+  - Avoid articles (the, a, an) in [microcopy headings](/content/actionable-language#headings-and-subheadings) to keep content short and actionable
   - Write in sentence case (first word capitalized, the rest is lowercase)
 
 Microcopy headings should be easy for merchants to scan and understand instantly.
@@ -137,7 +137,7 @@ A clear and consistent heading structure helps merchants who have difficulty wit
 
 Use the `element` prop to determine the specific HTML element that’s output for the heading. The component defaults to a level 2 heading (`<h2>`). Use a different value for the `element` prop if a different heading fits the context better.
 
-Learn more about writing helpful [headings and subheadings](/content/grammar-and-mechanics#section-headings-and-subheadings).
+Learn more about writing helpful [headings and subheadings](/content/actionable-language#section-headings-and-subheadings).
 
 <!-- usageblock -->
 

--- a/src/components/Layout/README.md
+++ b/src/components/Layout/README.md
@@ -49,7 +49,7 @@ Headings should be:
 - Concise and scannable:
   - Use simple, clear language that can be read at a glance
   - Keep to a single sentence and avoid using punctuation such as periods, commas, or semicolons
-  - Avoid articles (the, a, an) in [microcopy headings](/content/grammar-and-mechanics#headings-and-subheadings) to keep content short and actionable
+  - Avoid articles (the, a, an) in [microcopy headings](/content/actionable-language#headings-and-subheadings) to keep content short and actionable
   - Write in sentence case (first word capitalized, the rest is lowercase)
 
 <!-- usagelist -->

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -111,7 +111,7 @@ Titles should be:
 - Concise and scannable:
   - Use simple, clear language that can be read at a glance
   - Keep headings to single sentence and avoid using punctuation such as periods, commas, or semicolons
-  - Avoid articles (the, a, an) in [microcopy headings](/content/grammar-and-mechanics#section-headings-and-subheadings) to keep content short and actionable
+  - Avoid articles (the, a, an) in [microcopy headings](/content/actionable-language#section-headings-and-subheadings) to keep content short and actionable
   - Written in sentence case (first word capitalized, the rest is lowercase)
 
 <!-- usagelist -->

--- a/src/components/Subheading/README.md
+++ b/src/components/Subheading/README.md
@@ -121,7 +121,7 @@ A clear and consistent heading structure helps merchants who have difficulty wit
 
 Use the `element` prop to determine the specific HTML element that’s output for the subheading. The component defaults to a level 3 heading (`<h3>`). Use a different value for the `element` prop if a different subheading fits the context better.
 
-Learn more about writing helpful [headings and subheadings](/content/grammar-and-mechanics#section-headings-and-subheadings).
+Learn more about writing helpful [headings and subheadings](/content/actionable-language#section-headings-and-subheadings).
 
 <!-- usageblock -->
 


### PR DESCRIPTION
This PR updates links to the headings content guidelines which is being moved in this `polaris-styleguide` PR https://github.com/Shopify/polaris-styleguide/pull/2947 

FYI @kaelig 