### PR TITLE
[AppProvider] Added children type to props interface

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed modal border not being visible in Windows high contrast mode ([#2114](https://github.com/Shopify/polaris-react/pull/2114))
 - Added default accessibility label from `ResourceItem` ([#2097](https://github.com/Shopify/polaris-react/pull/2097))
 - Reverted `Page.primaryAction` forcing `primary` to be `true` ([#2137](https://github.com/Shopify/polaris-react/pull/2137))
+- Removed `React.Children.only` from `AppProvider`and `ThemeProvider` ([#2121](https://github.com/Shopify/polaris-react/pull/2121))
 
 ### Documentation
 

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -35,6 +35,8 @@ export interface AppProviderProps extends AppBridgeOptions {
   linkComponent?: LinkLikeComponent;
   /** Custom logos and colors provided to select components */
   theme?: Theme;
+  /** Inner content of the application */
+  children?: React.ReactNode;
 }
 
 export class AppProvider extends React.Component<AppProviderProps, State> {
@@ -102,9 +104,7 @@ export class AppProvider extends React.Component<AppProviderProps, State> {
             <UniqueIdFactoryContext.Provider value={this.uniqueIdFactory}>
               <AppBridgeContext.Provider value={appBridge}>
                 <LinkContext.Provider value={link}>
-                  <ThemeProvider theme={theme}>
-                    {React.Children.only(children)}
-                  </ThemeProvider>
+                  <ThemeProvider theme={theme}>{children}</ThemeProvider>
                 </LinkContext.Provider>
               </AppBridgeContext.Provider>
             </UniqueIdFactoryContext.Provider>

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -55,7 +55,7 @@ export class ThemeProvider extends React.Component<ThemeProviderProps, State> {
 
     return (
       <ThemeContext.Provider value={theme}>
-        <div style={styles}>{React.Children.only(children)}</div>
+        <div style={styles}>{children}</div>
       </ThemeContext.Provider>
     );
   }


### PR DESCRIPTION
### WHY are these changes introduced?

AppProvider uses `{React.Children.only(children)}` which has not been typed. 

### WHAT is this pull request doing?

* Adding a children type to the AppProvider prop interface
* Remove `React.Children.only` from `AppProvider` & `ThemeProvider` as it's an arbitary restriction

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
