### PR TITLE
Hookify Autocomplete, Banner, and ChoiceList examples

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -27,6 +27,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Converted `Autocomplete`, `Banner`, and `ChoiceList` examples to functional components ([#2127](https://github.com/Shopify/polaris-react/pull/2127))
 - Converted `Collapsible`, `ColorPicker`, and `DataTable` examples to functional components ([#2128](https://github.com/Shopify/polaris-react/pull/2128))
 - Updated the `withContext` section in the [v3 to v4 migration guide](https://github.com/Shopify/polaris-react/blob/master/documentation/guides/migrating-from-v3-to-v4.md) ([#2124](https://github.com/Shopify/polaris-react/pull/2124))
 

--- a/src/components/Autocomplete/README.md
+++ b/src/components/Autocomplete/README.md
@@ -37,74 +37,68 @@ The input field for autocomplete should follow the [content guidelines](https://
 Use to help merchants complete text input quickly from a list of options.
 
 ```jsx
-class AutocompleteExample extends React.Component {
-  options = [
+function AutocompleteExample() {
+  const deselectedOptions = [
     {value: 'rustic', label: 'Rustic'},
     {value: 'antique', label: 'Antique'},
     {value: 'vinyl', label: 'Vinyl'},
     {value: 'vintage', label: 'Vintage'},
     {value: 'refurbished', label: 'Refurbished'},
   ];
+  const [selectedOptions, setSelectedOptions] = useState([]);
+  const [inputValue, setInputValue] = useState('');
+  const [options, setOptions] = useState(deselectedOptions);
 
-  state = {
-    selected: [],
-    inputText: '',
-    options: this.options,
-  };
+  const updateText = useCallback(
+    (value) => {
+      setInputValue(value);
 
-  render() {
-    const textField = (
-      <Autocomplete.TextField
-        onChange={this.updateText}
-        label="Tags"
-        value={this.state.inputText}
-        prefix={<Icon source={SearchMinor} color="inkLighter" />}
-        placeholder="Search"
-      />
-    );
-    return (
-      <div style={{height: '225px'}}>
-        <Autocomplete
-          options={this.state.options}
-          selected={this.state.selected}
-          onSelect={this.updateSelection}
-          textField={textField}
-        />
-      </div>
-    );
-  }
+      if (value === '') {
+        setOptions(deselectedOptions);
+        return;
+      }
 
-  updateText = (newValue) => {
-    this.setState({inputText: newValue});
-    this.filterAndUpdateOptions(newValue);
-  };
+      const filterRegex = new RegExp(value, 'i');
+      const resultOptions = deselectedOptions.filter((option) =>
+        option.label.match(filterRegex),
+      );
+      setOptions(resultOptions);
+    },
+    [deselectedOptions],
+  );
 
-  filterAndUpdateOptions = (inputString) => {
-    if (inputString === '') {
-      this.setState({
-        options: this.options,
-      });
-      return;
-    }
-
-    const filterRegex = new RegExp(inputString, 'i');
-    const resultOptions = this.options.filter((option) =>
-      option.label.match(filterRegex),
-    );
-    this.setState({
-      options: resultOptions,
-    });
-  };
-
-  updateSelection = (selected) => {
-    const selectedText = selected.map((selectedItem) => {
-      const matchedOption = this.options.find((option) => {
+  const updateSelection = useCallback((selected) => {
+    const selectedValue = selected.map((selectedItem) => {
+      const matchedOption = options.find((option) => {
         return option.value.match(selectedItem);
       });
       return matchedOption && matchedOption.label;
     });
-    this.setState({selected, inputText: selectedText});
-  };
+
+    setSelectedOptions(selected);
+    setInputValue(selectedValue);
+  }, []);
+
+  const textField = (
+    <Autocomplete.TextField
+      onChange={updateText}
+      label="Tags"
+      value={inputValue}
+      prefix={<Icon source={SearchMinor} color="inkLighter" />}
+      placeholder="Search"
+    />
+  );
+
+  return (
+    <div style={{height: '225px'}}>
+      <Autocomplete
+        options={options}
+        selected={selectedOptions}
+        onSelect={updateSelection}
+        textField={textField}
+      />
+    </div>
+  );
 }
 ```
 
@@ -113,104 +107,95 @@ class AutocompleteExample extends React.Component {
 Use to help merchants select multiple options from a list curated by the text input.
 
 ```jsx
-class MultiAutocompleteExample extends React.Component {
-  options = [
+function MultiAutocompleteExample() {
+  const deselectedOptions = [
     {value: 'rustic', label: 'Rustic'},
     {value: 'antique', label: 'Antique'},
     {value: 'vinyl', label: 'Vinyl'},
     {value: 'vintage', label: 'Vintage'},
     {value: 'refurbished', label: 'Refurbished'},
   ];
+  const [selectedOptions, setSelectedOptions] = useState([]);
+  const [inputValue, setInputValue] = useState('');
+  const [options, setOptions] = useState(deselectedOptions);
 
-  state = {
-    selected: [],
-    inputText: '',
-    options: this.options,
-  };
+  const updateText = useCallback(
+    (value) => {
+      setInputValue(value);
 
-  render() {
-    const textField = (
-      <Autocomplete.TextField
-        onChange={this.updateText}
-        label="Tags"
-        value={this.state.inputText}
-        placeholder="Vintage, cotton, summer"
-      />
-    );
-    return (
-      <div style={{height: '325px'}}>
-        <TextContainer>
-          <Stack>{this.renderTags()}</Stack>
-        </TextContainer>
-        <br />
-        <Autocomplete
-          allowMultiple
-          options={this.state.options}
-          selected={this.state.selected}
-          textField={textField}
-          onSelect={this.updateSelection}
-          listTitle="Suggested Tags"
-        />
-      </div>
-    );
-  }
+      if (value === '') {
+        setOptions(deselectedOptions);
+        return;
+      }
 
-  updateText = (newValue) => {
-    this.setState({inputText: newValue});
-    this.filterAndUpdateOptions(newValue);
-  };
-
-  removeTag = (tag) => {
-    const {selected: newSelected} = this.state;
-    newSelected.splice(newSelected.indexOf(tag), 1);
-    this.setState({selected: newSelected});
-  };
-
-  renderTags = () => {
-    return this.state.selected.map((option) => {
-      let tagLabel = '';
-      tagLabel = option.replace('_', ' ');
-      tagLabel = titleCase(tagLabel);
-      return (
-        <Tag key={'option' + option} onRemove={() => this.removeTag(option)}>
-          {tagLabel}
-        </Tag>
+      const filterRegex = new RegExp(value, 'i');
+      const resultOptions = deselectedOptions.filter((option) =>
+        option.label.match(filterRegex),
       );
-    });
-  };
+      let endIndex = resultOptions.length - 1;
+      if (resultOptions.length === 0) {
+        endIndex = 0;
+      }
+      setOptions(resultOptions);
+    },
+    [deselectedOptions],
+  );
 
-  filterAndUpdateOptions = (inputString) => {
-    if (inputString === '') {
-      this.setState({
-        options: this.options,
-      });
-      return;
-    }
+  const removeTag = useCallback(
+    (tag) => () => {
+      const options = [...selectedOptions];
+      options.splice(options.indexOf(tag), 1);
+      setSelectedOptions(options);
+    },
+    [selectedOptions],
+  );
 
-    const filterRegex = new RegExp(inputString, 'i');
-    const resultOptions = this.options.filter((option) =>
-      option.label.match(filterRegex),
+  const tagsMarkup = selectedOptions.map((option) => {
+    let tagLabel = '';
+    tagLabel = option.replace('_', ' ');
+    tagLabel = titleCase(tagLabel);
+    return (
+      <Tag key={`option${option}`} onRemove={removeTag(option)}>
+        {tagLabel}
+      </Tag>
     );
-    let endIndex = resultOptions.length - 1;
-    if (resultOptions.length === 0) {
-      endIndex = 0;
-    }
-    this.setState({
-      options: resultOptions,
-    });
-  };
+  });
 
-  updateSelection = (selected) => this.setState({selected});
-}
+  const textField = (
+    <Autocomplete.TextField
+      onChange={updateText}
+      label="Tags"
+      value={inputValue}
+      placeholder="Vintage, cotton, summer"
+    />
+  );
 
-function titleCase(string) {
-  string = string
-    .toLowerCase()
-    .split(' ')
-    .map(function(word) {
-      return word.replace(word[0], word[0].toUpperCase());
-    });
-  return string.join(' ');
+  return (
+    <div style={{height: '325px'}}>
+      <TextContainer>
+        <Stack>{tagsMarkup}</Stack>
+      </TextContainer>
+      <br />
+      <Autocomplete
+        allowMultiple
+        options={options}
+        selected={selectedOptions}
+        textField={textField}
+        onSelect={setSelectedOptions}
+        listTitle="Suggested Tags"
+      />
+    </div>
+  );
+
+  function titleCase(string) {
+    return string
+      .toLowerCase()
+      .split(' ')
+      .map(function(word) {
+        return word.replace(word[0], word[0].toUpperCase());
+      })
+      .join('');
+  }
 }
 ```
 
@@ -219,206 +204,187 @@ function titleCase(string) {
 Use to indicate loading state to merchants while option data is processing.
 
 ```jsx
-class AutocompleteExample extends React.Component {
-  options = [
+function AutocompleteExample() {
+  const deselectedOptions = [
     {value: 'rustic', label: 'Rustic'},
     {value: 'antique', label: 'Antique'},
     {value: 'vinyl', label: 'Vinyl'},
     {value: 'vintage', label: 'Vintage'},
     {value: 'refurbished', label: 'Refurbished'},
   ];
+  const [selectedOptions, setSelectedOptions] = useState([]);
+  const [inputValue, setInputValue] = useState('');
+  const [options, setOptions] = useState(deselectedOptions);
+  const [loading, setLoading] = useState(false);
 
-  state = {
-    selected: [],
-    inputText: '',
-    options: this.options,
-    loading: false,
-  };
+  const updateText = useCallback(
+    (value) => {
+      setInputValue(value);
 
-  render() {
-    const textField = (
-      <Autocomplete.TextField
-        onChange={this.updateText}
-        label="Tags"
-        value={this.state.inputText}
-        prefix={<Icon source={SearchMinor} color="inkLighter" />}
-        placeholder="Search"
-      />
-    );
-    return (
-      <div style={{height: '225px'}}>
-        <Autocomplete
-          options={this.state.options}
-          selected={this.state.selected}
-          onSelect={this.updateSelection}
-          loading={this.state.loading}
-          textField={textField}
-        />
-      </div>
-    );
-  }
-
-  updateText = (newValue) => {
-    this.setState({inputText: newValue});
-    this.filterAndUpdateOptions(newValue);
-  };
-
-  filterAndUpdateOptions = (inputString) => {
-    if (!this.state.loading) {
-      this.setState({loading: true});
-    }
-
-    setTimeout(() => {
-      if (inputString === '') {
-        this.setState({
-          options: this.options,
-          loading: false,
-        });
-        return;
+      if (!loading) {
+        setLoading(true);
       }
-      const filterRegex = new RegExp(inputString, 'i');
-      const resultOptions = this.options.filter((option) =>
-        option.label.match(filterRegex),
-      );
 
-      this.setState({
-        options: resultOptions,
-        loading: false,
-      });
-    }, 300);
-  };
+      setTimeout(() => {
+        if (value === '') {
+          setOptions(deselectedOptions);
+          setLoading(true);
+          return;
+        }
+        const filterRegex = new RegExp(value, 'i');
+        const resultOptions = options.filter((option) =>
+          option.label.match(filterRegex),
+        );
+        setOptions(resultOptions);
+        setLoading(false);
+      }, 300);
+    },
+    [deselectedOptions],
+  );
 
-  updateSelection = (selected) => {
+  const updateSelection = useCallback((selected) => {
     const selectedText = selected.map((selectedItem) => {
-      const matchedOption = this.options.find((option) => {
+      const matchedOption = options.find((option) => {
         return option.value.match(selectedItem);
       });
       return matchedOption && matchedOption.label;
     });
-    this.setState({selected, inputText: selectedText});
-  };
+    setSelectedOptions(selected);
+    setInputValue(selectedText);
+  }, []);
+
+  const textField = (
+    <Autocomplete.TextField
+      onChange={updateText}
+      label="Tags"
+      value={inputValue}
+      prefix={<Icon source={SearchMinor} color="inkLighter" />}
+      placeholder="Search"
+    />
+  );
+
+  return (
+    <div style={{height: '225px'}}>
+      <Autocomplete
+        options={options}
+        selected={selectedOptions}
+        onSelect={updateSelection}
+        loading={loading}
+        textField={textField}
+      />
+    </div>
+  );
 }
 ```
 
 ### Autocomplete with lazy loading
 
 ```jsx
-class AutoCompleteLazyLoadExample extends React.Component {
-  paginationInterval = 25;
-
-  options = Array.from(Array(100)).map((_, index) => ({
+function AutoCompleteLazyLoadExample() {
+  const paginationInterval = 25;
+  const deselectedOptions = Array.from(Array(100)).map((_, index) => ({
     value: `rustic ${index}`,
     label: `Rustic ${index}`,
   }));
 
-  state = {
-    selected: [],
-    inputText: '',
-    options: this.options,
-    visibleOptionIndex: this.paginationInterval,
-  };
+  const [selectedOptions, setSelectedOptions] = useState([]);
+  const [inputValue, setInputValue] = useState('');
+  const [options, setOptions] = useState(deselectedOptions);
+  const [visibleOptionIndex, setVisibleOptionIndex] = useState(
+    paginationInterval,
+  );
 
-  render() {
-    const {visibleOptionIndex, selected, options} = this.state;
-    const textField = (
-      <Autocomplete.TextField
-        onChange={this.updateText}
-        label="Tags"
-        value={this.state.inputText}
-        placeholder="Vintage, cotton, summer"
-      />
-    );
-
-    const optionList = options.slice(0, visibleOptionIndex);
-    const selectedTagMarkup =
-      selected.length > 0 ? (
-        <Stack spacing="extraTight">{this.renderTags()}</Stack>
-      ) : null;
-
-    return (
-      <Stack vertical>
-        {selectedTagMarkup}
-        <Autocomplete
-          allowMultiple
-          options={optionList}
-          selected={this.state.selected}
-          textField={textField}
-          onSelect={this.updateSelection}
-          listTitle="Suggested Tags"
-          onLoadMoreResults={this.handleLoadMoreResults}
-        />
-      </Stack>
-    );
-  }
-
-  handleLoadMoreResults = () => {
-    const {visibleOptionIndex} = this.state;
-    const nextVisibleOptionIndex = visibleOptionIndex + this.paginationInterval;
-    if (nextVisibleOptionIndex <= this.options.length - 1) {
-      this.setState({visibleOptionIndex: nextVisibleOptionIndex});
+  const handleLoadMoreResults = useCallback(() => {
+    const nextVisibleOptionIndex = visibleOptionIndex + paginationInterval;
+    if (nextVisibleOptionIndex <= options.length - 1) {
+      setVisibleOptionIndex(nextVisibleOptionIndex);
     }
-  };
+  }, [visibleOptionIndex]);
 
-  updateText = (newValue) => {
-    this.setState({inputText: newValue});
-    this.filterAndUpdateOptions(newValue);
-  };
+  const removeTag = useCallback(
+    (tag) => () => {
+      const options = [...selectedOptions];
+      options.splice(options.indexOf(tag), 1);
+      setSelectedOptions(options);
+    },
+    [selectedOptions],
+  );
 
-  removeTag = (tag) => () => {
-    const {selected: newSelected} = this.state;
-    newSelected.splice(newSelected.indexOf(tag), 1);
-    this.setState({selected: newSelected});
-  };
+  const updateText = useCallback(
+    (value) => {
+      setInputValue(value);
 
-  renderTags = () => {
-    return this.state.selected.map((option) => {
-      let tagLabel = '';
-      tagLabel = option.replace('_', ' ');
-      tagLabel = titleCase(tagLabel);
-      return (
-        <Tag key={`option${option}`} onRemove={this.removeTag(option)}>
-          {tagLabel}
-        </Tag>
+      if (value === '') {
+        setOptions(deselectedOptions);
+        return;
+      }
+
+      const filterRegex = new RegExp(value, 'i');
+      const resultOptions = options.filter((option) =>
+        option.label.match(filterRegex),
       );
-    });
-  };
 
-  filterAndUpdateOptions = (inputString) => {
-    if (inputString === '') {
-      this.setState({options: this.options});
+      let endIndex = resultOptions.length - 1;
+      if (resultOptions.length === 0) {
+        endIndex = 0;
+      }
+      setOptions(resultOptions);
+    },
+    [deselectedOptions],
+  );
 
-      return;
-    }
+  const textField = (
+    <Autocomplete.TextField
+      onChange={updateText}
+      label="Tags"
+      value={inputValue}
+      placeholder="Vintage, cotton, summer"
+    />
+  );
 
-    const filterRegex = new RegExp(inputString, 'i');
-    const resultOptions = this.options.filter((option) =>
-      option.label.match(filterRegex),
-    );
+  const hasSelectedOptions = selectedOptions.length > 0;
 
-    let endIndex = resultOptions.length - 1;
+  const tagsMarkup = hasSelectedOptions
+    ? selectedOptions.map((option) => {
+        let tagLabel = '';
+        tagLabel = option.replace('_', ' ');
+        tagLabel = titleCase(tagLabel);
+        return (
+          <Tag key={`option${option}`} onRemove={removeTag(option)}>
+            {tagLabel}
+          </Tag>
+        );
+      })
+    : null;
+  const optionList = options.slice(0, visibleOptionIndex);
+  const selectedTagMarkup = hasSelectedOptions ? (
+    <Stack spacing="extraTight">{tagsMarkup}</Stack>
+  ) : null;
 
-    if (resultOptions.length === 0) {
-      endIndex = 0;
-    }
+  return (
+    <Stack vertical>
+      {selectedTagMarkup}
+      <Autocomplete
+        allowMultiple
+        options={optionList}
+        selected={selectedOptions}
+        textField={textField}
+        onSelect={setSelectedOptions}
+        listTitle="Suggested Tags"
+        onLoadMoreResults={handleLoadMoreResults}
+      />
+    </Stack>
+  );
 
-    this.updateOptions(resultOptions);
-  };
-
-  updateOptions = (options) => {
-    this.setState({options: resultOptions});
-  };
-
-  updateSelection = (selected) => this.setState({selected});
-}
-
-function titleCase(string) {
-  return string
-    .toLowerCase()
-    .split(' ')
-    .map((word) => {
-      return word.replace(word[0], word[0].toUpperCase());
-    })
-    .join(' ');
+  function titleCase(string) {
+    return string
+      .toLowerCase()
+      .split(' ')
+      .map((word) => {
+        return word.replace(word[0], word[0].toUpperCase());
+      })
+      .join(' ');
+  }
 }
 ```
 
@@ -427,92 +393,89 @@ function titleCase(string) {
 Use to indicate there are no search results.
 
 ```jsx
-class AutocompleteExample extends React.Component {
-  options = [
+function AutocompleteExample() {
+  const deselectedOptions = [
     {value: 'rustic', label: 'Rustic'},
     {value: 'antique', label: 'Antique'},
     {value: 'vinyl', label: 'Vinyl'},
     {value: 'vintage', label: 'Vintage'},
     {value: 'refurbished', label: 'Refurbished'},
   ];
+  const [selectedOptions, setSelectedOptions] = useState([]);
+  const [inputValue, setInputValue] = useState('');
+  const [options, setOptions] = useState(deselectedOptions);
+  const [loading, setLoading] = useState(false);
 
-  state = {
-    selected: [],
-    inputText: '',
-    options: this.options,
-    loading: false,
-  };
+  const updateText = useCallback(
+    (value) => {
+      setInputValue(value);
 
-  render() {
-    const textField = (
-      <Autocomplete.TextField
-        onChange={this.updateText}
-        label="Tags"
-        value={this.state.inputText}
-        prefix={<Icon source={SearchMinor} color="inkLighter" />}
-        placeholder="Search"
-      />
-    );
-    const emptyState = (
-      <React.Fragment>
-        <Icon source={SearchMinor} />
-        <div style={{textAlign: 'center'}}>
-          <TextContainer>Could not find any results</TextContainer>
-        </div>
-      </React.Fragment>
-    );
-    return (
-      <div style={{height: '225px'}}>
-        <Autocomplete
-          options={this.state.options}
-          selected={this.state.selected}
-          onSelect={this.updateSelection}
-          emptyState={emptyState}
-          loading={this.state.loading}
-          textField={textField}
-        />
-      </div>
-    );
-  }
-
-  updateText = (newValue) => {
-    this.setState({inputText: newValue});
-    this.filterAndUpdateOptions(newValue);
-  };
-
-  filterAndUpdateOptions = (inputString) => {
-    if (!this.state.loading) {
-      this.setState({loading: true});
-    }
-
-    setTimeout(() => {
-      if (inputString === '') {
-        this.setState({
-          options: this.options,
-          loading: false,
-        });
-        return;
+      if (!loading) {
+        setLoading(true);
       }
-      const filterRegex = new RegExp(inputString, 'i');
-      const resultOptions = this.options.filter((option) =>
-        option.label.match(filterRegex),
-      );
-      this.setState({
-        options: resultOptions,
-        loading: false,
-      });
-    }, 300);
-  };
 
-  updateSelection = (selected) => {
-    const selectedText = selected.map((selectedItem) => {
-      const matchedOption = this.options.find((option) => {
-        return option.value.match(selectedItem);
+      setTimeout(() => {
+        if (value === '') {
+          setOptions(deselectedOptions);
+          setLoading(false);
+          return;
+        }
+        const filterRegex = new RegExp(value, 'i');
+        const resultOptions = options.filter((option) =>
+          option.label.match(filterRegex),
+        );
+        setOptions(resultOptions);
+        setLoading(false);
+      }, 300);
+    },
+    [deselectedOptions, loading, options],
+  );
+
+  const updateSelection = useCallback(
+    (selected) => {
+      const selectedText = selected.map((selectedItem) => {
+        const matchedOption = options.find((option) => {
+          return option.value.match(selectedItem);
+        });
+        return matchedOption && matchedOption.label;
       });
-      return matchedOption && matchedOption.label;
-    });
-    this.setState({selected, inputText: selectedText});
-  };
+      setSelectedOptions(selected);
+      setInputValue(selectedText);
+    },
+    [options],
+  );
+
+  const textField = (
+    <Autocomplete.TextField
+      onChange={updateText}
+      label="Tags"
+      value={inputValue}
+      prefix={<Icon source={SearchMinor} color="inkLighter" />}
+      placeholder="Search"
+    />
+  );
+
+  const emptyState = (
+    <React.Fragment>
+      <Icon source={SearchMinor} />
+      <div style={{textAlign: 'center'}}>
+        <TextContainer>Could not find any results</TextContainer>
+      </div>
+    </React.Fragment>
+  );
+
+  return (
+    <div style={{height: '225px'}}>
+      <Autocomplete
+        options={options}
+        selected={selectedOptions}
+        onSelect={updateSelection}
+        emptyState={emptyState}
+        loading={loading}
+        textField={textField}
+      />
+    </div>
+  );
 }
 ```
 

--- a/src/components/Banner/README.md
+++ b/src/components/Banner/README.md
@@ -407,54 +407,46 @@ Use to update merchants about a change or give them advice.
 Banners inside of modals render with less spacing and a pared-back design to fit within a content context.
 
 ```jsx
-class ModalExample extends React.Component {
-  state = {
-    active: false,
-  };
+function BannerInModalExample() {
+  const [active, setActive] = useState(false);
 
-  render() {
-    const {active} = this.state;
+  const handleChange = useCallback(() => setActive(!active), [active]);
 
-    return (
-      <div style={{height: '500px'}}>
-        <Button onClick={this.handleChange}>Open</Button>
-        <Modal
-          open={active}
-          onClose={this.handleChange}
-          title="Reach more shoppers with Instagram product tags"
-          primaryAction={{
-            content: 'Add Instagram',
-            onAction: this.handleChange,
-          }}
-          secondaryActions={[
-            {
-              content: 'Learn more',
-              onAction: this.handleChange,
-            },
-          ]}
-        >
-          <Modal.Section>
-            <TextContainer>
-              <Banner action={{content: 'Connect account'}} status="warning">
-                <p>
-                  Connect your instagram account to your shop before proceeding.
-                </p>
-              </Banner>
+  return (
+    <div style={{height: '500px'}}>
+      <Button onClick={handleChange}>Open</Button>
+      <Modal
+        open={active}
+        onClose={handleChange}
+        title="Reach more shoppers with Instagram product tags"
+        primaryAction={{
+          content: 'Add Instagram',
+          onAction: handleChange,
+        }}
+        secondaryActions={[
+          {
+            content: 'Learn more',
+            onAction: handleChange,
+          },
+        ]}
+      >
+        <Modal.Section>
+          <TextContainer>
+            <Banner action={{content: 'Connect account'}} status="warning">
               <p>
-                Use Instagram posts to share your products with millions of
-                people. Let shoppers buy from your store without leaving
-                Instagram.
+                Connect your instagram account to your shop before proceeding.
               </p>
-            </TextContainer>
-          </Modal.Section>
-        </Modal>
-      </div>
-    );
-  }
-
-  handleChange = () => {
-    this.setState(({active}) => ({active: !active}));
-  };
+            </Banner>
+            <p>
+              Use Instagram posts to share your products with millions of
+              people. Let shoppers buy from your store without leaving
+              Instagram.
+            </p>
+          </TextContainer>
+        </Modal.Section>
+      </Modal>
+    </div>
+  );
 }
 ```
 
@@ -465,28 +457,24 @@ class ModalExample extends React.Component {
 Banner can programmatically receive focus. Use this functionality to draw the merchant's attention to the banner.
 
 ```jsx
-class ModalExample extends React.Component {
-  banner = React.createRef();
+function BannerWithFocusExample() {
+  const banner = useRef();
 
-  componentDidMount() {
-    this.banner.current.focus();
-  }
+  useEffect(() => banner.current.focus(), []);
 
-  render() {
-    return (
-      <Banner
-        title="High risk of fraud detected"
-        onDismiss={() => {}}
-        status="critical"
-        ref={this.banner}
-      >
-        <p>
-          Before fulfilling this order or capturing payment, please review the
-          fraud analysis and determine if this order is fraudulent
-        </p>
-      </Banner>
-    );
-  }
+  return (
+    <Banner
+      title="High risk of fraud detected"
+      onDismiss={() => {}}
+      status="critical"
+      ref={banner}
+    >
+      <p>
+        Before fulfilling this order or capturing payment, please review the
+        fraud analysis and determine if this order is fraudulent
+      </p>
+    </Banner>
+  );
 }
 ```
 

--- a/src/components/ChoiceList/README.md
+++ b/src/components/ChoiceList/README.md
@@ -178,31 +178,23 @@ Allows merchants to select one option from a list.
 - Make sure all options are an either/or choice.
 
 ```jsx
-class ChoiceListExample extends React.Component {
-  state = {
-    selected: ['hidden'],
-  };
+function SingleChoiceListExample() {
+  const [selected, setSelected] = useState(['hidden']);
 
-  render() {
-    const {selected} = this.state;
+  const handleChange = useCallback((value) => setSelected(value), []);
 
-    return (
-      <ChoiceList
-        title={'Company name'}
-        choices={[
-          {label: 'Hidden', value: 'hidden'},
-          {label: 'Optional', value: 'optional'},
-          {label: 'Required', value: 'required'},
-        ]}
-        selected={selected}
-        onChange={this.handleChange}
-      />
-    );
-  }
-
-  handleChange = (value) => {
-    this.setState({selected: value});
-  };
+  return (
+    <ChoiceList
+      title="Company name"
+      choices={[
+        {label: 'Hidden', value: 'hidden'},
+        {label: 'Optional', value: 'optional'},
+        {label: 'Required', value: 'required'},
+      ]}
+      selected={selected}
+      onChange={handleChange}
+    />
+  );
 }
 ```
 
@@ -223,32 +215,24 @@ class ChoiceListExample extends React.Component {
 Allows for accessible error handling by connecting the error message to the field with the error.
 
 ```jsx
-class ChoiceListExample extends React.Component {
-  state = {
-    selected: ['hidden'],
-  };
+function ChoiceListWithErrorExample() {
+  const [selected, setSelected] = useState('hidden');
 
-  render() {
-    const {selected} = this.state;
+  const handleChange = useCallback((value) => setSelected(value), []);
 
-    return (
-      <ChoiceList
-        title="Company name"
-        choices={[
-          {label: 'Hidden', value: 'hidden', describedByError: true},
-          {label: 'Optional', value: 'optional'},
-          {label: 'Required', value: 'required'},
-        ]}
-        selected={selected}
-        onChange={this.handleChange}
-        error="Company name cannot be hidden at this time"
-      />
-    );
-  }
-
-  handleChange = (value) => {
-    this.setState({selected: value});
-  };
+  return (
+    <ChoiceList
+      title="Company name"
+      choices={[
+        {label: 'Hidden', value: 'hidden', describedByError: true},
+        {label: 'Optional', value: 'optional'},
+        {label: 'Required', value: 'required'},
+      ]}
+      selected={selected}
+      onChange={handleChange}
+      error="Company name cannot be hidden at this time"
+    />
+  );
 }
 ```
 
@@ -271,41 +255,33 @@ Allows merchants to select multiple options from a list.
 - Avoid options that are an either/or choice.
 
 ```jsx
-class ChoiceListExample extends React.Component {
-  state = {
-    selected: ['hidden'],
-  };
+function MultiChoiceListExample() {
+  const [selected, setSelected] = useState(['hidden']);
 
-  render() {
-    const {selected} = this.state;
+  const handleChange = useCallback((value) => setSelected(value), []);
 
-    return (
-      <ChoiceList
-        allowMultiple
-        title={'While the customer is checking out'}
-        choices={[
-          {
-            label: 'Use the shipping address as the billing address by default',
-            value: 'shipping',
-            helpText:
-              'Reduces the number of fields required to check out. The billing address can still be edited.',
-          },
-          {
-            label: 'Require a confirmation step',
-            value: 'confirmation',
-            helpText:
-              'Customers must review their order details before purchasing.',
-          },
-        ]}
-        selected={selected}
-        onChange={this.handleChange}
-      />
-    );
-  }
-
-  handleChange = (value) => {
-    this.setState({selected: value});
-  };
+  return (
+    <ChoiceList
+      allowMultiple
+      title="While the customer is checking out"
+      choices={[
+        {
+          label: 'Use the shipping address as the billing address by default',
+          value: 'shipping',
+          helpText:
+            'Reduces the number of fields required to check out. The billing address can still be edited.',
+        },
+        {
+          label: 'Require a confirmation step',
+          value: 'confirmation',
+          helpText:
+            'Customers must review their order details before purchasing.',
+        },
+      ]}
+      selected={selected}
+      onChange={handleChange}
+    />
+  );
 }
 ```
 
@@ -328,49 +304,45 @@ class ChoiceListExample extends React.Component {
 Use when you need merchants to view and/or interact with additional content under a choice. The content will always be rendered. Works for both single-choice and multi-choice list.
 
 ```jsx
-class ChoiceListExample extends React.Component {
-  state = {
-    selected: ['none'],
-    textFieldValue: '',
-  };
+function SingleOrMultiChoiceListWithChildrenContextExample() {
+  const [selected, setSelected] = useState(['none']);
+  const [textFieldValue, setTextFieldValue] = useState('');
 
-  render() {
-    const {selected, textFieldValue} = this.state;
+  const handleChoiceListChange = useCallback((value) => setSelected(value), []);
 
-    return (
-      <ChoiceList
-        title={'Discount minimum requirements'}
-        choices={[
-          {label: 'None', value: 'none'},
-          {label: 'Minimum purchase', value: 'minimum_purchase'},
-          {
-            label: 'Minimum quantity',
-            value: 'minimum_quantity',
-            renderChildren: () => {
-              return (
-                <TextField
-                  label="Minimum Quantity"
-                  labelHidden
-                  onChange={this.handleTextFieldChange}
-                  value={textFieldValue}
-                />
-              );
-            },
-          },
-        ]}
-        selected={selected}
-        onChange={this.handleChange}
+  const handleTextFieldChange = useCallback(
+    (value) => setTextFieldValue(value),
+    [],
+  );
+
+  const renderChildren = useCallback(
+    () => (
+      <TextField
+        label="Minimum Quantity"
+        labelHidden
+        onChange={handleTextFieldChange}
+        value={textFieldValue}
       />
-    );
-  }
+    ),
+    [handleTextFieldChange, textFieldValue],
+  );
 
-  handleChange = (value) => {
-    this.setState({selected: value});
-  };
-
-  handleTextFieldChange = (value) => {
-    this.setState({textFieldValue: value});
-  };
+  return (
+    <ChoiceList
+      title="Discount minimum requirements"
+      choices={[
+        {label: 'None', value: 'none'},
+        {label: 'Minimum purchase', value: 'minimum_purchase'},
+        {
+          label: 'Minimum quantity',
+          value: 'minimum_quantity',
+          renderChildren,
+        },
+      ]}
+      selected={selected}
+      onChange={handleChoiceListChange}
+    />
+  );
 }
 ```
 
@@ -381,53 +353,48 @@ class ChoiceListExample extends React.Component {
 Use when you need merchants to view and/or interact with additional content under a choice. The content is only rendered when the choice is selected. Works for both single-choice and multi-choice list.
 
 ```jsx
-class ChoiceListExample extends React.Component {
-  state = {
-    selected: ['none'],
-    textFieldValue: '',
-  };
+function SingleOrMultuChoiceListWithChildrenContextWhenSelectedExample() {
+  const [selected, setSelected] = useState(['none']);
+  const [textFieldValue, setTextFieldValue] = useState('');
 
-  render() {
-    const {selected, textFieldValue} = this.state;
+  const handleChoiceListChange = useCallback((value) => setSelected(value), []);
 
-    return (
-      <div style={{height: '150px'}}>
-        <ChoiceList
-          title={'Discount minimum requirements'}
-          choices={[
-            {label: 'None', value: 'none'},
-            {label: 'Minimum purchase', value: 'minimum_purchase'},
-            {
-              label: 'Minimum quantity',
-              value: 'minimum_quantity',
-              renderChildren: (isSelected) => {
-                return (
-                  isSelected && (
-                    <TextField
-                      label="Minimum Quantity"
-                      labelHidden
-                      onChange={this.handleTextFieldChange}
-                      value={textFieldValue}
-                    />
-                  )
-                );
-              },
-            },
-          ]}
-          selected={selected}
-          onChange={this.handleChange}
+  const handleTextFieldChange = useCallback(
+    (value) => setTextFieldValue(value),
+    [],
+  );
+
+  const renderChildren = useCallback(
+    (isSelected) =>
+      isSelected && (
+        <TextField
+          label="Minimum Quantity"
+          labelHidden
+          onChange={handleTextFieldChange}
+          value={textFieldValue}
         />
-      </div>
-    );
-  }
+      ),
+    [handleTextFieldChange, textFieldValue],
+  );
 
-  handleChange = (value) => {
-    this.setState({selected: value});
-  };
-
-  handleTextFieldChange = (value) => {
-    this.setState({textFieldValue: value});
-  };
+  return (
+    <div style={{height: '150px'}}>
+      <ChoiceList
+        title="Discount minimum requirements"
+        choices={[
+          {label: 'None', value: 'none'},
+          {label: 'Minimum purchase', value: 'minimum_purchase'},
+          {
+            label: 'Minimum quantity',
+            value: 'minimum_quantity',
+            renderChildren,
+          },
+        ]}
+        selected={selected}
+        onChange={handleChoiceListChange}
+      />
+    </div>
+  );
 }
 ```
 


### PR DESCRIPTION
### WHY are these changes introduced?

Convert examples to hooks

### WHAT is this pull request doing?

Converting Autocomplete, Banner and ChoiceList class-based examples to hooks

### STILL TO DO

I'm making quite a few pr's converting examples to hooks so I anticipate lots of `unreleased.md` conflicts, so I'll add the entry before I merge.

```
- Converted `Autocomplete`, `Banner`, and `ChoiceList` examples to functional components ([#2127](https://github.com/Shopify/polaris-react/pull/2127))
```

### How to 🎩

Make sure the behavior of the example mirrors the style guide 

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
