### PR TITLE
Hookify Collapsible, ColorPicker, and DataTable examples

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Converted `Collapsible`, `ColorPicker`, and `DataTable` examples to functional components ([#2128](https://github.com/Shopify/polaris-react/pull/2128))
 - Updated the `withContext` section in the [v3 to v4 migration guide](https://github.com/Shopify/polaris-react/blob/master/documentation/guides/migrating-from-v3-to-v4.md) ([#2124](https://github.com/Shopify/polaris-react/pull/2124))
 
 ### Development workflow

--- a/src/components/Collapsible/README.md
+++ b/src/components/Collapsible/README.md
@@ -56,46 +56,33 @@ Collapsible containers are cards with expandable and collapsible functionality, 
 Use for a basic “show more” interaction when you need to display more content.
 
 ```jsx
-class CollapsibleExample extends React.Component {
-  state = {
-    open: true,
-  };
+function CollapsibleExample() {
+  const [active, setActive] = useState(true);
 
-  render() {
-    const {open} = this.state;
+  const handleToggle = useCallback(() => setActive((active) => !active), []);
 
-    return (
-      <div style={{height: '200px'}}>
-        <Card sectioned>
-          <Stack vertical>
-            <Button
-              onClick={this.handleToggleClick}
-              ariaExpanded={open}
-              ariaControls="basic-collapsible"
-            >
-              Toggle
-            </Button>
-            <Collapsible open={open} id="basic-collapsible">
-              <TextContainer>
-                Your mailing list lets you contact customers or visitors who
-                have shown an interest in your store. Reach out to them with
-                exclusive offers or updates about your products.
-              </TextContainer>
-            </Collapsible>
-          </Stack>
-        </Card>
-      </div>
-    );
-  }
-
-  handleToggleClick = () => {
-    this.setState((state) => {
-      const open = !state.open;
-      return {
-        open,
-      };
-    });
-  };
+  return (
+    <div style={{height: '200px'}}>
+      <Card sectioned>
+        <Stack vertical>
+          <Button
+            onClick={handleToggle}
+            ariaExpanded={active}
+            ariaControls="basic-collapsible"
+          >
+            Toggle
+          </Button>
+          <Collapsible open={active} id="basic-collapsible">
+            <TextContainer>
+              Your mailing list lets you contact customers or visitors who have
+              shown an interest in your store. Reach out to them with exclusive
+              offers or updates about your products.
+            </TextContainer>
+          </Collapsible>
+        </Stack>
+      </Card>
+    </div>
+  );
 }
 ```
 

--- a/src/components/ColorPicker/README.md
+++ b/src/components/ColorPicker/README.md
@@ -38,24 +38,16 @@ Use when merchants need to select a color to make the selection a visual
 task rather than a technical one.
 
 ```jsx
-class ColorPickerExample extends React.Component {
-  state = {
-    color: {
-      hue: 120,
-      brightness: 1,
-      saturation: 1,
-    },
-  };
+function ColorPickerExample() {
+  const [color, setColor] = useState({
+    hue: 120,
+    brightness: 1,
+    saturation: 1,
+  });
 
-  render() {
-    const {color} = this.state;
+  const handleChange = useCallback(setColor, []);
 
-    return <ColorPicker onChange={this.handleChange} color={color} />;
-  }
-
-  handleChange = (color) => {
-    this.setState({color});
-  };
+  return <ColorPicker onChange={handleChange} color={color} />;
 }
 ```
 
@@ -65,26 +57,16 @@ Use when attached to a visual builder to allow the designated object to have a
 transparent background that allows underlying objects to show through.
 
 ```jsx
-class ColorPickerExample extends React.Component {
-  state = {
-    color: {
-      hue: 300,
-      brightness: 1,
-      saturation: 0.7,
-      alpha: 0.7,
-    },
-  };
+function ColorPickerWithTransparentValueExample() {
+  const [color, setColor] = useState({
+    hue: 300,
+    brightness: 1,
+    saturation: 0.7,
+    alpha: 0.7,
+  });
 
-  render() {
-    const {color} = this.state;
+  const handleChange = useCallback(setColor, []);
 
-    return (
-      <ColorPicker onChange={this.handleChange} color={color} allowAlpha />
-    );
-  }
-
-  handleChange = (color) => {
-    this.setState({color});
-  };
+  return <ColorPicker onChange={handleChange} color={color} allowAlpha />;
 }
 ```

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -22,45 +22,43 @@ Data tables are used to organize and display all information from a data set. Wh
 Use to present small amounts of data for merchants to view statically.
 
 ```jsx
-class DataTableExample extends React.Component {
-  render() {
-    const rows = [
-      ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
-      ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
-      [
-        'Navy Merino Wool Blazer with khaki chinos and yellow belt',
-        '$445.00',
-        124518,
-        32,
-        '$14,240.00',
-      ],
-    ];
+function DataTableExample() {
+  const rows = [
+    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+    [
+      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+      '$445.00',
+      124518,
+      32,
+      '$14,240.00',
+    ],
+  ];
 
-    return (
-      <Page title="Sales by product">
-        <Card>
-          <DataTable
-            columnContentTypes={[
-              'text',
-              'numeric',
-              'numeric',
-              'numeric',
-              'numeric',
-            ]}
-            headings={[
-              'Product',
-              'Price',
-              'SKU Number',
-              'Net quantity',
-              'Net sales',
-            ]}
-            rows={rows}
-            totals={['', '', '', 255, '$155,830.00']}
-          />
-        </Card>
-      </Page>
-    );
-  }
+  return (
+    <Page title="Sales by product">
+      <Card>
+        <DataTable
+          columnContentTypes={[
+            'text',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+          ]}
+          headings={[
+            'Product',
+            'Price',
+            'SKU Number',
+            'Net quantity',
+            'Net sales',
+          ]}
+          rows={rows}
+          totals={['', '', '', 255, '$155,830.00']}
+        />
+      </Card>
+    </Page>
+  );
 }
 ```
 
@@ -69,67 +67,63 @@ class DataTableExample extends React.Component {
 Use when clarity of the table’s content is needed. For example, to note the number of rows currently shown in a data table with pagination.
 
 ```jsx
-class SortableDataTableExample extends React.Component {
-  state = {
-    sortedRows: null,
-  };
+function SortableDataTableExample() {
+  const [sortedRows, setSortedRows] = useState(null);
 
-  sortCurrency = (rows, index, direction) => {
+  const initiallySortedRows = [
+    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+    [
+      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+      '$445.00',
+      124518,
+      32,
+      '$14,240.00',
+    ],
+  ];
+  const rows = sortedRows ? sortedRows : initiallySortedRows;
+
+  const handleSort = useCallback(
+    (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
+    [rows],
+  );
+
+  return (
+    <Page title="Sales by product">
+      <Card>
+        <DataTable
+          columnContentTypes={[
+            'text',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+          ]}
+          headings={[
+            'Product',
+            'Price',
+            'SKU Number',
+            'Net quantity',
+            'Net sales',
+          ]}
+          rows={rows}
+          totals={['', '', '', 255, '$155,830.00']}
+          sortable={[false, true, false, false, true]}
+          defaultSortDirection="descending"
+          initialSortColumnIndex={4}
+          onSort={handleSort}
+        />
+      </Card>
+    </Page>
+  );
+
+  function sortCurrency(rows, index, direction) {
     return [...rows].sort((rowA, rowB) => {
       const amountA = parseFloat(rowA[index].substring(1));
       const amountB = parseFloat(rowB[index].substring(1));
 
       return direction === 'descending' ? amountB - amountA : amountA - amountB;
     });
-  };
-
-  handleSort = (rows) => (index, direction) => {
-    this.setState({sortedRows: this.sortCurrency(rows, index, direction)});
-  };
-
-  render() {
-    const {sortedRows} = this.state;
-    const initiallySortedRows = [
-      ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
-      ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
-      [
-        'Navy Merino Wool Blazer with khaki chinos and yellow belt',
-        '$445.00',
-        124518,
-        32,
-        '$14,240.00',
-      ],
-    ];
-    const rows = sortedRows ? sortedRows : initiallySortedRows;
-
-    return (
-      <Page title="Sales by product">
-        <Card>
-          <DataTable
-            columnContentTypes={[
-              'text',
-              'numeric',
-              'numeric',
-              'numeric',
-              'numeric',
-            ]}
-            headings={[
-              'Product',
-              'Price',
-              'SKU Number',
-              'Net quantity',
-              'Net sales',
-            ]}
-            rows={rows}
-            totals={['', '', '', 255, '$155,830.00']}
-            sortable={[false, true, false, false, true]}
-            defaultSortDirection="descending"
-            initialSortColumnIndex={4}
-            onSort={this.handleSort(rows)}
-          />
-        </Card>
-      </Page>
-    );
   }
 }
 ```
@@ -139,46 +133,44 @@ class SortableDataTableExample extends React.Component {
 Use when clarity of the table’s content is needed. For example, to note the number of rows currently shown in a data table with pagination.
 
 ```jsx
-class DataTableFooterExample extends React.Component {
-  render() {
-    const rows = [
-      ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
-      ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
-      [
-        'Navy Merino Wool Blazer with khaki chinos and yellow belt',
-        '$445.00',
-        124518,
-        32,
-        '$14,240.00',
-      ],
-    ];
+function DataTableFooterExample() {
+  const rows = [
+    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+    [
+      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+      '$445.00',
+      124518,
+      32,
+      '$14,240.00',
+    ],
+  ];
 
-    return (
-      <Page title="Sales by product">
-        <Card>
-          <DataTable
-            columnContentTypes={[
-              'text',
-              'numeric',
-              'numeric',
-              'numeric',
-              'numeric',
-            ]}
-            headings={[
-              'Product',
-              'Price',
-              'SKU Number',
-              'Net quantity',
-              'Net sales',
-            ]}
-            rows={rows}
-            totals={['', '', '', 255, '$155,830.00']}
-            footerContent={`Showing ${rows.length} of ${rows.length} results`}
-          />
-        </Card>
-      </Page>
-    );
-  }
+  return (
+    <Page title="Sales by product">
+      <Card>
+        <DataTable
+          columnContentTypes={[
+            'text',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+          ]}
+          headings={[
+            'Product',
+            'Price',
+            'SKU Number',
+            'Net quantity',
+            'Net sales',
+          ]}
+          rows={rows}
+          totals={['', '', '', 255, '$155,830.00']}
+          footerContent={`Showing ${rows.length} of ${rows.length} results`}
+        />
+      </Card>
+    </Page>
+  );
 }
 ```
 
@@ -187,59 +179,55 @@ class DataTableFooterExample extends React.Component {
 Use to help merchants find relevant, finer grained data sets.
 
 ```jsx
-class DataTableLinkExample extends React.Component {
-  render() {
-    const rows = [
-      [
-        <Link url="https://www.example.com">Emerald Silk Gown</Link>,
-        '$875.00',
-        124689,
-        140,
-        '$122,500.00',
-      ],
-      [
-        <Link url="https://www.example.com">Mauve Cashmere Scarf</Link>,
-        '$230.00',
-        124533,
-        83,
-        '$19,090.00',
-      ],
-      [
-        <Link url="https://www.example.com">
-          Navy Merino Wool Blazer with khaki chinos and yellow belt
-        </Link>,
-        '$445.00',
-        124518,
-        32,
-        '$14,240.00',
-      ],
-    ];
+function DataTableLinkExample() {
+  const rows = [
+    [
+      <Link url="https://www.example.com" key="emerald-silk-gown">
+        Emerald Silk Gown
+      </Link>,
+      '$875.00',
+      124689,
+      140,
+      '$122,500.00',
+    ],
+    [
+      <Link url="https://www.example.com" key="mauve-cashmere-scarf">
+        Mauve Cashmere Scarf
+      </Link>,
+      '$230.00',
+      124533,
+      83,
+      '$19,090.00',
+    ],
+    [
+      <Link url="https://www.example.com" key="navy-merino-wool">
+        Navy Merino Wool Blazer with khaki chinos and yellow belt
+      </Link>,
+      '$445.00',
+      124518,
+      32,
+      '$14,240.00',
+    ],
+  ];
 
-    return (
-      <Page title="Sales by product">
-        <Card>
-          <DataTable
-            columnContentTypes={[
-              'text',
-              'numeric',
-              'numeric',
-              'numeric',
-              'numeric',
-            ]}
-            headings={[
-              'Product',
-              'Price',
-              'SKU Number',
-              'Quantity',
-              'Net sales',
-            ]}
-            rows={rows}
-            totals={['', '', '', 255, '$155,830.00']}
-          />
-        </Card>
-      </Page>
-    );
-  }
+  return (
+    <Page title="Sales by product">
+      <Card>
+        <DataTable
+          columnContentTypes={[
+            'text',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+          ]}
+          headings={['Product', 'Price', 'SKU Number', 'Quantity', 'Net sales']}
+          rows={rows}
+          totals={['', '', '', 255, '$155,830.00']}
+        />
+      </Card>
+    </Page>
+  );
 }
 ```
 
@@ -248,84 +236,82 @@ class DataTableLinkExample extends React.Component {
 Use as a broad example that includes most props available to data table.
 
 ```jsx
-class FullDataTableExample extends React.Component {
-  state = {
-    sortedRows: null,
-  };
+function FullDataTableExample() {
+  const [sortedRows, setSortedRows] = useState(null);
 
-  sortCurrency = (rows, index, direction) => {
+  const initiallySortedRows = [
+    [
+      <Link url="https://www.example.com" key="emerald-silk-gown">
+        Emerald Silk Gown
+      </Link>,
+      '$875.00',
+      124689,
+      140,
+      '$121,500.00',
+    ],
+    [
+      <Link url="https://www.example.com" key="mauve-cashmere-scarf">
+        Mauve Cashmere Scarf
+      </Link>,
+      '$230.00',
+      124533,
+      83,
+      '$19,090.00',
+    ],
+    [
+      <Link url="https://www.example.com" key="navy-merino-wool">
+        Navy Merino Wool Blazer with khaki chinos and yellow belt
+      </Link>,
+      '$445.00',
+      124518,
+      32,
+      '$14,240.00',
+    ],
+  ];
+
+  const rows = sortedRows ? sortedRows : initiallySortedRows;
+  const handleSort = useCallback(
+    (index, direction) => setSortedRows(sortCurrency(rows, index, direction)),
+    [rows],
+  );
+
+  return (
+    <Page title="Sales by product">
+      <Card>
+        <DataTable
+          columnContentTypes={[
+            'text',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+          ]}
+          headings={[
+            'Product',
+            'Price',
+            'SKU Number',
+            'Net quantity',
+            'Net sales',
+          ]}
+          rows={rows}
+          totals={['', '', '', 255, '$155,830.00']}
+          sortable={[false, true, false, false, true]}
+          defaultSortDirection="descending"
+          initialSortColumnIndex={4}
+          onSort={handleSort}
+          footerContent={`Showing ${rows.length} of ${rows.length} results`}
+        />
+      </Card>
+    </Page>
+  );
+
+  function sortCurrency(rows, index, direction) {
     return [...rows].sort((rowA, rowB) => {
       const amountA = parseFloat(rowA[index].substring(1));
       const amountB = parseFloat(rowB[index].substring(1));
 
       return direction === 'descending' ? amountB - amountA : amountA - amountB;
     });
-  };
-
-  handleSort = (rows) => (index, direction) => {
-    this.setState({sortedRows: this.sortCurrency(rows, index, direction)});
-  };
-
-  render() {
-    const {sortedRows} = this.state;
-
-    const initiallySortedRows = [
-      [
-        <Link url="https://www.example.com">Emerald Silk Gown</Link>,
-        '$875.00',
-        124689,
-        140,
-        '$121,500.00',
-      ],
-      [
-        <Link url="https://www.example.com">Mauve Cashmere Scarf</Link>,
-        '$230.00',
-        124533,
-        83,
-        '$19,090.00',
-      ],
-      [
-        <Link url="https://www.example.com">
-          Navy Merino Wool Blazer with khaki chinos and yellow belt
-        </Link>,
-        '$445.00',
-        124518,
-        32,
-        '$14,240.00',
-      ],
-    ];
-
-    const rows = sortedRows ? sortedRows : initiallySortedRows;
-
-    return (
-      <Page title="Sales by product">
-        <Card>
-          <DataTable
-            columnContentTypes={[
-              'text',
-              'numeric',
-              'numeric',
-              'numeric',
-              'numeric',
-            ]}
-            headings={[
-              'Product',
-              'Price',
-              'SKU Number',
-              'Net quantity',
-              'Net sales',
-            ]}
-            rows={rows}
-            totals={['', '', '', 255, '$155,830.00']}
-            sortable={[false, true, false, false, true]}
-            defaultSortDirection="descending"
-            initialSortColumnIndex={4}
-            onSort={this.handleSort(rows)}
-            footerContent={`Showing ${rows.length} of ${rows.length} results`}
-          />
-        </Card>
-      </Page>
-    );
   }
 }
 ```


### PR DESCRIPTION
### WHY are these changes introduced?

Convert examples to hooks

### WHAT is this pull request doing?

Converting Collapsible, ColorPicker and DataTable class-based examples to hooks

### STILL TO DO

I'm making quite a few pr's converting examples to hooks so I anticipate lots of `unreleased.md` conflicts, so I'll add the entry before I merge.

```
- Converted `Collapsible`, `ColorPicker`, and `DataTable` examples to functional components ([#2128](https://github.com/Shopify/polaris-react/pull/2128))
```

### How to 🎩

Make sure the behavior of the example mirrors the style guide 

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
