### PR TITLE
Make links to the style guide point to valid URLs

### DIFF
--- a/src/components/AccountConnection/README.md
+++ b/src/components/AccountConnection/README.md
@@ -173,6 +173,6 @@ class AccountConnectionExample extends React.Component {
 
 <!-- content-for: web -->
 
-See accessibility guidance for the [setting toggle component](/components/actions/setting-toggle) to turn connections on and off.
+See accessibility guidance for the [setting toggle component](https://polaris.shopify.com/components/actions/setting-toggle) to turn connections on and off.
 
 <!-- /content-for-->

--- a/src/components/ActionList/README.md
+++ b/src/components/ActionList/README.md
@@ -15,7 +15,7 @@ keywords:
 
 # Action list
 
-Action lists render a list of actions or selectable options. This component is usually placed inside a [popover container](/components/overlays/popover) to create a dropdown menu or to let merchants select from a list of options.
+Action lists render a list of actions or selectable options. This component is usually placed inside a [popover container](https://polaris.shopify.com/components/overlays/popover) to create a dropdown menu or to let merchants select from a list of options.
 
 ---
 
@@ -324,8 +324,8 @@ class ActionListExample extends React.Component {
 
 ## Related components
 
-- To combine more than one button in a single layout, [use the button group component](/components/actions/button-group)
-- To display a list of related content, [use the list component](/components/lists-and-tables/list)
+- To combine more than one button in a single layout, [use the button group component](https://polaris.shopify.com/components/actions/button-group)
+- To display a list of related content, [use the list component](https://polaris.shopify.com/components/lists-and-tables/list)
 
 ---
 
@@ -351,7 +351,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-Items in an action list are organized as list items (`<li>`) in an unordered list (`<ul>`) and are conveyed as a group of related elements to assistive technology users. Each item is implemented as a [button](/components/actions/button).
+Items in an action list are organized as list items (`<li>`) in an unordered list (`<ul>`) and are conveyed as a group of related elements to assistive technology users. Each item is implemented as a [button](https://polaris.shopify.com/components/actions/button).
 
 ### Keyboard support
 

--- a/src/components/AppProvider/README.md
+++ b/src/components/AppProvider/README.md
@@ -92,7 +92,7 @@ AppProvider works by default without any additional options passed to it.
 
 ### With i18n
 
-With an `i18n`, `AppProvider` will provide these translations to polaris components. See [using translations](/components/structure/app-provider#using-translations)
+With an `i18n`, `AppProvider` will provide these translations to polaris components. See [using translations](https://polaris.shopify.com/components/structure/app-provider#using-translations)
 
 ```jsx
 <AppProvider
@@ -198,7 +198,7 @@ class ProviderLinkExample extends React.Component {
 
 ### With theme
 
-With a `theme`, the app provider component will set light, dark, and text colors for the [top bar](/components/structure/top-bar) component when given a `background` color, as well as a logo for the top bar and [contextual save bar](/components/forms/contextual-save-bar) components.
+With a `theme`, the app provider component will set light, dark, and text colors for the [top bar](https://polaris.shopify.com/components/structure/top-bar) component when given a `background` color, as well as a logo for the top bar and [contextual save bar](https://polaris.shopify.com/components/forms/contextual-save-bar) components.
 
 ```jsx
 class ProviderThemeExample extends React.Component {
@@ -314,7 +314,7 @@ class ProviderThemeExample extends React.Component {
 
 ### With theme using all theme keys
 
-Provide specific keys and corresponding colors to the [top bar](/components/structure/top-bar) component theme for finer control. When giving more than just the `background`, providing all keys is necessary to prevent falling back to default colors.
+Provide specific keys and corresponding colors to the [top bar](https://polaris.shopify.com/components/structure/top-bar) component theme for finer control. When giving more than just the `background`, providing all keys is necessary to prevent falling back to default colors.
 
 ```jsx
 class ProviderThemeExample extends React.Component {

--- a/src/components/Autocomplete/README.md
+++ b/src/components/Autocomplete/README.md
@@ -26,7 +26,7 @@ The autocomplete component should:
 
 ## Content guidelines
 
-The input field for autocomplete should follow the [content guidelines](/components/forms/text-field) for text fields.
+The input field for autocomplete should follow the [content guidelines](https://polaris.shopify.com/components/forms/text-field) for text fields.
 
 ---
 
@@ -520,8 +520,8 @@ class AutocompleteExample extends React.Component {
 
 ## Related components
 
-- For an input field without suggested options, [use the text field component](/components/forms/text-field)
-- For a list of selectable options not linked to an input field, [use the option list component](/components/lists-and-tables/option-list)
+- For an input field without suggested options, [use the text field component](https://polaris.shopify.com/components/forms/text-field)
+- For a list of selectable options not linked to an input field, [use the option list component](https://polaris.shopify.com/components/lists-and-tables/option-list)
 
 ---
 

--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -44,7 +44,7 @@ Avatars should be one of 3 sizes:
 
 ## Content guidelines
 
-Any time you use an image to communicate a concept on Shopify, it’s important to use descriptive [alt text](/content/alternative-text). Doing this is important for [accessibility](/patterns-and-guides/accessibility) because it allows screen readers to describe what’s in the image to people who may not be able to see it.
+Any time you use an image to communicate a concept on Shopify, it’s important to use descriptive [alt text](https://polaris.shopify.com/content/alternative-text). Doing this is important for [accessibility](https://polaris.shopify.com/patterns-and-guides/accessibility) because it allows screen readers to describe what’s in the image to people who may not be able to see it.
 
 For avatars, we recommend using a format that describes what will show in the
 image:
@@ -67,13 +67,13 @@ Use to present an avatar for a merchant, customer, or business.
 
 <!-- content-for: android -->
 
-![Default avatar](/public_images/components/Avatar/android/default@2x.png)
+![Default avatar](https://polaris.shopify.com/public_images/components/Avatar/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default avatar](/public_images/components/Avatar/ios/default@2x.png)
+![Default avatar](https://polaris.shopify.com/public_images/components/Avatar/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -81,7 +81,7 @@ Use to present an avatar for a merchant, customer, or business.
 
 ## Related components
 
-- To show a thumbnail for an object rather than a person or business, [use the thumbnail component](/components/images-and-icons/thumbnail)
+- To show a thumbnail for an object rather than a person or business, [use the thumbnail component](https://polaris.shopify.com/components/images-and-icons/thumbnail)
 
 ---
 

--- a/src/components/Badge/README.md
+++ b/src/components/Badge/README.md
@@ -88,13 +88,13 @@ Use to give a non-critical status update on a piece of information or action.
 
 <!-- content-for: android -->
 
-![Default badge with gray background](/public_images/components/Badge/android/default@2x.png)
+![Default badge with gray background](https://polaris.shopify.com/public_images/components/Badge/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default badge with gray background](/public_images/components/Badge/ios/default@2x.png)
+![Default badge with gray background](https://polaris.shopify.com/public_images/components/Badge/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -108,13 +108,13 @@ Use to call out an object or action as having an important attribute. For exampl
 
 <!-- content-for: android -->
 
-![Informational badge with blue background](/public_images/components/Badge/android/informational@2x.png)
+![Informational badge with blue background](https://polaris.shopify.com/public_images/components/Badge/android/informational@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Informational badge with blue background](/public_images/components/Badge/ios/informational@2x.png)
+![Informational badge with blue background](https://polaris.shopify.com/public_images/components/Badge/ios/informational@2x.png)
 
 <!-- /content-for -->
 
@@ -128,13 +128,13 @@ Use to indicate a successful, completed, or desirable state when it’s importan
 
 <!-- content-for: android -->
 
-![Success badge with green background](/public_images/components/Badge/android/success@2x.png)
+![Success badge with green background](https://polaris.shopify.com/public_images/components/Badge/android/success@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Success badge with green background](/public_images/components/Badge/ios/success@2x.png)
+![Success badge with green background](https://polaris.shopify.com/public_images/components/Badge/ios/success@2x.png)
 
 <!-- /content-for -->
 
@@ -148,13 +148,13 @@ Use when something requires merchants’ attention but the issue isn’t critica
 
 <!-- content-for: android -->
 
-![Attention badge with yellow background](/public_images/components/Badge/android/attention@2x.png)
+![Attention badge with yellow background](https://polaris.shopify.com/public_images/components/Badge/android/attention@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Attention badge with yellow background](/public_images/components/Badge/ios/attention@2x.png)
+![Attention badge with yellow background](https://polaris.shopify.com/public_images/components/Badge/ios/attention@2x.png)
 
 <!-- /content-for -->
 
@@ -170,13 +170,13 @@ Keep in mind that seeing this badge can feel stressful for merchants so it shoul
 
 <!-- content-for: android -->
 
-![Warning badge with orange background](/public_images/components/Badge/android/warning@2x.png)
+![Warning badge with orange background](https://polaris.shopify.com/public_images/components/Badge/android/warning@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Warning badge with orange background](/public_images/components/Badge/ios/warning@2x.png)
+![Warning badge with orange background](https://polaris.shopify.com/public_images/components/Badge/ios/warning@2x.png)
 
 <!-- /content-for -->
 
@@ -190,13 +190,13 @@ Keep in mind that seeing this badge can feel stressful for merchants so it shoul
 
 <!-- content-for: android -->
 
-![Critical badge with red background](/public_images/components/Badge/android/critical@2x.png)
+![Critical badge with red background](https://polaris.shopify.com/public_images/components/Badge/android/critical@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Critical badge with red background](/public_images/components/Badge/ios/critical@2x.png)
+![Critical badge with red background](https://polaris.shopify.com/public_images/components/Badge/ios/critical@2x.png)
 
 <!-- /content-for -->
 
@@ -210,13 +210,13 @@ Use to indicate when a given task has not yet been completed. For example, when 
 
 <!-- content-for: android -->
 
-![Incomplete badge. Default badge with incomplete status](/public_images/components/Badge/android/incomplete@2x.png)
+![Incomplete badge. Default badge with incomplete status](https://polaris.shopify.com/public_images/components/Badge/android/incomplete@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Incomplete badge. Default badge with incomplete status](/public_images/components/Badge/ios/incomplete@2x.png)
+![Incomplete badge. Default badge with incomplete status](https://polaris.shopify.com/public_images/components/Badge/ios/incomplete@2x.png)
 
 <!-- /content-for -->
 
@@ -230,13 +230,13 @@ Use to indicate when a given task has been partially completed. For example, whe
 
 <!-- content-for: android -->
 
-![Partially complete badge. Default badge with partially complete status](/public_images/components/Badge/android/partially-complete@2x.png)
+![Partially complete badge. Default badge with partially complete status](https://polaris.shopify.com/public_images/components/Badge/android/partially-complete@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Partially complete badge. Default badge with partially complete status](/public_images/components/Badge/ios/partially-complete@2x.png)
+![Partially complete badge. Default badge with partially complete status](https://polaris.shopify.com/public_images/components/Badge/ios/partially-complete@2x.png)
 
 <!-- /content-for -->
 
@@ -250,13 +250,13 @@ Use to indicate when a given task has been completed. For example, when merchant
 
 <!-- content-for: android -->
 
-![Complete badge. Default badge with complete status](/public_images/components/Badge/android/complete@2x.png)
+![Complete badge. Default badge with complete status](https://polaris.shopify.com/public_images/components/Badge/android/complete@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Complete badge. Default badge with complete status](/public_images/components/Badge/ios/complete@2x.png)
+![Complete badge. Default badge with complete status](https://polaris.shopify.com/public_images/components/Badge/ios/complete@2x.png)
 
 <!-- /content-for -->
 
@@ -264,7 +264,7 @@ Use to indicate when a given task has been completed. For example, when merchant
 
 ## Related components
 
-- To represent an interactive list of categories provided by merchants, [use tags](/components/forms/tag)
+- To represent an interactive list of categories provided by merchants, [use tags](https://polaris.shopify.com/components/forms/tag)
 
 ---
 
@@ -290,6 +290,6 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-Badges that convey information with icons or color include text provided by the [visually hidden component](/components/titles-and-text/visually-hidden#navigation). This text is read out by assistive technologies like screen readers so that merchants with vision issues can access the meaning of the badge in context.
+Badges that convey information with icons or color include text provided by the [visually hidden component](https://polaris.shopify.com/components/titles-and-text/visually-hidden#navigation). This text is read out by assistive technologies like screen readers so that merchants with vision issues can access the meaning of the badge in context.
 
 <!-- /content-for -->

--- a/src/components/Banner/README.md
+++ b/src/components/Banner/README.md
@@ -54,8 +54,8 @@ Banners should:
 - Be used thoughtfully and sparingly for only the most important information.
 - Not be used as the primary entry point to information or
   actions merchants need on a regular basis.
-- Not be used for marketing information or upsell—[use callout cards](/components/structure/callout-card) instead.
-- Use the default icon for `success`, `info`, `warning` and `critical` statuses. If the icon is changed, use only [major, duotone icons](/design/icons#using-icons-in-your-designs).
+- Not be used for marketing information or upsell—[use callout cards](https://polaris.shopify.com/components/structure/callout-card) instead.
+- Use the default icon for `success`, `info`, `warning` and `critical` statuses. If the icon is changed, use only [major, duotone icons](https://polaris.shopify.com/design/icons#using-icons-in-your-designs).
 
 ---
 
@@ -69,7 +69,7 @@ Banner headings should be:
   - Communicate when a situation is serious enough to warrant using a critical or
     warning banner. People who are unable to see the color of the banner need to
     clearly understand the importance of the situation without the benefit of
-    seeing the color of the banner. Learn more about [accessibility](/patterns-and-guides/accessibility).
+    seeing the color of the banner. Learn more about [accessibility](https://polaris.shopify.com/patterns-and-guides/accessibility).
 
 <!-- usagelist -->
 
@@ -270,13 +270,13 @@ including packaging.
 
 <!-- content-for: android -->
 
-![Default banner for Android](/public_images/components/Banner/android/default@2x.png)
+![Default banner for Android](https://polaris.shopify.com/public_images/components/Banner/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default banner for iOS](/public_images/components/Banner/ios/default@2x.png)
+![Default banner for iOS](https://polaris.shopify.com/public_images/components/Banner/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -315,13 +315,13 @@ Use when you want merchants to take an action after reading the banner.
 
 <!-- content-for: android -->
 
-![Banner with footer call-to-action for Android](/public_images/components/Banner/android/footer-action@2x.png)
+![Banner with footer call-to-action for Android](https://polaris.shopify.com/public_images/components/Banner/android/footer-action@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Banner with footer call-to-action for iOS](/public_images/components/Banner/ios/footer-action@2x.png)
+![Banner with footer call-to-action for iOS](https://polaris.shopify.com/public_images/components/Banner/ios/footer-action@2x.png)
 
 <!-- /content-for -->
 
@@ -342,13 +342,13 @@ Use to update merchants about a change or give them advice.
 
 <!-- content-for: android -->
 
-![Informational banner for Android](/public_images/components/Banner/android/informational@2x.png)
+![Informational banner for Android](https://polaris.shopify.com/public_images/components/Banner/android/informational@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Informational banner for iOS](/public_images/components/Banner/ios/informational@2x.png)
+![Informational banner for iOS](https://polaris.shopify.com/public_images/components/Banner/ios/informational@2x.png)
 
 <!-- /content-for -->
 
@@ -368,13 +368,13 @@ Use to update merchants about a change or give them advice.
 
 <!-- content-for: android -->
 
-![Success banner for Android](/public_images/components/Banner/android/success@2x.png)
+![Success banner for Android](https://polaris.shopify.com/public_images/components/Banner/android/success@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Success banner for iOS](/public_images/components/Banner/ios/success@2x.png)
+![Success banner for iOS](https://polaris.shopify.com/public_images/components/Banner/ios/success@2x.png)
 
 <!-- /content-for -->
 
@@ -400,13 +400,13 @@ Use to update merchants about a change or give them advice.
 
 <!-- content-for: android -->
 
-![Warning banner for Android](/public_images/components/Banner/android/warning@2x.png)
+![Warning banner for Android](https://polaris.shopify.com/public_images/components/Banner/android/warning@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Warning banner for iOS](/public_images/components/Banner/ios/warning@2x.png)
+![Warning banner for iOS](https://polaris.shopify.com/public_images/components/Banner/ios/warning@2x.png)
 
 <!-- /content-for -->
 
@@ -432,13 +432,13 @@ Use to update merchants about a change or give them advice.
 
 <!-- content-for: android -->
 
-![Critical banner for Android](/public_images/components/Banner/android/critical@2x.png)
+![Critical banner for Android](https://polaris.shopify.com/public_images/components/Banner/android/critical@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Critical banner for iOS](/public_images/components/Banner/ios/critical@2x.png)
+![Critical banner for iOS](https://polaris.shopify.com/public_images/components/Banner/ios/critical@2x.png)
 
 <!-- /content-for -->
 
@@ -580,8 +580,8 @@ Banners inside of the navigation render with less spacing and a pared-back desig
 
 ## Related components
 
-- To inform merchants about a new feature or opportunity, [use callout cards](/components/structure/callout-card)
-- To group similar concepts together in the interface, [use a card](/components/structure/card)
+- To inform merchants about a new feature or opportunity, [use callout cards](https://polaris.shopify.com/components/structure/callout-card)
+- To group similar concepts together in the interface, [use a card](https://polaris.shopify.com/components/structure/card)
 
 ---
 
@@ -614,7 +614,7 @@ Banners provide context and assist workflows for merchants with disabilities.
 - All banners have an `aria-live` attribute and are announced by assistive technologies when their content is updated. These announcements can be disabled by using the prop `stopAnnouncements`.
 - Banners use `aria-describedby` to describe their purpose to assistive technologies when they’re announced or receive focus. If a banner has a `title`, then the title content is used for the `aria-describedby`. If the banner doesn’t have a `title`, then all of the banner content is used for the `aria-describedby`.
 - Banner containers have a `tabindex=”0”` and display a visible keyboard focus indicator. Because of this, merchants can discover banners while tabbing through forms or other interactions, and developers can programmatically move focus to banners.
-- Banners use a combination of [icons](/design/icons) and [colors](/design/colors) to show their meaning and level of importance to merchants.
+- Banners use a combination of [icons](https://polaris.shopify.com/design/icons) and [colors](https://polaris.shopify.com/design/colors) to show their meaning and level of importance to merchants.
 
 ### Error notifications in forms
 
@@ -624,9 +624,9 @@ When merchants submit long or complex forms with errors, use a critical banner t
 
 #### Inline errors
 
-Always include [inline error](/components/forms/inline-error) messages for specific form fields so that merchants know what to do in context as they correct their mistakes.
+Always include [inline error](https://polaris.shopify.com/components/forms/inline-error) messages for specific form fields so that merchants know what to do in context as they correct their mistakes.
 
-To learn about creating helpful and accessible error message text, see the guidelines for [error messages](/patterns-and-guides/error-messages).
+To learn about creating helpful and accessible error message text, see the guidelines for [error messages](https://polaris.shopify.com/patterns-and-guides/error-messages).
 
 <!-- usageblock -->
 

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -66,13 +66,13 @@ Used most in the interface. Only use another style if a button requires more or 
 
 <!-- content-for: android -->
 
-![Basic button for Android](/public_images/components/Button/android/basic@2x.png)
+![Basic button for Android](https://polaris.shopify.com/public_images/components/Button/android/basic@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Basic button for iOS](/public_images/components/Button/ios/basic@2x.png)
+![Basic button for iOS](https://polaris.shopify.com/public_images/components/Button/ios/basic@2x.png)
 
 <!-- /content-for -->
 
@@ -110,13 +110,13 @@ Use for less important or less commonly used actions since they’re less promin
 
 <!-- content-for: android -->
 
-![Plain button for Android](/public_images/components/Button/android/plain@2x.png)
+![Plain button for Android](https://polaris.shopify.com/public_images/components/Button/android/plain@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Plain button for iOS](/public_images/components/Button/ios/plain@2x.png)
+![Plain button for iOS](https://polaris.shopify.com/public_images/components/Button/ios/plain@2x.png)
 
 <!-- /content-for -->
 
@@ -149,13 +149,13 @@ Use for actions that will delete merchant data or be otherwise difficult to reco
 
 <!-- content-for: android -->
 
-![Destructive plain button for Android](/public_images/components/Button/android/plain-destructive@2x.png)
+![Destructive plain button for Android](https://polaris.shopify.com/public_images/components/Button/android/plain-destructive@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Destructive plain button for iOS](/public_images/components/Button/ios/plain-destructive@2x.png)
+![Destructive plain button for iOS](https://polaris.shopify.com/public_images/components/Button/ios/plain-destructive@2x.png)
 
 <!-- /content-for -->
 
@@ -169,13 +169,13 @@ Use to highlight the most important actions in any experience. Don’t use more 
 
 <!-- content-for: android -->
 
-![Primary button for Android](/public_images/components/Button/android/primary@2x.png)
+![Primary button for Android](https://polaris.shopify.com/public_images/components/Button/android/primary@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Primary button for iOS](/public_images/components/Button/ios/primary@2x.png)
+![Primary button for iOS](https://polaris.shopify.com/public_images/components/Button/ios/primary@2x.png)
 
 <!-- /content-for -->
 
@@ -189,13 +189,13 @@ Use when the action will delete merchant data or be otherwise difficult to recov
 
 <!-- content-for: android -->
 
-![Destructive basic button for Android](/public_images/components/Button/android/basic-destructive@2x.png)
+![Destructive basic button for Android](https://polaris.shopify.com/public_images/components/Button/android/basic-destructive@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Destructive basic button for iOS](/public_images/components/Button/ios/basic-destructive@2x.png)
+![Destructive basic button for iOS](https://polaris.shopify.com/public_images/components/Button/ios/basic-destructive@2x.png)
 
 <!-- /content-for -->
 
@@ -253,13 +253,13 @@ Use for actions that aren’t currently available. The surrounding interface sho
 
 <!-- content-for: android -->
 
-![Disabled primary button for Android](/public_images/components/Button/android/disabled@2x.png)
+![Disabled primary button for Android](https://polaris.shopify.com/public_images/components/Button/android/disabled@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Disabled primary button for iOS](/public_images/components/Button/ios/disabled@2x.png)
+![Disabled primary button for iOS](https://polaris.shopify.com/public_images/components/Button/ios/disabled@2x.png)
 
 <!-- /content-for -->
 
@@ -277,8 +277,8 @@ Use when a button has been pressed and the associated action is in progress.
 
 ## Related components
 
-- To learn how to combine or lay out multiple buttons, [use the button group component](/components/actions/button-group)
-- To embed an action into a line of text, [use the link component](/components/navigation/link)
+- To learn how to combine or lay out multiple buttons, [use the button group component](https://polaris.shopify.com/components/actions/button-group)
+- To embed an action into a line of text, [use the link component](https://polaris.shopify.com/components/navigation/link)
 
 ---
 
@@ -315,7 +315,7 @@ Buttons can have different states that are visually and programmatically conveye
 
 Merchants generally expect buttons to submit data or take action, and for links to navigate. If navigation is required for the button component, use the `url` prop. The control will output an anchor styled as a button, instead of a button in HTML, to help convey this difference.
 
-For more information on making accessible links, see the [link component](/components/navigation/link).
+For more information on making accessible links, see the [link component](https://polaris.shopify.com/components/navigation/link).
 
 ### Labeling
 
@@ -363,7 +363,7 @@ When you use the button component to create a link to an external resource:
 - Use the `icon` prop to add the `external` icon to the button
 - Use the `accessibilityLabel` prop to include the warning about opening a new tab in the button text for non-visual screen reader users
 
-For more information on making accessible links, see the [link component](/components/navigation/link).
+For more information on making accessible links, see the [link component](https://polaris.shopify.com/components/navigation/link).
 
 <!-- usageblock -->
 

--- a/src/components/ButtonGroup/README.md
+++ b/src/components/ButtonGroup/README.md
@@ -36,7 +36,7 @@ Button group displays multiple related actions stacked or in a horizontal row to
 Button groups should:
 
 - Only use buttons that follow the
-  [best practices outlined in the button component](/components/actions/button#best-practices)
+  [best practices outlined in the button component](https://polaris.shopify.com/components/actions/button#best-practices)
 - Group together calls to action that have a relationship
 - Be used with consideration that too many calls to action can cause merchants
   to be unsure of what to do next
@@ -67,13 +67,13 @@ Use when you have multiple buttons to space them out evenly.
 
 <!-- content-for: android -->
 
-![Alt text](/public_images/components/ButtonGroup/android/default@2x.png)
+![Alt text](https://polaris.shopify.com/public_images/components/ButtonGroup/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Alt text](/public_images/components/ButtonGroup/ios/default@2x.png)
+![Alt text](https://polaris.shopify.com/public_images/components/ButtonGroup/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -91,13 +91,13 @@ Use to emphasize several buttons as a thematically-related set among other contr
 
 <!-- content-for: android -->
 
-![Alt text](/public_images/components/ButtonGroup/android/segmented-button@2x.png)
+![Alt text](https://polaris.shopify.com/public_images/components/ButtonGroup/android/segmented-button@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Alt text](/public_images/components/ButtonGroup/ios/segmented-button@2x.png)
+![Alt text](https://polaris.shopify.com/public_images/components/ButtonGroup/ios/segmented-button@2x.png)
 
 <!-- /content-for -->
 
@@ -105,5 +105,5 @@ Use to emphasize several buttons as a thematically-related set among other contr
 
 ## Related components
 
-- To learn how to use individual buttons, [use the button component](/components/actions/button)
-- To embed an action or navigation into a line of text, [use the link component](/components/navigation/link)
+- To learn how to use individual buttons, [use the button component](https://polaris.shopify.com/components/actions/button)
+- To embed an action or navigation into a line of text, [use the link component](https://polaris.shopify.com/components/navigation/link)

--- a/src/components/CalloutCard/README.md
+++ b/src/components/CalloutCard/README.md
@@ -223,9 +223,9 @@ Make all callout cards dismissible so merchants can get rid of cards about featu
 
 ## Related components
 
-- To group similar concepts and tasks together, [use the card component](/components/structure/card)
-- To create page-level layout, [use the layout component](/components/structure/layout)
-- To explain a feature that merchants haven’t tried yet, [use the empty state component](/components/structure/empty-state)
+- To group similar concepts and tasks together, [use the card component](https://polaris.shopify.com/components/structure/card)
+- To create page-level layout, [use the layout component](https://polaris.shopify.com/components/structure/layout)
+- To explain a feature that merchants haven’t tried yet, [use the empty state component](https://polaris.shopify.com/components/structure/empty-state)
 
 ---
 
@@ -255,6 +255,6 @@ The required `title` prop gives the callout card a level 2 heading (`<h2>`). Thi
 
 Illustrations included in callout cards are implemented as decorative images with empty `alt` attributes (`alt=""` ) so that they’re skipped by screen readers.
 
-Use [actionable language](/content/actionable-language#navigation) to ensure that the purpose of the callout card is clear to all merchants, including those with issues related to reading and language.
+Use [actionable language](https://polaris.shopify.com/content/actionable-language#navigation) to ensure that the purpose of the callout card is clear to all merchants, including those with issues related to reading and language.
 
 <!-- /content-for -->

--- a/src/components/Caption/README.md
+++ b/src/components/Caption/README.md
@@ -42,14 +42,14 @@ Caption text size is smaller than the recommended size for general reading. On w
 
 ### Captions
 
-Captions are primarily used in [data visualizations](/design/data-visualizations). Stick to a few words and don’t use this component for complete sentences or longer content.
+Captions are primarily used in [data visualizations](https://polaris.shopify.com/design/data-visualizations). Stick to a few words and don’t use this component for complete sentences or longer content.
 
 <!-- usagelist -->
 
 #### Do
 
 - Use caption for labelling data visualizations
-  ![Diagram of using captions to label graphs and other data content](/public_images/typography/display-styles/do-use-caption-for-labeling-data-visualizations@2x.png)
+  ![Diagram of using captions to label graphs and other data content](https://polaris.shopify.com/public_images/typography/display-styles/do-use-caption-for-labeling-data-visualizations@2x.png)
 - Received April 21, 2017
 
 #### Don’t
@@ -80,13 +80,13 @@ Use to provide details in situations where content is compact and space is tight
 
 <!-- content-for: android -->
 
-![Default caption](/public_images/components/Caption/android/default@2x.png)
+![Default caption](https://polaris.shopify.com/public_images/components/Caption/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default caption](/public_images/components/Caption/ios/default@2x.png)
+![Default caption](https://polaris.shopify.com/public_images/components/Caption/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -114,6 +114,6 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-Follow best practices for [data visualizations](/design/data-visualizations) to ensure that the purpose of captions is clear to all merchants, including those with issues related to seeing or understanding data and complex information.
+Follow best practices for [data visualizations](https://polaris.shopify.com/design/data-visualizations) to ensure that the purpose of captions is clear to all merchants, including those with issues related to seeing or understanding data and complex information.
 
 <!-- /content-for -->

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -208,13 +208,13 @@ Use when you have a simple message to communicate to merchants that doesn’t re
 
 <!-- content-for: android -->
 
-![Default card with a title and a short body](/public_images/components/Card/android/default@2x.png)
+![Default card with a title and a short body](https://polaris.shopify.com/public_images/components/Card/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default card with a title and a short body](/public_images/components/Card/ios/default@2x.png)
+![Default card with a title and a short body](https://polaris.shopify.com/public_images/components/Card/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -246,13 +246,13 @@ Use for less important card actions, or actions merchants may do before reviewin
 
 <!-- content-for: android -->
 
-![Card with a title (Conditions), a short body and a header action to add a condition](/public_images/components/Card/android/header-actions@2x.png)
+![Card with a title (Conditions), a short body and a header action to add a condition](https://polaris.shopify.com/public_images/components/Card/android/header-actions@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Card with a title (Conditions), a short body and a header action to add a condition](/public_images/components/Card/ios/header-actions@2x.png)
+![Card with a title (Conditions), a short body and a header action to add a condition](https://polaris.shopify.com/public_images/components/Card/ios/header-actions@2x.png)
 
 <!-- /content-for -->
 
@@ -290,13 +290,13 @@ Use footer actions for a card’s most important actions, or actions merchants s
 
 <!-- content-for: android -->
 
-![Card featuring footer actions: add variant, edit options](/public_images/components/Card/android/footer-actions@2x.png)
+![Card featuring footer actions: add variant, edit options](https://polaris.shopify.com/public_images/components/Card/android/footer-actions@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Card featuring footer actions: add variant, edit options](/public_images/components/Card/ios/footer-actions@2x.png)
+![Card featuring footer actions: add variant, edit options](https://polaris.shopify.com/public_images/components/Card/ios/footer-actions@2x.png)
 
 <!-- /content-for -->
 
@@ -390,13 +390,13 @@ Use when you have two related but distinct pieces of information to communicate 
 
 <!-- content-for: android -->
 
-![Shipping costs card with multiple sections: domestic, international](/public_images/components/Card/android/multiple-sections@2x.png)
+![Shipping costs card with multiple sections: domestic, international](https://polaris.shopify.com/public_images/components/Card/android/multiple-sections@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Shipping costs card with multiple sections: domestic, international](/public_images/components/Card/ios/multiple-sections@2x.png)
+![Shipping costs card with multiple sections: domestic, international](https://polaris.shopify.com/public_images/components/Card/ios/multiple-sections@2x.png)
 
 <!-- /content-for -->
 
@@ -497,13 +497,13 @@ Use when a card action applies only to one section and will delete merchant data
 
 <!-- content-for: android -->
 
-![Customer card with multiple titled sections: note, shipping address](/public_images/components/Card/android/multiple-titled-sections@2x.png)
+![Customer card with multiple titled sections: note, shipping address](https://polaris.shopify.com/public_images/components/Card/android/multiple-titled-sections@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Customer card with multiple titled sections: note, shipping address](/public_images/components/Card/ios/multiple-titled-sections@2x.png)
+![Customer card with multiple titled sections: note, shipping address](https://polaris.shopify.com/public_images/components/Card/ios/multiple-titled-sections@2x.png)
 
 <!-- /content-for -->
 
@@ -694,8 +694,8 @@ Use as a broad example that includes most props available to card.
 
 ## Related components
 
-- To create page-level layout, [use the layout component](/components/structure/layout)
-- To highlight a Shopify feature, [use the callout card component](/components/structure/callout-card)
+- To create page-level layout, [use the layout component](https://polaris.shopify.com/components/structure/layout)
+- To highlight a Shopify feature, [use the callout card component](https://polaris.shopify.com/components/structure/callout-card)
 
 ---
 

--- a/src/components/Checkbox/README.md
+++ b/src/components/Checkbox/README.md
@@ -124,13 +124,13 @@ function CheckboxExample() {
 
 <!-- content-for: android -->
 
-![Default checkbox on Android](/public_images/components/Checkbox/android/default@2x.png)
+![Default checkbox on Android](https://polaris.shopify.com/public_images/components/Checkbox/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default checkbox on iOS](/public_images/components/Checkbox/ios/default@2x.png)
+![Default checkbox on iOS](https://polaris.shopify.com/public_images/components/Checkbox/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -138,9 +138,9 @@ function CheckboxExample() {
 
 ## Related components
 
-- To present a list of options where merchants can only make a single choice, [use the radio button component](/components/forms/radio-button)
-- To display a list of related content, [use the choice list component](/components/forms/choice-list)
-- To create an ungrouped list, [use the content list component](/components/lists-and-tables/list)
+- To present a list of options where merchants can only make a single choice, [use the radio button component](https://polaris.shopify.com/components/forms/radio-button)
+- To display a list of related content, [use the choice list component](https://polaris.shopify.com/components/forms/choice-list)
+- To create an ungrouped list, [use the content list component](https://polaris.shopify.com/components/lists-and-tables/list)
 
 ---
 

--- a/src/components/ChoiceList/README.md
+++ b/src/components/ChoiceList/README.md
@@ -208,13 +208,13 @@ class ChoiceListExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Single choice list for Android](/public_images/components/ChoiceList/android/single-choice@2x.png)
+![Single choice list for Android](https://polaris.shopify.com/public_images/components/ChoiceList/android/single-choice@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Single choice list for iOS](/public_images/components/ChoiceList/ios/single-choice@2x.png)
+![Single choice list for iOS](https://polaris.shopify.com/public_images/components/ChoiceList/ios/single-choice@2x.png)
 
 <!-- /content-for -->
 
@@ -254,13 +254,13 @@ class ChoiceListExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Single choice list with error for Android](/public_images/components/ChoiceList/android/single-choice-error@2x.png)
+![Single choice list with error for Android](https://polaris.shopify.com/public_images/components/ChoiceList/android/single-choice-error@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Single choice list with error for iOS](/public_images/components/ChoiceList/ios/single-choice-error@2x.png)
+![Single choice list with error for iOS](https://polaris.shopify.com/public_images/components/ChoiceList/ios/single-choice-error@2x.png)
 
 <!-- /content-for -->
 
@@ -311,13 +311,13 @@ class ChoiceListExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Multi choice list for Android](/public_images/components/ChoiceList/android/multi-choice@2x.png)
+![Multi choice list for Android](https://polaris.shopify.com/public_images/components/ChoiceList/android/multi-choice@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Multi choice list for iOS](/public_images/components/ChoiceList/ios/multi-choice@2x.png)
+![Multi choice list for iOS](https://polaris.shopify.com/public_images/components/ChoiceList/ios/multi-choice@2x.png)
 
 <!-- /content-for -->
 
@@ -435,9 +435,9 @@ class ChoiceListExample extends React.Component {
 
 ## Related components
 
-- To present a long list of radio buttons or when space is constrained, [use the select component](/components/forms/select)
-- To build a group of radio buttons or checkboxes with a custom layout, use the [radio button component](/components/forms/radio-button) or [checkbox component](/components/forms/checkbox)
-- To display a simple, non-interactive list of related content, [use the list component](/components/lists-and-tables/list)
+- To present a long list of radio buttons or when space is constrained, [use the select component](https://polaris.shopify.com/components/forms/select)
+- To build a group of radio buttons or checkboxes with a custom layout, use the [radio button component](https://polaris.shopify.com/components/forms/radio-button) or [checkbox component](https://polaris.shopify.com/components/forms/checkbox)
+- To display a simple, non-interactive list of related content, [use the list component](https://polaris.shopify.com/components/lists-and-tables/list)
 
 ---
 
@@ -463,6 +463,6 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-The choice list component uses the accessibility features of the [checkbox](/components/forms/checkbox) and [radio button](/components/forms/radio-button) components.
+The choice list component uses the accessibility features of the [checkbox](https://polaris.shopify.com/components/forms/checkbox) and [radio button](https://polaris.shopify.com/components/forms/radio-button) components.
 
 <!-- /content-for -->

--- a/src/components/Collapsible/README.md
+++ b/src/components/Collapsible/README.md
@@ -45,7 +45,7 @@ The collapsible component should:
 
 ## Content guidelines
 
-Collapsible containers are cards with expandable and collapsible functionality, and should follow the [content guidelines](/components/structure/card#section-content-guidelines) for cards.
+Collapsible containers are cards with expandable and collapsible functionality, and should follow the [content guidelines](https://polaris.shopify.com/components/structure/card#section-content-guidelines) for cards.
 
 ---
 
@@ -101,13 +101,13 @@ class CollapsibleExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Collapsible on Android](/public_images/components/Collapsible/android/default@2x.png)
+![Collapsible on Android](https://polaris.shopify.com/public_images/components/Collapsible/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Collapsible on iOS](/public_images/components/Collapsible/ios/default@2x.png)
+![Collapsible on iOS](https://polaris.shopify.com/public_images/components/Collapsible/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -115,8 +115,8 @@ class CollapsibleExample extends React.Component {
 
 ## Related components
 
-- To control a collapsible component, use the [button](/components/actions/button) component
-- To put long sections of information in a container that allows for scrolling, [use the scrollable component](/components/behavior/scrollable)
+- To control a collapsible component, use the [button](https://polaris.shopify.com/components/actions/button) component
+- To put long sections of information in a container that allows for scrolling, [use the scrollable component](https://polaris.shopify.com/components/behavior/scrollable)
 
 ---
 
@@ -142,7 +142,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-Use the collapsible component in conjunction with a [button](/components/actions/button). Place the collapsible content immediately after the button that controls it, so merchants with vision or attention issues can easily discover what content is being affected.
+Use the collapsible component in conjunction with a [button](https://polaris.shopify.com/components/actions/button). Place the collapsible content immediately after the button that controls it, so merchants with vision or attention issues can easily discover what content is being affected.
 
 - Use the required `id` prop of the collapsible component to give the content a unique `id` value
 - Use the `ariaExpanded` prop on the button component to add an `aria-expanded` attribute, which conveys the expanded or collapsed state to screen reader users

--- a/src/components/ContextualSaveBar/README.md
+++ b/src/components/ContextualSaveBar/README.md
@@ -19,7 +19,7 @@ The contextual save bar tells merchants their options once they have made change
 
 ## Required components
 
-The contextual save bar component must be wrapped in the [frame](/components/structure/frame) component.
+The contextual save bar component must be wrapped in the [frame](https://polaris.shopify.com/components/structure/frame) component.
 
 ---
 
@@ -36,7 +36,7 @@ The contextual save bar component should:
 - Become visible when a form on the page has unsaved changes
 - Be used to save or discard in-progress changes
 - Provide brief and helpful context on the nature of in-progress changes
-- Save all changes on the page. Avoid scenarios where multiple forms on a single page can be edited at the same time. If specific sections of a page need to be independently editable, use an Edit button to launch a [modal dialog](/components/overlays/modal) for each section where changes can be made and saved.
+- Save all changes on the page. Avoid scenarios where multiple forms on a single page can be edited at the same time. If specific sections of a page need to be independently editable, use an Edit button to launch a [modal dialog](https://polaris.shopify.com/components/overlays/modal) for each section where changes can be made and saved.
 
 ---
 
@@ -216,6 +216,6 @@ repurpose that space to extend the message contents fully to the left side of th
 
 ## Related components
 
-- To wrap your entire application, [use the frame component](/components/structure//frame)
-- To build the outer wrapper of a page, including page title and associated actions, [use the page component](/components/structure/page)
-- To wrap form elements and handle the submission of a form, [use the form component](/components/forms/form)
+- To wrap your entire application, [use the frame component](https://polaris.shopify.com/components/structure//frame)
+- To build the outer wrapper of a page, including page title and associated actions, [use the page component](https://polaris.shopify.com/components/structure/page)
+- To wrap form elements and handle the submission of a form, [use the form component](https://polaris.shopify.com/components/forms/form)

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -392,7 +392,7 @@ Keep decimals consistent. For example, don’t use 3 decimals in one row and 2 i
 
 ## Related components
 
-- To create an actionable list of related items that link to details pages, such as a list of customers, use the [resource list component](/components/lists-and-tables/resource-list).
+- To create an actionable list of related items that link to details pages, such as a list of customers, use the [resource list component](https://polaris.shopify.com/components/lists-and-tables/resource-list).
 
 ---
 
@@ -432,7 +432,7 @@ Use tables for tabular data.
 
 #### Don’t
 
-Use tables for layout. For a table-like layout that doesn’t use table HTML elements, use the [resource list component](/components/lists-and-tables/resource-list).
+Use tables for layout. For a table-like layout that doesn’t use table HTML elements, use the [resource list component](https://polaris.shopify.com/components/lists-and-tables/resource-list).
 
 <!-- end -->
 

--- a/src/components/DatePicker/README.md
+++ b/src/components/DatePicker/README.md
@@ -87,12 +87,12 @@ class DatePickerExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Date picker on Android](/public_images/components/DatePicker/android/default@2x.png)
+![Date picker on Android](https://polaris.shopify.com/public_images/components/DatePicker/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Date picker on iOS](/public_images/components/DatePicker/ios/default@2x.png)
+![Date picker on iOS](https://polaris.shopify.com/public_images/components/DatePicker/ios/default@2x.png)
 
 <!-- /content-for -->

--- a/src/components/DescriptionList/README.md
+++ b/src/components/DescriptionList/README.md
@@ -131,13 +131,13 @@ Use when you need to present merchants with a list of items or terms alongside d
 
 <!-- content-for: android -->
 
-![Description list for Android](/public_images/components/DescriptionList/android/default@2x.png)
+![Description list for Android](https://polaris.shopify.com/public_images/components/DescriptionList/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Description list for iOS](/public_images/components/DescriptionList/ios/default@2x.png)
+![Description list for iOS](https://polaris.shopify.com/public_images/components/DescriptionList/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -145,7 +145,7 @@ Use when you need to present merchants with a list of items or terms alongside d
 
 ## Related components
 
-- To create a list of actions or navigation, [use the action list component](/components/actions/action-list).
+- To create a list of actions or navigation, [use the action list component](https://polaris.shopify.com/components/actions/action-list).
 
 ---
 

--- a/src/components/DisplayText/README.md
+++ b/src/components/DisplayText/README.md
@@ -80,13 +80,13 @@ Use this size sparingly and never multiple times on the same page.
 
 <!-- content-for: android -->
 
-![Extra large display text](/public_images/components/DisplayText/android/extra-large@2x.png)
+![Extra large display text](https://polaris.shopify.com/public_images/components/DisplayText/android/extra-large@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Extra large display text](/public_images/components/DisplayText/ios/extra-large@2x.png)
+![Extra large display text](https://polaris.shopify.com/public_images/components/DisplayText/ios/extra-large@2x.png)
 
 <!-- /content-for -->
 
@@ -110,13 +110,13 @@ Use for display text that’s more important than the small size, but less impor
 
 <!-- content-for: android -->
 
-![Medium and large display text](/public_images/components/DisplayText/android/medium-large@2x.png)
+![Medium and large display text](https://polaris.shopify.com/public_images/components/DisplayText/android/medium-large@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Medium and large display text](/public_images/components/DisplayText/ios/medium-large@2x.png)
+![Medium and large display text](https://polaris.shopify.com/public_images/components/DisplayText/ios/medium-large@2x.png)
 
 <!-- /content-for -->
 
@@ -166,7 +166,7 @@ Use display text to create visual interest along with a meaningful heading struc
 
 #### Don’t
 
-Use display text in place of standard headings. Use the [heading component](/components/titles-and-text/heading) and [subheading component](/components/titles-and-text/subheading) to provide structure.
+Use display text in place of standard headings. Use the [heading component](https://polaris.shopify.com/components/titles-and-text/heading) and [subheading component](https://polaris.shopify.com/components/titles-and-text/subheading) to provide structure.
 
 <!-- end -->
 

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -28,7 +28,7 @@ Drop zones should:
 
 - Inform merchants when the file(s) can’t be uploaded:
   - When possible, use validation errors on drag to detect and explain things like file size limits or file types accepted.
-  - Use the [banner component](/components/feedback-indicators/banner) with a critical status to communicate errors that happen on the server.
+  - Use the [banner component](https://polaris.shopify.com/components/feedback-indicators/banner) with a critical status to communicate errors that happen on the server.
 - Provide feedback once the file(s) have been dropped and uploading begins.
 - For convenience, allow files to be dropped anywhere on the page by enabling `dropOnPage`.
 - Provide a file upload button to allow merchants to select files for upload in a traditional way. Do this by using the `DropZone.FileUpload` subcomponent.
@@ -61,7 +61,7 @@ Server-side upload errors give feedback after file submission.
 
 Upload error messages should:
 
-- Be displayed as a [banner](/components/feedback-indicators/banner) with a critical status
+- Be displayed as a [banner](https://polaris.shopify.com/components/feedback-indicators/banner) with a critical status
 - Show the name of the file(s) that were not uploaded successfully
 - Describe why the file(s) couldn’t be uploaded and what merchants should change to upload their file successfully, as seen below
 
@@ -503,5 +503,5 @@ Use file upload with the drop zone component to let merchants select files for u
 
 ## Related components
 
-- To provide context to upload errors when they occur, use the [banner component](/components/feedback-indicators/banner)
-- To provide feedback during file upload, use the [spinner component](/components/feedback-indicators/spinner)
+- To provide context to upload errors when they occur, use the [banner component](https://polaris.shopify.com/components/feedback-indicators/banner)
+- To provide feedback during file upload, use the [spinner component](https://polaris.shopify.com/components/feedback-indicators/spinner)

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -45,7 +45,7 @@ Empty states should:
 - Be encouraging and never make merchants feel unsuccessful or guilty because
   they haven’t used a product or feature
 - Explain the steps merchants need to take to activate a product or feature
-- Use illustrations thoughtfully as outlined in our [illustration guidelines](/design/illustrations)
+- Use illustrations thoughtfully as outlined in our [illustration guidelines](https://polaris.shopify.com/design/illustrations)
 - Use only one primary call-to-action button
 
 ---
@@ -165,13 +165,13 @@ Use to explain a single feature before merchants have used it.
 
 <!-- content-for: android -->
 
-![Default empty state](/public_images/components/EmptyState/android/default@2x.png)
+![Default empty state](https://polaris.shopify.com/public_images/components/EmptyState/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default empty state](/public_images/components/EmptyState/ios/default@2x.png)
+![Default empty state](https://polaris.shopify.com/public_images/components/EmptyState/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -205,6 +205,6 @@ Use to provide additional but non-critical context for a new product or feature.
 
 ## Related components
 
-- To learn more about illustrations for empty states, [read the illustration guidelines](/design/illustrations)
-- To create page-level layout, [use the layout component](/components/structure/layout)
-- To highlight a Shopify feature, [use the callout card component](/components/structure/callout-card)
+- To learn more about illustrations for empty states, [read the illustration guidelines](https://polaris.shopify.com/design/illustrations)
+- To create page-level layout, [use the layout component](https://polaris.shopify.com/components/structure/layout)
+- To highlight a Shopify feature, [use the callout card component](https://polaris.shopify.com/components/structure/callout-card)

--- a/src/components/ExceptionList/README.md
+++ b/src/components/ExceptionList/README.md
@@ -55,11 +55,11 @@ If placed next to an item in a [resource list](https://polaris.shopify.com/compo
 
 #### Do
 
-- ![Exception list being used inside a resource list item](/public_images/exception-list/do-exception-list@2x.png)
+- ![Exception list being used inside a resource list item](https://polaris.shopify.com/public_images/exception-list/do-exception-list@2x.png)
 
 #### Don’t
 
-- ![Exception list being used in place of a banner](/public_images/exception-list/dont-exception-list@2x.png)
+- ![Exception list being used in place of a banner](https://polaris.shopify.com/public_images/exception-list/dont-exception-list@2x.png)
 
 <!-- end -->
 

--- a/src/components/Filters/README.md
+++ b/src/components/Filters/README.md
@@ -21,7 +21,7 @@ Merchants use filters to:
 - filter by typing into a text field
 - filter by selecting filters or promoted filters
 
-The way that merchants interact with filters depends on the components that you decide to incorporate. In its simplest form, filters includes a text field and a set of filters, which can be displayed in different ways. For example, you could show promoted filters and a More button that opens a [sheet](/components/overlays/sheet) containing more filters. What the filters are and how they’re exposed to merchants is flexible.
+The way that merchants interact with filters depends on the components that you decide to incorporate. In its simplest form, filters includes a text field and a set of filters, which can be displayed in different ways. For example, you could show promoted filters and a More button that opens a [sheet](https://polaris.shopify.com/components/overlays/sheet) containing more filters. What the filters are and how they’re exposed to merchants is flexible.
 
 ---
 

--- a/src/components/FooterHelp/README.md
+++ b/src/components/FooterHelp/README.md
@@ -35,7 +35,7 @@ If you’re a Shopify app developer, footer help could also:
 
 - Provide links to contact information or a support ticketing system
 
-It’s recommended to link your footer help component to [help documentation](/content/help-documentation). Linking directly to your contact information might result in receiving a higher number of emails or calls.
+It’s recommended to link your footer help component to [help documentation](https://polaris.shopify.com/content/help-documentation). Linking directly to your contact information might result in receiving a higher number of emails or calls.
 
 ---
 
@@ -92,6 +92,6 @@ Use to direct merchants to more information related to the product or feature th
 
 ## Related components and documentation
 
-- To learn how to embed a link in a piece of text, [use the link component](/components/link)
-- To learn how to write documentation for an app or theme, [use the the guide on how to write product documentation](/content/help-documentation)
+- To learn how to embed a link in a piece of text, [use the link component](https://polaris.shopify.com/components/link)
+- To learn how to write documentation for an app or theme, [use the the guide on how to write product documentation](https://polaris.shopify.com/content/help-documentation)
 - To learn how to provide support for an app, [use the guide on supporting your app](https://help.shopify.com/en/api/app-store/being-successful-in-the-app-store/supporting-your-app)

--- a/src/components/Form/README.md
+++ b/src/components/Form/README.md
@@ -125,8 +125,8 @@ class FormExample extends React.Component {
 
 ## Related components
 
-- To arrange fields within a form using standard spacing, [use the form layout component](/components/forms/form-layout)
-- To see all of the components that make up a form, [visit the form section](/components/forms/checkbox#navigation) of the component library
+- To arrange fields within a form using standard spacing, [use the form layout component](https://polaris.shopify.com/components/forms/form-layout)
+- To see all of the components that make up a form, [visit the form section](https://polaris.shopify.com/components/forms/checkbox#navigation) of the component library
 
 ---
 

--- a/src/components/FormLayout/README.md
+++ b/src/components/FormLayout/README.md
@@ -128,13 +128,13 @@ Use to stack form fields vertically, which makes them easier to scan and complet
 
 <!-- content-for: android -->
 
-![Default form layout for Android](/public_images/components/FormLayout/android/default@2x.png)
+![Default form layout for Android](https://polaris.shopify.com/public_images/components/FormLayout/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default form layout for iOS](/public_images/components/FormLayout/ios/default@2x.png)
+![Default form layout for iOS](https://polaris.shopify.com/public_images/components/FormLayout/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -157,13 +157,13 @@ Field groups will wrap automatically on smaller screens.
 
 <!-- content-for: android -->
 
-![Form layout with field group for Android](/public_images/components/FormLayout/android/field-group@2x.png)
+![Form layout with field group for Android](https://polaris.shopify.com/public_images/components/FormLayout/android/field-group@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Form layout with field group for iOS](/public_images/components/FormLayout/ios/field-group@2x.png)
+![Form layout with field group for iOS](https://polaris.shopify.com/public_images/components/FormLayout/ios/field-group@2x.png)
 
 <!-- /content-for -->
 
@@ -188,4 +188,4 @@ For very short inputs, the width of the inputs may be reduced in order to fit mo
 
 ## Related components
 
-- To arrange the largest sections of a page, [use the layout component](/components/structure/layout)
+- To arrange the largest sections of a page, [use the layout component](https://polaris.shopify.com/components/structure/layout)

--- a/src/components/Frame/README.md
+++ b/src/components/Frame/README.md
@@ -20,7 +20,7 @@ fullSizeExamples: true
 
 # Frame
 
-The frame component, while not visible in the user interface itself, provides the structure for any non-embedded application. It wraps the main elements and houses the primary [navigation](/components/navigation/navigation), [top bar](/components/structure/top-bar), [toast](/components/feedback-indicators/toast), and [contextual save bar](/components/forms/contextual-save-bar) components.
+The frame component, while not visible in the user interface itself, provides the structure for any non-embedded application. It wraps the main elements and houses the primary [navigation](https://polaris.shopify.com/components/navigation/navigation), [top bar](https://polaris.shopify.com/components/structure/top-bar), [toast](https://polaris.shopify.com/components/feedback-indicators/toast), and [contextual save bar](https://polaris.shopify.com/components/forms/contextual-save-bar) components.
 
 ---
 
@@ -28,11 +28,11 @@ The frame component, while not visible in the user interface itself, provides th
 
 For the best experience when creating an application frame, use the following components:
 
-- [Top bar](/components/structure/top-bar)
-- [Navigation](/components/navigation/navigation)
-- [Contextual save bar](/components/forms/contextual-save-bar)
-- [Toast](/components/feedback-indicators/toast)
-- [Loading](/components/feedback-indicators/loading)
+- [Top bar](https://polaris.shopify.com/components/structure/top-bar)
+- [Navigation](https://polaris.shopify.com/components/navigation/navigation)
+- [Contextual save bar](https://polaris.shopify.com/components/forms/contextual-save-bar)
+- [Toast](https://polaris.shopify.com/components/feedback-indicators/toast)
+- [Loading](https://polaris.shopify.com/components/feedback-indicators/loading)
 
 ---
 
@@ -397,8 +397,8 @@ class FrameExample extends React.Component {
 
 ## Related components
 
-- To display the navigation component on small screens, to provide search and a user menu, or to style the [frame](/components/structure/frame) component to reflect an application’s brand, use the [top bar](/components/structure/top-bar) component.
-- To display the primary navigation within the frame of a non-embedded application, use the [navigation](/components/structure/navigation) component.
-- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](/components/forms/contextual-save-bar) component.
-- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](/components/feedback-indicators/toast) component.
-- To indicate to merchants that a page is loading or an upload is processing use the [loading](/components/feedback-indicators/loading) component.
+- To display the navigation component on small screens, to provide search and a user menu, or to style the [frame](https://polaris.shopify.com/components/structure/frame) component to reflect an application’s brand, use the [top bar](https://polaris.shopify.com/components/structure/top-bar) component.
+- To display the primary navigation within the frame of a non-embedded application, use the [navigation](https://polaris.shopify.com/components/structure/navigation) component.
+- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/forms/contextual-save-bar) component.
+- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/feedback-indicators/toast) component.
+- To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/feedback-indicators/loading) component.

--- a/src/components/Heading/README.md
+++ b/src/components/Heading/README.md
@@ -23,7 +23,7 @@ keywords:
 
 # Heading
 
-Headings are used as the titles of each major section of a page in the interface. For example, [card components](/components/card) generally use headings as their title.
+Headings are used as the titles of each major section of a page in the interface. For example, [card components](https://polaris.shopify.com/components/card) generally use headings as their title.
 
 ---
 
@@ -48,7 +48,7 @@ Headings should be:
 - Concise and scannable:
   - Use simple, clear language that can be read at a glance
   - Keep headings to single sentence and avoid using punctuation such as periods, commas, or semicolons
-  - Avoid articles (the, a, an) in [microcopy headings](/content/actionable-language#headings-and-subheadings) to keep content short and actionable
+  - Avoid articles (the, a, an) in [microcopy headings](https://polaris.shopify.com/content/actionable-language#headings-and-subheadings) to keep content short and actionable
   - Write in sentence case (first word capitalized, the rest is lowercase)
 
 Microcopy headings should be easy for merchants to scan and understand instantly.
@@ -93,13 +93,13 @@ Use for the title of each top-level page section.
 
 <!-- content-for: android -->
 
-![Typographic heading](/public_images/components/Heading/android/default@2x.png)
+![Typographic heading](https://polaris.shopify.com/public_images/components/Heading/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Typographic heading](/public_images/components/Heading/ios/default@2x.png)
+![Typographic heading](https://polaris.shopify.com/public_images/components/Heading/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -107,7 +107,7 @@ Use for the title of each top-level page section.
 
 ## Related components
 
-- To break up a section with a heading into sub-sections, [use the subheading component](/components/subheading)
+- To break up a section with a heading into sub-sections, [use the subheading component](https://polaris.shopify.com/components/subheading)
 
 ---
 
@@ -137,7 +137,7 @@ A clear and consistent heading structure helps merchants who have difficulty wit
 
 Use the `element` prop to determine the specific HTML element that’s output for the heading. The component defaults to a level 2 heading (`<h2>`). Use a different value for the `element` prop if a different heading fits the context better.
 
-Learn more about writing helpful [headings and subheadings](/content/actionable-language#section-headings-and-subheadings).
+Learn more about writing helpful [headings and subheadings](https://polaris.shopify.com/content/actionable-language#section-headings-and-subheadings).
 
 <!-- usageblock -->
 

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -73,7 +73,7 @@ If the icon appears without text, then use the `accessibilityLabel` prop to give
 
 - Pair text and icons for clarity
 - Give the icon a text equivalent if its purpose isn’t conveyed in another way
-- Review our [alternative text](/content/alternative-text) guidelines to make sure your use of icon works for all merchants
+- Review our [alternative text](https://polaris.shopify.com/content/alternative-text) guidelines to make sure your use of icon works for all merchants
 
 ```jsx
 <Icon source={OrdersMajorTwotone} />
@@ -105,6 +105,6 @@ If the icon appears without text, then use the `accessibilityLabel` prop to give
 
 - To learn about implementing Polaris icons with [Polaris React](https://github.com/Shopify/polaris-react) in your projects, see the [`@shopify/polaris-icons` documentation](https://github.com/Shopify/polaris-icons/tree/master/packages/polaris-icons)
 
-- To learn about the best practices for designing and using icons in your projects, see the [icon design guidelines](/design/icons)
+- To learn about the best practices for designing and using icons in your projects, see the [icon design guidelines](https://polaris.shopify.com/design/icons)
 
-- To learn how to name icons, see the [icon naming guidelines](/content/naming#section-icons)
+- To learn how to name icons, see the [icon naming guidelines](https://polaris.shopify.com/content/naming#section-icons)

--- a/src/components/InlineError/README.md
+++ b/src/components/InlineError/README.md
@@ -30,7 +30,7 @@ Inline errors should:
 - Describe specific solutions so merchants can successfully complete their task in the form
 - Not be placed out of context of the input or group of inputs they describe
 
-[Learn more about error message patterns](/patterns-and-guides/error-messages#section-form-validation)
+[Learn more about error message patterns](https://polaris.shopify.com/patterns-and-guides/error-messages#section-form-validation)
 
 ---
 
@@ -44,7 +44,7 @@ Inline error messages should:
 
 - Clearly explain what went wrong, give a next step, or offer a one-click fix
 - Be short and concise, no more than a single sentence
-- Use [passive voice](/content/grammar-and-mechanics) so merchants don’t feel like they’re being blamed for the error
+- Use [passive voice](https://polaris.shopify.com/content/grammar-and-mechanics) so merchants don’t feel like they’re being blamed for the error
 
 <!-- usagelist -->
 
@@ -72,13 +72,13 @@ Use when the merchant has entered invalid information into multiple fields insid
 
 <!-- content-for: android -->
 
-![Inline error for Android](/public_images/components/InlineError/android/default@2x.png)
+![Inline error for Android](https://polaris.shopify.com/public_images/components/InlineError/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Inline error for iOS](/public_images/components/InlineError/ios/default@2x.png)
+![Inline error for iOS](https://polaris.shopify.com/public_images/components/InlineError/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -86,7 +86,7 @@ Use when the merchant has entered invalid information into multiple fields insid
 
 ## Related components
 
-- To create a list of exceptions that describe a resource, [use the exception list component](/components/lists-and-tables/exception-list)
+- To create a list of exceptions that describe a resource, [use the exception list component](https://polaris.shopify.com/components/lists-and-tables/exception-list)
 
 ---
 
@@ -114,6 +114,6 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 - Use the required `fieldID` prop to give the inline error a unique `id`. This ties the error to a form field using `aria-describedby` so that it's conveyed to screen reader users.
 - Use the required `message` prop to provide the text that describes the error.
-- The inline error [icon](/design/icons) helps visually identify the error message for merchants who have difficulty seeing [colors](/design/colors) or who use settings that remove color from the page.
+- The inline error [icon](https://polaris.shopify.com/design/icons) helps visually identify the error message for merchants who have difficulty seeing [colors](https://polaris.shopify.com/design/colors) or who use settings that remove color from the page.
 
 <!-- /content-for -->

--- a/src/components/KeyboardAccessories/README.md
+++ b/src/components/KeyboardAccessories/README.md
@@ -41,13 +41,13 @@ Use the action accessories to add actions that are relevant to what merchants ar
 
 <!-- content-for: android -->
 
-![Keyboard accessory with actions](/public_images/components/KeyboardAccessories/android/toolbar@2x.png)
+![Keyboard accessory with actions](https://polaris.shopify.com/public_images/components/KeyboardAccessories/android/toolbar@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Keyboard accessory with actions](/public_images/components/KeyboardAccessories/ios/toolbar@2x.png)
+![Keyboard accessory with actions](https://polaris.shopify.com/public_images/components/KeyboardAccessories/ios/toolbar@2x.png)
 
 <!-- /content-for -->
 
@@ -59,13 +59,13 @@ Use to make message entry easier in messaging and chat-based products.
 
 <!-- content-for: android -->
 
-![Keyboard accessory with text field](/public_images/components/KeyboardAccessories/android/text-field@2x.png)
+![Keyboard accessory with text field](https://polaris.shopify.com/public_images/components/KeyboardAccessories/android/text-field@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Keyboard accessory with text field](/public_images/components/KeyboardAccessories/ios/text-field@2x.png)
+![Keyboard accessory with text field](https://polaris.shopify.com/public_images/components/KeyboardAccessories/ios/text-field@2x.png)
 
 <!-- /content-for -->
 
@@ -73,6 +73,6 @@ Use to make message entry easier in messaging and chat-based products.
 
 ## Related components
 
-- To make more actions visible in keyboard accessories, use [the icon component](/components/images-and-icons/icon) for action labels
-- To group actions within keyboard accessories, use [the button group component](/components/actions/button-group)
-- For chat-based interfaces, use [the text field component](/components/forms/text-field) in keyboard accessories
+- To make more actions visible in keyboard accessories, use [the icon component](https://polaris.shopify.com/components/images-and-icons/icon) for action labels
+- To group actions within keyboard accessories, use [the button group component](https://polaris.shopify.com/components/actions/button-group)
+- For chat-based interfaces, use [the text field component](https://polaris.shopify.com/components/forms/text-field) in keyboard accessories

--- a/src/components/KeyboardKey/README.md
+++ b/src/components/KeyboardKey/README.md
@@ -60,7 +60,7 @@ Use to list a related set of keyboard shortcuts.
 
 ## Related components
 
-- To add a tooltip for a button with an associated keyboard shortcut, [use the tooltip component](/components/tooltip)
+- To add a tooltip for a button with an associated keyboard shortcut, [use the tooltip component](https://polaris.shopify.com/components/tooltip)
 
 ---
 

--- a/src/components/Layout/README.md
+++ b/src/components/Layout/README.md
@@ -49,7 +49,7 @@ Headings should be:
 - Concise and scannable:
   - Use simple, clear language that can be read at a glance
   - Keep to a single sentence and avoid using punctuation such as periods, commas, or semicolons
-  - Avoid articles (the, a, an) in [microcopy headings](/content/actionable-language#headings-and-subheadings) to keep content short and actionable
+  - Avoid articles (the, a, an) in [microcopy headings](https://polaris.shopify.com/content/actionable-language#headings-and-subheadings) to keep content short and actionable
   - Write in sentence case (first word capitalized, the rest is lowercase)
 
 <!-- usagelist -->
@@ -545,6 +545,6 @@ Use for settings pages. When settings are grouped thematically in annotated sect
 
 ## Related components
 
-- To visually group content in a layout section, [use the card component](/components/structure/card)
-- To lay out a set of smaller components in a row, [use the stack component](/components/structure/stack)
-- To lay out form fields, [use the form layout component](/components/forms/form-layout)
+- To visually group content in a layout section, [use the card component](https://polaris.shopify.com/components/structure/card)
+- To lay out a set of smaller components in a row, [use the stack component](https://polaris.shopify.com/components/structure/stack)
+- To lay out form fields, [use the form layout component](https://polaris.shopify.com/components/forms/form-layout)

--- a/src/components/Link/README.md
+++ b/src/components/Link/README.md
@@ -32,13 +32,13 @@ Links are used to embed actions or pathways to more information in a sentence.
 Links should:
 
 - Consist of text that clearly describes either the action that merchants will take or the location they’ll navigate to.
-- Only be used in a sentence. For stand-alone navigational actions, [use the button component](/components/actions/button).
+- Only be used in a sentence. For stand-alone navigational actions, [use the button component](https://polaris.shopify.com/components/actions/button).
 
 ---
 
 ## Content guidelines
 
-The link component should follow the general [content guidelines](/content/actionable-language#section-links) for links.
+The link component should follow the general [content guidelines](https://polaris.shopify.com/content/actionable-language#section-links) for links.
 
 ### Links
 
@@ -117,7 +117,7 @@ Use for text links that point to a different website. They will open in a new br
 
 ## Related components
 
-- To create navigational actions that aren’t part of a line of text, [use the button component](/components/actions/button)
+- To create navigational actions that aren’t part of a line of text, [use the button component](https://polaris.shopify.com/components/actions/button)
 
 ---
 
@@ -129,7 +129,7 @@ Use the `url` prop to give the link component a valid `href` value. This allows 
 
 ### Submitting data
 
-Merchants generally expect links to navigate, and not to submit data or take action. If you need a component that doesn’t have a URL associated with it, then use the [button component](/components/actions/button) instead.
+Merchants generally expect links to navigate, and not to submit data or take action. If you need a component that doesn’t have a URL associated with it, then use the [button component](https://polaris.shopify.com/components/actions/button) instead.
 
 ### Labeling
 

--- a/src/components/List/README.md
+++ b/src/components/List/README.md
@@ -95,13 +95,13 @@ Use for a text-only list of related items that don’t need to be in a specific 
 
 <!-- content-for: android -->
 
-![Bulleted list on Android](/public_images/components/List/android/bullets@2x.png)
+![Bulleted list on Android](https://polaris.shopify.com/public_images/components/List/android/bullets@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Bulleted list on iOS](/public_images/components/List/ios/bullets@2x.png)
+![Bulleted list on iOS](https://polaris.shopify.com/public_images/components/List/ios/bullets@2x.png)
 
 <!-- /content-for -->
 
@@ -119,13 +119,13 @@ Use for a text-only list of related items when an inherent order, priority, or s
 
 <!-- content-for: android -->
 
-![Numbered list on Android](/public_images/components/List/android/numbered@2x.png)
+![Numbered list on Android](https://polaris.shopify.com/public_images/components/List/android/numbered@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Numbered list on iOS](/public_images/components/List/ios/numbered@2x.png)
+![Numbered list on iOS](https://polaris.shopify.com/public_images/components/List/ios/numbered@2x.png)
 
 <!-- /content-for -->
 
@@ -133,9 +133,9 @@ Use for a text-only list of related items when an inherent order, priority, or s
 
 ## Related components
 
-- To create a list of checkboxes or radio buttons, [use the choice list component](/components/forms/choice-list)
-- To present a collection of objects of the same type such as customers, products, or orders, [use the resource list component](/components/lists-and-tables/resource-list)
-- When text labels for each item are useful for describing the content, [use the Description List component](/components/lists-and-tables/description-list)
+- To create a list of checkboxes or radio buttons, [use the choice list component](https://polaris.shopify.com/components/forms/choice-list)
+- To present a collection of objects of the same type such as customers, products, or orders, [use the resource list component](https://polaris.shopify.com/components/lists-and-tables/resource-list)
+- When text labels for each item are useful for describing the content, [use the Description List component](https://polaris.shopify.com/components/lists-and-tables/description-list)
 
 ---
 
@@ -163,6 +163,6 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 The list component outputs list items (`<li>`) inside a list wrapper (`<ul>` for bullet lists or `<ol>` for numbered lists). By default, list items are conveyed as a group of related elements to assistive technology users.
 
-To group items for layout only, consider using the [stack component](/components/structure/stack).
+To group items for layout only, consider using the [stack component](https://polaris.shopify.com/components/structure/stack).
 
 <!-- /content-for -->

--- a/src/components/Loading/README.md
+++ b/src/components/Loading/README.md
@@ -32,7 +32,7 @@ Use to indicate that the page is loading.
 
 ## Required components
 
-The loading component must be wrapped in the [frame](/components/structure/frame) component or used in an embedded application.
+The loading component must be wrapped in the [frame](https://polaris.shopify.com/components/structure/frame) component or used in an embedded application.
 
 ---
 
@@ -77,9 +77,9 @@ The loading component should:
 
 ## Related components
 
-- To indicate that an action has been received, use the [Spinner](/components/feedback-indicators/spinner)
-- To improve user experience and reduce the appearance of long loading times, use the [Progress bar](/components/feedback-indicators/progress-bar) component.
-- To better represent loading content, use [Skeleton page](/components/feedback-indicators/skeleton-page) along with [Skeleton body text](/components/feedback-indicators/skeleton-body-text) and [Skeleton display text](/components/feedback-indicators/skeleton-display-text) components.
+- To indicate that an action has been received, use the [Spinner](https://polaris.shopify.com/components/feedback-indicators/spinner)
+- To improve user experience and reduce the appearance of long loading times, use the [Progress bar](https://polaris.shopify.com/components/feedback-indicators/progress-bar) component.
+- To better represent loading content, use [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) along with [Skeleton body text](https://polaris.shopify.com/components/feedback-indicators/skeleton-body-text) and [Skeleton display text](https://polaris.shopify.com/components/feedback-indicators/skeleton-display-text) components.
 
 ---
 

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -111,7 +111,7 @@ Titles should be:
 - Concise and scannable:
   - Use simple, clear language that can be read at a glance
   - Keep headings to single sentence and avoid using punctuation such as periods, commas, or semicolons
-  - Avoid articles (the, a, an) in [microcopy headings](/content/actionable-language#section-headings-and-subheadings) to keep content short and actionable
+  - Avoid articles (the, a, an) in [microcopy headings](https://polaris.shopify.com/content/actionable-language#section-headings-and-subheadings) to keep content short and actionable
   - Written in sentence case (first word capitalized, the rest is lowercase)
 
 <!-- usagelist -->
@@ -229,12 +229,12 @@ Tertiary actions should:
 #### Do
 
 - Use a plain button for a tertiary action if needed
-  ![Screenshot of modal with a plain button as a tertiary action](/public_images/components/Modal/do-use-plain-button-for-tertiary-action@2x.png)
+  ![Screenshot of modal with a plain button as a tertiary action](https://polaris.shopify.com/public_images/components/Modal/do-use-plain-button-for-tertiary-action@2x.png)
 
 #### Don’t
 
 - Use a tertiary action for a destructive action
-  ![Screenshot of modal with a destructive button as a tertiary action](/public_images/components/Modal/dont-use-destructive-tertiary-action@2x.png)
+  ![Screenshot of modal with a destructive button as a tertiary action](https://polaris.shopify.com/public_images/components/Modal/dont-use-destructive-tertiary-action@2x.png)
 
 <!-- end -->
 
@@ -419,13 +419,13 @@ class ModalExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Modal with primary action on Android](/public_images/components/Modal/android/information@2x.png)
+![Modal with primary action on Android](https://polaris.shopify.com/public_images/components/Modal/android/information@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Modal with primary action on iOS](/public_images/components/Modal/ios/information@2x.png)
+![Modal with primary action on iOS](https://polaris.shopify.com/public_images/components/Modal/ios/information@2x.png)
 
 <!-- /content-for -->
 
@@ -524,13 +524,13 @@ class ModalExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Modal with primary and secondary actions on Android](/public_images/components/Modal/android/basic@2x.png)
+![Modal with primary and secondary actions on Android](https://polaris.shopify.com/public_images/components/Modal/android/basic@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Modal with primary and secondary actions on iOS](/public_images/components/Modal/ios/basic@2x.png)
+![Modal with primary and secondary actions on iOS](https://polaris.shopify.com/public_images/components/Modal/ios/basic@2x.png)
 
 <!-- /content-for -->
 
@@ -703,13 +703,13 @@ Use to make it clear to the merchant that the action is potentially dangerous. O
 
 <!-- content-for: android -->
 
-![Warning modal on Android](/public_images/components/Modal/android/default@2x.png)
+![Warning modal on Android](https://polaris.shopify.com/public_images/components/Modal/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Warning modal on iOS](/public_images/components/Modal/ios/default@2x.png)
+![Warning modal on iOS](https://polaris.shopify.com/public_images/components/Modal/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -717,9 +717,9 @@ Use to make it clear to the merchant that the action is potentially dangerous. O
 
 ## Related components
 
-- To present large amounts of additional information or actions that don’t require confirmation, [use the collapsible component](/components/behavior/collapsible) to expand content in place within the page
-- To present a small amount of content or a menu of actions in a non-blocking overlay, [use the popover component](/components/popover)
-- To communicate a change or condition that needs the merchant’s attention within the context of a page, [use the banner component](/components/feedback-indicators/banner)
+- To present large amounts of additional information or actions that don’t require confirmation, [use the collapsible component](https://polaris.shopify.com/components/behavior/collapsible) to expand content in place within the page
+- To present a small amount of content or a menu of actions in a non-blocking overlay, [use the popover component](https://polaris.shopify.com/components/popover)
+- To communicate a change or condition that needs the merchant’s attention within the context of a page, [use the banner component](https://polaris.shopify.com/components/feedback-indicators/banner)
 
 ---
 

--- a/src/components/Navigation/README.md
+++ b/src/components/Navigation/README.md
@@ -14,13 +14,13 @@ keywords:
 
 # Navigation
 
-The navigation component is used to display the primary navigation in the sidebar of the [frame](/components/structure/frame) of any non-embedded application. Navigation includes a list of links that merchants use to move between sections of the application.
+The navigation component is used to display the primary navigation in the sidebar of the [frame](https://polaris.shopify.com/components/structure/frame) of any non-embedded application. Navigation includes a list of links that merchants use to move between sections of the application.
 
 ---
 
 ## Required components
 
-The navigation component must be passed to the [frame](/components/structure/frame) component. The mobile version of the navigation component appears in the [top bar](/components/structure/top-bar) component.
+The navigation component must be passed to the [frame](https://polaris.shopify.com/components/structure/frame) component. The mobile version of the navigation component appears in the [top bar](https://polaris.shopify.com/components/structure/top-bar) component.
 
 ---
 
@@ -166,7 +166,7 @@ Action allows a complementary icon-only action to render next to the section tit
 
 ### Basic navigation
 
-Use to present a navigation menu in the [frame](/components/structure/frame).
+Use to present a navigation menu in the [frame](https://polaris.shopify.com/components/structure/frame).
 
 ```jsx
 <Navigation location="/">
@@ -345,10 +345,10 @@ Use to add a horizontal line below the section.
 
 ## Related components
 
-- To provide the structure for the navigation component, including the left sidebar and the top bar use the [frame](/components/structure/frame) component.
-- To display the navigation component on small screens, to provide search and a user menu, or to theme the [frame](/components/structure/frame) component to reflect an application’s brand, use the [top bar](/components/structure/top-bar) component.
-- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](/components/forms/contextual-save-bar) component.
-- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](/components/feedback-indicators/toast) component.
-- To indicate to merchants that a page is loading or an upload is processing use the [loading](/components/feedback-indicators/loading) component.
-- To alternate among related views within the same context, use the [tabs](/components/navigation/tabs) component.
-- To embed a single action or link within a larger span of text, use the [link](/components/navigation/link) component.
+- To provide the structure for the navigation component, including the left sidebar and the top bar use the [frame](https://polaris.shopify.com/components/structure/frame) component.
+- To display the navigation component on small screens, to provide search and a user menu, or to theme the [frame](https://polaris.shopify.com/components/structure/frame) component to reflect an application’s brand, use the [top bar](https://polaris.shopify.com/components/structure/top-bar) component.
+- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/forms/contextual-save-bar) component.
+- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/feedback-indicators/toast) component.
+- To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/feedback-indicators/loading) component.
+- To alternate among related views within the same context, use the [tabs](https://polaris.shopify.com/components/navigation/tabs) component.
+- To embed a single action or link within a larger span of text, use the [link](https://polaris.shopify.com/components/navigation/link) component.

--- a/src/components/OptionList/README.md
+++ b/src/components/OptionList/README.md
@@ -19,7 +19,7 @@ The option list component lets you create a list of grouped items that
 merchants can pick from. This can include single selection or multiple selection
 of options. Option list usually appears in a popover, and sometimes in a modal
 or a sidebar. Option lists are styled differently than
-[choice lists](/components/forms/choice-list) and should not be used within a form, but as a standalone menu.
+[choice lists](https://polaris.shopify.com/components/forms/choice-list) and should not be used within a form, but as a standalone menu.
 
 ---
 
@@ -28,9 +28,9 @@ or a sidebar. Option lists are styled differently than
 The option list component should:
 
 - Be placed on its own inside a container. Usually the container behaves like a
-  menu, as it does with [popover](/components/overlays/popover). Don’t
+  menu, as it does with [popover](https://polaris.shopify.com/components/overlays/popover). Don’t
   place other components within the same container.
-- Not be used when a [select component](/components/forms/select) will do.
+- Not be used when a [select component](https://polaris.shopify.com/components/forms/select) will do.
 
 ---
 
@@ -212,11 +212,11 @@ class OptionListExample extends React.Component {
 ## Related components
 
 - To render a list of actions,
-  [use the action list component](/components/actions/action-list)
+  [use the action list component](https://polaris.shopify.com/components/actions/action-list)
 - To create a list of grouped radio buttons or checkboxes,
-  [use the choice list component](/components/forms/choice-list)
+  [use the choice list component](https://polaris.shopify.com/components/forms/choice-list)
 - For a basic version of option list as a single choice menu,
-  [use the select component](/components/forms/select)
+  [use the select component](https://polaris.shopify.com/components/forms/select)
 
 ---
 
@@ -244,7 +244,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 Items in an option list are organized as list items (`<li>`) in an unordered list (`<ul>`) and are conveyed as a group of related elements to assistive technology users.
 
-Controls in simple option lists are [buttons](/components/actions/button), and controls in multiple option lists are [checkboxes](/components/forms/checkbox).
+Controls in simple option lists are [buttons](https://polaris.shopify.com/components/actions/button), and controls in multiple option lists are [checkboxes](https://polaris.shopify.com/components/forms/checkbox).
 
 If you customize the option list, you can provide ARIA roles that fit the context. These roles must be valid according to the [W3C ARIA specification](https://www.w3.org/TR/wai-aria-1.1/) to be conveyed correctly to screen reader users.
 

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -42,7 +42,7 @@ Passing an API key to the [app provider component](https://polaris.shopify.com/c
 
 Note in the props table that a number of properties are only available in stand-alone applications, and won't work in an embedded context. Configure your application's icon and navigation in the [Shopify Partner Dashboard](https://partners.shopify.com) app setup section. To help visualize the page component in an embedded application, we've provided the following screenshot.
 
-![Screenshot of page component in an embedded application](/public_images/embedded/page/page@2x.jpg)
+![Screenshot of page component in an embedded application](https://polaris.shopify.com/public_images/embedded/page/page@2x.jpg)
 
 ```jsx
 ReactDOM.render(
@@ -233,7 +233,7 @@ Use for detail pages, which should have breadcrumbs, and also often have several
 
 Use for building any page on Android.
 
-![Page on Android](/public_images/components/Page/android/with-header@2x.png)
+![Page on Android](https://polaris.shopify.com/public_images/components/Page/android/with-header@2x.png)
 
 <!-- /content-for -->
 
@@ -243,7 +243,7 @@ Use for detail pages, which should have breadcrumbs, and also often have several
 
 Use for building any page on iOS.
 
-![Page on iOS](/public_images/components/Page/ios/with-header@2x.png)
+![Page on iOS](https://polaris.shopify.com/public_images/components/Page/ios/with-header@2x.png)
 
 <!-- /content-for -->
 
@@ -453,7 +453,7 @@ Use action groups for sets of actions that relate to one another, particularly w
 
 <!-- example-for: web -->
 
-Use a separator for pages that have an [empty state](/components/structure/empty-state) as their only content, or that have an [annotated section](/components/structure/layout) as the first component on the page.
+Use a separator for pages that have an [empty state](https://polaris.shopify.com/components/structure/empty-state) as their only content, or that have an [annotated section](https://polaris.shopify.com/components/structure/layout) as the first component on the page.
 
 ```jsx
 <Page title="Settings" separator>
@@ -491,7 +491,7 @@ Title metadata appears immediately after the page’s title. Use it to communica
 
 ## Related components
 
-- To lay out the content within a page, use the [layout component](/components/structure/layout)
-- To add pagination within the context of a list or other page content, use the [pagination component](/components/navigation/pagination)
-- To add primary and secondary calls to action at the bottom of a page, see the [page actions component](/components/structure/page-actions)
+- To lay out the content within a page, use the [layout component](https://polaris.shopify.com/components/structure/layout)
+- To add pagination within the context of a list or other page content, use the [pagination component](https://polaris.shopify.com/components/navigation/pagination)
+- To add primary and secondary calls to action at the bottom of a page, see the [page actions component](https://polaris.shopify.com/components/structure/page-actions)
 - When you use the page component within an [embedded app](https://github.com/Shopify/polaris-react/blob/master/documentation/Embedded%20apps.md), the [app provider component](https://polaris.shopify.com/components/structure/app-provider) delegates rendering to the Shopify App Bridge

--- a/src/components/PageActions/README.md
+++ b/src/components/PageActions/README.md
@@ -117,6 +117,6 @@ Not all page actions require a secondary action.
 
 ## Related components
 
-- To add actions to the top of a page, see the [page component's](/components/structure/page) action props
-- To create a call to action within the context of other page content, use the [button component](/components/actions/button)
-- To let merchants move through a collection of items that spans multiple pages, see the [pagination component](/components/navigation/pagination)
+- To add actions to the top of a page, see the [page component's](https://polaris.shopify.com/components/structure/page) action props
+- To create a call to action within the context of other page content, use the [button component](https://polaris.shopify.com/components/actions/button)
+- To let merchants move through a collection of items that spans multiple pages, see the [pagination component](https://polaris.shopify.com/components/navigation/pagination)

--- a/src/components/Pagination/README.md
+++ b/src/components/Pagination/README.md
@@ -46,7 +46,7 @@ Web pagination should:
 iOS and Android pagination should:
 
 - Start loading items when merchants are close to the bottom, roughly 5 items from the end
-- Show [a spinner](/components/feedback-indicators/spinner) below the list to indicate that items have been requested
+- Show [a spinner](https://polaris.shopify.com/components/feedback-indicators/spinner) below the list to indicate that items have been requested
 
 ---
 
@@ -104,13 +104,13 @@ Use for lists longer than 25 items. In mobile apps it’s natural to scroll to t
 
 <!-- content-for: android -->
 
-![Infinite scroll pagination on Android](/public_images/components/Pagination/android/default@2x.png)
+![Infinite scroll pagination on Android](https://polaris.shopify.com/public_images/components/Pagination/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Infinite scroll pagination on iOS](/public_images/components/Pagination/ios/default@2x.png)
+![Infinite scroll pagination on iOS](https://polaris.shopify.com/public_images/components/Pagination/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -118,8 +118,8 @@ Use for lists longer than 25 items. In mobile apps it’s natural to scroll to t
 
 ## Related components
 
-- To see how pagination is used on a page, see the [page component](/components/structure/page)
-- To add primary and secondary calls to action at the bottom of a page, see the [page actions component](/components/structure/page-actions)
-- The [resource list component](/components/lists-and-tables/resource-list) is often combined with pagination to handle long lists of resources such as orders or customers
-- To create stand-alone navigational links or calls to action, use the [button component](/components/actions/button)
-- To embed actions or pathways to more information within a sentence, use the [link component](/components/navigation/link)
+- To see how pagination is used on a page, see the [page component](https://polaris.shopify.com/components/structure/page)
+- To add primary and secondary calls to action at the bottom of a page, see the [page actions component](https://polaris.shopify.com/components/structure/page-actions)
+- The [resource list component](https://polaris.shopify.com/components/lists-and-tables/resource-list) is often combined with pagination to handle long lists of resources such as orders or customers
+- To create stand-alone navigational links or calls to action, use the [button component](https://polaris.shopify.com/components/actions/button)
+- To embed actions or pathways to more information within a sentence, use the [link component](https://polaris.shopify.com/components/navigation/link)

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -159,13 +159,13 @@ class PopoverExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Popover with action list for Android](/public_images/components/Popover/android/action-list@2x.png)
+![Popover with action list for Android](https://polaris.shopify.com/public_images/components/Popover/android/action-list@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Popover with action list for iOS](/public_images/components/Popover/ios/action-list@2x.png)
+![Popover with action list for iOS](https://polaris.shopify.com/public_images/components/Popover/ios/action-list@2x.png)
 
 <!-- /content-for -->
 
@@ -220,13 +220,13 @@ class PopoverContentExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Popover with content and actions for Android](/public_images/components/Popover/android/action-content@2x.png)
+![Popover with content and actions for Android](https://polaris.shopify.com/public_images/components/Popover/android/action-content@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Popover with content and actions for iOS](/public_images/components/Popover/ios/action-content@2x.png)
+![Popover with content and actions for iOS](https://polaris.shopify.com/public_images/components/Popover/ios/action-content@2x.png)
 
 <!-- /content-for -->
 
@@ -402,7 +402,7 @@ Use when you have few actions that affects the whole page. Action sheets doesnâ€
 
 <!-- content-for: ios -->
 
-![iOS action sheet](/public_images/components/Popover/ios/action-sheet@2x.png)
+![iOS action sheet](https://polaris.shopify.com/public_images/components/Popover/ios/action-sheet@2x.png)
 
 <!-- /content-for -->
 
@@ -410,8 +410,8 @@ Use when you have few actions that affects the whole page. Action sheets doesnâ€
 
 ## Related components
 
-- To put a list of actions in a popover, [use the action list component](/components/actions/action-list)
-- To let merchants select simple options from a list, [use the select component](/components/forms/select)
+- To put a list of actions in a popover, [use the action list component](https://polaris.shopify.com/components/actions/action-list)
+- To let merchants select simple options from a list, [use the select component](https://polaris.shopify.com/components/forms/select)
 
 ---
 
@@ -437,7 +437,7 @@ See Appleâ€™s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-Popovers usually contain an [option list](/components/lists-and-tables/option-list) or an [action list](/components/actions/action-list), but can also contain other controls or content.
+Popovers usually contain an [option list](https://polaris.shopify.com/components/lists-and-tables/option-list) or an [action list](https://polaris.shopify.com/components/actions/action-list), but can also contain other controls or content.
 
 ### Keyboard support
 

--- a/src/components/ProgressBar/README.md
+++ b/src/components/ProgressBar/README.md
@@ -20,7 +20,7 @@ The progress bar component is used to visually represent the completion of a tas
 Progress bar components should:
 
 - Give merchants an indication of how much of the task has completed and how much is left.
-- Not be used for entire page loads. In this case, use the [Skeleton page](/components/feedback-indicators/skeleton-page) component.
+- Not be used for entire page loads. In this case, use the [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) component.
 
 ---
 
@@ -46,5 +46,5 @@ Use the size option when you need to increase or decrease the visual weight of t
 
 ## Related components
 
-- For tasks with a short load time, use the [Spinner](/components/feedback-indicators/spinner) component
-- For full page loads, use the [Skeleton page](/components/feedback-indicators/skeleton-page) component
+- For tasks with a short load time, use the [Spinner](https://polaris.shopify.com/components/feedback-indicators/spinner) component
+- For full page loads, use the [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) component

--- a/src/components/RadioButton/README.md
+++ b/src/components/RadioButton/README.md
@@ -135,13 +135,13 @@ class RadioButtonExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default radio button on Android](/public_images/components/RadioButton/android/default@2x.png)
+![Default radio button on Android](https://polaris.shopify.com/public_images/components/RadioButton/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default radio button on iOS](/public_images/components/RadioButton/ios/default@2x.png)
+![Default radio button on iOS](https://polaris.shopify.com/public_images/components/RadioButton/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -153,13 +153,13 @@ Use toggles when merchants need to make a binary choice (on or off).
 
 <!-- content-for: android -->
 
-![Android toggle with on or off options](/public_images/components/RadioButton/android/toggle@2x.png)
+![Android toggle with on or off options](https://polaris.shopify.com/public_images/components/RadioButton/android/toggle@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![iOS toggle with on or off options](/public_images/components/RadioButton/ios/toggle@2x.png)
+![iOS toggle with on or off options](https://polaris.shopify.com/public_images/components/RadioButton/ios/toggle@2x.png)
 
 <!-- /content-for -->
 
@@ -167,10 +167,10 @@ Use toggles when merchants need to make a binary choice (on or off).
 
 ## Related components
 
-- To make simple lists of radio buttons easier to build, [use the choice list component](/components/forms/choice-list)
-- For long lists of options, [consider the select component](/components/forms/select) to avoid overwhelming merchants
-- To present merchants with a list of checkboxes, [use the choice list component](/components/forms/choice-list) with the “allow multiple” option
-- To display non-interactive list of related content, [use the content list component](/components/lists-and-tables/list)
+- To make simple lists of radio buttons easier to build, [use the choice list component](https://polaris.shopify.com/components/forms/choice-list)
+- For long lists of options, [consider the select component](https://polaris.shopify.com/components/forms/select) to avoid overwhelming merchants
+- To present merchants with a list of checkboxes, [use the choice list component](https://polaris.shopify.com/components/forms/choice-list) with the “allow multiple” option
+- To display non-interactive list of related content, [use the content list component](https://polaris.shopify.com/components/lists-and-tables/list)
 
 ---
 

--- a/src/components/RangeSlider/README.md
+++ b/src/components/RangeSlider/README.md
@@ -96,7 +96,7 @@ Error messages should:
 
 - Clearly explain what went wrong and how to fix it
 - Be short and concise, no more than a single sentence
-- Use [passive voice](/content/grammar-and-mechanics) so merchants don’t feel like they’re being blamed for the error
+- Use [passive voice](https://polaris.shopify.com/content/grammar-and-mechanics) so merchants don’t feel like they’re being blamed for the error
 
 <!-- usagelist -->
 
@@ -145,13 +145,13 @@ class RangeSliderExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Range slider for Android](/public_images/components/RangeSlider/android/default@2x.png)
+![Range slider for Android](https://polaris.shopify.com/public_images/components/RangeSlider/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Range slider for iOS](/public_images/components/RangeSlider/ios/default@2x.png)
+![Range slider for iOS](https://polaris.shopify.com/public_images/components/RangeSlider/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -341,7 +341,7 @@ class RangeSliderExample extends React.Component {
 
 ## Related components
 
-- To collect a number value as a text input, [use the text field component](/components/forms/text-field)
+- To collect a number value as a text input, [use the text field component](https://polaris.shopify.com/components/forms/text-field)
 
 ---
 

--- a/src/components/ResourceItem/README.md
+++ b/src/components/ResourceItem/README.md
@@ -88,7 +88,7 @@ class ResourceListExample extends React.Component {
 
 ### Item with media
 
-The media element can hold an [avatar](/components/images-and-icons/avatar), [thumbnail](/components/images-and-icons/thumbnail), or other small-format graphic.
+The media element can hold an [avatar](https://polaris.shopify.com/components/images-and-icons/avatar), [thumbnail](https://polaris.shopify.com/components/images-and-icons/thumbnail), or other small-format graphic.
 
 ```jsx
 <Card>
@@ -179,7 +179,7 @@ Shortcut actions present popular actions from the resource’s details page for 
 
 ## Required components
 
-The resource item component must be wrapped in the [resource list](/components/lists-and-tables/resource-list) component.
+The resource item component must be wrapped in the [resource list](https://polaris.shopify.com/components/lists-and-tables/resource-list) component.
 
 ---
 
@@ -210,7 +210,7 @@ Resource items should:
 
 Resource items can optionally:
 
-- Provide [shortcut actions](/components/lists-and-tables/resource-list#study-custom-item-shortcut-actions) for quick access to frequent actions from the resource’s details page.
+- Provide [shortcut actions](https://polaris.shopify.com/components/lists-and-tables/resource-list#study-custom-item-shortcut-actions) for quick access to frequent actions from the resource’s details page.
 
 ---
 
@@ -221,10 +221,10 @@ Resource items should:
 - Present the information that merchants need to find the items that they’re looking for.
 - Support merchant tasks for the particular type of resource.
 - Avoid colons.
-- [Shortcut actions](/components/lists-and-tables/resource-list#study-custom-item-shortcut-actions) don’t need to follow the full verb + noun formula for buttons.
+- [Shortcut actions](https://polaris.shopify.com/components/lists-and-tables/resource-list#study-custom-item-shortcut-actions) don’t need to follow the full verb + noun formula for buttons.
 
 ---
 
 ## Related components
 
-To display a simple list of related content, [use the list component](/components/lists-and-tables/list).
+To display a simple list of related content, [use the list component](https://polaris.shopify.com/components/lists-and-tables/list).

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -31,9 +31,9 @@ A resource list displays a collection of objects of the same type, like products
 
 Resource lists can also:
 
-- Support [customized list items](/components/lists-and-tables/resource-item)
+- Support [customized list items](https://polaris.shopify.com/components/lists-and-tables/resource-item)
 - Include bulk actions so merchants can act on multiple objects at once
-- Support sorting and [filtering](/components/lists-and-tables/filters) of long lists
+- Support sorting and [filtering](https://polaris.shopify.com/components/lists-and-tables/filters) of long lists
 - Be paired with pagination to make long lists digestible
 
 ---
@@ -343,7 +343,7 @@ class ResourceListExample extends React.Component {
 
 ### Resource list with sorting
 
-Allows merchants to change the way the list is sorted by selecting one of several options from a [Select](/components/forms/select) control.
+Allows merchants to change the way the list is sorted by selecting one of several options from a [Select](https://polaris.shopify.com/components/forms/select) control.
 
 ```jsx
 class ResourceListExample extends React.Component {
@@ -1048,8 +1048,8 @@ function isEmpty(value) {
 Using a resource list in a project involves combining the following components and subcomponents:
 
 - ResourceList
-- [ResourceItem](/components/lists-and-tables/resource-item) or a customized list item
-- [Filters](/components/lists-and-tables/filters) (optional)
+- [ResourceItem](https://polaris.shopify.com/components/lists-and-tables/resource-item) or a customized list item
+- [Filters](https://polaris.shopify.com/components/lists-and-tables/filters) (optional)
 - Pagination component (optional)
 
 <!-- hint -->
@@ -1080,7 +1080,7 @@ Because a details page displays all the content and actions for an individual re
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Schematic showing content from a details page being surfaced on a resource list](/public_images/resource-list/list-surfacing-show@2x.png)
+![Schematic showing content from a details page being surfaced on a resource list](https://polaris.shopify.com/public_images/resource-list/list-surfacing-show@2x.png)
 
 </div>
 
@@ -1094,7 +1094,7 @@ On wide screens, a resource list often looks like a table, especially if some co
 
 A data table is a form of data visualization. It works best to present highly structured data for comparison and analysis.
 
-If your use case is more about visualizing or analyzing data, use the [data table component](/components/lists-and-tables/data-table). If your use case is more about finding and taking action on objects, use a resource list.
+If your use case is more about visualizing or analyzing data, use the [data table component](https://polaris.shopify.com/components/lists-and-tables/data-table). If your use case is more about finding and taking action on objects, use a resource list.
 
 <!-- end -->
 
@@ -1107,11 +1107,11 @@ Resource lists can live in many places in Shopify. You could include a short res
 Resource lists should:
 
 - Have items that perform an action when clicked. The action should navigate to the resource’s details page or otherwise provide more detail about the item.
-- [Customize the content and layout](/components/lists-and-tables/resource-item) of their list items to support merchants’ needs.
+- [Customize the content and layout](https://polaris.shopify.com/components/lists-and-tables/resource-item) of their list items to support merchants’ needs.
 - Support sorting if the list can be long, and especially if different merchant tasks benefit from different sort orders.
-- Support [filtering](/components/lists-and-tables/filters) if the list can be long.
+- Support [filtering](https://polaris.shopify.com/components/lists-and-tables/filters) if the list can be long.
 - Paginate when the current list contains more than 50 items.
-- Use the [skeleton page](/components/feedback-indicators/skeleton-page) component on initial page load for the rest of the page if the loading prop is true and items are processing.
+- Use the [skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) component on initial page load for the rest of the page if the loading prop is true and items are processing.
 
 Resource lists can optionally:
 
@@ -1160,5 +1160,5 @@ Resource lists should:
 
 ## Related components
 
-- To present structured data for comparison and analysis, like when helping merchants to gain insights or review analytics, use the [data table component](/components/lists-and-tables/data-table)
-- To display a simple list of related content, [use the list component](/components/lists-and-tables/list)
+- To present structured data for comparison and analysis, like when helping merchants to gain insights or review analytics, use the [data table component](https://polaris.shopify.com/components/lists-and-tables/data-table)
+- To display a simple list of related content, [use the list component](https://polaris.shopify.com/components/lists-and-tables/list)

--- a/src/components/ResourcePicker/README.md
+++ b/src/components/ResourcePicker/README.md
@@ -33,7 +33,7 @@ Enable the resource picker component to delegate to the [Shopify App Bridge](htt
 
 Use of the resource picker component is only supported in an embedded application—it will not render in a stand-alone application. To help visualize the resource picker component in an embedded application, we've provided the following screenshot.
 
-![Screenshot product picker - multiple product selection component](/public_images/embedded/resource-picker/product-picker-multiple@2x.jpg)
+![Screenshot product picker - multiple product selection component](https://polaris.shopify.com/public_images/embedded/resource-picker/product-picker-multiple@2x.jpg)
 
 ### Deprecation rationale
 

--- a/src/components/Scrollable/README.md
+++ b/src/components/Scrollable/README.md
@@ -34,7 +34,7 @@ Scrollable containers should:
 
 ## Content guidelines
 
-Scrollable containers are cards with scrolling functionality, and should follow the [content guidelines](/components/structure/card#section-content-guidelines) for cards.
+Scrollable containers are cards with scrolling functionality, and should follow the [content guidelines](https://polaris.shopify.com/components/structure/card#section-content-guidelines) for cards.
 
 ---
 
@@ -355,4 +355,4 @@ Use when you need to programmatically scroll a child component into view in the 
 
 ## Related components
 
-- To put long sections of information under a block that merchants can expand or collapse, [use the collapsible component](/components/collapsible)
+- To put long sections of information under a block that merchants can expand or collapse, [use the collapsible component](https://polaris.shopify.com/components/collapsible)

--- a/src/components/SectionHeader/README.md
+++ b/src/components/SectionHeader/README.md
@@ -49,7 +49,7 @@ Use the section header component to group items in a list. It helps merchants to
 
 <!-- end -->
 
-Read more about [dates and numbers](/content/grammar-and-mechanics#section-dates-numbers-and-addresses).
+Read more about [dates and numbers](https://polaris.shopify.com/content/grammar-and-mechanics#section-dates-numbers-and-addresses).
 
 - Use a clear sort order
 
@@ -78,13 +78,13 @@ Use to group related content together, for example orders received on the same d
 
 <!-- content-for: android -->
 
-![Shipping costs card with multiple sections: domestic, international](/public_images/components/SectionHeader/android/default@2x.png)
+![Shipping costs card with multiple sections: domestic, international](https://polaris.shopify.com/public_images/components/SectionHeader/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Shipping costs card with multiple sections: domestic, international](/public_images/components/SectionHeader/ios/default@2x.png)
+![Shipping costs card with multiple sections: domestic, international](https://polaris.shopify.com/public_images/components/SectionHeader/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -94,10 +94,10 @@ Use to group related content together, for example orders received on the same d
 
 Use if your list section could be longer than the height of the screen. For example you may need fixed section headers for a list of orders, because merchants may receive many orders in one day.
 
-![Shipping costs card with multiple sections: domestic, international](/public_images/components/SectionHeader/ios/fixed@2x.png)
+![Shipping costs card with multiple sections: domestic, international](https://polaris.shopify.com/public_images/components/SectionHeader/ios/fixed@2x.png)
 
 ---
 
 ## Related components
 
-- Use section headers if you want to organize [resource list items](/components/lists-and-tables/resource-list) into groups.
+- Use section headers if you want to organize [resource list items](https://polaris.shopify.com/components/lists-and-tables/resource-list) into groups.

--- a/src/components/Select/README.md
+++ b/src/components/Select/README.md
@@ -52,7 +52,7 @@ Labels should:
 - Give a short description (1–3 words) of the requested input.
 - Be written in sentence case (the first word capitalized, the rest lowercase).
 - Avoid punctuation and articles (“the”, “an”, “a”).
-- Be independent sentences. To support [internationalization](/patterns-and-guides/internationalization), they should not act as the first part of a sentence that is finished by the component’s options.
+- Be independent sentences. To support [internationalization](https://polaris.shopify.com/patterns-and-guides/internationalization), they should not act as the first part of a sentence that is finished by the component’s options.
 - Be descriptive, not instructional. If the selection needs more explanation, use help text below the field.
 
 <!-- usagelist -->
@@ -133,7 +133,7 @@ class SelectExample extends React.Component {
 
 The iOS picker expands in-line. Merchants scroll to select the item they want.
 
-![iOS select, and select with option menu](/public_images/components/Select/ios/default@2x.png)
+![iOS select, and select with option menu](https://polaris.shopify.com/public_images/components/Select/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -141,7 +141,7 @@ The iOS picker expands in-line. Merchants scroll to select the item they want.
 
 The Android menu is similar in behavior to the web dropdown.
 
-![Android select, and select with option menu](/public_images/components/Select/android/default@2x.png)
+![Android select, and select with option menu](https://polaris.shopify.com/public_images/components/Select/android/default@2x.png)
 
 <!-- /content-for -->
 
@@ -202,13 +202,13 @@ Use for selections that aren’t currently available. The surrounding interface 
 
 <!-- content-for: ios -->
 
-![Disabled select component on iOS](/public_images/components/Select/ios/disabled@2x.png)
+![Disabled select component on iOS](https://polaris.shopify.com/public_images/components/Select/ios/disabled@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: android -->
 
-![Disabled select component on Android](/public_images/components/Select/android/disabled@2x.png)
+![Disabled select component on Android](https://polaris.shopify.com/public_images/components/Select/android/disabled@2x.png)
 
 <!-- /content-for -->
 
@@ -254,7 +254,7 @@ To render an invalid select and its validation error separately:
 
 - Set a unique identifier to the select component `id` prop
 - Set a boolean to the select component `error` prop
-- Use an [inline error component](/components/forms/inline-error) to describe the invalid select input and set its `fieldID` prop to the same unique identifier used for the text field `id`
+- Use an [inline error component](https://polaris.shopify.com/components/forms/inline-error) to describe the invalid select input and set its `fieldID` prop to the same unique identifier used for the text field `id`
 
 ```jsx
 class SeparateValidationErrorExample extends React.Component {
@@ -329,5 +329,5 @@ class SeparateValidationErrorExample extends React.Component {
 
 ## Related components
 
-- To let merchants select one option from a list with less than 4 options, use [the choice list component](/components/forms/choice-list)
-- To create a select where merchants can make multiple selections, or to allow advanced formatting of option text, use an [option list](/components/lists-and-tables/option-list) inside a [popover](/components/overlays/popover)
+- To let merchants select one option from a list with less than 4 options, use [the choice list component](https://polaris.shopify.com/components/forms/choice-list)
+- To create a select where merchants can make multiple selections, or to allow advanced formatting of option text, use an [option list](https://polaris.shopify.com/components/lists-and-tables/option-list) inside a [popover](https://polaris.shopify.com/components/overlays/popover)

--- a/src/components/SettingToggle/README.md
+++ b/src/components/SettingToggle/README.md
@@ -114,7 +114,7 @@ class SettingToggleExample extends React.Component {
 
 ## Related components
 
-- To let merchants to connect or disconnect their store to third-party services and apps, [use the account connection component](/components/actions/account-connection)
+- To let merchants to connect or disconnect their store to third-party services and apps, [use the account connection component](https://polaris.shopify.com/components/actions/account-connection)
 
 ---
 
@@ -124,6 +124,6 @@ class SettingToggleExample extends React.Component {
 
 The setting toggle component is implemented as an HTML `<button>`. The current label should convey what happens when the button is pressed.
 
-To learn more about button accessibility, see the [button component](/components/actions/button).
+To learn more about button accessibility, see the [button component](https://polaris.shopify.com/components/actions/button).
 
 <!-- /content-for-->

--- a/src/components/Sheet/README.md
+++ b/src/components/Sheet/README.md
@@ -283,5 +283,5 @@ class SheetExample extends React.Component {
 
 ## Related components
 
-- To offer an action before merchants can go to the next step in the flow, use the [modal component](/components/overlays/modal)
-- To present a small amount of content or a menu of actions in a non-blocking overlay, use the [popover component](/components/overlays/popover)
+- To offer an action before merchants can go to the next step in the flow, use the [modal component](https://polaris.shopify.com/components/overlays/modal)
+- To present a small amount of content or a menu of actions in a non-blocking overlay, use the [popover component](https://polaris.shopify.com/components/overlays/popover)

--- a/src/components/SkeletonBodyText/README.md
+++ b/src/components/SkeletonBodyText/README.md
@@ -19,8 +19,8 @@ Skeleton body text is used to provide a low fidelity representation of content b
 
 Skeleton body text component should:
 
-- Be used with [Skeleton page](/components/feedback-indicators/skeleton-page) when page content loads all at once. Together, these components give merchants an indication of what the page layout will be once loaded.
-- Be used on its own, inside any content container component (like a [card](/components/structure/card)), and when content loads after the main page load.
+- Be used with [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) when page content loads all at once. Together, these components give merchants an indication of what the page layout will be once loaded.
+- Be used on its own, inside any content container component (like a [card](https://polaris.shopify.com/components/structure/card)), and when content loads after the main page load.
 - Try to match the number of lines to the content being loaded so it gives an accurate representation.
 
 ---
@@ -36,12 +36,12 @@ Show static content that never changes on a page and use skeleton loading for dy
 #### Do
 
 Use skeleton body text for dynamic content.
-![Image showing skeleton body text for dynamic content](/public_images/skeleton/do-use-skeleton-body-for-dynamic-content@2x.png)
+![Image showing skeleton body text for dynamic content](https://polaris.shopify.com/public_images/skeleton/do-use-skeleton-body-for-dynamic-content@2x.png)
 
 #### Don’t
 
 Use skeleton body text for static content or use placeholder content for dynamic content.
-![Image showing skeleton body text for static content](/public_images/skeleton/dont-use-skeleton-body-for-static-or-placeholder-for-dynamic-text@2x.png)
+![Image showing skeleton body text for static content](https://polaris.shopify.com/public_images/skeleton/dont-use-skeleton-body-for-static-or-placeholder-for-dynamic-text@2x.png)
 
 <!-- end -->
 
@@ -69,5 +69,5 @@ Use this component to represent a short, single line of text, like a timestamp.
 
 ## Related components
 
-- Use this component with [Skeleton page](/components/feedback-indicators/skeleton-page) and [Skeleton display text](/components/feedback-indicators/skeleton-display-text) to represent the content of a page while it’s loading.
-- When giving feedback for in-context operations, use [Progress bar](/components/feedback-indicators/progress-bar) or [Spinner](/components/feedback-indicators/spinner) component.
+- Use this component with [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) and [Skeleton display text](https://polaris.shopify.com/components/feedback-indicators/skeleton-display-text) to represent the content of a page while it’s loading.
+- When giving feedback for in-context operations, use [Progress bar](https://polaris.shopify.com/components/feedback-indicators/progress-bar) or [Spinner](https://polaris.shopify.com/components/feedback-indicators/spinner) component.

--- a/src/components/SkeletonDisplayText/README.md
+++ b/src/components/SkeletonDisplayText/README.md
@@ -35,12 +35,12 @@ Show static display text that that never changes on a page. For example, keep pa
 #### Do
 
 Show actual display text for static content and use skeleton display text for dynamic content.
-![Image showing skeleton display text for dynamic content](/public_images/skeleton/do-show-display-text-for-static-content@2x.png)
+![Image showing skeleton display text for dynamic content](https://polaris.shopify.com/public_images/skeleton/do-show-display-text-for-static-content@2x.png)
 
 #### Don’t
 
 Use skeleton display text for static content or placeholder content for dynamic content.
-![Image showing skeleton display text for static content and placeholder text for dynamic content](/public_images/skeleton/dont-use-skeleton-for-static-or-placeholder-content-for-dynamic@2x.png)
+![Image showing skeleton display text for static content and placeholder text for dynamic content](https://polaris.shopify.com/public_images/skeleton/dont-use-skeleton-for-static-or-placeholder-content-for-dynamic@2x.png)
 
 <!-- end -->
 
@@ -52,7 +52,7 @@ Show skeleton display text for dynamic page titles.
 
 <div class="TypographyUsageBlockImg">
 
-![Image showing skeleton display text for dynamic page title](/public_images/skeleton/do-use-skeleton-for-dynamic-page-titles@2x.png)
+![Image showing skeleton display text for dynamic page title](https://polaris.shopify.com/public_images/skeleton/do-use-skeleton-for-dynamic-page-titles@2x.png)
 
 </div>
 
@@ -90,5 +90,5 @@ Use this component to represent small display text such as content headings.
 
 ## Related components
 
-- Use this component with [Skeleton page](/components/feedback-indicators/skeleton-page) and [Skeleton body text](/components/feedback-indicators/skeleton-body-text) to represent the content of a page before it’s loaded.
-- When giving feedback for in-context operations, use [Progress bar](/components/feedback-indicators/progress-bar) or [Spinner](/components/feedback-indicators/spinner) component.
+- Use this component with [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) and [Skeleton body text](https://polaris.shopify.com/components/feedback-indicators/skeleton-body-text) to represent the content of a page before it’s loaded.
+- When giving feedback for in-context operations, use [Progress bar](https://polaris.shopify.com/components/feedback-indicators/progress-bar) or [Spinner](https://polaris.shopify.com/components/feedback-indicators/spinner) component.

--- a/src/components/SkeletonPage/README.md
+++ b/src/components/SkeletonPage/README.md
@@ -38,7 +38,7 @@ Use skeleton loading for dynamic content, and use actual content for content tha
 
 <div class="TypographyUsageBlockImg">
 
-![Image showing skeleton loading for changing content](/public_images/skeleton/do-use-skeleton-for-changing-content@2x.png)
+![Image showing skeleton loading for changing content](https://polaris.shopify.com/public_images/skeleton/do-use-skeleton-for-changing-content@2x.png)
 
 </div>
 
@@ -48,7 +48,7 @@ Use placeholder content that will change when the page fully loads. This will co
 
 <div class="TypographyUsageBlockImg">
 
-![Image showing placeholder content that will change](/public_images/skeleton/dont-use-placeholder-content-that-will-change@2x.png)
+![Image showing placeholder content that will change](https://polaris.shopify.com/public_images/skeleton/dont-use-placeholder-content-that-will-change@2x.png)
 
 </div>
 
@@ -154,5 +154,5 @@ Use this component to compose a loading version of a page where the page title a
 
 ## Related components
 
-- Use the [Skeleton body text](/components/feedback-indicators/skeleton-body-text) and [Skeleton display text](/components/feedback-indicators/skeleton-display-text) components to represent blocks of content.
-- When giving feedback for in-context operations, use [Progress bar](/components/feedback-indicators/progress-bar) or [Spinner](/components/feedback-indicators/spinner) component.
+- Use the [Skeleton body text](https://polaris.shopify.com/components/feedback-indicators/skeleton-body-text) and [Skeleton display text](https://polaris.shopify.com/components/feedback-indicators/skeleton-display-text) components to represent blocks of content.
+- When giving feedback for in-context operations, use [Progress bar](https://polaris.shopify.com/components/feedback-indicators/progress-bar) or [Spinner](https://polaris.shopify.com/components/feedback-indicators/spinner) component.

--- a/src/components/SkeletonThumbnail/README.md
+++ b/src/components/SkeletonThumbnail/README.md
@@ -53,4 +53,4 @@ Use this component to represent small thumbnails.
 
 ## Related components
 
-- Use this component with [Skeleton display text](/components/feedback-indicators/skeleton-display-text) to represent the content of a card while it’s loading.
+- Use this component with [Skeleton display text](https://polaris.shopify.com/components/feedback-indicators/skeleton-display-text) to represent the content of a card while it’s loading.

--- a/src/components/Spinner/README.md
+++ b/src/components/Spinner/README.md
@@ -33,13 +33,13 @@ Use to notify merchants that their requested action is being processed.
 
 <!-- content-for: android -->
 
-![Material design spinner for Android](/public_images/components/Spinner/android/default@2x.gif)
+![Material design spinner for Android](https://polaris.shopify.com/public_images/components/Spinner/android/default@2x.gif)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Apple’s spinner for iOS](/public_images/components/Spinner/ios/default@2x.gif)
+![Apple’s spinner for iOS](https://polaris.shopify.com/public_images/components/Spinner/ios/default@2x.gif)
 
 <!-- /content-for -->
 
@@ -79,5 +79,5 @@ Spinner accessibility label should:
 
 ## Related components
 
-- To improve user experience and reduce the appearance of long loading times, use the [Progress bar](/components/feedback-indicators/progress-bar) component.
-- To better represent loading content, use [Skeleton page](/components/feedback-indicators/skeleton-page) along with [Skeleton body text](/components/feedback-indicators/skeleton-body-text) and [Skeleton display text](/components/feedback-indicators/skeleton-display-text) components.
+- To improve user experience and reduce the appearance of long loading times, use the [Progress bar](https://polaris.shopify.com/components/feedback-indicators/progress-bar) component.
+- To better represent loading content, use [Skeleton page](https://polaris.shopify.com/components/feedback-indicators/skeleton-page) along with [Skeleton body text](https://polaris.shopify.com/components/feedback-indicators/skeleton-body-text) and [Skeleton display text](https://polaris.shopify.com/components/feedback-indicators/skeleton-display-text) components.

--- a/src/components/Stack/README.md
+++ b/src/components/Stack/README.md
@@ -153,7 +153,7 @@ The stack component will treat multiple elements wrapped in a stack item compone
 
 ## Related components
 
-- To create the large-scale structure of pages, [use the layout component](/components/structure/layout)
+- To create the large-scale structure of pages, [use the layout component](https://polaris.shopify.com/components/structure/layout)
 
 ---
 
@@ -179,6 +179,6 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-The stack component is for alignment only and doesn’t provide any structural information for assistive technologies. To convey relationships between specific items, consider using the [list component](/components/lists-and-tables/list).
+The stack component is for alignment only and doesn’t provide any structural information for assistive technologies. To convey relationships between specific items, consider using the [list component](https://polaris.shopify.com/components/lists-and-tables/list).
 
 <!-- /content-for -->

--- a/src/components/Stepper/README.md
+++ b/src/components/Stepper/README.md
@@ -69,13 +69,13 @@ The stepper has two buttons, a minus and a plus button. It’s possible to tap i
 
 <!-- content-for: android -->
 
-![Default stepper with enabled decrease and increase button](/public_images/components/Stepper/android/default@2x.png)
+![Default stepper with enabled decrease and increase button](https://polaris.shopify.com/public_images/components/Stepper/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default stepper with enabled decrease and increase button](/public_images/components/Stepper/ios/default@2x.png)
+![Default stepper with enabled decrease and increase button](https://polaris.shopify.com/public_images/components/Stepper/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -87,13 +87,13 @@ If you reach the bottom or top value, the appropriate button becomes disabled.
 
 <!-- content-for: android -->
 
-![Disabled stepper](/public_images/components/Stepper/android/disabled@2x.png)
+![Disabled stepper](https://polaris.shopify.com/public_images/components/Stepper/android/disabled@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Disabled stepper](/public_images/components/Stepper/ios/disabled@2x.png)
+![Disabled stepper](https://polaris.shopify.com/public_images/components/Stepper/ios/disabled@2x.png)
 
 <!-- /content-for -->
 
@@ -101,5 +101,5 @@ If you reach the bottom or top value, the appropriate button becomes disabled.
 
 ## Related components
 
-- If values need to change dramatically, use [text field with number field](/components/forms/text-field)
-- If values shouldn’t change or won’t be changing, use [disabled text field](/components/forms/text-field)
+- If values need to change dramatically, use [text field with number field](https://polaris.shopify.com/components/forms/text-field)
+- If values shouldn’t change or won’t be changing, use [disabled text field](https://polaris.shopify.com/components/forms/text-field)

--- a/src/components/Subheading/README.md
+++ b/src/components/Subheading/README.md
@@ -34,7 +34,7 @@ Subheadings should:
 
 - Be used to explain and clearly label logical groups in existing sections of a page
 - Not be used without a parent heading
-- Not be used in tables or list items, such as for the primary content in a [resource list](/components/lists-and-tables/resource-list)
+- Not be used in tables or list items, such as for the primary content in a [resource list](https://polaris.shopify.com/components/lists-and-tables/resource-list)
 
 ---
 
@@ -76,13 +76,13 @@ Use to structure content in a card.
 
 <!-- content-for: android -->
 
-![Subheading in a card](/public_images/components/Subheading/android/default@2x.png)
+![Subheading in a card](https://polaris.shopify.com/public_images/components/Subheading/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Subheading in a card](/public_images/components/Subheading/ios/default@2x.png)
+![Subheading in a card](https://polaris.shopify.com/public_images/components/Subheading/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -90,8 +90,8 @@ Use to structure content in a card.
 
 ## Related components
 
-- To learn how a card is structured to group similar concepts and tasks together, [use the card component](/components/structure/card)
-- To create a title for a card or top-level page section, [use the heading component](/components/titles-and-text/heading)
+- To learn how a card is structured to group similar concepts and tasks together, [use the card component](https://polaris.shopify.com/components/structure/card)
+- To create a title for a card or top-level page section, [use the heading component](https://polaris.shopify.com/components/titles-and-text/heading)
 
 ---
 
@@ -121,7 +121,7 @@ A clear and consistent heading structure helps merchants who have difficulty wit
 
 Use the `element` prop to determine the specific HTML element that’s output for the subheading. The component defaults to a level 3 heading (`<h3>`). Use a different value for the `element` prop if a different subheading fits the context better.
 
-Learn more about writing helpful [headings and subheadings](/content/actionable-language#section-headings-and-subheadings).
+Learn more about writing helpful [headings and subheadings](https://polaris.shopify.com/content/actionable-language#section-headings-and-subheadings).
 
 <!-- usageblock -->
 

--- a/src/components/Tabs/README.md
+++ b/src/components/Tabs/README.md
@@ -125,13 +125,13 @@ class TabsExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default tabs on Android](/public_images/components/Tabs/android/default@2x.png)
+![Default tabs on Android](https://polaris.shopify.com/public_images/components/Tabs/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default tabs on iOS](/public_images/components/Tabs/ios/default@2x.png)
+![Default tabs on iOS](https://polaris.shopify.com/public_images/components/Tabs/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -186,7 +186,7 @@ class FittedTabsExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Fixed tabs on Android](/public_images/components/Tabs/android/fixed@2x.png)
+![Fixed tabs on Android](https://polaris.shopify.com/public_images/components/Tabs/android/fixed@2x.png)
 
 <!-- /content-for -->
 
@@ -194,6 +194,6 @@ class FittedTabsExample extends React.Component {
 
 Also known as [Segmented controls](https://developer.apple.com/design/human-interface-guidelines/ios/controls/segmented-controls/) on iOS.
 
-![Fixed tabs on iOS](/public_images/components/Tabs/ios/fixed@2x.png)
+![Fixed tabs on iOS](https://polaris.shopify.com/public_images/components/Tabs/ios/fixed@2x.png)
 
 <!-- /content-for -->

--- a/src/components/Tag/README.md
+++ b/src/components/Tag/README.md
@@ -41,13 +41,13 @@ Use to allow merchants to add attributes to, and remove attributes from, an obje
 
 <!-- content-for: android -->
 
-![Tag for Android](/public_images/components/Tag/android/default@2x.png)
+![Tag for Android](https://polaris.shopify.com/public_images/components/Tag/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Tag for iOS](/public_images/components/Tag/ios/default@2x.png)
+![Tag for iOS](https://polaris.shopify.com/public_images/components/Tag/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -55,8 +55,8 @@ Use to allow merchants to add attributes to, and remove attributes from, an obje
 
 ## Related components
 
-- To show the status of an object, [use the badge component](/components/images-and-icons/badge)
-- To add and remove tags, [use the text field component](/components/forms/text-field)
+- To show the status of an object, [use the badge component](https://polaris.shopify.com/components/images-and-icons/badge)
+- To add and remove tags, [use the text field component](https://polaris.shopify.com/components/forms/text-field)
 
 ---
 

--- a/src/components/TextContainer/README.md
+++ b/src/components/TextContainer/README.md
@@ -51,13 +51,13 @@ Use this component for default vertical spacing.
 
 <!-- content-for: android -->
 
-![Default text container](/public_images/components/TextContainer/android/default@2x.png)
+![Default text container](https://polaris.shopify.com/public_images/components/TextContainer/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text container](/public_images/components/TextContainer/ios/default@2x.png)
+![Default text container](https://polaris.shopify.com/public_images/components/TextContainer/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -77,13 +77,13 @@ Use the tight spacing option to relate content topics to each other.
 
 <!-- content-for: android -->
 
-![Tight text container](/public_images/components/TextContainer/android/tight@2x.png)
+![Tight text container](https://polaris.shopify.com/public_images/components/TextContainer/android/tight@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Tight text container](/public_images/components/TextContainer/ios/tight@2x.png)
+![Tight text container](https://polaris.shopify.com/public_images/components/TextContainer/ios/tight@2x.png)
 
 <!-- /content-for -->
 
@@ -107,13 +107,13 @@ Use the loose spacing option to separate concepts that are independent of each o
 
 <!-- content-for: android -->
 
-![Loose text container](/public_images/components/TextContainer/android/loose@2x.png)
+![Loose text container](https://polaris.shopify.com/public_images/components/TextContainer/android/loose@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Loose text container](/public_images/components/TextContainer/ios/loose@2x.png)
+![Loose text container](https://polaris.shopify.com/public_images/components/TextContainer/ios/loose@2x.png)
 
 <!-- /content-for -->
 
@@ -121,4 +121,4 @@ Use the loose spacing option to separate concepts that are independent of each o
 
 ## Related components
 
-- For more layout variations, or if you’re looking to vertically space components other than text, use [Stack](/components/structure/stack).
+- For more layout variations, or if you’re looking to vertically space components other than text, use [Stack](https://polaris.shopify.com/components/structure/stack).

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -150,7 +150,7 @@ Error messages should:
 
 - Clearly explain what went wrong and how to fix it
 - Be short and concise, no more than a single sentence
-- Use [passive voice](/content/grammar-and-mechanics) so merchants don’t feel like they’re being blamed for the error
+- Use [passive voice](https://polaris.shopify.com/content/grammar-and-mechanics) so merchants don’t feel like they’re being blamed for the error
 
 <!-- usagelist -->
 
@@ -183,13 +183,13 @@ function TextFieldExample() {
 
 <!-- content-for: android -->
 
-![Default text field](/public_images/components/TextField/android/default@2x.png)
+![Default text field](https://polaris.shopify.com/public_images/components/TextField/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text field](/public_images/components/TextField/ios/default@2x.png)
+![Default text field](https://polaris.shopify.com/public_images/components/TextField/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -217,7 +217,7 @@ function NumberFieldExample() {
 
 This will display the right keyboard on mobile devices.
 
-![Number text field with numeric keyboard](/public_images/components/TextField/android/number@2x.png)
+![Number text field with numeric keyboard](https://polaris.shopify.com/public_images/components/TextField/android/number@2x.png)
 
 <!-- /content-for -->
 
@@ -225,7 +225,7 @@ This will display the right keyboard on mobile devices.
 
 This will display the right keyboard on mobile devices.
 
-![Number text field with numeric keyboard](/public_images/components/TextField/ios/number@2x.png)
+![Number text field with numeric keyboard](https://polaris.shopify.com/public_images/components/TextField/ios/number@2x.png)
 
 <!-- /content-for -->
 
@@ -253,7 +253,7 @@ function EmailFieldExample() {
 
 This will display the right keyboard on mobile devices.
 
-![Email field with email keyboard](/public_images/components/TextField/android/email@2x.png)
+![Email field with email keyboard](https://polaris.shopify.com/public_images/components/TextField/android/email@2x.png)
 
 <!-- /content-for -->
 
@@ -261,7 +261,7 @@ This will display the right keyboard on mobile devices.
 
 This will display the right keyboard on mobile devices.
 
-![Email field with email keyboard](/public_images/components/TextField/ios/email@2x.png)
+![Email field with email keyboard](https://polaris.shopify.com/public_images/components/TextField/ios/email@2x.png)
 
 <!-- /content-for -->
 
@@ -287,13 +287,13 @@ function MultilineFieldExample() {
 
 <!-- content-for: android -->
 
-![Multi-line text field](/public_images/components/TextField/android/multi-line@2x.png)
+![Multi-line text field](https://polaris.shopify.com/public_images/components/TextField/android/multi-line@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Multi-line text field](/public_images/components/TextField/ios/multi-line@2x.png)
+![Multi-line text field](https://polaris.shopify.com/public_images/components/TextField/ios/multi-line@2x.png)
 
 <!-- /content-for -->
 
@@ -435,13 +435,13 @@ class PlaceholderExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default text field with placeholder text hint](/public_images/components/TextField/android/placeholder-text@2x.png)
+![Default text field with placeholder text hint](https://polaris.shopify.com/public_images/components/TextField/android/placeholder-text@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text field with placeholder text hint](/public_images/components/TextField/ios/placeholder-text@2x.png)
+![Default text field with placeholder text hint](https://polaris.shopify.com/public_images/components/TextField/ios/placeholder-text@2x.png)
 
 <!-- /content-for -->
 
@@ -475,13 +475,13 @@ class HelpTextExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default text field with help text](/public_images/components/TextField/android/help-text@2x.png)
+![Default text field with help text](https://polaris.shopify.com/public_images/components/TextField/android/help-text@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text field with help text](/public_images/components/TextField/ios/help-text@2x.png)
+![Default text field with help text](https://polaris.shopify.com/public_images/components/TextField/ios/help-text@2x.png)
 
 <!-- /content-for -->
 
@@ -518,13 +518,13 @@ class PrefixExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default text field with prefix and suffix](/public_images/components/TextField/android/prefix-suffix@2x.png)
+![Default text field with prefix and suffix](https://polaris.shopify.com/public_images/components/TextField/android/prefix-suffix@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text field with prefix and suffix](/public_images/components/TextField/ios/prefix-suffix@2x.png)
+![Default text field with prefix and suffix](https://polaris.shopify.com/public_images/components/TextField/ios/prefix-suffix@2x.png)
 
 <!-- /content-for -->
 
@@ -534,7 +534,7 @@ Use when a text field and several related fields make up a logical unit.
 
 <!-- content-for: web -->
 
-If inputting weight as a number and a separate unit of measurement, use a text field with a [select dropdown menu](/components/forms/select) (for example “kg”, “lb”) as a connected field.
+If inputting weight as a number and a separate unit of measurement, use a text field with a [select dropdown menu](https://polaris.shopify.com/components/forms/select) (for example “kg”, “lb”) as a connected field.
 
 <!-- /content-for -->
 
@@ -579,7 +579,7 @@ class ConnectedFieldsExample extends React.Component {
 
 If inputting weight as a number and a separate unit of measurement, use a text field with a selector (like “kg” or “lb”) as a connected field.
 
-![Text field with connected selector](/public_images/components/TextField/android/connected-fields@2x.png)
+![Text field with connected selector](https://polaris.shopify.com/public_images/components/TextField/android/connected-fields@2x.png)
 
 <!-- /content-for -->
 
@@ -587,7 +587,7 @@ If inputting weight as a number and a separate unit of measurement, use a text f
 
 If inputting weight as a number and a separate unit of measurement, use a text field with a selector (like “kg” or “lb”) as a connected field.
 
-![Text field with connected selector](/public_images/components/TextField/ios/connected-fields@2x.png)
+![Text field with connected selector](https://polaris.shopify.com/public_images/components/TextField/ios/connected-fields@2x.png)
 
 <!-- /content-for -->
 
@@ -601,13 +601,13 @@ For example, tap on a barcode icon to launch the camera and scan barcode for the
 
 <!-- content-for: android -->
 
-![Text field with icon action inside the text field](/public_images/components/TextField/android/accessory@2x.png)
+![Text field with icon action inside the text field](https://polaris.shopify.com/public_images/components/TextField/android/accessory@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Text field with icon action inside the text field](/public_images/components/TextField/ios/accessory@2x.png)
+![Text field with icon action inside the text field](https://polaris.shopify.com/public_images/components/TextField/ios/accessory@2x.png)
 
 <!-- /content-for -->
 
@@ -640,13 +640,13 @@ class ValidationErrorExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Text field with error](/public_images/components/TextField/android/error@2x.png)
+![Text field with error](https://polaris.shopify.com/public_images/components/TextField/android/error@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Text field with error](/public_images/components/TextField/ios/error@2x.png)
+![Text field with error](https://polaris.shopify.com/public_images/components/TextField/ios/error@2x.png)
 
 <!-- /content-for -->
 
@@ -662,7 +662,7 @@ To render an invalid text field and its validation error separately:
 
 - Set a unique identifier on the text field component `id` prop
 - Set a boolean on the text field component `error` prop
-- Use an [inline error component](/components/forms/inline-error) to describe the invalid text field input, and set its `fieldID` prop to be the same unique indentifier as the text field component’s `id`
+- Use an [inline error component](https://polaris.shopify.com/components/forms/inline-error) to describe the invalid text field input, and set its `fieldID` prop to be the same unique indentifier as the text field component’s `id`
 
 ```jsx
 class SeparateValidationErrorExample extends React.Component {
@@ -822,9 +822,9 @@ class TextFieldExample extends React.Component {
 
 ## Related components
 
-- To lay out the elements in a responsive form, [use the form layout component](/components/forms/form-layout)
-- To describe an invalid form input with a separate validation error, [use the inline error component](/components/forms/inline-error)
-- It’s common to [use a select component](/components/forms/select) connected to the left or right of a text field.
+- To lay out the elements in a responsive form, [use the form layout component](https://polaris.shopify.com/components/forms/form-layout)
+- To describe an invalid form input with a separate validation error, [use the inline error component](https://polaris.shopify.com/components/forms/inline-error)
+- It’s common to [use a select component](https://polaris.shopify.com/components/forms/select) connected to the left or right of a text field.
 
 ---
 

--- a/src/components/TextStyle/README.md
+++ b/src/components/TextStyle/README.md
@@ -54,13 +54,13 @@ Use to de-emphasize a piece of text that is less important to merchants than oth
 
 <!-- content-for: android -->
 
-![Subdued textstyle](/public_images/components/TextStyle/android/subdued@2x.png)
+![Subdued textstyle](https://polaris.shopify.com/public_images/components/TextStyle/android/subdued@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Subdued text style](/public_images/components/TextStyle/ios/subdued@2x.png)
+![Subdued text style](https://polaris.shopify.com/public_images/components/TextStyle/ios/subdued@2x.png)
 
 <!-- /content-for -->
 
@@ -74,13 +74,13 @@ Use to mark text representing user input, or to emphasize the totals row in a pr
 
 <!-- content-for: android -->
 
-![Strong text style](/public_images/components/TextStyle/android/strong@2x.png)
+![Strong text style](https://polaris.shopify.com/public_images/components/TextStyle/android/strong@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Strong text style](/public_images/components/TextStyle/ios/strong@2x.png)
+![Strong text style](https://polaris.shopify.com/public_images/components/TextStyle/ios/strong@2x.png)
 
 <!-- /content-for -->
 
@@ -94,13 +94,13 @@ Use in combination with a symbol showing an increasing value to indicate an upwa
 
 <!-- content-for: android -->
 
-![Positive text style](/public_images/components/TextStyle/android/positive@2x.png)
+![Positive text style](https://polaris.shopify.com/public_images/components/TextStyle/android/positive@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Positive text style](/public_images/components/TextStyle/ios/positive@2x.png)
+![Positive text style](https://polaris.shopify.com/public_images/components/TextStyle/ios/positive@2x.png)
 
 <!-- /content-for -->
 
@@ -114,13 +114,13 @@ Use in combination with a symbol showing a decreasing value to indicate a downwa
 
 <!-- content-for: android -->
 
-![Negative text style](/public_images/components/TextStyle/android/negative@2x.png)
+![Negative text style](https://polaris.shopify.com/public_images/components/TextStyle/android/negative@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Negative text style](/public_images/components/TextStyle/ios/negative@2x.png)
+![Negative text style](https://polaris.shopify.com/public_images/components/TextStyle/ios/negative@2x.png)
 
 <!-- /content-for -->
 
@@ -137,13 +137,13 @@ Use to display inline snippets of code or code-like text.
 
 <!-- content-for: android -->
 
-![Code text style](/public_images/components/TextStyle/android/code@2x.png)
+![Code text style](https://polaris.shopify.com/public_images/components/TextStyle/android/code@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Code text style](/public_images/components/TextStyle/ios/code@2x.png)
+![Code text style](https://polaris.shopify.com/public_images/components/TextStyle/ios/code@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Thumbnail/README.md
+++ b/src/components/Thumbnail/README.md
@@ -42,7 +42,7 @@ On Android and iOS, thumbnails should:
 
 ## Content guidelines
 
-Any time you use an image to communicate a concept on Shopify, it’s important to use descriptive [alt text](/content/alternative-text). Doing this is important for [accessibility](/patterns-and-guides/accessibility) because it allows screen readers to describe what’s in the image to people who may not be able to see it.
+Any time you use an image to communicate a concept on Shopify, it’s important to use descriptive [alt text](https://polaris.shopify.com/content/alternative-text). Doing this is important for [accessibility](https://polaris.shopify.com/patterns-and-guides/accessibility) because it allows screen readers to describe what’s in the image to people who may not be able to see it.
 
 For thumbnails, we recommend using a format that describes what will show in the image:
 
@@ -68,13 +68,13 @@ Use as the default size.
 
 <!-- content-for: android -->
 
-![Default thumbnail](/public_images/components/Thumbnail/android/default@2x.png)
+![Default thumbnail](https://polaris.shopify.com/public_images/components/Thumbnail/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default thumbnail](/public_images/components/Thumbnail/ios/default@2x.png)
+![Default thumbnail](https://polaris.shopify.com/public_images/components/Thumbnail/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -106,13 +106,13 @@ Use when a thumbnail is a major focal point. Avoid this size in lists of like it
 
 <!-- content-for: android -->
 
-![Large thumbnail](/public_images/components/Thumbnail/android/large@2x.png)
+![Large thumbnail](https://polaris.shopify.com/public_images/components/Thumbnail/android/large@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Large thumbnail](/public_images/components/Thumbnail/ios/large@2x.png)
+![Large thumbnail](https://polaris.shopify.com/public_images/components/Thumbnail/ios/large@2x.png)
 
 <!-- /content-for -->
 
@@ -120,4 +120,4 @@ Use when a thumbnail is a major focal point. Avoid this size in lists of like it
 
 ## Related components
 
-- To present a thumbnail representation of an individual or business in the interface, [use the avatar component](/components/images-and-icons/avatar)
+- To present a thumbnail representation of an individual or business in the interface, [use the avatar component](https://polaris.shopify.com/components/images-and-icons/avatar)

--- a/src/components/Toast/README.md
+++ b/src/components/Toast/README.md
@@ -33,7 +33,7 @@ The toast component is a non-disruptive message that appears at the bottom of th
 
 ## Required components
 
-The toast component must be wrapped in the [frame](/components/structure/frame) component or used in an embedded application.
+The toast component must be wrapped in the [frame](https://polaris.shopify.com/components/structure/frame) component or used in an embedded application.
 
 ---
 
@@ -336,7 +336,7 @@ Use default toast for informative and neutral feedback.
 
 <!-- content-for: android -->
 
-![Default toast with neutral color](/public_images/components/Toast/android/default@2x.png)
+![Default toast with neutral color](https://polaris.shopify.com/public_images/components/Toast/android/default@2x.png)
 
 <!-- /content-for -->
 
@@ -344,7 +344,7 @@ Use default toast for informative and neutral feedback.
 
 On iOS, icons are available for cases where you want to re-inforce the message.
 
-![Default toast with neutral color](/public_images/components/Toast/ios/default@2x.png)
+![Default toast with neutral color](https://polaris.shopify.com/public_images/components/Toast/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -356,7 +356,7 @@ Use success toast to indicate that something was successful. For example, a prod
 
 <!-- content-for: android -->
 
-![Success toast](/public_images/components/Toast/android/success@2x.png)
+![Success toast](https://polaris.shopify.com/public_images/components/Toast/android/success@2x.png)
 
 <!-- /content-for -->
 
@@ -364,7 +364,7 @@ Use success toast to indicate that something was successful. For example, a prod
 
 On iOS, icons are available for cases where you want to re-inforce the message.
 
-![Success toast](/public_images/components/Toast/ios/success@2x.png)
+![Success toast](https://polaris.shopify.com/public_images/components/Toast/ios/success@2x.png)
 
 <!-- /content-for -->
 
@@ -372,7 +372,7 @@ On iOS, icons are available for cases where you want to re-inforce the message.
 
 <!-- example-for: android, ios, web -->
 
-Although error toast is still available and used in the system, we discourage its use. Reserve it for errors not caused by merchants, like a connection issue. Error toast should convey what went wrong in plain language and should not go over 3 words. For all other error message types, follow the [error message guidelines](/patterns/error-messages).
+Although error toast is still available and used in the system, we discourage its use. Reserve it for errors not caused by merchants, like a connection issue. Error toast should convey what went wrong in plain language and should not go over 3 words. For all other error message types, follow the [error message guidelines](https://polaris.shopify.com/patterns/error-messages).
 
 <!-- content-for: web -->
 
@@ -410,7 +410,7 @@ class ToastExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Error toast](/public_images/components/Toast/android/error@2x.png)
+![Error toast](https://polaris.shopify.com/public_images/components/Toast/android/error@2x.png)
 
 <!-- /content-for -->
 
@@ -418,7 +418,7 @@ class ToastExample extends React.Component {
 
 On iOS, icons are available for cases where you want to re-inforce the message.
 
-![Error toast](/public_images/components/Toast/ios/error@2x.png)
+![Error toast](https://polaris.shopify.com/public_images/components/Toast/ios/error@2x.png)
 
 <!-- /content-for -->
 
@@ -430,13 +430,13 @@ Use action when merchants have the ability to act on the message. For example, t
 
 <!-- content-for: android -->
 
-![Default toast with action to undo](/public_images/components/Toast/android/default-action@2x.png)
+![Default toast with action to undo](https://polaris.shopify.com/public_images/components/Toast/android/default-action@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default toast with action to undo](/public_images/components/Toast/ios/default-action@2x.png)
+![Default toast with action to undo](https://polaris.shopify.com/public_images/components/Toast/ios/default-action@2x.png)
 
 <!-- /content-for -->
 
@@ -444,8 +444,8 @@ Use action when merchants have the ability to act on the message. For example, t
 
 ## Related component
 
-- To present a small amount of content or a menu of actions in a non-blocking overlay, [use the popover component](/components/popover)
-- To communicate a change or condition that needs the merchant’s attention within the context of a page, [use the banner component](/components/feedback-indicators/banner)
+- To present a small amount of content or a menu of actions in a non-blocking overlay, [use the popover component](https://polaris.shopify.com/components/popover)
+- To communicate a change or condition that needs the merchant’s attention within the context of a page, [use the banner component](https://polaris.shopify.com/components/feedback-indicators/banner)
 
 ---
 

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -78,4 +78,4 @@ Use only when necessary to provide an explanation for an interface element.
 
 ## Related components
 
-- To make helpful content more visible to merchants, use the help text portions of form components such as [text fields](/components/forms/text-field), [footer help](/components/titles-and-text/footer-help), or [an inline link to help](/components/navigation/link)
+- To make helpful content more visible to merchants, use the help text portions of form components such as [text fields](https://polaris.shopify.com/components/forms/text-field), [footer help](https://polaris.shopify.com/components/titles-and-text/footer-help), or [an inline link to help](https://polaris.shopify.com/components/navigation/link)

--- a/src/components/TopBar/README.md
+++ b/src/components/TopBar/README.md
@@ -18,13 +18,13 @@ keywords:
 
 # Top bar
 
-Merchants can use the top bar component to search, access menus, and navigate by clicking on the logo. It’s always visible at the top of non-embedded interfaces like Shopify or Shopify Plus. Third-party apps that use the top bar can customize the color to match their brand using the [app provider](/components/structure/app-provider) component and are required to use their own logo.
+Merchants can use the top bar component to search, access menus, and navigate by clicking on the logo. It’s always visible at the top of non-embedded interfaces like Shopify or Shopify Plus. Third-party apps that use the top bar can customize the color to match their brand using the [app provider](https://polaris.shopify.com/components/structure/app-provider) component and are required to use their own logo.
 
 ---
 
 ## Required components
 
-The top bar component must be passed to the [frame](/components/structure/frame) component.
+The top bar component must be passed to the [frame](https://polaris.shopify.com/components/structure/frame) component.
 
 ---
 
@@ -33,10 +33,10 @@ The top bar component must be passed to the [frame](/components/structure/frame)
 The top bar component should:
 
 - Not provide global navigation for an application
-  - Use the [navigation component](/components/structure/navigation) instead
+  - Use the [navigation component](https://polaris.shopify.com/components/structure/navigation) instead
 - Include search to help merchants find resources and navigate an application
 - Include a user menu component to indicate the logged-in merchant and provide them with global actions
-- Provide a color through the [app provider](/components/structure/app-provider) component to style the background
+- Provide a color through the [app provider](https://polaris.shopify.com/components/structure/app-provider) component to style the background
 - The global menu text should contrast with the rest of the top bar and pass the minimum contrast ratio of the WCAG 2.0 guidelines
 - Use an SVG file for the logo
 - Use a logo that passes the minimum contrast ratio of the WCAG 2.0 guidelines when compared to the top bar background color
@@ -423,8 +423,8 @@ class TopBarExample extends React.Component {
 
 ## Related components
 
-- To provide the structure for the top bar component, as well as the primary navigation use the [frame](/components/structure/frame) component.
-- To display the primary navigation within the frame of a non-embedded application, use the [navigation](/components/structure/navigation) component.
-- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](/components/forms/contextual-save-bar) component.
-- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](/components/feedback-indicators/toast) component.
-- To indicate to merchants that a page is loading or an upload is processing use the [loading](/components/feedback-indicators/loading) component.
+- To provide the structure for the top bar component, as well as the primary navigation use the [frame](https://polaris.shopify.com/components/structure/frame) component.
+- To display the primary navigation within the frame of a non-embedded application, use the [navigation](https://polaris.shopify.com/components/structure/navigation) component.
+- To tell merchants their options once they have made changes to a form on the page use the [contextual save bar](https://polaris.shopify.com/components/forms/contextual-save-bar) component.
+- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/feedback-indicators/toast) component.
+- To indicate to merchants that a page is loading or an upload is processing use the [loading](https://polaris.shopify.com/components/feedback-indicators/loading) component.


### PR DESCRIPTION
Related to #934 – this makes READMEs more usable in GitHub, as links to docs actually lead to the site.