### PR TITLE
Hookify Modal, OptionList, and Popover examples

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -27,11 +27,12 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Converted `Collapsible`, `ColorPicker`, and `DataTable` examples to functional components ([#2128](https://github.com/Shopify/polaris-react/pull/2128))
+- Converted `Modal`, `OptionList`, and `Popover` examples to functional components ([#2131](https://github.com/Shopify/polaris-react/pull/2131))
 - Converted `RadioButton`, `RangeSlider`, and `ResourceItem` examples to functional components ([#2132](https://github.com/Shopify/polaris-react/pull/2132))
 - Converted `ResourceList`, `ResourcePicker`, and `Select` examples to functional components ([#2133](https://github.com/Shopify/polaris-react/pull/2133))
-- Converted `Collapsible`, `ColorPicker`, and `DataTable` examples to functional components ([#2128](https://github.com/Shopify/polaris-react/pull/2128))
-- Updated the `withContext` section in the [v3 to v4 migration guide](https://github.com/Shopify/polaris-react/blob/master/documentation/guides/migrating-from-v3-to-v4.md) ([#2124](https://github.com/Shopify/polaris-react/pull/2124))
 - Converted `TextField`, `Toast`, and `TopBar` examples to functional components ([#2135](https://github.com/Shopify/polaris-react/pull/2135))
+- Updated the `withContext` section in the [v3 to v4 migration guide](https://github.com/Shopify/polaris-react/blob/master/documentation/guides/migrating-from-v3-to-v4.md) ([#2124](https://github.com/Shopify/polaris-react/pull/2124))
 
 ### Development workflow
 

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -51,33 +51,31 @@ Properties that are available only in a stand-alone context are documented as `(
 The following example shows the modal component in an embedded application context:
 
 ```jsx
-class EmbeddedAppModalExample extends React.Component {
-  state = {
-    modalOpen: false,
-  };
+function EmbeddedAppModalExample() {
+  const [modalOpen, setModalOpen] = useState(false);
 
-  render() {
-    return (
-      <AppProvider apiKey="YOUR_API_KEY" i18n={{}}>
-        <Modal
-          src="https://my-app.com/upgrade-to-retail-package"
-          open={this.state.modalOpen}
-          title="Upgrade your Shopify POS with the Retail Package"
-          primaryAction={{
-            content: 'Add Retail Package',
-            onAction: () => this.setState({modalOpen: false}),
-          }}
-          secondaryActions={[
-            {
-              content: 'Cancel',
-              onAction: () => this.setState({modalOpen: false}),
-            },
-          ]}
-          onClose={() => this.setState({modalOpen: false})}
-        />
-      </AppProvider>
-    );
-  }
+  const handleModalClose = useCallback(() => setModalOpen(false), []);
+
+  return (
+    <AppProvider apiKey="YOUR_API_KEY" i18n={{}} shopOrigin="YOUR_SHOP_ORIGIN">
+      <Modal
+        src="https://my-app.com/upgrade-to-retail-package"
+        open={modalOpen}
+        title="Upgrade your Shopify POS with the Retail Package"
+        primaryAction={{
+          content: 'Add Retail Package',
+          onAction: handleModalClose,
+        }}
+        secondaryActions={[
+          {
+            content: 'Cancel',
+            onAction: handleModalClose,
+          },
+        ]}
+        onClose={handleModalClose}
+      />
+    </AppProvider>
+  );
 }
 ```
 
@@ -276,49 +274,41 @@ Body content should be:
 Use as the default option for a modal.
 
 ```jsx
-class ModalExample extends React.Component {
-  state = {
-    active: true,
-  };
+function ModalExample() {
+  const [active, setActive] = useState(true);
 
-  render() {
-    const {active} = this.state;
+  const handleChange = useCallback(() => setActive(!active), [active]);
 
-    return (
-      <div style={{height: '500px'}}>
-        <Button onClick={this.handleChange}>Open</Button>
-        <Modal
-          open={active}
-          onClose={this.handleChange}
-          title="Reach more shoppers with Instagram product tags"
-          primaryAction={{
-            content: 'Add Instagram',
-            onAction: this.handleChange,
-          }}
-          secondaryActions={[
-            {
-              content: 'Learn more',
-              onAction: this.handleChange,
-            },
-          ]}
-        >
-          <Modal.Section>
-            <TextContainer>
-              <p>
-                Use Instagram posts to share your products with millions of
-                people. Let shoppers buy from your store without leaving
-                Instagram.
-              </p>
-            </TextContainer>
-          </Modal.Section>
-        </Modal>
-      </div>
-    );
-  }
-
-  handleChange = () => {
-    this.setState(({active}) => ({active: !active}));
-  };
+  return (
+    <div style={{height: '500px'}}>
+      <Button onClick={handleChange}>Open</Button>
+      <Modal
+        open={active}
+        onClose={handleChange}
+        title="Reach more shoppers with Instagram product tags"
+        primaryAction={{
+          content: 'Add Instagram',
+          onAction: handleChange,
+        }}
+        secondaryActions={[
+          {
+            content: 'Learn more',
+            onAction: handleChange,
+          },
+        ]}
+      >
+        <Modal.Section>
+          <TextContainer>
+            <p>
+              Use Instagram posts to share your products with millions of
+              people. Let shoppers buy from your store without leaving
+              Instagram.
+            </p>
+          </TextContainer>
+        </Modal.Section>
+      </Modal>
+    </div>
+  );
 }
 ```
 
@@ -327,87 +317,68 @@ class ModalExample extends React.Component {
 Use to let merchants take a key action.
 
 ```jsx
-const DISCOUNT_LINK = 'https://polaris.shopify.com/';
+function ModalWithPrimaryActionExample() {
+  const DISCOUNT_LINK = 'https://polaris.shopify.com/';
 
-class ModalExample extends React.Component {
-  state = {
-    active: true,
-  };
+  const [active, setActive] = useState(true);
+  const node = useRef(null);
 
-  node = null;
+  const handleClick = useCallback(() => {
+    node.current && node.current.input.focus();
+  }, []);
 
-  render() {
-    const {active} = this.state;
-
-    return (
-      <div style={{height: '500px'}}>
-        <Button onClick={this.toggleModal}>Open</Button>
-        <Modal
-          open={active}
-          onClose={this.toggleModal}
-          title="Get a shareable link"
-          primaryAction={{
-            content: 'Close',
-            onAction: this.toggleModal,
-          }}
-        >
-          <Modal.Section>
-            <Stack>
-              <Stack.Item>
-                <TextContainer>
-                  <p>
-                    You can share this discount link with your customers via
-                    email or social media. Your discount will be automatically
-                    applied at checkout.
-                  </p>
-                </TextContainer>
-              </Stack.Item>
-              <Stack.Item fill>
-                <TextField
-                  ref={this.bindNode}
-                  label="Discount link"
-                  onFocus={this.handleFocus}
-                  value={DISCOUNT_LINK}
-                  onChange={() => {}}
-                  connectedRight={
-                    <Button primary onClick={this.handleClick}>
-                      Copy link
-                    </Button>
-                  }
-                />
-              </Stack.Item>
-            </Stack>
-          </Modal.Section>
-        </Modal>
-      </div>
-    );
-  }
-
-  handleClick = () => {
-    if (this.node == null) {
+  const handleFocus = useCallback(() => {
+    if (node.current == null) {
       return;
     }
-    this.node.input.focus();
-  };
-
-  handleFocus = () => {
-    if (this.node == null) {
-      return;
-    }
-    this.node.input.select();
+    node.current.input.select();
     document.execCommand('copy');
-  };
+  }, []);
 
-  toggleModal = () => {
-    this.setState(({active}) => ({active: !active}));
-  };
+  const toggleModal = useCallback(() => setActive((active) => !active), []);
 
-  bindNode = (node) => {
-    if (node == null) {
-      return;
-    }
-    this.node = node;
-  };
+  return (
+    <div style={{height: '500px'}}>
+      <Button onClick={toggleModal}>Open</Button>
+      <Modal
+        open={active}
+        onClose={toggleModal}
+        title="Get a shareable link"
+        primaryAction={{
+          content: 'Close',
+          onAction: toggleModal,
+        }}
+      >
+        <Modal.Section>
+          <Stack>
+            <Stack.Item>
+              <TextContainer>
+                <p>
+                  You can share this discount link with your customers via email
+                  or social media. Your discount will be automatically applied
+                  at checkout.
+                </p>
+              </TextContainer>
+            </Stack.Item>
+            <Stack.Item fill>
+              <TextField
+                ref={node}
+                label="Discount link"
+                onFocus={handleFocus}
+                value={DISCOUNT_LINK}
+                onChange={() => {}}
+                connectedRight={
+                  <Button primary onClick={handleClick}>
+                    Copy link
+                  </Button>
+                }
+              />
+            </Stack.Item>
+          </Stack>
+        </Modal.Section>
+      </Modal>
+    </div>
+  );
 }
 ```
 
@@ -428,91 +399,87 @@ class ModalExample extends React.Component {
 Use to let merchants take key actions at the bottom of the modal.
 
 ```jsx
-const CURRENT_PAGE = 'current_page';
-const ALL_CUSTOMERS = 'all_customers';
-const SELECTED_CUSTOMERS = 'selected_customers';
-const CSV_EXCEL = 'csv_excel';
-const CSV_PLAIN = 'csv_plain';
+function ModalWithPrimaryAndSecondaryActionsExample() {
+  const CURRENT_PAGE = 'current_page';
+  const ALL_CUSTOMERS = 'all_customers';
+  const SELECTED_CUSTOMERS = 'selected_customers';
+  const CSV_EXCEL = 'csv_excel';
+  const CSV_PLAIN = 'csv_plain';
 
-class ModalExample extends React.Component {
-  state = {
-    active: true,
-    selectedExport: [],
-    selectedExportAs: [],
+  const [active, setActive] = useState(true);
+  const [selectedExport, setSelectedExport] = useState([]);
+  const [selectedExportAs, setSelectedExportAs] = useState([]);
+
+  const handleModalChange = useCallback(() => setActive(!active), [active]);
+
+  const handleClose = () => {
+    handleModalChange();
+    handleSelectedExport([]);
+    handleSelectedExportAs([]);
   };
 
-  render() {
-    const {active, selectedExport, selectedExportAs} = this.state;
+  const handleSelectedExport = useCallback(
+    (value) => setSelectedExport(value),
+    [],
+  );
 
-    return (
-      <div style={{height: '500px'}}>
-        <Button onClick={this.handleModalChange}>Open</Button>
-        <Modal
-          open={active}
-          onClose={this.handleClose}
-          title="Export customers"
-          primaryAction={{
-            content: 'Export customers',
-            onAction: this.handleClose,
-          }}
-          secondaryActions={[
-            {
-              content: 'Cancel',
-              onAction: this.handleClose,
-            },
-          ]}
-        >
-          <Modal.Section>
-            <Stack vertical>
-              <Stack.Item>
-                <ChoiceList
-                  title={'Export'}
-                  choices={[
-                    {label: 'Current page', value: CURRENT_PAGE},
-                    {label: 'All customers', value: ALL_CUSTOMERS},
-                    {label: 'Selected customers', value: SELECTED_CUSTOMERS},
-                  ]}
-                  selected={selectedExport}
-                  onChange={this.handleCheckboxChange('selectedExport')}
-                />
-              </Stack.Item>
-              <Stack.Item>
-                <ChoiceList
-                  title={'Export as'}
-                  choices={[
-                    {
-                      label:
-                        'CSV for Excel, Numbers, or other spreadsheet programs',
-                      value: CSV_EXCEL,
-                    },
-                    {label: 'Plain CSV file', value: CSV_PLAIN},
-                  ]}
-                  selected={selectedExportAs}
-                  onChange={this.handleCheckboxChange('selectedExportAs')}
-                />
-              </Stack.Item>
-            </Stack>
-          </Modal.Section>
-        </Modal>
-      </div>
-    );
-  }
+  const handleSelectedExportAs = useCallback(
+    (value) => setSelectedExportAs(value),
+    [],
+  );
 
-  handleModalChange = () => {
-    this.setState(({active}) => ({active: !active}));
-  };
-
-  handleClose = () => {
-    this.setState(({active}) => ({
-      active: !active,
-      selectedExport: [],
-      selectedExportAs: [],
-    }));
-  };
-
-  handleCheckboxChange = (key) => {
-    return (value) => this.setState({[key]: value});
-  };
+  return (
+    <div style={{height: '500px'}}>
+      <Button onClick={handleModalChange}>Open</Button>
+      <Modal
+        open={active}
+        onClose={handleClose}
+        title="Export customers"
+        primaryAction={{
+          content: 'Export customers',
+          onAction: handleClose,
+        }}
+        secondaryActions={[
+          {
+            content: 'Cancel',
+            onAction: handleClose,
+          },
+        ]}
+      >
+        <Modal.Section>
+          <Stack vertical>
+            <Stack.Item>
+              <ChoiceList
+                title="Export"
+                choices={[
+                  {label: 'Current page', value: CURRENT_PAGE},
+                  {label: 'All customers', value: ALL_CUSTOMERS},
+                  {label: 'Selected customers', value: SELECTED_CUSTOMERS},
+                ]}
+                selected={selectedExport}
+                onChange={handleSelectedExport}
+              />
+            </Stack.Item>
+            <Stack.Item>
+              <ChoiceList
+                title="Export as"
+                choices={[
+                  {
+                    label:
+                      'CSV for Excel, Numbers, or other spreadsheet programs',
+                    value: CSV_EXCEL,
+                  },
+                  {label: 'Plain CSV file', value: CSV_PLAIN},
+                ]}
+                selected={selectedExportAs}
+                onChange={handleSelectedExportAs}
+              />
+            </Stack.Item>
+          </Stack>
+        </Modal.Section>
+      </Modal>
+    </div>
+  );
 }
 ```
 
@@ -535,63 +502,53 @@ class ModalExample extends React.Component {
 Use when you need to increase the width of your modal.
 
 ```jsx
-class ModalExample extends React.Component {
-  state = {
-    active: true,
-    checked: false,
-  };
+function LargeModalExample() {
+  const [active, setActive] = useState(true);
+  const [checked, setChecked] = useState(false);
 
-  render() {
-    const {active, checked} = this.state;
+  const toggleActive = useCallback(() => setActive((active) => !active), []);
 
-    return (
-      <div style={{height: '500px'}}>
-        <Button onClick={this.handleChange}>Open</Button>
-        <Modal
-          large
-          open={active}
-          onClose={this.handleChange}
-          title="Import customers by CSV"
-          primaryAction={{
-            content: 'Import customers',
-            onAction: this.handleChange,
-          }}
-          secondaryActions={[
-            {
-              content: 'Cancel',
-              onAction: this.handleChange,
-            },
-          ]}
-        >
-          <Modal.Section>
-            <Stack vertical>
-              <DropZone
-                accept=".csv"
-                errorOverlayText="File type must be .csv"
-                type="file"
-                onDrop={() => {}}
-              >
-                <DropZone.FileUpload />
-              </DropZone>
-              <Checkbox
-                checked={checked}
-                label="Overwrite existing customers that have the same email or phone"
-                onChange={this.handleCheckbox}
-              />
-            </Stack>
-          </Modal.Section>
-        </Modal>
-      </div>
-    );
-  }
+  const handleCheckbox = useCallback((value) => setChecked(value), []);
 
-  handleChange = () => {
-    this.setState(({active}) => ({active: !active}));
-  };
-
-  handleCheckbox = (value) => {
-    this.setState({checked: value});
-  };
+  return (
+    <div style={{height: '500px'}}>
+      <Button onClick={toggleActive}>Open</Button>
+      <Modal
+        large
+        open={active}
+        onClose={toggleActive}
+        title="Import customers by CSV"
+        primaryAction={{
+          content: 'Import customers',
+          onAction: toggleActive,
+        }}
+        secondaryActions={[
+          {
+            content: 'Cancel',
+            onAction: toggleActive,
+          },
+        ]}
+      >
+        <Modal.Section>
+          <Stack vertical>
+            <DropZone
+              accept=".csv"
+              errorOverlayText="File type must be .csv"
+              type="file"
+              onDrop={() => {}}
+            >
+              <DropZone.FileUpload />
+            </DropZone>
+            <Checkbox
+              checked={checked}
+              label="Overwrite existing customers that have the same email or phone"
+              onChange={handleCheckbox}
+            />
+          </Stack>
+        </Modal.Section>
+      </Modal>
+    </div>
+  );
 }
 ```
 
@@ -602,48 +559,40 @@ class ModalExample extends React.Component {
 We recommend you add a title to your modal, but you may leave it blank.
 
 ```jsx
-class ModalExample extends React.Component {
-  state = {
-    active: true,
-  };
+function ModalWithoutTitleExample() {
+  const [active, setActive] = useState(true);
 
-  render() {
-    const {active} = this.state;
+  const handleChange = useCallback(() => setActive(!active), [active]);
 
-    return (
-      <div style={{height: '500px'}}>
-        <Button onClick={this.handleChange}>Open</Button>
-        <Modal
-          open={active}
-          onClose={this.handleChange}
-          primaryAction={{
-            content: 'Add Instagram',
-            onAction: this.handleChange,
-          }}
-          secondaryActions={[
-            {
-              content: 'Learn more',
-              onAction: this.handleChange,
-            },
-          ]}
-        >
-          <Modal.Section>
-            <TextContainer>
-              <p>
-                Use Instagram posts to share your products with millions of
-                people. Let shoppers buy from your store without leaving
-                Instagram.
-              </p>
-            </TextContainer>
-          </Modal.Section>
-        </Modal>
-      </div>
-    );
-  }
-
-  handleChange = () => {
-    this.setState(({active}) => ({active: !active}));
-  };
+  return (
+    <div style={{height: '500px'}}>
+      <Button onClick={handleChange}>Open</Button>
+      <Modal
+        open={active}
+        onClose={handleChange}
+        primaryAction={{
+          content: 'Add Instagram',
+          onAction: handleChange,
+        }}
+        secondaryActions={[
+          {
+            content: 'Learn more',
+            onAction: handleChange,
+          },
+        ]}
+      >
+        <Modal.Section>
+          <TextContainer>
+            <p>
+              Use Instagram posts to share your products with millions of
+              people. Let shoppers buy from your store without leaving
+              Instagram.
+            </p>
+          </TextContainer>
+        </Modal.Section>
+      </Modal>
+    </div>
+  );
 }
 ```
 
@@ -654,38 +603,32 @@ class ModalExample extends React.Component {
 Use to implement infinite scroll of modal content.
 
 ```jsx
-class ModalExample extends React.Component {
-  state = {
-    active: true,
-  };
+function ModalWithScrollListenerExample() {
+  const [active, setActive] = useState(true);
 
-  render() {
-    const {active} = this.state;
+  const handleChange = useCallback(() => setActive(!active), [active]);
 
-    return (
-      <div style={{height: '500px'}}>
-        <Button onClick={this.handleChange}>Open</Button>
-        <Modal
-          open={active}
-          title="Scrollable content"
-          onClose={this.toggleModalVisibility}
-          onScrolledToBottom={() => alert('Scrolled to bottom')}
-        >
-          {Array.from({length: 50}, (_, index) => (
-            <Modal.Section key={index}>
-              <TextContainer>
-                <p>Item #{index}</p>
-              </TextContainer>
-            </Modal.Section>
-          ))}
-        </Modal>
-      </div>
-    );
-  }
+  const handleScrollBottom = useCallback(() => alert('Scrolled to bottom'), []);
 
-  toggleModalVisibility = () => {
-    this.setState(({active}) => ({active: !active}));
-  };
+  return (
+    <div style={{height: '500px'}}>
+      <Button onClick={handleChange}>Open</Button>
+      <Modal
+        open={active}
+        title="Scrollable content"
+        onClose={handleChange}
+        onScrolledToBottom={handleScrollBottom}
+      >
+        {Array.from({length: 50}, (_, index) => (
+          <Modal.Section key={index}>
+            <TextContainer>
+              <p>Item #{index}</p>
+            </TextContainer>
+          </Modal.Section>
+        ))}
+      </Modal>
+    </div>
+  );
 }
 ```
 

--- a/src/components/OptionList/README.md
+++ b/src/components/OptionList/README.md
@@ -61,29 +61,25 @@ Each item in an option list should be clear and descriptive.
 Use for a group of similar selectable items when only one should be selectable at once.
 
 ```jsx
-class OptionListExample extends React.Component {
-  state = {selected: []};
+function OptionListExample() {
+  const [selected, setSelected] = useState([]);
 
-  render() {
-    return (
-      <Card>
-        <OptionList
-          title="Inventory Location"
-          onChange={(updated) => {
-            this.setState({selected: updated});
-          }}
-          options={[
-            {value: 'byward_market', label: 'Byward Market'},
-            {value: 'centretown', label: 'Centretown'},
-            {value: 'hintonburg', label: 'Hintonburg'},
-            {value: 'westboro', label: 'Westboro'},
-            {value: 'downtown', label: 'Downtown'},
-          ]}
-          selected={this.state.selected}
-        />
-      </Card>
-    );
-  }
+  return (
+    <Card>
+      <OptionList
+        title="Inventory Location"
+        onChange={setSelected}
+        options={[
+          {value: 'byward_market', label: 'Byward Market'},
+          {value: 'centretown', label: 'Centretown'},
+          {value: 'hintonburg', label: 'Hintonburg'},
+          {value: 'westboro', label: 'Westboro'},
+          {value: 'downtown', label: 'Downtown'},
+        ]}
+        selected={selected}
+      />
+    </Card>
+  );
 }
 ```
 
@@ -92,30 +88,26 @@ class OptionListExample extends React.Component {
 Use when you have a group of similar selectable items and more than one item can be selected at once.
 
 ```jsx
-class OptionListExample extends React.Component {
-  state = {selected: []};
+function MultipleOptionListExample() {
+  const [selected, setSelected] = useState([]);
 
-  render() {
-    return (
-      <Card>
-        <OptionList
-          title="Manage sales channels availability"
-          onChange={(updated) => {
-            this.setState({selected: updated});
-          }}
-          options={[
-            {value: 'online_store', label: 'Online Store'},
-            {value: 'messenger', label: 'Messenger'},
-            {value: 'facebook', label: 'Facebook'},
-            {value: 'wholesale', label: 'Wholesale'},
-            {value: 'buzzfeed', label: 'BuzzFeed'},
-          ]}
-          selected={this.state.selected}
-          allowMultiple
-        />
-      </Card>
-    );
-  }
+  return (
+    <Card>
+      <OptionList
+        title="Manage sales channels availability"
+        onChange={setSelected}
+        options={[
+          {value: 'online_store', label: 'Online Store'},
+          {value: 'messenger', label: 'Messenger'},
+          {value: 'facebook', label: 'Facebook'},
+          {value: 'wholesale', label: 'Wholesale'},
+          {value: 'buzzfeed', label: 'BuzzFeed'},
+        ]}
+        selected={selected}
+        allowMultiple
+      />
+    </Card>
+  );
 }
 ```
 
@@ -124,38 +116,34 @@ class OptionListExample extends React.Component {
 Use sections when you have multiple groups of similar selectable items.
 
 ```jsx
-class OptionListExample extends React.Component {
-  state = {selected: []};
+function OptionListWithSectionsExample() {
+  const [selected, setSelected] = useState([]);
 
-  render() {
-    return (
-      <Card>
-        <OptionList
-          onChange={(updated) => {
-            this.setState({selected: updated});
-          }}
-          sections={[
-            {
-              options: [
-                {value: 'type', label: 'Sale item type'},
-                {value: 'kind', label: 'Sale kind'},
-              ],
-            },
-            {
-              title: 'Traffic',
-              options: [
-                {value: 'source', label: 'Traffic referrer source'},
-                {value: 'host', label: 'Traffic referrer host'},
-                {value: 'path', label: 'Traffic referrer path'},
-              ],
-            },
-          ]}
-          selected={this.state.selected}
-          allowMultiple
-        />
-      </Card>
-    );
-  }
+  return (
+    <Card>
+      <OptionList
+        onChange={setSelected}
+        sections={[
+          {
+            options: [
+              {value: 'type', label: 'Sale item type'},
+              {value: 'kind', label: 'Sale kind'},
+            ],
+          },
+          {
+            title: 'Traffic',
+            options: [
+              {value: 'source', label: 'Traffic referrer source'},
+              {value: 'host', label: 'Traffic referrer host'},
+              {value: 'path', label: 'Traffic referrer path'},
+            ],
+          },
+        ]}
+        selected={selected}
+        allowMultiple
+      />
+    </Card>
+  );
 }
 ```
 
@@ -164,46 +152,39 @@ class OptionListExample extends React.Component {
 Use when a set of selections won’t fit in the available screen space.
 
 ```jsx
-class OptionListExample extends React.Component {
-  state = {
-    selected: [],
-    popoverActive: true,
-  };
+function OptionListInPopoverExample() {
+  const [selected, setSelected] = useState([]);
+  const [popoverActive, setPopoverActive] = useState(true);
 
-  togglePopover = () => {
-    this.setState(({popoverActive}) => {
-      return {popoverActive: !popoverActive};
-    });
-  };
+  const togglePopoverActive = useCallback(
+    () => setPopoverActive((popoverActive) => !popoverActive),
+    [],
+  );
 
-  render() {
-    const activator = <Button onClick={this.togglePopover}>Options</Button>;
+  const activator = <Button onClick={togglePopoverActive}>Options</Button>;
 
-    return (
-      <div style={{height: '275px'}}>
-        <Popover
-          active={this.state.popoverActive}
-          activator={activator}
-          onClose={this.togglePopover}
-        >
-          <OptionList
-            title="Inventory Location"
-            onChange={(updated) => {
-              this.setState({selected: updated});
-            }}
-            options={[
-              {value: 'byward_market', label: 'Byward Market'},
-              {value: 'centretown', label: 'Centretown'},
-              {value: 'hintonburg', label: 'Hintonburg'},
-              {value: 'westboro', label: 'Westboro'},
-              {value: 'downtown', label: 'Downtown'},
-            ]}
-            selected={this.state.selected}
-          />
-        </Popover>
-      </div>
-    );
-  }
+  return (
+    <div style={{height: '275px'}}>
+      <Popover
+        active={popoverActive}
+        activator={activator}
+        onClose={togglePopoverActive}
+      >
+        <OptionList
+          title="Inventory Location"
+          onChange={setSelected}
+          options={[
+            {value: 'byward_market', label: 'Byward Market'},
+            {value: 'centretown', label: 'Centretown'},
+            {value: 'hintonburg', label: 'Hintonburg'},
+            {value: 'westboro', label: 'Westboro'},
+            {value: 'downtown', label: 'Downtown'},
+          ]}
+          selected={selected}
+        />
+      </Popover>
+    </div>
+  );
 }
 ```
 

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -126,34 +126,27 @@ If the popover includes a series of navigational links, each item should:
 Use when presenting a set of actions in a disclosable menu.
 
 ```jsx
-class PopoverExample extends React.Component {
-  state = {
-    active: true,
-  };
+function PopoverWithActionListExample() {
+  const [popoverActive, setPopoverActive] = useState(true);
 
-  togglePopover = () => {
-    this.setState(({active}) => {
-      return {active: !active};
-    });
-  };
+  const togglePopoverActive = useCallback(
+    () => setPopoverActive((popoverActive) => !popoverActive),
+    [],
+  );
 
-  render() {
-    const activator = (
-      <Button onClick={this.togglePopover}>More actions</Button>
-    );
+  const activator = <Button onClick={togglePopoverActive}>More actions</Button>;
 
-    return (
-      <div style={{height: '250px'}}>
-        <Popover
-          active={this.state.active}
-          activator={activator}
-          onClose={this.togglePopover}
-        >
-          <ActionList items={[{content: 'Import'}, {content: 'Export'}]} />
-        </Popover>
-      </div>
-    );
-  }
+  return (
+    <div style={{height: '250px'}}>
+      <Popover
+        active={popoverActive}
+        activator={activator}
+        onClose={togglePopoverActive}
+      >
+        <ActionList items={[{content: 'Import'}, {content: 'Export'}]} />
+      </Popover>
+    </div>
+  );
 }
 ```
 
@@ -174,47 +167,42 @@ class PopoverExample extends React.Component {
 Use to present a combination of content, instructions, and actions in a panel for tasks that are of low or secondary importance to the current page. When used this way, popovers provide useful entry points to related features without overwhelming merchants.
 
 ```jsx
-class PopoverContentExample extends React.Component {
-  state = {
-    active: true,
-  };
+function PopoverContentExample() {
+  const [popoverActive, setPopoverActive] = useState(true);
 
-  togglePopover = () => {
-    this.setState(({active}) => {
-      return {active: !active};
-    });
-  };
+  const togglePopoverActive = useCallback(
+    () => setPopoverActive((popoverActive) => !popoverActive),
+    [],
+  );
 
-  render() {
-    const activator = (
-      <Button onClick={this.togglePopover}>Sales channels</Button>
-    );
+  const activator = (
+    <Button onClick={togglePopoverActive}>Sales channels</Button>
+  );
 
-    return (
-      <div style={{height: '250px'}}>
-        <Popover
-          active={this.state.active}
-          activator={activator}
-          onClose={this.togglePopover}
-        >
-          <Popover.Pane fixed>
-            <Popover.Section>
-              <p>Available sales channels</p>
-            </Popover.Section>
-          </Popover.Pane>
-          <Popover.Pane>
-            <ActionList
-              items={[
-                {content: 'Online store'},
-                {content: 'Facebook'},
-                {content: 'Shopify POS'},
-              ]}
-            />
-          </Popover.Pane>
-        </Popover>
-      </div>
-    );
-  }
+  return (
+    <div style={{height: '250px'}}>
+      <Popover
+        active={popoverActive}
+        activator={activator}
+        onClose={togglePopoverActive}
+      >
+        <Popover.Pane fixed>
+          <Popover.Section>
+            <p>Available sales channels</p>
+          </Popover.Section>
+        </Popover.Pane>
+        <Popover.Pane>
+          <ActionList
+            items={[
+              {content: 'Online store'},
+              {content: 'Facebook'},
+              {content: 'Shopify POS'},
+            ]}
+          />
+        </Popover.Pane>
+      </Popover>
+    </div>
+  );
 }
 ```
 
@@ -237,55 +225,43 @@ class PopoverContentExample extends React.Component {
 Use to present secondary input tasks on demand.
 
 ```jsx
-class PopoverFormExample extends React.Component {
-  state = {
-    active: true,
-    tagValue: '',
-  };
+function PopoverFormExample() {
+  const [popoverActive, setPopoverActive] = useState(true);
+  const [tagValue, setTagValue] = useState('');
 
-  togglePopover = () => {
-    this.setState(({active}) => {
-      return {active: !active};
-    });
-  };
+  const togglePopoverActive = useCallback(
+    () => setPopoverActive((popoverActive) => !popoverActive),
+    [],
+  );
 
-  handleTagChange = (value) => {
-    this.setState({
-      tagValue: value,
-    });
-  };
+  const handleTagValueChange = useCallback((value) => setTagValue(value), []);
 
-  render() {
-    const activator = (
-      <Button onClick={this.togglePopover} disclosure>
-        Filter
-      </Button>
-    );
+  const activator = (
+    <Button onClick={togglePopoverActive} disclosure>
+      Filter
+    </Button>
+  );
 
-    return (
-      <div style={{height: '280px'}}>
-        <Popover
-          active={this.state.active}
-          activator={activator}
-          onClose={this.togglePopover}
-          sectioned
-        >
-          <FormLayout>
-            <Select
-              label="Show all customers where:"
-              options={['Tagged with']}
-            />
-            <TextField
-              label="Tags"
-              value={this.state.tagValue}
-              onChange={this.handleTagChange}
-            />
-            <Button size="slim">Add filter</Button>
-          </FormLayout>
-        </Popover>
-      </div>
-    );
-  }
+  return (
+    <div style={{height: '280px'}}>
+      <Popover
+        active={popoverActive}
+        activator={activator}
+        onClose={togglePopoverActive}
+        sectioned
+      >
+        <FormLayout>
+          <Select label="Show all customers where:" options={['Tagged with']} />
+          <TextField
+            label="Tags"
+            value={tagValue}
+            onChange={handleTagValueChange}
+          />
+          <Button size="slim">Add filter</Button>
+        </FormLayout>
+      </Popover>
+    </div>
+  );
 }
 ```
 
@@ -296,13 +272,10 @@ class PopoverFormExample extends React.Component {
 Use to present merchants with a list that dynamically loads more items on scroll or arrow down.
 
 ```jsx
-class PopoverLazyLoadExample extends React.Component {
-  state = {
-    visibleStaffIndex: 5,
-    active: true,
-  };
-
-  staff = [
+function PopoverLazyLoadExample() {
+  const [popoverActive, setPopoverActive] = useState(true);
+  const [visibleStaffIndex, setVisibleStaffIndex] = useState(5);
+  const staff = [
     'Abbey Mayert',
     'Abbi Senger',
     'Abdul Goodwin',
@@ -321,76 +294,73 @@ class PopoverLazyLoadExample extends React.Component {
     'Alex Hernandez',
   ];
 
-  render() {
-    const {active, visibleStaffIndex} = this.state;
+  const togglePopoverActive = useCallback(
+    () => setPopoverActive((popoverActive) => !popoverActive),
+    [],
+  );
 
-    const activator = (
-      <Button onClick={this.togglePopover} disclosure>
-        View staff
-      </Button>
-    );
-
-    const staffList = this.staff.slice(0, visibleStaffIndex).map((name) => ({
-      name,
-      initials: this.getInitials(name),
-    }));
-
-    return (
-      <Card sectioned>
-        <div style={{height: '280px'}}>
-          <Popover
-            sectioned
-            active={active}
-            activator={activator}
-            onClose={this.togglePopover}
-          >
-            <Popover.Pane onScrolledToBottom={this.handleScrolledToBottom}>
-              <ResourceList items={staffList} renderItem={this.renderItem} />
-            </Popover.Pane>
-          </Popover>
-        </div>
-      </Card>
-    );
-  }
-
-  handleScrolledToBottom = () => {
-    const {visibleStaffIndex} = this.state;
-    const totalIndexes = this.staff.length;
+  const handleScrolledToBottom = useCallback(() => {
+    const totalIndexes = staff.length;
     const interval =
       visibleStaffIndex + 3 < totalIndexes
         ? 3
         : totalIndexes - visibleStaffIndex;
 
     if (interval > 0) {
-      this.setState({visibleStaffIndex: visibleStaffIndex + interval});
+      setVisibleStaffIndex(visibleStaffIndex + interval);
     }
-  };
+  }, [staff.length, visibleStaffIndex]);
 
-  togglePopover = () => {
-    this.setState(({active}) => {
-      return {active: !active};
-    });
-  };
+  const handleResourceListItemClick = useCallback(() => {}, []);
 
-  renderItem = ({name, initials}) => {
+  const activator = (
+    <Button onClick={togglePopoverActive} disclosure>
+      View staff
+    </Button>
+  );
+
+  const staffList = staff.slice(0, visibleStaffIndex).map((name) => ({
+    name,
+    initials: getInitials(name),
+  }));
+
+  return (
+    <Card sectioned>
+      <div style={{height: '280px'}}>
+        <Popover
+          sectioned
+          active={popoverActive}
+          activator={activator}
+          onClose={togglePopoverActive}
+        >
+          <Popover.Pane onScrolledToBottom={handleScrolledToBottom}>
+            <ResourceList items={staffList} renderItem={renderItem} />
+          </Popover.Pane>
+        </Popover>
+      </div>
+    </Card>
+  );
+
+  function renderItem({name, initials}) {
     return (
       <ResourceList.Item
         id={name}
         media={<Avatar size="medium" name={name} initials={initials} />}
+        onClick={handleResourceListItemClick}
       >
         {name}
       </ResourceList.Item>
     );
-  };
+  }
 
-  getInitials = (name) => {
+  function getInitials(name) {
     return name
       .split(' ')
       .map((surnameOrFamilyName) => {
         return surnameOrFamilyName.slice(0, 1);
       })
       .join('');
-  };
+  }
 }
 ```
 


### PR DESCRIPTION

### WHY are these changes introduced?

Convert examples to hooks

### WHAT is this pull request doing?

Converting Modal, OptionList, and Popover class-based examples to hooks

### STILL TO DO

I'm making quite a few pr's converting examples to hooks so I anticipate lots of `unreleased.md` conflicts, so I'll add the entry before I merge.

```
- Converted `Modal`, `OptionList`, and `Popover` examples to functional components ([#2131](https://github.com/Shopify/polaris-react/pull/2131))
```

### How to 🎩

Make sure the behavior of the example mirrors the style guide 

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)
