### PR TITLE
[CHANGELOG] Prep for v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [these versioning and changelog guidelines](https://git.i
 
 ---
 
+## 4.2.1 - 2019-09-10
+
+### Bug fixes
+
+- Fixed TypeScript not generating correct types for functional components that have subcomponents ([#2111](https://github.com/Shopify/polaris-react/pull/2111))
+
 ## 4.2.0 - 2019-09-09
 
 ### Enhancements

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,8 +12,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
-- Worked around issue where TypeScript will not generate correct types for functional components that have subcomponents ([#2111](https://github.com/Shopify/polaris-react/pull/2111))
-
 ### Documentation
 
 ### Development workflow


### PR DESCRIPTION
### WHY are these changes introduced?

v4.2.0 shipped with a type issue that causes the build to fail in consuming apps. This PR preps the change log for a patch.