### PR TITLE
🔥[AppProvider] Remove unnecessary state

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- Migrated `AppProvider` to a functional component and reduce complexity ([#2105](https://github.com/Shopify/polaris-react/pull/2105))
 - Added `external` prop to `ResourceList` ([#2408](https://github.com/Shopify/polaris-react/pull/2408))
 - Added `onMouseEnter` and `onTouchStart` props to `Button` ([#2409](https://github.com/Shopify/polaris-react/pull/2409))
 - Added `ariaHaspopup` prop to `Popover` ([#2248](https://github.com/Shopify/polaris-react/pull/2248))

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -65,7 +65,11 @@ export function AppProvider({
 
   useEffect(() => {
     stickyManager.current.setContainer(document);
-  }, [stickyManager]);
+    // We're using a disable because stickyManager is a ref
+    // Refs are used for values which don't trigger a re-render
+    // and intended to be mutated outside the render data flow
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <FeaturesContext.Provider value={features}>


### PR DESCRIPTION
Discovered some old code while pairing with @AndrewMusgrave and we figured it best to remove.

### Tophat Instructions

This pull request is removing stale code and converting `AppProvider` to a functional component. You'll want to test that the app context stored on the app provider still works as intended. These contexts include; sticky manager (resource list header), scroll lock manager (scrollable), app bridge (some frame components/page/modal), and i18n (the majority of our components)
