### PR TITLE
Hookify RadioButton, RangeSlider, and ResourceItem

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -27,6 +27,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Converted `RadioButton`, `RangeSlider`, and `ResourceItem` examples to functional components ([#2132](https://github.com/Shopify/polaris-react/pull/2132))
 - Converted `ResourceList`, `ResourcePicker`, and `Select` examples to functional components ([#2133](https://github.com/Shopify/polaris-react/pull/2133))
 - Converted `Collapsible`, `ColorPicker`, and `DataTable` examples to functional components ([#2128](https://github.com/Shopify/polaris-react/pull/2128))
 - Updated the `withContext` section in the [v3 to v4 migration guide](https://github.com/Shopify/polaris-react/blob/master/documentation/guides/migrating-from-v3-to-v4.md) ([#2124](https://github.com/Shopify/polaris-react/pull/2124))

--- a/src/components/RadioButton/README.md
+++ b/src/components/RadioButton/README.md
@@ -98,38 +98,34 @@ Toggle values should:
 Use radio buttons where merchants must make a single selection.
 
 ```jsx
-class RadioButtonExample extends React.Component {
-  state = {
-    value: 'disabled',
-  };
+function RadioButtonExample() {
+  const [value, setValue] = useState('disabled');
 
-  handleChange = (checked, newValue) => {
-    this.setState({value: newValue});
-  };
+  const handleChange = useCallback(
+    (_checked, newValue) => setValue(newValue),
+    [],
+  );
 
-  render() {
-    const {value} = this.state;
-    return (
-      <Stack vertical>
-        <RadioButton
-          label="Accounts are disabled"
-          helpText="Customers will only be able to check out as guests."
-          checked={value === 'disabled'}
-          id="disabled"
-          name="accounts"
-          onChange={this.handleChange}
-        />
-        <RadioButton
-          label="Accounts are optional"
-          helpText="Customers will be able to check out with a customer account or as a guest."
-          id="optional"
-          name="accounts"
-          checked={value === 'optional'}
-          onChange={this.handleChange}
-        />
-      </Stack>
-    );
-  }
+  return (
+    <Stack vertical>
+      <RadioButton
+        label="Accounts are disabled"
+        helpText="Customers will only be able to check out as guests."
+        checked={value === 'disabled'}
+        id="disabled"
+        name="accounts"
+        onChange={handleChange}
+      />
+      <RadioButton
+        label="Accounts are optional"
+        helpText="Customers will be able to check out with a customer account or as a guest."
+        id="optional"
+        name="accounts"
+        checked={value === 'optional'}
+        onChange={handleChange}
+      />
+    </Stack>
+  );
 }
 ```
 

--- a/src/components/RangeSlider/README.md
+++ b/src/components/RangeSlider/README.md
@@ -119,27 +119,24 @@ Error messages should:
 Use range sliders where merchants may need to select a percentage between `0 — 100`.
 
 ```jsx
-class RangeSliderExample extends React.Component {
-  state = {
-    value: 32,
-  };
+function RangeSliderExample() {
+  const [rangeValue, setRangeValue] = useState(32);
 
-  handleChange = (value) => {
-    this.setState({value});
-  };
+  const handleRangeSliderChange = useCallback(
+    (value) => setRangeValue(value),
+    [],
+  );
 
-  render() {
-    return (
-      <Card sectioned>
-        <RangeSlider
-          label="Opacity percentage"
-          value={this.state.value}
-          onChange={this.handleChange}
-          output
-        />
-      </Card>
-    );
-  }
+  return (
+    <Card sectioned>
+      <RangeSlider
+        label="Opacity percentage"
+        value={rangeValue}
+        onChange={handleRangeSliderChange}
+        output
+      />
+    </Card>
+  );
 }
 ```
 
@@ -162,29 +159,26 @@ class RangeSliderExample extends React.Component {
 For a more precise value, you can define a `min` and `max` range, as well as the amount with which the slider will be incremented.
 
 ```jsx
-class RangeSliderExample extends React.Component {
-  state = {
-    value: 5,
-  };
+function RangeSliderWithPreciseRangeControlExample() {
+  const [rangeValue, setRangeValue] = useState(5);
 
-  handleChange = (value) => {
-    this.setState({value});
-  };
+  const handleRangeSliderChange = useCallback(
+    (value) => setRangeValue(value),
+    [],
+  );
 
-  render() {
-    return (
-      <Card sectioned>
-        <RangeSlider
-          label="Logo offset"
-          min={-10}
-          max={10}
-          step={5}
-          value={this.state.value}
-          onChange={this.handleChange}
-        />
-      </Card>
-    );
-  }
+  return (
+    <Card sectioned>
+      <RangeSlider
+        label="Logo offset"
+        min={-10}
+        max={10}
+        step={5}
+        value={rangeValue}
+        onChange={handleRangeSliderChange}
+      />
+    </Card>
+  );
 }
 ```
 
@@ -195,35 +189,32 @@ class RangeSliderExample extends React.Component {
 Because a range slider can also output a `label` and `helpText`, the height of the overall component can vary. `prefix` and `suffix` props allow you to pass in a React element to be placed before or after the rendered `input`, allowing for perfect vertical alignment and easier stylistic control.
 
 ```jsx
-class RangeSliderExample extends React.Component {
-  state = {
-    value: 100,
+function RangeSliderWithPrefixAndSuffixExample() {
+  const [rangeValue, setRangeValue] = useState(100);
+
+  const handleRangeSliderChange = useCallback(
+    (value) => setRangeValue(value),
+    [],
+  );
+
+  const suffixStyles = {
+    minWidth: '24px',
+    textAlign: 'right',
   };
 
-  handleChange = (value) => {
-    this.setState({value});
-  };
-
-  render() {
-    const suffixStyles = {
-      minWidth: '24px',
-      textAlign: 'right',
-    };
-
-    return (
-      <Card sectioned>
-        <RangeSlider
-          label="Hue color mix"
-          min={0}
-          max={360}
-          value={this.state.value}
-          onChange={this.handleChange}
-          prefix={<p>Hue</p>}
-          suffix={<p style={suffixStyles}>{this.state.value}</p>}
-        />
-      </Card>
-    );
-  }
+  return (
+    <Card sectioned>
+      <RangeSlider
+        label="Hue color mix"
+        min={0}
+        max={360}
+        value={rangeValue}
+        onChange={handleRangeSliderChange}
+        prefix={<p>Hue</p>}
+        suffix={<p style={suffixStyles}>{rangeValue}</p>}
+      />
+    </Card>
+  );
 }
 ```
 
@@ -232,108 +223,114 @@ class RangeSliderExample extends React.Component {
 Use a dual thumb range slider when merchants need to select a range of values.
 
 ```jsx
-const initialValue = [900, 1000];
+function DualThumbRangeSliderExample() {
+  const initialValue = [900, 1000];
+  const prefix = '$';
+  const min = 0;
+  const max = 2000;
+  const step = 10;
 
-class RangeSliderExample extends React.Component {
-  state = {
-    intermediateTextFieldValue: initialValue,
-    value: initialValue,
-  };
+  const [intermediateTextFieldValue, setIntermediateTextFieldValue] = useState(
+    initialValue,
+  );
+  const [rangeValue, setRangeValue] = useState(initialValue);
 
-  handleRangeSliderChange = (value) => {
-    this.setState({value, intermediateTextFieldValue: value});
-  };
+  const handleRangeSliderChange = useCallback((value) => {
+    setRangeValue(value);
+    setIntermediateTextFieldValue(value);
+  }, []);
 
-  handleLowerTextFieldChange = (value) => {
-    const upperValue = this.state.value[1];
-    this.setState({intermediateTextFieldValue: [parseInt(value), upperValue]});
-  };
+  const handleLowerTextFieldChange = useCallback(
+    (value) => {
+      const upperValue = rangeValue[1];
+      setIntermediateTextFieldValue([parseInt(value, 10), upperValue]);
+    },
+    [rangeValue],
+  );
 
-  handleUpperTextFieldChange = (value) => {
-    const lowerValue = this.state.value[0];
-    this.setState({intermediateTextFieldValue: [lowerValue, parseInt(value)]});
-  };
+  const handleUpperTextFieldChange = useCallback(
+    (value) => {
+      const lowerValue = rangeValue[0];
+      setIntermediateTextFieldValue([lowerValue, parseInt(value, 10)]);
+    },
+    [rangeValue],
+  );
 
-  handleLowerTextFieldBlur = () => {
-    const upperValue = this.state.value[1];
-    const value = this.state.intermediateTextFieldValue[0];
+  const handleLowerTextFieldBlur = useCallback(() => {
+    const upperValue = rangeValue[1];
+    const value = intermediateTextFieldValue[0];
 
-    this.setState({value: [parseInt(value), upperValue]});
-  };
+    setRangeValue([parseInt(value, 10), upperValue]);
+  }, [intermediateTextFieldValue, rangeValue]);
 
-  handleUpperTextFieldBlur = () => {
-    const lowerValue = this.state.value[0];
-    const value = this.state.intermediateTextFieldValue[1];
+  const handleUpperTextFieldBlur = useCallback(() => {
+    const lowerValue = rangeValue[0];
+    const value = intermediateTextFieldValue[1];
 
-    this.setState({value: [lowerValue, parseInt(value)]});
-  };
+    setRangeValue([lowerValue, parseInt(value, 10)]);
+  }, [intermediateTextFieldValue, rangeValue]);
 
-  handleEnterKeyPress = (event) => {
-    const newValue = this.state.intermediateTextFieldValue;
-    const oldValue = this.state.value;
+  const handleEnterKeyPress = useCallback(
+    (event) => {
+      const newValue = intermediateTextFieldValue;
+      const oldValue = rangeValue;
 
-    if (event.keyCode === Key.Enter && newValue !== oldValue) {
-      this.setState({value: newValue});
-    }
-  };
+      if (event.keyCode === Key.Enter && newValue !== oldValue) {
+        setRangeValue(newValue);
+      }
+    },
+    [intermediateTextFieldValue, rangeValue],
+  );
 
-  render() {
-    const {value, intermediateTextFieldValue} = this.state;
-    const prefix = '$';
-    const min = 0;
-    const max = 2000;
-    const step = 10;
+  const lowerTextFieldValue =
+    intermediateTextFieldValue[0] === rangeValue[0]
+      ? rangeValue[0]
+      : intermediateTextFieldValue[0];
+  const upperTextFieldValue =
+    intermediateTextFieldValue[1] === rangeValue[1]
+      ? rangeValue[1]
+      : intermediateTextFieldValue[1];
 
-    const lowerTextFieldValue =
-      intermediateTextFieldValue[0] === value[0]
-        ? value[0]
-        : intermediateTextFieldValue[0];
-    const upperTextFieldValue =
-      intermediateTextFieldValue[1] === value[1]
-        ? value[1]
-        : intermediateTextFieldValue[1];
-
-    return (
-      <Card sectioned>
-        <div style={{marginTop: '20px'}} onKeyDown={this.handleEnterKeyPress}>
-          <RangeSlider
-            label="Money spent is between"
-            value={value}
+  return (
+    <Card sectioned>
+      <div style={{marginTop: '20px'}} onKeyDown={handleEnterKeyPress}>
+        <RangeSlider
+          label="Money spent is between"
+          value={rangeValue}
+          prefix={prefix}
+          output
+          min={min}
+          max={max}
+          step={step}
+          onChange={handleRangeSliderChange}
+        />
+        <Stack distribution="equalSpacing" spacing="extraLoose">
+          <TextField
+            label="Min money spent"
+            type="number"
+            value={`${lowerTextFieldValue}`}
             prefix={prefix}
-            output
             min={min}
             max={max}
             step={step}
-            onChange={this.handleRangeSliderChange}
+            onChange={handleLowerTextFieldChange}
+            onBlur={handleLowerTextFieldBlur}
           />
-          <Stack distribution="equalSpacing" spacing="extraLoose">
-            <TextField
-              label="Min money spent"
-              type="number"
-              value={`${lowerTextFieldValue}`}
-              prefix={prefix}
-              min={min}
-              max={max}
-              step={step}
-              onChange={this.handleLowerTextFieldChange}
-              onBlur={this.handleLowerTextFieldBlur}
-            />
-            <TextField
-              label="Max money spent"
-              type="number"
-              value={`${upperTextFieldValue}`}
-              prefix={prefix}
-              min={min}
-              max={max}
-              step={step}
-              onChange={this.handleUpperTextFieldChange}
-              onBlur={this.handleUpperTextFieldBlur}
-            />
-          </Stack>
-        </div>
-      </Card>
-    );
-  }
+          <TextField
+            label="Max money spent"
+            type="number"
+            value={`${upperTextFieldValue}`}
+            prefix={prefix}
+            min={min}
+            max={max}
+            step={step}
+            onChange={handleUpperTextFieldChange}
+            onBlur={handleUpperTextFieldBlur}
+          />
+        </Stack>
+      </div>
+    </Card>
+  );
 }
 ```
 

--- a/src/components/ResourceItem/README.md
+++ b/src/components/ResourceItem/README.md
@@ -37,52 +37,44 @@ Resource items represent specific objects within a collection, such as products 
 A basic resource item with its details filled in at the point of use.
 
 ```jsx
-class ResourceListExample extends React.Component {
-  state = {
-    selectedItems: [],
-  };
+function ResourceItemExample() {
+  const [selectedItems, setSelectedItems] = useState([]);
 
-  render() {
-    return (
-      <Card>
-        <ResourceList
-          resourceName={{singular: 'blog post', plural: 'blog posts'}}
-          items={[
-            {
-              id: 6,
-              url: 'posts/6',
-              title: 'How To Get Value From Wireframes',
-              author: 'Jonathan Mangrove',
-            },
-          ]}
-          selectedItems={this.state.selectedItems}
-          onSelectionChange={this.handleSelectionChange}
-          selectable
-          renderItem={(item) => {
-            const {id, url, title, author} = item;
-            const authorMarkup = author ? <div>by {author}</div> : null;
-            return (
-              <ResourceItem
-                id={id}
-                url={url}
-                accessibilityLabel={`View details for ${title}`}
-                name={title}
-              >
-                <h3>
-                  <TextStyle variation="strong">{title}</TextStyle>
-                </h3>
-                {authorMarkup}
-              </ResourceItem>
-            );
-          }}
-        />
-      </Card>
-    );
-  }
-
-  handleSelectionChange = (selectedItems) => {
-    this.setState({selectedItems});
-  };
+  return (
+    <Card>
+      <ResourceList
+        resourceName={{singular: 'blog post', plural: 'blog posts'}}
+        items={[
+          {
+            id: 6,
+            url: 'posts/6',
+            title: 'How To Get Value From Wireframes',
+            author: 'Jonathan Mangrove',
+          },
+        ]}
+        selectedItems={selectedItems}
+        onSelectionChange={setSelectedItems}
+        selectable
+        renderItem={(item) => {
+          const {id, url, title, author} = item;
+          const authorMarkup = author ? <div>by {author}</div> : null;
+          return (
+            <ResourceItem
+              id={id}
+              url={url}
+              accessibilityLabel={`View details for ${title}`}
+              name={title}
+            >
+              <h3>
+                <TextStyle variation="strong">{title}</TextStyle>
+              </h3>
+              {authorMarkup}
+            </ResourceItem>
+          );
+        }}
+      />
+    </Card>
+  );
 }
 ```
 


### PR DESCRIPTION
### WHY are these changes introduced?

Convert examples to hooks

### WHAT is this pull request doing?

Converting RadioButton, RangeSlider, and ResourceItem class-based examples to hooks

### STILL TO DO

I'm making quite a few pr's converting examples to hooks so I anticipate lots of `unreleased.md` conflicts, so I'll add the entry before I merge.

```
- Converted `RadioButton`, `RangeSlider`, and `ResourceItem` examples to functional components ([#2132](https://github.com/Shopify/polaris-react/pull/2132))
```

### How to 🎩

Make sure the behavior of the example mirrors the style guide 

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)
