### PR TITLE
[MediaQueryProvider] Add media query provider

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,4 +22,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Code quality
 
+- Added `MediaQueryProvider` to ease the use of media queries and reduce duplication ([#2117](https://github.com/Shopify/polaris-react/pull/2117))
+
 ### Deprecations

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Theme} from '../../utilities/theme';
 import {ThemeProvider} from '../ThemeProvider';
+import {MediaQueryProvider} from '../MediaQueryProvider';
 import {I18n, I18nContext, TranslationDictionary} from '../../utilities/i18n';
 import {
   ScrollLockManager,
@@ -104,7 +105,9 @@ export class AppProvider extends React.Component<AppProviderProps, State> {
             <UniqueIdFactoryContext.Provider value={this.uniqueIdFactory}>
               <AppBridgeContext.Provider value={appBridge}>
                 <LinkContext.Provider value={link}>
-                  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+                  <ThemeProvider theme={theme}>
+                    <MediaQueryProvider>{children}</MediaQueryProvider>
+                  </ThemeProvider>
                 </LinkContext.Provider>
               </AppBridgeContext.Provider>
             </UniqueIdFactoryContext.Provider>

--- a/src/components/AppProvider/tests/AppProvider.test.tsx
+++ b/src/components/AppProvider/tests/AppProvider.test.tsx
@@ -1,9 +1,20 @@
 import React, {useContext} from 'react';
+import {matchMedia} from '@shopify/jest-dom-mocks';
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities/react-testing';
+import {MediaQueryProvider} from 'components/MediaQueryProvider';
 import {LinkContext} from '../../../utilities/link';
 import {AppProvider} from '../AppProvider';
 
 describe('<AppProvider />', () => {
+  beforeEach(() => {
+    matchMedia.mock();
+  });
+
+  afterEach(() => {
+    matchMedia.restore();
+  });
+
   it('updates context when props change', () => {
     const Child: React.SFC<{}> = () => {
       // eslint-disable-next-line shopify/jest/no-if
@@ -21,5 +32,14 @@ describe('<AppProvider />', () => {
     wrapper.setProps({linkComponent: LinkComponent});
     wrapper.update();
     expect(wrapper.find('#child')).toHaveLength(1);
+  });
+
+  it('renders a MediaProvider', () => {
+    const appProvider = mountWithApp(
+      <AppProvider i18n={{}}>
+        <div>Child</div>
+      </AppProvider>,
+    );
+    expect(appProvider).toContainReactComponent(MediaQueryProvider);
   });
 });

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -1,5 +1,4 @@
 import React, {createRef} from 'react';
-import debounce from 'lodash/debounce';
 import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
 import {
   SearchMinor,
@@ -21,7 +20,6 @@ import {ScrollLock} from '../ScrollLock';
 import {Icon} from '../Icon';
 import {TextField} from '../TextField';
 import {Tag} from '../Tag';
-import {EventListener} from '../EventListener';
 import {TextStyle} from '../TextStyle';
 import {Badge} from '../Badge';
 import {Focus} from '../Focus';
@@ -29,7 +27,6 @@ import {Sheet} from '../Sheet';
 import {Stack} from '../Stack';
 import {Key} from '../../types';
 
-import {navigationBarCollapsed} from '../../utilities/breakpoints';
 import {KeypressListener} from '../KeypressListener';
 import {ConnectedFilterControl, PopoverableAction} from './components';
 
@@ -84,7 +81,6 @@ type ComposedProps = FiltersProps & WithAppProviderProps;
 
 interface State {
   open: boolean;
-  mobile: boolean;
   readyForFocus: boolean;
   [key: string]: boolean;
 }
@@ -99,7 +95,6 @@ class Filters extends React.Component<ComposedProps, State> {
 
   state: State = {
     open: false,
-    mobile: false,
     readyForFocus: false,
   };
 
@@ -114,21 +109,6 @@ class Filters extends React.Component<ComposedProps, State> {
     return filtersApplied || queryApplied;
   }
 
-  private handleResize = debounce(
-    () => {
-      const {mobile} = this.state;
-      if (mobile !== isMobile()) {
-        this.setState({mobile: !mobile});
-      }
-    },
-    40,
-    {leading: true, trailing: true, maxWait: 40},
-  );
-
-  componentDidMount() {
-    this.handleResize();
-  }
-
   render() {
     const {
       filters,
@@ -139,13 +119,16 @@ class Filters extends React.Component<ComposedProps, State> {
       focused,
       onClearAll,
       appliedFilters,
-      polaris: {intl},
+      polaris: {
+        intl,
+        mediaQuery: {isNavigationCollapsed},
+      },
       onQueryClear,
       queryPlaceholder,
       children,
     } = this.props;
     const {resourceName} = this.context;
-    const {open, mobile, readyForFocus} = this.state;
+    const {open, readyForFocus} = this.state;
 
     const backdropMarkup = open ? (
       <React.Fragment>
@@ -336,7 +319,7 @@ class Filters extends React.Component<ComposedProps, State> {
         </div>
       ) : null;
 
-    const filtersContainerMarkup = mobile ? (
+    const filtersContainerMarkup = isNavigationCollapsed ? (
       <Sheet
         open={open}
         onClose={this.closeFilters}
@@ -372,7 +355,6 @@ class Filters extends React.Component<ComposedProps, State> {
         {filtersContainerMarkup}
         {tagsMarkup}
         {backdropMarkup}
-        <EventListener event="resize" handler={this.handleResize} />
         <KeypressListener keyCode={Key.Escape} handler={this.closeFilters} />
       </div>
     );
@@ -504,10 +486,6 @@ class Filters extends React.Component<ComposedProps, State> {
       </div>
     );
   }
-}
-
-function isMobile(): boolean {
-  return navigationBarCollapsed().matches;
 }
 
 function getShortcutFilters(filters: FilterInterface[]) {

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -41,15 +41,10 @@ describe('<Frame />', () => {
   });
 
   it('renders a TrapFocus with a `trapping` prop set to true around the navigation on small screens and showMobileNavigation is true', () => {
-    Object.defineProperty(window, 'innerWidth', {
-      configurable: true,
-      writable: true,
-      value: 500,
-    });
-
     const navigation = <div />;
     const frame = mountWithAppProvider(
       <Frame showMobileNavigation navigation={navigation} />,
+      {mediaQuery: {isNavigationCollapsed: true}},
     ).find(Frame);
 
     const trapFocus = frame.find(TrapFocus);
@@ -59,16 +54,10 @@ describe('<Frame />', () => {
   });
 
   it('renders a TrapFocus with a `trapping` prop set to false prop around the navigation on small screens and showMobileNavigation is false', () => {
-    Object.defineProperty(window, 'innerWidth', {
-      configurable: true,
-      writable: true,
-      value: 500,
-    });
-
     const navigation = <div />;
-    const frame = mountWithAppProvider(<Frame navigation={navigation} />).find(
-      Frame,
-    );
+    const frame = mountWithAppProvider(<Frame navigation={navigation} />, {
+      mediaQuery: {isNavigationCollapsed: false},
+    }).find(Frame);
 
     const trapFocus = frame.find(TrapFocus);
     expect(trapFocus.exists()).toBe(true);
@@ -86,15 +75,10 @@ describe('<Frame />', () => {
   });
 
   it('renders a CSSTransition around the navigation with `appear` and `exit` set to true on small screen', () => {
-    Object.defineProperty(window, 'innerWidth', {
-      configurable: true,
-      writable: true,
-      value: 500,
-    });
-
     const navigation = <div />;
     const cssTransition = mountWithAppProvider(
       <Frame showMobileNavigation navigation={navigation} />,
+      {mediaQuery: {isNavigationCollapsed: true}},
     )
       .find(TrapFocus)
       .find(CSSTransition);

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -56,7 +56,7 @@ describe('<Frame />', () => {
   it('renders a TrapFocus with a `trapping` prop set to false prop around the navigation on small screens and showMobileNavigation is false', () => {
     const navigation = <div />;
     const frame = mountWithAppProvider(<Frame navigation={navigation} />, {
-      mediaQuery: {isNavigationCollapsed: false},
+      mediaQuery: {isNavigationCollapsed: true},
     }).find(Frame);
 
     const trapFocus = frame.find(TrapFocus);

--- a/src/components/MediaQueryProvider/MediaQueryProvider.tsx
+++ b/src/components/MediaQueryProvider/MediaQueryProvider.tsx
@@ -1,0 +1,41 @@
+import React, {useEffect, useState, useCallback} from 'react';
+import debounce from 'lodash/debounce';
+import {MediaQueryContext} from '../../utilities/media-query';
+import {navigationBarCollapsed} from '../../utilities/breakpoints';
+import {EventListener} from '../EventListener';
+
+interface Props {
+  children?: React.ReactNode;
+}
+
+export const MediaQueryProvider = function MediaQueryProvider({
+  children,
+}: Props) {
+  const [isNavigationCollapsed, setIsNavigationCollapsed] = useState(
+    navigationBarCollapsed().matches,
+  );
+
+  const handleResize = useCallback(
+    debounce(
+      () => {
+        if (isNavigationCollapsed !== navigationBarCollapsed().matches) {
+          setIsNavigationCollapsed(!isNavigationCollapsed);
+        }
+      },
+      40,
+      {trailing: true, leading: true, maxWait: 40},
+    ),
+    [isNavigationCollapsed],
+  );
+
+  useEffect(() => {
+    setIsNavigationCollapsed(navigationBarCollapsed().matches);
+  }, []);
+
+  return (
+    <MediaQueryContext.Provider value={{isNavigationCollapsed}}>
+      <EventListener event="resize" handler={handleResize} />
+      {children}
+    </MediaQueryContext.Provider>
+  );
+};

--- a/src/components/MediaQueryProvider/index.ts
+++ b/src/components/MediaQueryProvider/index.ts
@@ -1,0 +1,1 @@
+export {MediaQueryProvider} from './MediaQueryProvider';

--- a/src/components/MediaQueryProvider/tests/MediaQueryProvider.test.tsx
+++ b/src/components/MediaQueryProvider/tests/MediaQueryProvider.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {matchMedia} from '@shopify/jest-dom-mocks';
+import {act} from 'react-dom/test-utils';
+import {mountWithApp} from 'test-utilities';
+import {EventListener} from 'components';
+import {MediaQueryProvider} from '../MediaQueryProvider';
+import {useMediaQuery} from '../../../utilities/media-query';
+
+describe('MediaQueryProvider', () => {
+  beforeEach(() => {
+    matchMedia.mock();
+  });
+
+  afterEach(() => {
+    matchMedia.restore();
+  });
+
+  it('renders EventListener with the resize event', () => {
+    const mediaQueryProvider = mountWithApp(<MediaQueryProvider />);
+    expect(mediaQueryProvider).toContainReactComponentTimes(EventListener, 1, {
+      event: 'resize',
+    });
+  });
+
+  it('passes isNavigationCollapsed to MediaQueryContext.Provider', () => {
+    function Component() {
+      const mediaQuery = useMediaQuery();
+      // eslint-disable-next-line shopify/jest/no-if
+      return mediaQuery !== undefined ? <div /> : null;
+    }
+
+    const mediaQueryProvider = mountWithApp(
+      <MediaQueryProvider>
+        <Component />
+      </MediaQueryProvider>,
+    );
+    expect(mediaQueryProvider).toContainReactComponentTimes('div', 1);
+  });
+
+  it('sets isNavigationCollapsed when resize occurs', () => {
+    function Component() {
+      const {isNavigationCollapsed} = useMediaQuery();
+      // eslint-disable-next-line shopify/jest/no-if
+      return isNavigationCollapsed ? <div>content</div> : null;
+    }
+    const mediaQueryProvider = mountWithApp(
+      <MediaQueryProvider>
+        <Component />
+      </MediaQueryProvider>,
+    );
+
+    matchMedia.setMedia(() => ({matches: true}));
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    mediaQueryProvider.forceUpdate();
+    expect(mediaQueryProvider).toContainReactComponentTimes('div', 1);
+  });
+});

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -1,6 +1,5 @@
 import React, {
   useEffect,
-  useCallback,
   useContext,
   useState,
   MouseEvent,
@@ -9,7 +8,6 @@ import React, {
 } from 'react';
 
 import {classNames} from '../../../../utilities/css';
-import {navigationBarCollapsed} from '../../../../utilities/breakpoints';
 
 import {NavigationContext} from '../../context';
 import {Badge} from '../../../Badge';
@@ -18,6 +16,7 @@ import {IconProps} from '../../../../types';
 import {Indicator} from '../../../Indicator';
 import {UnstyledLink} from '../../../UnstyledLink';
 import {useI18n} from '../../../../utilities/i18n';
+import {useMediaQuery} from '../../../../utilities/media-query';
 
 import styles from '../../Navigation.scss';
 
@@ -85,21 +84,15 @@ export function Item({
   excludePaths,
 }: ItemProps) {
   const intl = useI18n();
+  const {isNavigationCollapsed} = useMediaQuery();
   const {location, onNavigationDismiss} = useContext(NavigationContext);
   const [expanded, setExpanded] = useState(false);
 
-  const handleResize = useCallback(() => {
-    if (!navigationBarCollapsed().matches && expanded) {
+  useEffect(() => {
+    if (!isNavigationCollapsed && expanded) {
       setExpanded(false);
     }
-  }, [expanded]);
-
-  useEffect(() => {
-    navigationBarCollapsed().addListener(handleResize);
-    return () => {
-      navigationBarCollapsed().removeListener(handleResize);
-    };
-  }, [handleResize]);
+  }, [expanded, isNavigationCollapsed]);
 
   const tabIndex = disabled ? -1 : 0;
 
@@ -281,7 +274,7 @@ export function Item({
       if (
         subNavigationItems &&
         subNavigationItems.length > 0 &&
-        navigationBarCollapsed().matches
+        isNavigationCollapsed
       ) {
         event.preventDefault();
         setExpanded(!expanded);

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import debounce from 'lodash/debounce';
 import {classNames} from '../../../../utilities/css';
 import {buttonsFrom} from '../../../Button';
-import {navigationBarCollapsed} from '../../../../utilities/breakpoints';
-import {EventListener} from '../../../EventListener';
+import {useMediaQuery} from '../../../../utilities/media-query';
 import {ComplexAction, MenuGroupDescriptor} from '../../../../types';
 import {Breadcrumbs, BreadcrumbsProps} from '../../../Breadcrumbs';
 
@@ -31,145 +29,94 @@ export interface HeaderProps extends TitleProps {
   actionGroups?: MenuGroupDescriptor[];
 }
 
-interface State {
-  mobileView?: boolean;
-}
+export function Header({
+  title,
+  subtitle,
+  titleMetadata,
+  thumbnail,
+  titleHidden = false,
+  separator,
+  primaryAction,
+  pagination,
+  breadcrumbs = [],
+  secondaryActions = [],
+  actionGroups = [],
+}: HeaderProps) {
+  const {isNavigationCollapsed} = useMediaQuery();
 
-export class Header extends React.PureComponent<HeaderProps, State> {
-  state: State = {
-    mobileView: isMobileView(),
-  };
-
-  private handleResize = debounce(
-    () => {
-      const {
-        state: {mobileView},
-        handleToggleMobile,
-      } = this;
-
-      if (mobileView !== isMobileView()) {
-        handleToggleMobile();
-      }
-    },
-    40,
-    {leading: true, trailing: true, maxWait: 40},
-  );
-
-  componentDidMount() {
-    const {
-      state: {mobileView},
-      handleToggleMobile,
-    } = this;
-
-    if (mobileView !== isMobileView()) {
-      handleToggleMobile();
-    }
-  }
-
-  render() {
-    const {
-      title,
-      subtitle,
-      titleMetadata,
-      thumbnail,
-      titleHidden = false,
-      separator,
-      primaryAction,
-      pagination,
-      breadcrumbs = [],
-      secondaryActions = [],
-      actionGroups = [],
-    } = this.props;
-
-    const {mobileView} = this.state;
-
-    const breadcrumbMarkup =
-      breadcrumbs.length > 0 ? (
-        <div className={styles.BreadcrumbWrapper}>
-          <Breadcrumbs breadcrumbs={breadcrumbs} />
-        </div>
-      ) : null;
-
-    const paginationMarkup =
-      pagination && !mobileView ? (
-        <div className={styles.PaginationWrapper}>
-          <Pagination {...pagination} plain />
-        </div>
-      ) : null;
-
-    const navigationMarkup =
-      breadcrumbMarkup || paginationMarkup ? (
-        <div className={styles.Navigation}>
-          {breadcrumbMarkup}
-          {paginationMarkup}
-        </div>
-      ) : null;
-
-    const pageTitleMarkup = (
-      <Title
-        title={title}
-        subtitle={subtitle}
-        titleMetadata={titleMetadata}
-        thumbnail={thumbnail}
-      />
-    );
-
-    const primary =
-      primaryAction &&
-      (primaryAction.primary === undefined ? true : primaryAction.primary);
-
-    const primaryActionMarkup = primaryAction ? (
-      <div className={styles.PrimaryActionWrapper}>
-        {buttonsFrom(primaryAction, {primary})}
+  const breadcrumbMarkup =
+    breadcrumbs.length > 0 ? (
+      <div className={styles.BreadcrumbWrapper}>
+        <Breadcrumbs breadcrumbs={breadcrumbs} />
       </div>
     ) : null;
 
-    const actionMenuMarkup =
-      secondaryActions.length > 0 || hasGroupsWithActions(actionGroups) ? (
-        <div className={styles.ActionMenuWrapper}>
-          <ActionMenu
-            actions={secondaryActions}
-            groups={actionGroups}
-            rollup={mobileView}
-          />
-        </div>
-      ) : null;
-
-    const headerClassNames = classNames(
-      styles.Header,
-      titleHidden && styles.titleHidden,
-      separator && styles.separator,
-      navigationMarkup && styles.hasNavigation,
-      actionMenuMarkup && styles.hasActionMenu,
-      mobileView && styles.mobileView,
-    );
-
-    return (
-      <div className={headerClassNames}>
-        {navigationMarkup}
-
-        <div className={styles.MainContent}>
-          <div className={styles.TitleActionMenuWrapper}>
-            {pageTitleMarkup}
-            {actionMenuMarkup}
-          </div>
-
-          {primaryActionMarkup}
-        </div>
-
-        <EventListener event="resize" handler={this.handleResize} passive />
+  const paginationMarkup =
+    pagination && !isNavigationCollapsed ? (
+      <div className={styles.PaginationWrapper}>
+        <Pagination {...pagination} plain />
       </div>
-    );
-  }
+    ) : null;
 
-  private handleToggleMobile = () => {
-    const {mobileView} = this.state;
-    this.setState({mobileView: !mobileView});
-  };
-}
+  const navigationMarkup =
+    breadcrumbMarkup || paginationMarkup ? (
+      <div className={styles.Navigation}>
+        {breadcrumbMarkup}
+        {paginationMarkup}
+      </div>
+    ) : null;
 
-// TODO: Can we instead get this from the <Frame />?
-// Or perhaps store in Context to be shared across components?
-function isMobileView(): boolean {
-  return navigationBarCollapsed().matches;
+  const pageTitleMarkup = (
+    <Title
+      title={title}
+      subtitle={subtitle}
+      titleMetadata={titleMetadata}
+      thumbnail={thumbnail}
+    />
+  );
+
+  const primary =
+    primaryAction &&
+    (primaryAction.primary === undefined ? true : primaryAction.primary);
+
+  const primaryActionMarkup = primaryAction ? (
+    <div className={styles.PrimaryActionWrapper}>
+      {buttonsFrom(primaryAction, {primary})}
+    </div>
+  ) : null;
+
+  const actionMenuMarkup =
+    secondaryActions.length > 0 || hasGroupsWithActions(actionGroups) ? (
+      <div className={styles.ActionMenuWrapper}>
+        <ActionMenu
+          actions={secondaryActions}
+          groups={actionGroups}
+          rollup={isNavigationCollapsed}
+        />
+      </div>
+    ) : null;
+
+  const headerClassNames = classNames(
+    styles.Header,
+    titleHidden && styles.titleHidden,
+    separator && styles.separator,
+    navigationMarkup && styles.hasNavigation,
+    actionMenuMarkup && styles.hasActionMenu,
+    isNavigationCollapsed && styles.mobileView,
+  );
+
+  return (
+    <div className={headerClassNames}>
+      {navigationMarkup}
+
+      <div className={styles.MainContent}>
+        <div className={styles.TitleActionMenuWrapper}>
+          {pageTitleMarkup}
+          {actionMenuMarkup}
+        </div>
+
+        {primaryActionMarkup}
+      </div>
+    </div>
+  );
 }

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import {matchMedia} from '@shopify/jest-dom-mocks';
 import {
   ActionMenu,
   Breadcrumbs,
   buttonsFrom,
-  EventListener,
   Pagination,
   Badge,
   Avatar,
@@ -18,23 +16,6 @@ describe('<Header />', () => {
   const mockProps: HeaderProps = {
     title: 'mock title',
   };
-
-  beforeEach(() => {
-    matchMedia.mock();
-  });
-
-  afterEach(() => {
-    matchMedia.restore();
-  });
-
-  it('renders resize <EventListener />', () => {
-    const wrapper = mountWithAppProvider(<Header {...mockProps} />);
-    const resizeEventListener = wrapper
-      .find(EventListener)
-      .filterWhere((component) => component.prop('event') === 'resize');
-
-    expect(resizeEventListener).toHaveLength(1);
-  });
 
   describe('Header', () => {
     const mockProps = {
@@ -232,10 +213,9 @@ describe('<Header />', () => {
     });
 
     it('renders with `rollup` as `true` when on mobile', () => {
-      matchMedia.setMedia(() => ({matches: true}));
-
       const wrapper = mountWithAppProvider(
         <Header {...mockProps} secondaryActions={mockSecondaryActions} />,
+        {mediaQuery: {isNavigationCollapsed: true}},
       );
 
       expect(wrapper.find(ActionMenu).prop('rollup')).toBe(true);

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -20,8 +20,6 @@ window.matchMedia =
     };
   };
 
-const defaultWindowWidth = window.innerWidth;
-
 jest.mock('../../../utilities/app-bridge-transformers', () => ({
   ...require.requireActual('../../../utilities/app-bridge-transformers'),
   generateRedirect: jest.fn((...args) => args),
@@ -57,11 +55,6 @@ describe('<Page />', () => {
 
   afterEach(() => {
     animationFrame.restore();
-    Object.defineProperty(window, 'innerWidth', {
-      configurable: true,
-      writable: true,
-      value: defaultWindowWidth,
-    });
   });
 
   describe('forceRender renders children in page', () => {

--- a/src/components/PolarisTestProvider/PolarisTestProvider.tsx
+++ b/src/components/PolarisTestProvider/PolarisTestProvider.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import {merge} from '../../utilities/merge';
 import {FrameContext} from '../../utilities/frame';
 import {Theme, ThemeContext} from '../../utilities/theme';
+import {MediaQueryContext} from '../../utilities/media-query';
 import {
   ScrollLockManager,
   ScrollLockManagerContext,
@@ -19,6 +21,9 @@ import {
 } from '../../utilities/unique-id';
 
 type FrameContextType = NonNullable<React.ContextType<typeof FrameContext>>;
+type MediaQueryContextType = NonNullable<
+  React.ContextType<typeof MediaQueryContext>
+>;
 
 /**
  * When writing a custom mounting function `mountWithAppContext(node, options)`
@@ -31,6 +36,7 @@ export type WithPolarisTestProviderOptions = {
   appBridge?: AppBridgeOptions;
   link?: LinkLikeComponent;
   theme?: Partial<Theme>;
+  mediaQuery?: Partial<MediaQueryContextType>;
   // Contexts provided by Frame
   frame?: Partial<FrameContextType>;
 };
@@ -41,6 +47,10 @@ export interface PolarisTestProviderProps
   strict?: boolean;
 }
 
+const defaultMediaQuery: MediaQueryContextType = {
+  isNavigationCollapsed: false,
+};
+
 export function PolarisTestProvider({
   strict,
   children,
@@ -49,6 +59,7 @@ export function PolarisTestProvider({
   link,
   theme,
   frame,
+  mediaQuery,
 }: PolarisTestProviderProps) {
   const Wrapper = strict ? React.StrictMode : React.Fragment;
 
@@ -68,6 +79,8 @@ export function PolarisTestProvider({
 
   const mergedFrame = createFrameContext(frame);
 
+  const mergedMediaQuery = merge(defaultMediaQuery, mediaQuery);
+
   return (
     <Wrapper>
       <I18nContext.Provider value={intl}>
@@ -78,7 +91,9 @@ export function PolarisTestProvider({
                 <LinkContext.Provider value={link}>
                   <ThemeContext.Provider value={mergedTheme}>
                     <FrameContext.Provider value={mergedFrame}>
-                      {children}
+                      <MediaQueryContext.Provider value={mergedMediaQuery}>
+                        {children}
+                      </MediaQueryContext.Provider>
                     </FrameContext.Provider>
                   </ThemeContext.Provider>
                 </LinkContext.Provider>

--- a/src/components/PolarisTestProvider/tests/PolarisTestProvider.test.tsx
+++ b/src/components/PolarisTestProvider/tests/PolarisTestProvider.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {mount} from '@shopify/react-testing';
+import {mount, mountWithApp} from 'test-utilities';
+import {MediaQueryContext, useMediaQuery} from 'utilities/media-query';
 import {PolarisTestProvider} from '../PolarisTestProvider';
 
 describe('PolarisTestProvider', () => {
@@ -21,5 +22,35 @@ describe('PolarisTestProvider', () => {
     );
 
     expect(polarisTestProvider).toContainReactComponent(React.StrictMode);
+  });
+
+  describe('MediaQueryContext', () => {
+    it('contains a MediaQueryContext provider', () => {
+      const polarisTestProvider = mountWithApp(
+        <PolarisTestProvider>
+          <div>Children</div>
+        </PolarisTestProvider>,
+      );
+
+      expect(polarisTestProvider).toContainReactComponent(
+        MediaQueryContext.Provider,
+      );
+    });
+
+    it('allows isNavigationCollapsed to be overwritten', () => {
+      function Component() {
+        const {isNavigationCollapsed} = useMediaQuery();
+        // eslint-disable-next-line shopify/jest/no-if
+        return isNavigationCollapsed ? <div /> : null;
+      }
+
+      const polarisTestProvider = mountWithApp(
+        <PolarisTestProvider mediaQuery={{isNavigationCollapsed: true}}>
+          <Component />
+        </PolarisTestProvider>,
+      );
+
+      expect(polarisTestProvider).toContainReactComponentTimes('div', 1);
+    });
   });
 });

--- a/src/components/Sheet/Sheet.tsx
+++ b/src/components/Sheet/Sheet.tsx
@@ -1,10 +1,9 @@
-import React, {useCallback, useEffect, useState, useRef} from 'react';
+import React, {useCallback, useRef} from 'react';
 
 import {CSSTransition} from '@material-ui/react-transition-group';
-import debounce from 'lodash/debounce';
+import {useMediaQuery} from '../../utilities/media-query';
 import {classNames} from '../../utilities/css';
 
-import {navigationBarCollapsed} from '../../utilities/breakpoints';
 import {Key} from '../../types';
 import {layer, overlay, Duration} from '../shared';
 
@@ -12,7 +11,6 @@ import {Backdrop} from '../Backdrop';
 import {TrapFocus} from '../TrapFocus';
 import {Portal} from '../Portal';
 import {KeypressListener} from '../KeypressListener';
-import {EventListener} from '../EventListener';
 
 import styles from './Sheet.scss';
 
@@ -50,36 +48,20 @@ export function Sheet({
   onEntered,
   onExit,
 }: SheetProps) {
+  const {isNavigationCollapsed} = useMediaQuery();
   const container = useRef<HTMLDivElement>(null);
-  const [mobile, setMobile] = useState(false);
 
   const findDOMNode = useCallback(() => {
     return container.current;
-  }, []);
-
-  const handleResize = useCallback(
-    debounce(
-      () => {
-        if (mobile !== isMobile()) {
-          handleToggleMobile();
-        }
-      },
-      40,
-      {leading: true, trailing: true, maxWait: 40},
-    ),
-    [mobile],
-  );
-
-  useEffect(() => {
-    handleResize();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
     <Portal idPrefix="sheet">
       <CSSTransition
         findDOMNode={findDOMNode}
-        classNames={mobile ? BOTTOM_CLASS_NAMES : RIGHT_CLASS_NAMES}
+        classNames={
+          isNavigationCollapsed ? BOTTOM_CLASS_NAMES : RIGHT_CLASS_NAMES
+        }
         timeout={Duration.Slow}
         in={open}
         mountOnEnter
@@ -101,16 +83,7 @@ export function Sheet({
         </div>
       </CSSTransition>
       <KeypressListener keyCode={Key.Escape} handler={onClose} />
-      <EventListener event="resize" handler={handleResize} />
       {open && <Backdrop transparent onClick={onClose} />}
     </Portal>
   );
-
-  function handleToggleMobile() {
-    setMobile((mobile) => !mobile);
-  }
-}
-
-function isMobile(): boolean {
-  return navigationBarCollapsed().matches;
 }

--- a/src/components/Sheet/tests/Sheet.test.tsx
+++ b/src/components/Sheet/tests/Sheet.test.tsx
@@ -1,20 +1,11 @@
 import React from 'react';
 import {CSSTransition} from '@material-ui/react-transition-group';
-import {matchMedia} from '@shopify/jest-dom-mocks';
 import {mountWithAppProvider} from 'test-utilities/legacy';
 
 import {Backdrop} from 'components/Backdrop';
 import {Sheet, BOTTOM_CLASS_NAMES, RIGHT_CLASS_NAMES} from '../Sheet';
 
 describe('<Sheet />', () => {
-  beforeEach(() => {
-    matchMedia.mock();
-  });
-
-  afterEach(() => {
-    matchMedia.restore();
-  });
-
   const mockProps = {
     open: true,
     onClose: noop,
@@ -42,12 +33,11 @@ describe('<Sheet />', () => {
   });
 
   it('renders a css transition component with bottom class names at mobile sizes', () => {
-    matchMedia.setMedia(() => ({matches: true}));
-
     const sheet = mountWithAppProvider(
       <Sheet {...mockProps}>
         <div>Content</div>
       </Sheet>,
+      {mediaQuery: {isNavigationCollapsed: true}},
     );
 
     expect(sheet.find(CSSTransition).props().classNames).toStrictEqual(

--- a/src/utilities/media-query/context.tsx
+++ b/src/utilities/media-query/context.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+type MediaQueryContextType = {
+  isNavigationCollapsed: boolean;
+};
+
+export const MediaQueryContext = React.createContext<
+  MediaQueryContextType | undefined
+>(undefined);

--- a/src/utilities/media-query/hooks.tsx
+++ b/src/utilities/media-query/hooks.tsx
@@ -1,0 +1,14 @@
+import {useContext} from 'react';
+import {MediaQueryContext} from './context';
+
+export function useMediaQuery() {
+  const mediaQuery = useContext(MediaQueryContext);
+
+  if (!mediaQuery) {
+    throw new Error(
+      'No mediaQuery was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.',
+    );
+  }
+
+  return mediaQuery;
+}

--- a/src/utilities/media-query/index.ts
+++ b/src/utilities/media-query/index.ts
@@ -1,0 +1,2 @@
+export {MediaQueryContext} from './context';
+export {useMediaQuery} from './hooks';

--- a/src/utilities/media-query/tests/hooks.test.tsx
+++ b/src/utilities/media-query/tests/hooks.test.tsx
@@ -1,0 +1,32 @@
+import React, {useContext} from 'react';
+import {mount, mountWithApp} from 'test-utilities';
+import {useMediaQuery} from '../hooks';
+import {MediaQueryContext} from '../context';
+
+let consoleErrorSpy: jest.SpyInstance;
+
+function Component() {
+  return useMediaQuery() === useContext(MediaQueryContext) ? <div /> : null;
+}
+
+describe('useMediaQuery', () => {
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('returns context', () => {
+    const component = mountWithApp(<Component />);
+    expect(component).toContainReactComponent('div');
+  });
+
+  it('throws an error if context is not set', () => {
+    const attemptMount = () => mount(<Component />);
+    expect(attemptMount).toThrow(
+      'No mediaQuery was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.',
+    );
+  });
+});

--- a/src/utilities/with-app-provider.tsx
+++ b/src/utilities/with-app-provider.tsx
@@ -6,6 +6,7 @@ import {useScrollLockManager} from './scroll-lock-manager';
 import {useTheme} from './theme';
 import {useStickyManager} from './sticky-manager';
 import {useAppBridge} from './app-bridge';
+import {useMediaQuery} from './media-query';
 
 export interface WithAppProviderProps {
   polaris: {
@@ -15,6 +16,7 @@ export interface WithAppProviderProps {
     scrollLockManager: ReturnType<typeof useScrollLockManager>;
     stickyManager: ReturnType<typeof useStickyManager>;
     appBridge: ReturnType<typeof useAppBridge>;
+    mediaQuery: ReturnType<typeof useMediaQuery>;
   };
 }
 
@@ -30,6 +32,7 @@ export function withAppProvider<OwnProps>() {
         scrollLockManager: useScrollLockManager(),
         stickyManager: useStickyManager(),
         appBridge: useAppBridge(),
+        mediaQuery: useMediaQuery(),
       };
 
       return <WrappedComponent {...(props as any)} polaris={polaris} />;


### PR DESCRIPTION
### WHY are these changes introduced?

Reduce duplicated logic and add a location where we can easily add to it

### WHAT is this pull request doing?

* Create MediaQueryProvider, hooks, and context
* Add it to AppProvider, withAppProvider, PolarisTestProvider
* Add tests
* Replace all occurrences of navigationBarCollapsed() with useMediaQuery or mediaQuery

### How to 🎩

You'll want to check Filters, Frame, Navigation, Page and Sheet in the deployment across screen sizes to ensure navigation collapsed is still working correctly.

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
