### PR TITLE
Remove polaris domain name from image markdown elements

### DIFF
--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -67,13 +67,13 @@ Use to present an avatar for a merchant, customer, or business.
 
 <!-- content-for: android -->
 
-![Default avatar](https://polaris.shopify.com/public_images/components/Avatar/android/default@2x.png)
+![Default avatar](/public_images/components/Avatar/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default avatar](https://polaris.shopify.com/public_images/components/Avatar/ios/default@2x.png)
+![Default avatar](/public_images/components/Avatar/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Badge/README.md
+++ b/src/components/Badge/README.md
@@ -88,13 +88,13 @@ Use to give a non-critical status update on a piece of information or action.
 
 <!-- content-for: android -->
 
-![Default badge with gray background](https://polaris.shopify.com/public_images/components/Badge/android/default@2x.png)
+![Default badge with gray background](/public_images/components/Badge/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default badge with gray background](https://polaris.shopify.com/public_images/components/Badge/ios/default@2x.png)
+![Default badge with gray background](/public_images/components/Badge/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -108,13 +108,13 @@ Use to call out an object or action as having an important attribute. For exampl
 
 <!-- content-for: android -->
 
-![Informational badge with blue background](https://polaris.shopify.com/public_images/components/Badge/android/informational@2x.png)
+![Informational badge with blue background](/public_images/components/Badge/android/informational@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Informational badge with blue background](https://polaris.shopify.com/public_images/components/Badge/ios/informational@2x.png)
+![Informational badge with blue background](/public_images/components/Badge/ios/informational@2x.png)
 
 <!-- /content-for -->
 
@@ -128,13 +128,13 @@ Use to indicate a successful, completed, or desirable state when it’s importan
 
 <!-- content-for: android -->
 
-![Success badge with green background](https://polaris.shopify.com/public_images/components/Badge/android/success@2x.png)
+![Success badge with green background](/public_images/components/Badge/android/success@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Success badge with green background](https://polaris.shopify.com/public_images/components/Badge/ios/success@2x.png)
+![Success badge with green background](/public_images/components/Badge/ios/success@2x.png)
 
 <!-- /content-for -->
 
@@ -148,13 +148,13 @@ Use when something requires merchants’ attention but the issue isn’t critica
 
 <!-- content-for: android -->
 
-![Attention badge with yellow background](https://polaris.shopify.com/public_images/components/Badge/android/attention@2x.png)
+![Attention badge with yellow background](/public_images/components/Badge/android/attention@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Attention badge with yellow background](https://polaris.shopify.com/public_images/components/Badge/ios/attention@2x.png)
+![Attention badge with yellow background](/public_images/components/Badge/ios/attention@2x.png)
 
 <!-- /content-for -->
 
@@ -170,13 +170,13 @@ Keep in mind that seeing this badge can feel stressful for merchants so it shoul
 
 <!-- content-for: android -->
 
-![Warning badge with orange background](https://polaris.shopify.com/public_images/components/Badge/android/warning@2x.png)
+![Warning badge with orange background](/public_images/components/Badge/android/warning@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Warning badge with orange background](https://polaris.shopify.com/public_images/components/Badge/ios/warning@2x.png)
+![Warning badge with orange background](/public_images/components/Badge/ios/warning@2x.png)
 
 <!-- /content-for -->
 
@@ -190,13 +190,13 @@ Keep in mind that seeing this badge can feel stressful for merchants so it shoul
 
 <!-- content-for: android -->
 
-![Critical badge with red background](https://polaris.shopify.com/public_images/components/Badge/android/critical@2x.png)
+![Critical badge with red background](/public_images/components/Badge/android/critical@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Critical badge with red background](https://polaris.shopify.com/public_images/components/Badge/ios/critical@2x.png)
+![Critical badge with red background](/public_images/components/Badge/ios/critical@2x.png)
 
 <!-- /content-for -->
 
@@ -210,13 +210,13 @@ Use to indicate when a given task has not yet been completed. For example, when 
 
 <!-- content-for: android -->
 
-![Incomplete badge. Default badge with incomplete status](https://polaris.shopify.com/public_images/components/Badge/android/incomplete@2x.png)
+![Incomplete badge. Default badge with incomplete status](/public_images/components/Badge/android/incomplete@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Incomplete badge. Default badge with incomplete status](https://polaris.shopify.com/public_images/components/Badge/ios/incomplete@2x.png)
+![Incomplete badge. Default badge with incomplete status](/public_images/components/Badge/ios/incomplete@2x.png)
 
 <!-- /content-for -->
 
@@ -230,13 +230,13 @@ Use to indicate when a given task has been partially completed. For example, whe
 
 <!-- content-for: android -->
 
-![Partially complete badge. Default badge with partially complete status](https://polaris.shopify.com/public_images/components/Badge/android/partially-complete@2x.png)
+![Partially complete badge. Default badge with partially complete status](/public_images/components/Badge/android/partially-complete@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Partially complete badge. Default badge with partially complete status](https://polaris.shopify.com/public_images/components/Badge/ios/partially-complete@2x.png)
+![Partially complete badge. Default badge with partially complete status](/public_images/components/Badge/ios/partially-complete@2x.png)
 
 <!-- /content-for -->
 
@@ -250,13 +250,13 @@ Use to indicate when a given task has been completed. For example, when merchant
 
 <!-- content-for: android -->
 
-![Complete badge. Default badge with complete status](https://polaris.shopify.com/public_images/components/Badge/android/complete@2x.png)
+![Complete badge. Default badge with complete status](/public_images/components/Badge/android/complete@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Complete badge. Default badge with complete status](https://polaris.shopify.com/public_images/components/Badge/ios/complete@2x.png)
+![Complete badge. Default badge with complete status](/public_images/components/Badge/ios/complete@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Banner/README.md
+++ b/src/components/Banner/README.md
@@ -270,13 +270,13 @@ including packaging.
 
 <!-- content-for: android -->
 
-![Default banner for Android](https://polaris.shopify.com/public_images/components/Banner/android/default@2x.png)
+![Default banner for Android](/public_images/components/Banner/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default banner for iOS](https://polaris.shopify.com/public_images/components/Banner/ios/default@2x.png)
+![Default banner for iOS](/public_images/components/Banner/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -315,13 +315,13 @@ Use when you want merchants to take an action after reading the banner.
 
 <!-- content-for: android -->
 
-![Banner with footer call-to-action for Android](https://polaris.shopify.com/public_images/components/Banner/android/footer-action@2x.png)
+![Banner with footer call-to-action for Android](/public_images/components/Banner/android/footer-action@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Banner with footer call-to-action for iOS](https://polaris.shopify.com/public_images/components/Banner/ios/footer-action@2x.png)
+![Banner with footer call-to-action for iOS](/public_images/components/Banner/ios/footer-action@2x.png)
 
 <!-- /content-for -->
 
@@ -342,13 +342,13 @@ Use to update merchants about a change or give them advice.
 
 <!-- content-for: android -->
 
-![Informational banner for Android](https://polaris.shopify.com/public_images/components/Banner/android/informational@2x.png)
+![Informational banner for Android](/public_images/components/Banner/android/informational@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Informational banner for iOS](https://polaris.shopify.com/public_images/components/Banner/ios/informational@2x.png)
+![Informational banner for iOS](/public_images/components/Banner/ios/informational@2x.png)
 
 <!-- /content-for -->
 
@@ -368,13 +368,13 @@ Use to update merchants about a change or give them advice.
 
 <!-- content-for: android -->
 
-![Success banner for Android](https://polaris.shopify.com/public_images/components/Banner/android/success@2x.png)
+![Success banner for Android](/public_images/components/Banner/android/success@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Success banner for iOS](https://polaris.shopify.com/public_images/components/Banner/ios/success@2x.png)
+![Success banner for iOS](/public_images/components/Banner/ios/success@2x.png)
 
 <!-- /content-for -->
 
@@ -400,13 +400,13 @@ Use to update merchants about a change or give them advice.
 
 <!-- content-for: android -->
 
-![Warning banner for Android](https://polaris.shopify.com/public_images/components/Banner/android/warning@2x.png)
+![Warning banner for Android](/public_images/components/Banner/android/warning@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Warning banner for iOS](https://polaris.shopify.com/public_images/components/Banner/ios/warning@2x.png)
+![Warning banner for iOS](/public_images/components/Banner/ios/warning@2x.png)
 
 <!-- /content-for -->
 
@@ -432,13 +432,13 @@ Use to update merchants about a change or give them advice.
 
 <!-- content-for: android -->
 
-![Critical banner for Android](https://polaris.shopify.com/public_images/components/Banner/android/critical@2x.png)
+![Critical banner for Android](/public_images/components/Banner/android/critical@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Critical banner for iOS](https://polaris.shopify.com/public_images/components/Banner/ios/critical@2x.png)
+![Critical banner for iOS](/public_images/components/Banner/ios/critical@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -66,13 +66,13 @@ Used most in the interface. Only use another style if a button requires more or 
 
 <!-- content-for: android -->
 
-![Basic button for Android](https://polaris.shopify.com/public_images/components/Button/android/basic@2x.png)
+![Basic button for Android](/public_images/components/Button/android/basic@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Basic button for iOS](https://polaris.shopify.com/public_images/components/Button/ios/basic@2x.png)
+![Basic button for iOS](/public_images/components/Button/ios/basic@2x.png)
 
 <!-- /content-for -->
 
@@ -110,13 +110,13 @@ Use for less important or less commonly used actions since they’re less promin
 
 <!-- content-for: android -->
 
-![Plain button for Android](https://polaris.shopify.com/public_images/components/Button/android/plain@2x.png)
+![Plain button for Android](/public_images/components/Button/android/plain@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Plain button for iOS](https://polaris.shopify.com/public_images/components/Button/ios/plain@2x.png)
+![Plain button for iOS](/public_images/components/Button/ios/plain@2x.png)
 
 <!-- /content-for -->
 
@@ -149,13 +149,13 @@ Use for actions that will delete merchant data or be otherwise difficult to reco
 
 <!-- content-for: android -->
 
-![Destructive plain button for Android](https://polaris.shopify.com/public_images/components/Button/android/plain-destructive@2x.png)
+![Destructive plain button for Android](/public_images/components/Button/android/plain-destructive@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Destructive plain button for iOS](https://polaris.shopify.com/public_images/components/Button/ios/plain-destructive@2x.png)
+![Destructive plain button for iOS](/public_images/components/Button/ios/plain-destructive@2x.png)
 
 <!-- /content-for -->
 
@@ -169,13 +169,13 @@ Use to highlight the most important actions in any experience. Don’t use more 
 
 <!-- content-for: android -->
 
-![Primary button for Android](https://polaris.shopify.com/public_images/components/Button/android/primary@2x.png)
+![Primary button for Android](/public_images/components/Button/android/primary@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Primary button for iOS](https://polaris.shopify.com/public_images/components/Button/ios/primary@2x.png)
+![Primary button for iOS](/public_images/components/Button/ios/primary@2x.png)
 
 <!-- /content-for -->
 
@@ -189,13 +189,13 @@ Use when the action will delete merchant data or be otherwise difficult to recov
 
 <!-- content-for: android -->
 
-![Destructive basic button for Android](https://polaris.shopify.com/public_images/components/Button/android/basic-destructive@2x.png)
+![Destructive basic button for Android](/public_images/components/Button/android/basic-destructive@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Destructive basic button for iOS](https://polaris.shopify.com/public_images/components/Button/ios/basic-destructive@2x.png)
+![Destructive basic button for iOS](/public_images/components/Button/ios/basic-destructive@2x.png)
 
 <!-- /content-for -->
 
@@ -253,13 +253,13 @@ Use for actions that aren’t currently available. The surrounding interface sho
 
 <!-- content-for: android -->
 
-![Disabled primary button for Android](https://polaris.shopify.com/public_images/components/Button/android/disabled@2x.png)
+![Disabled primary button for Android](/public_images/components/Button/android/disabled@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Disabled primary button for iOS](https://polaris.shopify.com/public_images/components/Button/ios/disabled@2x.png)
+![Disabled primary button for iOS](/public_images/components/Button/ios/disabled@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/ButtonGroup/README.md
+++ b/src/components/ButtonGroup/README.md
@@ -67,13 +67,13 @@ Use when you have multiple buttons to space them out evenly.
 
 <!-- content-for: android -->
 
-![Alt text](https://polaris.shopify.com/public_images/components/ButtonGroup/android/default@2x.png)
+![Alt text](/public_images/components/ButtonGroup/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Alt text](https://polaris.shopify.com/public_images/components/ButtonGroup/ios/default@2x.png)
+![Alt text](/public_images/components/ButtonGroup/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -91,13 +91,13 @@ Use to emphasize several buttons as a thematically-related set among other contr
 
 <!-- content-for: android -->
 
-![Alt text](https://polaris.shopify.com/public_images/components/ButtonGroup/android/segmented-button@2x.png)
+![Alt text](/public_images/components/ButtonGroup/android/segmented-button@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Alt text](https://polaris.shopify.com/public_images/components/ButtonGroup/ios/segmented-button@2x.png)
+![Alt text](/public_images/components/ButtonGroup/ios/segmented-button@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Caption/README.md
+++ b/src/components/Caption/README.md
@@ -49,7 +49,7 @@ Captions are primarily used in [data visualizations](https://polaris.shopify.com
 #### Do
 
 - Use caption for labelling data visualizations
-  ![Diagram of using captions to label graphs and other data content](https://polaris.shopify.com/public_images/typography/display-styles/do-use-caption-for-labeling-data-visualizations@2x.png)
+  ![Diagram of using captions to label graphs and other data content](/public_images/typography/display-styles/do-use-caption-for-labeling-data-visualizations@2x.png)
 - Received April 21, 2017
 
 #### Don’t
@@ -80,13 +80,13 @@ Use to provide details in situations where content is compact and space is tight
 
 <!-- content-for: android -->
 
-![Default caption](https://polaris.shopify.com/public_images/components/Caption/android/default@2x.png)
+![Default caption](/public_images/components/Caption/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default caption](https://polaris.shopify.com/public_images/components/Caption/ios/default@2x.png)
+![Default caption](/public_images/components/Caption/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -208,13 +208,13 @@ Use when you have a simple message to communicate to merchants that doesn’t re
 
 <!-- content-for: android -->
 
-![Default card with a title and a short body](https://polaris.shopify.com/public_images/components/Card/android/default@2x.png)
+![Default card with a title and a short body](/public_images/components/Card/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default card with a title and a short body](https://polaris.shopify.com/public_images/components/Card/ios/default@2x.png)
+![Default card with a title and a short body](/public_images/components/Card/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -246,13 +246,13 @@ Use for less important card actions, or actions merchants may do before reviewin
 
 <!-- content-for: android -->
 
-![Card with a title (Conditions), a short body and a header action to add a condition](https://polaris.shopify.com/public_images/components/Card/android/header-actions@2x.png)
+![Card with a title (Conditions), a short body and a header action to add a condition](/public_images/components/Card/android/header-actions@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Card with a title (Conditions), a short body and a header action to add a condition](https://polaris.shopify.com/public_images/components/Card/ios/header-actions@2x.png)
+![Card with a title (Conditions), a short body and a header action to add a condition](/public_images/components/Card/ios/header-actions@2x.png)
 
 <!-- /content-for -->
 
@@ -290,13 +290,13 @@ Use footer actions for a card’s most important actions, or actions merchants s
 
 <!-- content-for: android -->
 
-![Card featuring footer actions: add variant, edit options](https://polaris.shopify.com/public_images/components/Card/android/footer-actions@2x.png)
+![Card featuring footer actions: add variant, edit options](/public_images/components/Card/android/footer-actions@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Card featuring footer actions: add variant, edit options](https://polaris.shopify.com/public_images/components/Card/ios/footer-actions@2x.png)
+![Card featuring footer actions: add variant, edit options](/public_images/components/Card/ios/footer-actions@2x.png)
 
 <!-- /content-for -->
 
@@ -390,13 +390,13 @@ Use when you have two related but distinct pieces of information to communicate 
 
 <!-- content-for: android -->
 
-![Shipping costs card with multiple sections: domestic, international](https://polaris.shopify.com/public_images/components/Card/android/multiple-sections@2x.png)
+![Shipping costs card with multiple sections: domestic, international](/public_images/components/Card/android/multiple-sections@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Shipping costs card with multiple sections: domestic, international](https://polaris.shopify.com/public_images/components/Card/ios/multiple-sections@2x.png)
+![Shipping costs card with multiple sections: domestic, international](/public_images/components/Card/ios/multiple-sections@2x.png)
 
 <!-- /content-for -->
 
@@ -497,13 +497,13 @@ Use when a card action applies only to one section and will delete merchant data
 
 <!-- content-for: android -->
 
-![Customer card with multiple titled sections: note, shipping address](https://polaris.shopify.com/public_images/components/Card/android/multiple-titled-sections@2x.png)
+![Customer card with multiple titled sections: note, shipping address](/public_images/components/Card/android/multiple-titled-sections@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Customer card with multiple titled sections: note, shipping address](https://polaris.shopify.com/public_images/components/Card/ios/multiple-titled-sections@2x.png)
+![Customer card with multiple titled sections: note, shipping address](/public_images/components/Card/ios/multiple-titled-sections@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Checkbox/README.md
+++ b/src/components/Checkbox/README.md
@@ -124,13 +124,13 @@ function CheckboxExample() {
 
 <!-- content-for: android -->
 
-![Default checkbox on Android](https://polaris.shopify.com/public_images/components/Checkbox/android/default@2x.png)
+![Default checkbox on Android](/public_images/components/Checkbox/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default checkbox on iOS](https://polaris.shopify.com/public_images/components/Checkbox/ios/default@2x.png)
+![Default checkbox on iOS](/public_images/components/Checkbox/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/ChoiceList/README.md
+++ b/src/components/ChoiceList/README.md
@@ -208,13 +208,13 @@ class ChoiceListExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Single choice list for Android](https://polaris.shopify.com/public_images/components/ChoiceList/android/single-choice@2x.png)
+![Single choice list for Android](/public_images/components/ChoiceList/android/single-choice@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Single choice list for iOS](https://polaris.shopify.com/public_images/components/ChoiceList/ios/single-choice@2x.png)
+![Single choice list for iOS](/public_images/components/ChoiceList/ios/single-choice@2x.png)
 
 <!-- /content-for -->
 
@@ -254,13 +254,13 @@ class ChoiceListExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Single choice list with error for Android](https://polaris.shopify.com/public_images/components/ChoiceList/android/single-choice-error@2x.png)
+![Single choice list with error for Android](/public_images/components/ChoiceList/android/single-choice-error@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Single choice list with error for iOS](https://polaris.shopify.com/public_images/components/ChoiceList/ios/single-choice-error@2x.png)
+![Single choice list with error for iOS](/public_images/components/ChoiceList/ios/single-choice-error@2x.png)
 
 <!-- /content-for -->
 
@@ -311,13 +311,13 @@ class ChoiceListExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Multi choice list for Android](https://polaris.shopify.com/public_images/components/ChoiceList/android/multi-choice@2x.png)
+![Multi choice list for Android](/public_images/components/ChoiceList/android/multi-choice@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Multi choice list for iOS](https://polaris.shopify.com/public_images/components/ChoiceList/ios/multi-choice@2x.png)
+![Multi choice list for iOS](/public_images/components/ChoiceList/ios/multi-choice@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Collapsible/README.md
+++ b/src/components/Collapsible/README.md
@@ -101,13 +101,13 @@ class CollapsibleExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Collapsible on Android](https://polaris.shopify.com/public_images/components/Collapsible/android/default@2x.png)
+![Collapsible on Android](/public_images/components/Collapsible/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Collapsible on iOS](https://polaris.shopify.com/public_images/components/Collapsible/ios/default@2x.png)
+![Collapsible on iOS](/public_images/components/Collapsible/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/DatePicker/README.md
+++ b/src/components/DatePicker/README.md
@@ -87,12 +87,12 @@ class DatePickerExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Date picker on Android](https://polaris.shopify.com/public_images/components/DatePicker/android/default@2x.png)
+![Date picker on Android](/public_images/components/DatePicker/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Date picker on iOS](https://polaris.shopify.com/public_images/components/DatePicker/ios/default@2x.png)
+![Date picker on iOS](/public_images/components/DatePicker/ios/default@2x.png)
 
 <!-- /content-for -->

--- a/src/components/DescriptionList/README.md
+++ b/src/components/DescriptionList/README.md
@@ -131,13 +131,13 @@ Use when you need to present merchants with a list of items or terms alongside d
 
 <!-- content-for: android -->
 
-![Description list for Android](https://polaris.shopify.com/public_images/components/DescriptionList/android/default@2x.png)
+![Description list for Android](/public_images/components/DescriptionList/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Description list for iOS](https://polaris.shopify.com/public_images/components/DescriptionList/ios/default@2x.png)
+![Description list for iOS](/public_images/components/DescriptionList/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/DisplayText/README.md
+++ b/src/components/DisplayText/README.md
@@ -80,13 +80,13 @@ Use this size sparingly and never multiple times on the same page.
 
 <!-- content-for: android -->
 
-![Extra large display text](https://polaris.shopify.com/public_images/components/DisplayText/android/extra-large@2x.png)
+![Extra large display text](/public_images/components/DisplayText/android/extra-large@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Extra large display text](https://polaris.shopify.com/public_images/components/DisplayText/ios/extra-large@2x.png)
+![Extra large display text](/public_images/components/DisplayText/ios/extra-large@2x.png)
 
 <!-- /content-for -->
 
@@ -110,13 +110,13 @@ Use for display text that’s more important than the small size, but less impor
 
 <!-- content-for: android -->
 
-![Medium and large display text](https://polaris.shopify.com/public_images/components/DisplayText/android/medium-large@2x.png)
+![Medium and large display text](/public_images/components/DisplayText/android/medium-large@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Medium and large display text](https://polaris.shopify.com/public_images/components/DisplayText/ios/medium-large@2x.png)
+![Medium and large display text](/public_images/components/DisplayText/ios/medium-large@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -165,13 +165,13 @@ Use to explain a single feature before merchants have used it.
 
 <!-- content-for: android -->
 
-![Default empty state](https://polaris.shopify.com/public_images/components/EmptyState/android/default@2x.png)
+![Default empty state](/public_images/components/EmptyState/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default empty state](https://polaris.shopify.com/public_images/components/EmptyState/ios/default@2x.png)
+![Default empty state](/public_images/components/EmptyState/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/ExceptionList/README.md
+++ b/src/components/ExceptionList/README.md
@@ -55,11 +55,11 @@ If placed next to an item in a [resource list](https://polaris.shopify.com/compo
 
 #### Do
 
-- ![Exception list being used inside a resource list item](https://polaris.shopify.com/public_images/exception-list/do-exception-list@2x.png)
+- ![Exception list being used inside a resource list item](/public_images/exception-list/do-exception-list@2x.png)
 
 #### Don’t
 
-- ![Exception list being used in place of a banner](https://polaris.shopify.com/public_images/exception-list/dont-exception-list@2x.png)
+- ![Exception list being used in place of a banner](/public_images/exception-list/dont-exception-list@2x.png)
 
 <!-- end -->
 

--- a/src/components/FormLayout/README.md
+++ b/src/components/FormLayout/README.md
@@ -128,13 +128,13 @@ Use to stack form fields vertically, which makes them easier to scan and complet
 
 <!-- content-for: android -->
 
-![Default form layout for Android](https://polaris.shopify.com/public_images/components/FormLayout/android/default@2x.png)
+![Default form layout for Android](/public_images/components/FormLayout/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default form layout for iOS](https://polaris.shopify.com/public_images/components/FormLayout/ios/default@2x.png)
+![Default form layout for iOS](/public_images/components/FormLayout/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -157,13 +157,13 @@ Field groups will wrap automatically on smaller screens.
 
 <!-- content-for: android -->
 
-![Form layout with field group for Android](https://polaris.shopify.com/public_images/components/FormLayout/android/field-group@2x.png)
+![Form layout with field group for Android](/public_images/components/FormLayout/android/field-group@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Form layout with field group for iOS](https://polaris.shopify.com/public_images/components/FormLayout/ios/field-group@2x.png)
+![Form layout with field group for iOS](/public_images/components/FormLayout/ios/field-group@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Heading/README.md
+++ b/src/components/Heading/README.md
@@ -93,13 +93,13 @@ Use for the title of each top-level page section.
 
 <!-- content-for: android -->
 
-![Typographic heading](https://polaris.shopify.com/public_images/components/Heading/android/default@2x.png)
+![Typographic heading](/public_images/components/Heading/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Typographic heading](https://polaris.shopify.com/public_images/components/Heading/ios/default@2x.png)
+![Typographic heading](/public_images/components/Heading/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/InlineError/README.md
+++ b/src/components/InlineError/README.md
@@ -72,13 +72,13 @@ Use when the merchant has entered invalid information into multiple fields insid
 
 <!-- content-for: android -->
 
-![Inline error for Android](https://polaris.shopify.com/public_images/components/InlineError/android/default@2x.png)
+![Inline error for Android](/public_images/components/InlineError/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Inline error for iOS](https://polaris.shopify.com/public_images/components/InlineError/ios/default@2x.png)
+![Inline error for iOS](/public_images/components/InlineError/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/KeyboardAccessories/README.md
+++ b/src/components/KeyboardAccessories/README.md
@@ -41,13 +41,13 @@ Use the action accessories to add actions that are relevant to what merchants ar
 
 <!-- content-for: android -->
 
-![Keyboard accessory with actions](https://polaris.shopify.com/public_images/components/KeyboardAccessories/android/toolbar@2x.png)
+![Keyboard accessory with actions](/public_images/components/KeyboardAccessories/android/toolbar@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Keyboard accessory with actions](https://polaris.shopify.com/public_images/components/KeyboardAccessories/ios/toolbar@2x.png)
+![Keyboard accessory with actions](/public_images/components/KeyboardAccessories/ios/toolbar@2x.png)
 
 <!-- /content-for -->
 
@@ -59,13 +59,13 @@ Use to make message entry easier in messaging and chat-based products.
 
 <!-- content-for: android -->
 
-![Keyboard accessory with text field](https://polaris.shopify.com/public_images/components/KeyboardAccessories/android/text-field@2x.png)
+![Keyboard accessory with text field](/public_images/components/KeyboardAccessories/android/text-field@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Keyboard accessory with text field](https://polaris.shopify.com/public_images/components/KeyboardAccessories/ios/text-field@2x.png)
+![Keyboard accessory with text field](/public_images/components/KeyboardAccessories/ios/text-field@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/List/README.md
+++ b/src/components/List/README.md
@@ -95,13 +95,13 @@ Use for a text-only list of related items that don’t need to be in a specific 
 
 <!-- content-for: android -->
 
-![Bulleted list on Android](https://polaris.shopify.com/public_images/components/List/android/bullets@2x.png)
+![Bulleted list on Android](/public_images/components/List/android/bullets@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Bulleted list on iOS](https://polaris.shopify.com/public_images/components/List/ios/bullets@2x.png)
+![Bulleted list on iOS](/public_images/components/List/ios/bullets@2x.png)
 
 <!-- /content-for -->
 
@@ -119,13 +119,13 @@ Use for a text-only list of related items when an inherent order, priority, or s
 
 <!-- content-for: android -->
 
-![Numbered list on Android](https://polaris.shopify.com/public_images/components/List/android/numbered@2x.png)
+![Numbered list on Android](/public_images/components/List/android/numbered@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Numbered list on iOS](https://polaris.shopify.com/public_images/components/List/ios/numbered@2x.png)
+![Numbered list on iOS](/public_images/components/List/ios/numbered@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -229,12 +229,12 @@ Tertiary actions should:
 #### Do
 
 - Use a plain button for a tertiary action if needed
-  ![Screenshot of modal with a plain button as a tertiary action](https://polaris.shopify.com/public_images/components/Modal/do-use-plain-button-for-tertiary-action@2x.png)
+  ![Screenshot of modal with a plain button as a tertiary action](/public_images/components/Modal/do-use-plain-button-for-tertiary-action@2x.png)
 
 #### Don’t
 
 - Use a tertiary action for a destructive action
-  ![Screenshot of modal with a destructive button as a tertiary action](https://polaris.shopify.com/public_images/components/Modal/dont-use-destructive-tertiary-action@2x.png)
+  ![Screenshot of modal with a destructive button as a tertiary action](/public_images/components/Modal/dont-use-destructive-tertiary-action@2x.png)
 
 <!-- end -->
 
@@ -419,13 +419,13 @@ class ModalExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Modal with primary action on Android](https://polaris.shopify.com/public_images/components/Modal/android/information@2x.png)
+![Modal with primary action on Android](/public_images/components/Modal/android/information@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Modal with primary action on iOS](https://polaris.shopify.com/public_images/components/Modal/ios/information@2x.png)
+![Modal with primary action on iOS](/public_images/components/Modal/ios/information@2x.png)
 
 <!-- /content-for -->
 
@@ -524,13 +524,13 @@ class ModalExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Modal with primary and secondary actions on Android](https://polaris.shopify.com/public_images/components/Modal/android/basic@2x.png)
+![Modal with primary and secondary actions on Android](/public_images/components/Modal/android/basic@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Modal with primary and secondary actions on iOS](https://polaris.shopify.com/public_images/components/Modal/ios/basic@2x.png)
+![Modal with primary and secondary actions on iOS](/public_images/components/Modal/ios/basic@2x.png)
 
 <!-- /content-for -->
 
@@ -703,13 +703,13 @@ Use to make it clear to the merchant that the action is potentially dangerous. O
 
 <!-- content-for: android -->
 
-![Warning modal on Android](https://polaris.shopify.com/public_images/components/Modal/android/default@2x.png)
+![Warning modal on Android](/public_images/components/Modal/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Warning modal on iOS](https://polaris.shopify.com/public_images/components/Modal/ios/default@2x.png)
+![Warning modal on iOS](/public_images/components/Modal/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -42,7 +42,7 @@ Passing an API key to the [app provider component](https://polaris.shopify.com/c
 
 Note in the props table that a number of properties are only available in stand-alone applications, and won't work in an embedded context. Configure your application's icon and navigation in the [Shopify Partner Dashboard](https://partners.shopify.com) app setup section. To help visualize the page component in an embedded application, we've provided the following screenshot.
 
-![Screenshot of page component in an embedded application](https://polaris.shopify.com/public_images/embedded/page/page@2x.jpg)
+![Screenshot of page component in an embedded application](/public_images/embedded/page/page@2x.jpg)
 
 ```jsx
 ReactDOM.render(
@@ -233,7 +233,7 @@ Use for detail pages, which should have breadcrumbs, and also often have several
 
 Use for building any page on Android.
 
-![Page on Android](https://polaris.shopify.com/public_images/components/Page/android/with-header@2x.png)
+![Page on Android](/public_images/components/Page/android/with-header@2x.png)
 
 <!-- /content-for -->
 
@@ -243,7 +243,7 @@ Use for detail pages, which should have breadcrumbs, and also often have several
 
 Use for building any page on iOS.
 
-![Page on iOS](https://polaris.shopify.com/public_images/components/Page/ios/with-header@2x.png)
+![Page on iOS](/public_images/components/Page/ios/with-header@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Pagination/README.md
+++ b/src/components/Pagination/README.md
@@ -104,13 +104,13 @@ Use for lists longer than 25 items. In mobile apps it’s natural to scroll to t
 
 <!-- content-for: android -->
 
-![Infinite scroll pagination on Android](https://polaris.shopify.com/public_images/components/Pagination/android/default@2x.png)
+![Infinite scroll pagination on Android](/public_images/components/Pagination/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Infinite scroll pagination on iOS](https://polaris.shopify.com/public_images/components/Pagination/ios/default@2x.png)
+![Infinite scroll pagination on iOS](/public_images/components/Pagination/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -159,13 +159,13 @@ class PopoverExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Popover with action list for Android](https://polaris.shopify.com/public_images/components/Popover/android/action-list@2x.png)
+![Popover with action list for Android](/public_images/components/Popover/android/action-list@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Popover with action list for iOS](https://polaris.shopify.com/public_images/components/Popover/ios/action-list@2x.png)
+![Popover with action list for iOS](/public_images/components/Popover/ios/action-list@2x.png)
 
 <!-- /content-for -->
 
@@ -220,13 +220,13 @@ class PopoverContentExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Popover with content and actions for Android](https://polaris.shopify.com/public_images/components/Popover/android/action-content@2x.png)
+![Popover with content and actions for Android](/public_images/components/Popover/android/action-content@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Popover with content and actions for iOS](https://polaris.shopify.com/public_images/components/Popover/ios/action-content@2x.png)
+![Popover with content and actions for iOS](/public_images/components/Popover/ios/action-content@2x.png)
 
 <!-- /content-for -->
 
@@ -402,7 +402,7 @@ Use when you have few actions that affects the whole page. Action sheets doesnâ€
 
 <!-- content-for: ios -->
 
-![iOS action sheet](https://polaris.shopify.com/public_images/components/Popover/ios/action-sheet@2x.png)
+![iOS action sheet](/public_images/components/Popover/ios/action-sheet@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/RadioButton/README.md
+++ b/src/components/RadioButton/README.md
@@ -135,13 +135,13 @@ class RadioButtonExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default radio button on Android](https://polaris.shopify.com/public_images/components/RadioButton/android/default@2x.png)
+![Default radio button on Android](/public_images/components/RadioButton/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default radio button on iOS](https://polaris.shopify.com/public_images/components/RadioButton/ios/default@2x.png)
+![Default radio button on iOS](/public_images/components/RadioButton/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -153,13 +153,13 @@ Use toggles when merchants need to make a binary choice (on or off).
 
 <!-- content-for: android -->
 
-![Android toggle with on or off options](https://polaris.shopify.com/public_images/components/RadioButton/android/toggle@2x.png)
+![Android toggle with on or off options](/public_images/components/RadioButton/android/toggle@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![iOS toggle with on or off options](https://polaris.shopify.com/public_images/components/RadioButton/ios/toggle@2x.png)
+![iOS toggle with on or off options](/public_images/components/RadioButton/ios/toggle@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/RangeSlider/README.md
+++ b/src/components/RangeSlider/README.md
@@ -145,13 +145,13 @@ class RangeSliderExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Range slider for Android](https://polaris.shopify.com/public_images/components/RangeSlider/android/default@2x.png)
+![Range slider for Android](/public_images/components/RangeSlider/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Range slider for iOS](https://polaris.shopify.com/public_images/components/RangeSlider/ios/default@2x.png)
+![Range slider for iOS](/public_images/components/RangeSlider/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -1080,7 +1080,7 @@ Because a details page displays all the content and actions for an individual re
 
 <div class="TypeContainerImage TypeContainerImage--PageBackground">
 
-![Schematic showing content from a details page being surfaced on a resource list](https://polaris.shopify.com/public_images/resource-list/list-surfacing-show@2x.png)
+![Schematic showing content from a details page being surfaced on a resource list](/public_images/resource-list/list-surfacing-show@2x.png)
 
 </div>
 

--- a/src/components/ResourcePicker/README.md
+++ b/src/components/ResourcePicker/README.md
@@ -33,7 +33,7 @@ Enable the resource picker component to delegate to the [Shopify App Bridge](htt
 
 Use of the resource picker component is only supported in an embedded application—it will not render in a stand-alone application. To help visualize the resource picker component in an embedded application, we've provided the following screenshot.
 
-![Screenshot product picker - multiple product selection component](https://polaris.shopify.com/public_images/embedded/resource-picker/product-picker-multiple@2x.jpg)
+![Screenshot product picker - multiple product selection component](/public_images/embedded/resource-picker/product-picker-multiple@2x.jpg)
 
 ### Deprecation rationale
 

--- a/src/components/SectionHeader/README.md
+++ b/src/components/SectionHeader/README.md
@@ -78,13 +78,13 @@ Use to group related content together, for example orders received on the same d
 
 <!-- content-for: android -->
 
-![Shipping costs card with multiple sections: domestic, international](https://polaris.shopify.com/public_images/components/SectionHeader/android/default@2x.png)
+![Shipping costs card with multiple sections: domestic, international](/public_images/components/SectionHeader/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Shipping costs card with multiple sections: domestic, international](https://polaris.shopify.com/public_images/components/SectionHeader/ios/default@2x.png)
+![Shipping costs card with multiple sections: domestic, international](/public_images/components/SectionHeader/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -94,7 +94,7 @@ Use to group related content together, for example orders received on the same d
 
 Use if your list section could be longer than the height of the screen. For example you may need fixed section headers for a list of orders, because merchants may receive many orders in one day.
 
-![Shipping costs card with multiple sections: domestic, international](https://polaris.shopify.com/public_images/components/SectionHeader/ios/fixed@2x.png)
+![Shipping costs card with multiple sections: domestic, international](/public_images/components/SectionHeader/ios/fixed@2x.png)
 
 ---
 

--- a/src/components/Select/README.md
+++ b/src/components/Select/README.md
@@ -133,7 +133,7 @@ class SelectExample extends React.Component {
 
 The iOS picker expands in-line. Merchants scroll to select the item they want.
 
-![iOS select, and select with option menu](https://polaris.shopify.com/public_images/components/Select/ios/default@2x.png)
+![iOS select, and select with option menu](/public_images/components/Select/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -141,7 +141,7 @@ The iOS picker expands in-line. Merchants scroll to select the item they want.
 
 The Android menu is similar in behavior to the web dropdown.
 
-![Android select, and select with option menu](https://polaris.shopify.com/public_images/components/Select/android/default@2x.png)
+![Android select, and select with option menu](/public_images/components/Select/android/default@2x.png)
 
 <!-- /content-for -->
 
@@ -202,13 +202,13 @@ Use for selections that aren’t currently available. The surrounding interface 
 
 <!-- content-for: ios -->
 
-![Disabled select component on iOS](https://polaris.shopify.com/public_images/components/Select/ios/disabled@2x.png)
+![Disabled select component on iOS](/public_images/components/Select/ios/disabled@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: android -->
 
-![Disabled select component on Android](https://polaris.shopify.com/public_images/components/Select/android/disabled@2x.png)
+![Disabled select component on Android](/public_images/components/Select/android/disabled@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/SkeletonBodyText/README.md
+++ b/src/components/SkeletonBodyText/README.md
@@ -36,12 +36,12 @@ Show static content that never changes on a page and use skeleton loading for dy
 #### Do
 
 Use skeleton body text for dynamic content.
-![Image showing skeleton body text for dynamic content](https://polaris.shopify.com/public_images/skeleton/do-use-skeleton-body-for-dynamic-content@2x.png)
+![Image showing skeleton body text for dynamic content](/public_images/skeleton/do-use-skeleton-body-for-dynamic-content@2x.png)
 
 #### Don’t
 
 Use skeleton body text for static content or use placeholder content for dynamic content.
-![Image showing skeleton body text for static content](https://polaris.shopify.com/public_images/skeleton/dont-use-skeleton-body-for-static-or-placeholder-for-dynamic-text@2x.png)
+![Image showing skeleton body text for static content](/public_images/skeleton/dont-use-skeleton-body-for-static-or-placeholder-for-dynamic-text@2x.png)
 
 <!-- end -->
 

--- a/src/components/SkeletonDisplayText/README.md
+++ b/src/components/SkeletonDisplayText/README.md
@@ -35,12 +35,12 @@ Show static display text that that never changes on a page. For example, keep pa
 #### Do
 
 Show actual display text for static content and use skeleton display text for dynamic content.
-![Image showing skeleton display text for dynamic content](https://polaris.shopify.com/public_images/skeleton/do-show-display-text-for-static-content@2x.png)
+![Image showing skeleton display text for dynamic content](/public_images/skeleton/do-show-display-text-for-static-content@2x.png)
 
 #### Don’t
 
 Use skeleton display text for static content or placeholder content for dynamic content.
-![Image showing skeleton display text for static content and placeholder text for dynamic content](https://polaris.shopify.com/public_images/skeleton/dont-use-skeleton-for-static-or-placeholder-content-for-dynamic@2x.png)
+![Image showing skeleton display text for static content and placeholder text for dynamic content](/public_images/skeleton/dont-use-skeleton-for-static-or-placeholder-content-for-dynamic@2x.png)
 
 <!-- end -->
 
@@ -52,7 +52,7 @@ Show skeleton display text for dynamic page titles.
 
 <div class="TypographyUsageBlockImg">
 
-![Image showing skeleton display text for dynamic page title](https://polaris.shopify.com/public_images/skeleton/do-use-skeleton-for-dynamic-page-titles@2x.png)
+![Image showing skeleton display text for dynamic page title](/public_images/skeleton/do-use-skeleton-for-dynamic-page-titles@2x.png)
 
 </div>
 

--- a/src/components/SkeletonPage/README.md
+++ b/src/components/SkeletonPage/README.md
@@ -38,7 +38,7 @@ Use skeleton loading for dynamic content, and use actual content for content tha
 
 <div class="TypographyUsageBlockImg">
 
-![Image showing skeleton loading for changing content](https://polaris.shopify.com/public_images/skeleton/do-use-skeleton-for-changing-content@2x.png)
+![Image showing skeleton loading for changing content](/public_images/skeleton/do-use-skeleton-for-changing-content@2x.png)
 
 </div>
 
@@ -48,7 +48,7 @@ Use placeholder content that will change when the page fully loads. This will co
 
 <div class="TypographyUsageBlockImg">
 
-![Image showing placeholder content that will change](https://polaris.shopify.com/public_images/skeleton/dont-use-placeholder-content-that-will-change@2x.png)
+![Image showing placeholder content that will change](/public_images/skeleton/dont-use-placeholder-content-that-will-change@2x.png)
 
 </div>
 

--- a/src/components/Spinner/README.md
+++ b/src/components/Spinner/README.md
@@ -33,13 +33,13 @@ Use to notify merchants that their requested action is being processed.
 
 <!-- content-for: android -->
 
-![Material design spinner for Android](https://polaris.shopify.com/public_images/components/Spinner/android/default@2x.gif)
+![Material design spinner for Android](/public_images/components/Spinner/android/default@2x.gif)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Apple’s spinner for iOS](https://polaris.shopify.com/public_images/components/Spinner/ios/default@2x.gif)
+![Apple’s spinner for iOS](/public_images/components/Spinner/ios/default@2x.gif)
 
 <!-- /content-for -->
 

--- a/src/components/Stepper/README.md
+++ b/src/components/Stepper/README.md
@@ -69,13 +69,13 @@ The stepper has two buttons, a minus and a plus button. It’s possible to tap i
 
 <!-- content-for: android -->
 
-![Default stepper with enabled decrease and increase button](https://polaris.shopify.com/public_images/components/Stepper/android/default@2x.png)
+![Default stepper with enabled decrease and increase button](/public_images/components/Stepper/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default stepper with enabled decrease and increase button](https://polaris.shopify.com/public_images/components/Stepper/ios/default@2x.png)
+![Default stepper with enabled decrease and increase button](/public_images/components/Stepper/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -87,13 +87,13 @@ If you reach the bottom or top value, the appropriate button becomes disabled.
 
 <!-- content-for: android -->
 
-![Disabled stepper](https://polaris.shopify.com/public_images/components/Stepper/android/disabled@2x.png)
+![Disabled stepper](/public_images/components/Stepper/android/disabled@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Disabled stepper](https://polaris.shopify.com/public_images/components/Stepper/ios/disabled@2x.png)
+![Disabled stepper](/public_images/components/Stepper/ios/disabled@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Subheading/README.md
+++ b/src/components/Subheading/README.md
@@ -76,13 +76,13 @@ Use to structure content in a card.
 
 <!-- content-for: android -->
 
-![Subheading in a card](https://polaris.shopify.com/public_images/components/Subheading/android/default@2x.png)
+![Subheading in a card](/public_images/components/Subheading/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Subheading in a card](https://polaris.shopify.com/public_images/components/Subheading/ios/default@2x.png)
+![Subheading in a card](/public_images/components/Subheading/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Tabs/README.md
+++ b/src/components/Tabs/README.md
@@ -125,13 +125,13 @@ class TabsExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default tabs on Android](https://polaris.shopify.com/public_images/components/Tabs/android/default@2x.png)
+![Default tabs on Android](/public_images/components/Tabs/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default tabs on iOS](https://polaris.shopify.com/public_images/components/Tabs/ios/default@2x.png)
+![Default tabs on iOS](/public_images/components/Tabs/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -186,7 +186,7 @@ class FittedTabsExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Fixed tabs on Android](https://polaris.shopify.com/public_images/components/Tabs/android/fixed@2x.png)
+![Fixed tabs on Android](/public_images/components/Tabs/android/fixed@2x.png)
 
 <!-- /content-for -->
 
@@ -194,6 +194,6 @@ class FittedTabsExample extends React.Component {
 
 Also known as [Segmented controls](https://developer.apple.com/design/human-interface-guidelines/ios/controls/segmented-controls/) on iOS.
 
-![Fixed tabs on iOS](https://polaris.shopify.com/public_images/components/Tabs/ios/fixed@2x.png)
+![Fixed tabs on iOS](/public_images/components/Tabs/ios/fixed@2x.png)
 
 <!-- /content-for -->

--- a/src/components/Tag/README.md
+++ b/src/components/Tag/README.md
@@ -41,13 +41,13 @@ Use to allow merchants to add attributes to, and remove attributes from, an obje
 
 <!-- content-for: android -->
 
-![Tag for Android](https://polaris.shopify.com/public_images/components/Tag/android/default@2x.png)
+![Tag for Android](/public_images/components/Tag/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Tag for iOS](https://polaris.shopify.com/public_images/components/Tag/ios/default@2x.png)
+![Tag for iOS](/public_images/components/Tag/ios/default@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/TextContainer/README.md
+++ b/src/components/TextContainer/README.md
@@ -51,13 +51,13 @@ Use this component for default vertical spacing.
 
 <!-- content-for: android -->
 
-![Default text container](https://polaris.shopify.com/public_images/components/TextContainer/android/default@2x.png)
+![Default text container](/public_images/components/TextContainer/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text container](https://polaris.shopify.com/public_images/components/TextContainer/ios/default@2x.png)
+![Default text container](/public_images/components/TextContainer/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -77,13 +77,13 @@ Use the tight spacing option to relate content topics to each other.
 
 <!-- content-for: android -->
 
-![Tight text container](https://polaris.shopify.com/public_images/components/TextContainer/android/tight@2x.png)
+![Tight text container](/public_images/components/TextContainer/android/tight@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Tight text container](https://polaris.shopify.com/public_images/components/TextContainer/ios/tight@2x.png)
+![Tight text container](/public_images/components/TextContainer/ios/tight@2x.png)
 
 <!-- /content-for -->
 
@@ -107,13 +107,13 @@ Use the loose spacing option to separate concepts that are independent of each o
 
 <!-- content-for: android -->
 
-![Loose text container](https://polaris.shopify.com/public_images/components/TextContainer/android/loose@2x.png)
+![Loose text container](/public_images/components/TextContainer/android/loose@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Loose text container](https://polaris.shopify.com/public_images/components/TextContainer/ios/loose@2x.png)
+![Loose text container](/public_images/components/TextContainer/ios/loose@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -183,13 +183,13 @@ function TextFieldExample() {
 
 <!-- content-for: android -->
 
-![Default text field](https://polaris.shopify.com/public_images/components/TextField/android/default@2x.png)
+![Default text field](/public_images/components/TextField/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text field](https://polaris.shopify.com/public_images/components/TextField/ios/default@2x.png)
+![Default text field](/public_images/components/TextField/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -217,7 +217,7 @@ function NumberFieldExample() {
 
 This will display the right keyboard on mobile devices.
 
-![Number text field with numeric keyboard](https://polaris.shopify.com/public_images/components/TextField/android/number@2x.png)
+![Number text field with numeric keyboard](/public_images/components/TextField/android/number@2x.png)
 
 <!-- /content-for -->
 
@@ -225,7 +225,7 @@ This will display the right keyboard on mobile devices.
 
 This will display the right keyboard on mobile devices.
 
-![Number text field with numeric keyboard](https://polaris.shopify.com/public_images/components/TextField/ios/number@2x.png)
+![Number text field with numeric keyboard](/public_images/components/TextField/ios/number@2x.png)
 
 <!-- /content-for -->
 
@@ -253,7 +253,7 @@ function EmailFieldExample() {
 
 This will display the right keyboard on mobile devices.
 
-![Email field with email keyboard](https://polaris.shopify.com/public_images/components/TextField/android/email@2x.png)
+![Email field with email keyboard](/public_images/components/TextField/android/email@2x.png)
 
 <!-- /content-for -->
 
@@ -261,7 +261,7 @@ This will display the right keyboard on mobile devices.
 
 This will display the right keyboard on mobile devices.
 
-![Email field with email keyboard](https://polaris.shopify.com/public_images/components/TextField/ios/email@2x.png)
+![Email field with email keyboard](/public_images/components/TextField/ios/email@2x.png)
 
 <!-- /content-for -->
 
@@ -287,13 +287,13 @@ function MultilineFieldExample() {
 
 <!-- content-for: android -->
 
-![Multi-line text field](https://polaris.shopify.com/public_images/components/TextField/android/multi-line@2x.png)
+![Multi-line text field](/public_images/components/TextField/android/multi-line@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Multi-line text field](https://polaris.shopify.com/public_images/components/TextField/ios/multi-line@2x.png)
+![Multi-line text field](/public_images/components/TextField/ios/multi-line@2x.png)
 
 <!-- /content-for -->
 
@@ -435,13 +435,13 @@ class PlaceholderExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default text field with placeholder text hint](https://polaris.shopify.com/public_images/components/TextField/android/placeholder-text@2x.png)
+![Default text field with placeholder text hint](/public_images/components/TextField/android/placeholder-text@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text field with placeholder text hint](https://polaris.shopify.com/public_images/components/TextField/ios/placeholder-text@2x.png)
+![Default text field with placeholder text hint](/public_images/components/TextField/ios/placeholder-text@2x.png)
 
 <!-- /content-for -->
 
@@ -475,13 +475,13 @@ class HelpTextExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default text field with help text](https://polaris.shopify.com/public_images/components/TextField/android/help-text@2x.png)
+![Default text field with help text](/public_images/components/TextField/android/help-text@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text field with help text](https://polaris.shopify.com/public_images/components/TextField/ios/help-text@2x.png)
+![Default text field with help text](/public_images/components/TextField/ios/help-text@2x.png)
 
 <!-- /content-for -->
 
@@ -518,13 +518,13 @@ class PrefixExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Default text field with prefix and suffix](https://polaris.shopify.com/public_images/components/TextField/android/prefix-suffix@2x.png)
+![Default text field with prefix and suffix](/public_images/components/TextField/android/prefix-suffix@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default text field with prefix and suffix](https://polaris.shopify.com/public_images/components/TextField/ios/prefix-suffix@2x.png)
+![Default text field with prefix and suffix](/public_images/components/TextField/ios/prefix-suffix@2x.png)
 
 <!-- /content-for -->
 
@@ -579,7 +579,7 @@ class ConnectedFieldsExample extends React.Component {
 
 If inputting weight as a number and a separate unit of measurement, use a text field with a selector (like “kg” or “lb”) as a connected field.
 
-![Text field with connected selector](https://polaris.shopify.com/public_images/components/TextField/android/connected-fields@2x.png)
+![Text field with connected selector](/public_images/components/TextField/android/connected-fields@2x.png)
 
 <!-- /content-for -->
 
@@ -587,7 +587,7 @@ If inputting weight as a number and a separate unit of measurement, use a text f
 
 If inputting weight as a number and a separate unit of measurement, use a text field with a selector (like “kg” or “lb”) as a connected field.
 
-![Text field with connected selector](https://polaris.shopify.com/public_images/components/TextField/ios/connected-fields@2x.png)
+![Text field with connected selector](/public_images/components/TextField/ios/connected-fields@2x.png)
 
 <!-- /content-for -->
 
@@ -601,13 +601,13 @@ For example, tap on a barcode icon to launch the camera and scan barcode for the
 
 <!-- content-for: android -->
 
-![Text field with icon action inside the text field](https://polaris.shopify.com/public_images/components/TextField/android/accessory@2x.png)
+![Text field with icon action inside the text field](/public_images/components/TextField/android/accessory@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Text field with icon action inside the text field](https://polaris.shopify.com/public_images/components/TextField/ios/accessory@2x.png)
+![Text field with icon action inside the text field](/public_images/components/TextField/ios/accessory@2x.png)
 
 <!-- /content-for -->
 
@@ -640,13 +640,13 @@ class ValidationErrorExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Text field with error](https://polaris.shopify.com/public_images/components/TextField/android/error@2x.png)
+![Text field with error](/public_images/components/TextField/android/error@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Text field with error](https://polaris.shopify.com/public_images/components/TextField/ios/error@2x.png)
+![Text field with error](/public_images/components/TextField/ios/error@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/TextStyle/README.md
+++ b/src/components/TextStyle/README.md
@@ -54,13 +54,13 @@ Use to de-emphasize a piece of text that is less important to merchants than oth
 
 <!-- content-for: android -->
 
-![Subdued textstyle](https://polaris.shopify.com/public_images/components/TextStyle/android/subdued@2x.png)
+![Subdued textstyle](/public_images/components/TextStyle/android/subdued@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Subdued text style](https://polaris.shopify.com/public_images/components/TextStyle/ios/subdued@2x.png)
+![Subdued text style](/public_images/components/TextStyle/ios/subdued@2x.png)
 
 <!-- /content-for -->
 
@@ -74,13 +74,13 @@ Use to mark text representing user input, or to emphasize the totals row in a pr
 
 <!-- content-for: android -->
 
-![Strong text style](https://polaris.shopify.com/public_images/components/TextStyle/android/strong@2x.png)
+![Strong text style](/public_images/components/TextStyle/android/strong@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Strong text style](https://polaris.shopify.com/public_images/components/TextStyle/ios/strong@2x.png)
+![Strong text style](/public_images/components/TextStyle/ios/strong@2x.png)
 
 <!-- /content-for -->
 
@@ -94,13 +94,13 @@ Use in combination with a symbol showing an increasing value to indicate an upwa
 
 <!-- content-for: android -->
 
-![Positive text style](https://polaris.shopify.com/public_images/components/TextStyle/android/positive@2x.png)
+![Positive text style](/public_images/components/TextStyle/android/positive@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Positive text style](https://polaris.shopify.com/public_images/components/TextStyle/ios/positive@2x.png)
+![Positive text style](/public_images/components/TextStyle/ios/positive@2x.png)
 
 <!-- /content-for -->
 
@@ -114,13 +114,13 @@ Use in combination with a symbol showing a decreasing value to indicate a downwa
 
 <!-- content-for: android -->
 
-![Negative text style](https://polaris.shopify.com/public_images/components/TextStyle/android/negative@2x.png)
+![Negative text style](/public_images/components/TextStyle/android/negative@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Negative text style](https://polaris.shopify.com/public_images/components/TextStyle/ios/negative@2x.png)
+![Negative text style](/public_images/components/TextStyle/ios/negative@2x.png)
 
 <!-- /content-for -->
 
@@ -137,13 +137,13 @@ Use to display inline snippets of code or code-like text.
 
 <!-- content-for: android -->
 
-![Code text style](https://polaris.shopify.com/public_images/components/TextStyle/android/code@2x.png)
+![Code text style](/public_images/components/TextStyle/android/code@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Code text style](https://polaris.shopify.com/public_images/components/TextStyle/ios/code@2x.png)
+![Code text style](/public_images/components/TextStyle/ios/code@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Thumbnail/README.md
+++ b/src/components/Thumbnail/README.md
@@ -68,13 +68,13 @@ Use as the default size.
 
 <!-- content-for: android -->
 
-![Default thumbnail](https://polaris.shopify.com/public_images/components/Thumbnail/android/default@2x.png)
+![Default thumbnail](/public_images/components/Thumbnail/android/default@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default thumbnail](https://polaris.shopify.com/public_images/components/Thumbnail/ios/default@2x.png)
+![Default thumbnail](/public_images/components/Thumbnail/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -106,13 +106,13 @@ Use when a thumbnail is a major focal point. Avoid this size in lists of like it
 
 <!-- content-for: android -->
 
-![Large thumbnail](https://polaris.shopify.com/public_images/components/Thumbnail/android/large@2x.png)
+![Large thumbnail](/public_images/components/Thumbnail/android/large@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Large thumbnail](https://polaris.shopify.com/public_images/components/Thumbnail/ios/large@2x.png)
+![Large thumbnail](/public_images/components/Thumbnail/ios/large@2x.png)
 
 <!-- /content-for -->
 

--- a/src/components/Toast/README.md
+++ b/src/components/Toast/README.md
@@ -336,7 +336,7 @@ Use default toast for informative and neutral feedback.
 
 <!-- content-for: android -->
 
-![Default toast with neutral color](https://polaris.shopify.com/public_images/components/Toast/android/default@2x.png)
+![Default toast with neutral color](/public_images/components/Toast/android/default@2x.png)
 
 <!-- /content-for -->
 
@@ -344,7 +344,7 @@ Use default toast for informative and neutral feedback.
 
 On iOS, icons are available for cases where you want to re-inforce the message.
 
-![Default toast with neutral color](https://polaris.shopify.com/public_images/components/Toast/ios/default@2x.png)
+![Default toast with neutral color](/public_images/components/Toast/ios/default@2x.png)
 
 <!-- /content-for -->
 
@@ -356,7 +356,7 @@ Use success toast to indicate that something was successful. For example, a prod
 
 <!-- content-for: android -->
 
-![Success toast](https://polaris.shopify.com/public_images/components/Toast/android/success@2x.png)
+![Success toast](/public_images/components/Toast/android/success@2x.png)
 
 <!-- /content-for -->
 
@@ -364,7 +364,7 @@ Use success toast to indicate that something was successful. For example, a prod
 
 On iOS, icons are available for cases where you want to re-inforce the message.
 
-![Success toast](https://polaris.shopify.com/public_images/components/Toast/ios/success@2x.png)
+![Success toast](/public_images/components/Toast/ios/success@2x.png)
 
 <!-- /content-for -->
 
@@ -410,7 +410,7 @@ class ToastExample extends React.Component {
 
 <!-- content-for: android -->
 
-![Error toast](https://polaris.shopify.com/public_images/components/Toast/android/error@2x.png)
+![Error toast](/public_images/components/Toast/android/error@2x.png)
 
 <!-- /content-for -->
 
@@ -418,7 +418,7 @@ class ToastExample extends React.Component {
 
 On iOS, icons are available for cases where you want to re-inforce the message.
 
-![Error toast](https://polaris.shopify.com/public_images/components/Toast/ios/error@2x.png)
+![Error toast](/public_images/components/Toast/ios/error@2x.png)
 
 <!-- /content-for -->
 
@@ -430,13 +430,13 @@ Use action when merchants have the ability to act on the message. For example, t
 
 <!-- content-for: android -->
 
-![Default toast with action to undo](https://polaris.shopify.com/public_images/components/Toast/android/default-action@2x.png)
+![Default toast with action to undo](/public_images/components/Toast/android/default-action@2x.png)
 
 <!-- /content-for -->
 
 <!-- content-for: ios -->
 
-![Default toast with action to undo](https://polaris.shopify.com/public_images/components/Toast/ios/default-action@2x.png)
+![Default toast with action to undo](/public_images/components/Toast/ios/default-action@2x.png)
 
 <!-- /content-for -->
 


### PR DESCRIPTION
https://github.com/Shopify/polaris-react/pull/2102 caused a regression where not only links were edited, but also images, causing images to 404 in the style guide.

This Pull Request fixes it.

A hotfix was deployed on polaris-styleguide, to minimize the impact on users: https://github.com/Shopify/polaris-styleguide/commit/322025a33f0d13f96c361486e6b7ac76b73d55a8