### PR TITLE
[Docs] Update migration docs

### DIFF
--- a/documentation/guides/migrating-from-v3-to-v4.md
+++ b/documentation/guides/migrating-from-v3-to-v4.md
@@ -237,7 +237,7 @@ The `Tabs.Panel` subcomponent has been removed. This was an undocumented subcomp
 
 ### WithContext <a name="polaris-withcontext"></a>
 
-The `WithContext` component has been removed. It was used as a utility to handle multiple [legacy contexts](https://reactjs.org/docs/legacy-context.html) at once. Use [modern contexts](https://reactjs.org/docs/context.html#api) and access them using providers, hooks or `Class.contextType` instead.
+The `WithContext` component has been removed. It was used as a utility to handle [legacy contexts](https://reactjs.org/docs/legacy-context.html) in class based components and multiple contexts at once. Use [modern contexts](https://reactjs.org/docs/context.html#api) and access them using providers, hooks or `Class.contextType` instead.
 
 ```jsx
 // old


### PR DESCRIPTION
### WHY are these changes introduced?

`withContext` was originally added to be used in class-based components since when the new context API was originally added there wasn't a clean way of using it. `contextType` was only added a few releases later

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
