### PR TITLE
Hookify SettingToggle, Sheet, and Tabs examples

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Converted `SettingToggle`, `Sheet`, and `Tabs` examples to functional components ([#2134](https://github.com/Shopify/polaris-react/pull/2134))
 - Converted `Form`, `Frame`, and `Loading` examples to functional components ([#2130](https://github.com/Shopify/polaris-react/pull/2130))
 - Replaced Latin abbreviations with English words in Text field content guidelines ([#2192](https://github.com/Shopify/polaris-react/pull/2192))
 

--- a/src/components/SettingToggle/README.md
+++ b/src/components/SettingToggle/README.md
@@ -79,34 +79,25 @@ say “Enable” to allow merchants to turn it on.
 Use on settings pages to allow merchants to toggle a setting that has an enabled or a disabled state.
 
 ```jsx
-class SettingToggleExample extends React.Component {
-  state = {
-    enabled: false,
-  };
+function SettingToggleExample() {
+  const [active, setActive] = useState(false);
 
-  render() {
-    const {enabled} = this.state;
-    const contentStatus = enabled ? 'Disable' : 'Enable';
-    const textStatus = enabled ? 'enabled' : 'disabled';
+  const handleToggle = useCallback(() => setActive((active) => !active), []);
 
-    return (
-      <SettingToggle
-        action={{
-          content: contentStatus,
-          onAction: this.handleChange,
-        }}
-        enabled={enabled}
-      >
-        This setting is <TextStyle variation="strong">{textStatus}</TextStyle>.
-      </SettingToggle>
-    );
-  }
+  const contentStatus = active ? 'Disable' : 'Enable';
+  const textStatus = active ? 'enabled' : 'disabled';
 
-  handleChange = () => {
-    this.setState(({enabled}) => {
-      return {enabled: !enabled};
-    });
-  };
+  return (
+    <SettingToggle
+      action={{
+        content: contentStatus,
+        onAction: handleToggle,
+      }}
+      enabled={active}
+    >
+      This setting is <TextStyle variation="strong">{textStatus}</TextStyle>.
+    </SettingToggle>
+  );
 }
 ```
 

--- a/src/components/Sheet/README.md
+++ b/src/components/Sheet/README.md
@@ -66,216 +66,185 @@ The sheet component is best used in cases where the merchant needs to see elemen
 Use as the default option for a sheet.
 
 ```jsx
-class SheetExample extends React.Component {
-  state = {
-    sheetActive: true,
-    title: 'Big yellow socks',
-    description:
-      "They're big, yellow socks. What more could you possibly want from socks? These socks will change your life.\n\nThey're made from light, hand-loomed cotton that's so soft, you'll feel like you are walking on a cloud.",
-    salesChannels: [
-      {value: 'onlineStore', label: 'Online Store'},
-      {value: 'facebook', label: 'Facebook'},
-      {value: 'googleShopping', label: 'Google shopping'},
-      {value: 'facebookMarketing', label: 'Facebook Marketing'},
-    ],
-    selected: [],
+function SheetExample() {
+  const [sheetActive, setSheetActive] = useState(true);
+  const [title, setTitle] = useState('Big yellow socks');
+  const [description, setDescription] = useState(
+    "They're big, yellow socks. What more could you possibly want from socks? These socks will change your life.\n\nThey're made from light, hand-loomed cotton that's so soft, you'll feel like you are walking on a cloud.",
+  );
+  const [salesChannels, setSalesChannels] = useState([
+    {value: 'onlineStore', label: 'Online Store'},
+    {value: 'facebook', label: 'Facebook'},
+    {value: 'googleShopping', label: 'Google shopping'},
+    {value: 'facebookMarketing', label: 'Facebook Marketing'},
+  ]);
+  const [selected, setSelected] = useState([]);
+
+  const toggleSheetActive = useCallback(
+    () => setSheetActive((sheetActive) => !sheetActive),
+    [],
+  );
+  const handleSelectedChange = useCallback((value) => setSelected(value), []);
+  const handleTitleChange = useCallback((value) => setTitle(value), []);
+  const handleDescriptionChange = useCallback(
+    (value) => setDescription(value),
+    [],
+  );
+
+  const selectedSalesChannels = selected.map((key) => {
+    return salesChannels.reduce((accumulator, current) => {
+      accumulator[current.value] = current.label;
+      return accumulator;
+    }, {})[key];
+  });
+  const hasSelectedSalesChannels = selectedSalesChannels.length > 0;
+
+  const theme = {
+    colors: {
+      topBar: {
+        background: '#357997',
+      },
+    },
+    logo: {
+      width: 124,
+      topBarSource:
+        'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-color.svg?6215648040070010999',
+      contextualSaveBarSource:
+        'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
+      url: 'http://jadedpixel.com',
+      accessibilityLabel: 'Jaded Pixel',
+    },
   };
 
-  render() {
-    const {
-      state: {sheetActive, title, description, salesChannels, selected},
-      handleCloseSheet,
-      handleOpenSheet,
-      handleChange,
-      handleToggleSheet,
-      hasSelectedSalesChannels,
-      selectedSalesChannels,
-    } = this;
+  const salesChannelsCardMarkup = hasSelectedSalesChannels ? (
+    <List>
+      {selectedSalesChannels.map((channel, index) => (
+        <List.Item key={index}>{channel}</List.Item>
+      ))}
+    </List>
+  ) : (
+    <div
+      style={{
+        alignItems: 'center',
+        display: 'flex',
+        justifyContent: 'space-between',
+        width: '100%',
+      }}
+    >
+      <p>No sales channels selected</p>
+      <Button onClick={toggleSheetActive}>Manage sales channels</Button>
+    </div>
+  );
 
-    const theme = {
-      colors: {
-        topBar: {
-          background: '#357997',
+  const salesChannelAction = hasSelectedSalesChannels
+    ? [
+        {
+          onAction: toggleSheetActive,
+          content: 'Manage sales channels',
         },
-      },
-      logo: {
-        width: 124,
-        topBarSource:
-          'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-color.svg?6215648040070010999',
-        contextualSaveBarSource:
-          'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
-        url: 'http://jadedpixel.com',
-        accessibilityLabel: 'Jaded Pixel',
-      },
-    };
+      ]
+    : null;
 
-    const salesChannelsCardMarkup = hasSelectedSalesChannels ? (
-      <List>
-        {selectedSalesChannels.map((channel, index) => (
-          <List.Item key={index}>{channel}</List.Item>
-        ))}
-      </List>
-    ) : (
-      <div
-        style={{
-          alignItems: 'center',
-          display: 'flex',
-          justifyContent: 'space-between',
-          width: '100%',
+  return (
+    <div style={{maxHeight: '640px', overflow: 'visible'}}>
+      <AppProvider
+        theme={theme}
+        i18n={{
+          Polaris: {
+            Frame: {
+              skipToContent: 'Skip to content',
+            },
+            TextField: {
+              characterCount: '{count} characters',
+            },
+          },
         }}
       >
-        <p>No sales channels selected</p>
-        <Button onClick={handleToggleSheet}>Manage sales channels</Button>
-      </div>
-    );
-
-    const salesChannelAction = hasSelectedSalesChannels
-      ? [
-          {
-            onAction: handleOpenSheet,
-            content: 'Manage sales channels',
-          },
-        ]
-      : null;
-
-    return (
-      <div style={{maxHeight: '640px', overflow: 'visible'}}>
-        <AppProvider
-          theme={theme}
-          i18n={{
-            Polaris: {
-              Frame: {
-                skipToContent: 'Skip to content',
-              },
-              TextField: {
-                characterCount: '{count} characters',
-              },
-            },
-          }}
-        >
-          <Frame topBar={<TopBar />}>
-            <Page narrowWidth title="Big yellow socks">
-              <Card sectioned>
-                <FormLayout>
-                  <TextField
-                    label="Title"
-                    onChange={handleChange('title')}
-                    value={title}
-                    readOnly
-                  />
-                  <TextField
-                    label="Description"
-                    onChange={handleChange('description')}
-                    value={description}
-                    multiline
-                  />
-                </FormLayout>
-              </Card>
-              <Card
-                sectioned
-                subdued
-                title="Product availability"
-                actions={salesChannelAction}
+        <Frame topBar={<TopBar />}>
+          <Page narrowWidth title="Big yellow socks">
+            <Card sectioned>
+              <FormLayout>
+                <TextField
+                  label="Title"
+                  onChange={handleTitleChange}
+                  value={title}
+                  readOnly
+                />
+                <TextField
+                  label="Description"
+                  onChange={handleDescriptionChange}
+                  value={description}
+                  multiline
+                />
+              </FormLayout>
+            </Card>
+            <Card
+              sectioned
+              subdued
+              title="Product availability"
+              actions={salesChannelAction}
+            >
+              {salesChannelsCardMarkup}
+            </Card>
+            <Sheet open={sheetActive} onClose={toggleSheetActive}>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  height: '100%',
+                }}
               >
-                {salesChannelsCardMarkup}
-              </Card>
-              <Sheet open={sheetActive} onClose={handleCloseSheet}>
                 <div
                   style={{
+                    alignItems: 'center',
+                    borderBottom: '1px solid #DFE3E8',
                     display: 'flex',
-                    flexDirection: 'column',
-                    height: '100%',
+                    justifyContent: 'space-between',
+                    padding: '1.6rem',
+                    width: '100%',
                   }}
                 >
-                  <div
-                    style={{
-                      alignItems: 'center',
-                      borderBottom: '1px solid #DFE3E8',
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      padding: '1.6rem',
-                      width: '100%',
-                    }}
-                  >
-                    <Heading>Manage sales channels</Heading>
-                    <Button
-                      accessibilityLabel="Cancel"
-                      icon={MobileCancelMajorMonotone}
-                      onClick={handleCloseSheet}
-                      plain
-                    />
-                  </div>
-                  <Scrollable style={{padding: '1.6rem', height: '100%'}}>
-                    <ChoiceList
-                      title="Select a sales channel"
-                      name="salesChannelsList"
-                      choices={salesChannels}
-                      selected={selected}
-                      titleHidden
-                      allowMultiple
-                      onChange={handleChange('selected')}
-                    />
-                  </Scrollable>
-                  <div
-                    style={{
-                      alignItems: 'center',
-                      borderTop: '1px solid #DFE3E8',
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      padding: '1.6rem',
-                      width: '100%',
-                    }}
-                  >
-                    <Button onClick={handleCloseSheet}>Cancel</Button>
-                    <Button primary onClick={handleCloseSheet}>
-                      Done
-                    </Button>
-                  </div>
+                  <Heading>Manage sales channels</Heading>
+                  <Button
+                    accessibilityLabel="Cancel"
+                    icon={MobileCancelMajorMonotone}
+                    onClick={toggleSheetActive}
+                    plain
+                  />
                 </div>
-              </Sheet>
-            </Page>
-          </Frame>
-        </AppProvider>
-      </div>
-    );
-  }
-
-  handleOpenSheet = () => {
-    this.setState({sheetActive: true});
-  };
-
-  handleCloseSheet = () => {
-    this.setState({sheetActive: false});
-  };
-
-  handleToggleSheet = () => {
-    const {
-      state: {sheetActive},
-      handleCloseSheet,
-      handleOpenSheet,
-    } = this;
-
-    sheetActive ? handleCloseSheet() : handleOpenSheet();
-  };
-
-  handleChange = (field) => {
-    return (value) => this.setState({[field]: value});
-  };
-
-  get hasSelectedSalesChannels() {
-    return this.selectedSalesChannels.length > 0;
-  }
-
-  get selectedSalesChannels() {
-    const {salesChannels, selected} = this.state;
-
-    return selected.map((key) => {
-      return salesChannels.reduce((accumulator, current) => {
-        accumulator[current.value] = current.label;
-        return accumulator;
-      }, {})[key];
-    });
-  }
+                <Scrollable style={{padding: '1.6rem', height: '100%'}}>
+                  <ChoiceList
+                    title="Select a sales channel"
+                    name="salesChannelsList"
+                    choices={salesChannels}
+                    selected={selected}
+                    titleHidden
+                    allowMultiple
+                    onChange={handleSelectedChange}
+                  />
+                </Scrollable>
+                <div
+                  style={{
+                    alignItems: 'center',
+                    borderTop: '1px solid #DFE3E8',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    padding: '1.6rem',
+                    width: '100%',
+                  }}
+                >
+                  <Button onClick={toggleSheetActive}>Cancel</Button>
+                  <Button primary onClick={toggleSheetActive}>
+                    Done
+                  </Button>
+                </div>
+              </div>
+            </Sheet>
+          </Page>
+        </Frame>
+      </AppProvider>
+    </div>
+  );
 }
 ```
 

--- a/src/components/Tabs/README.md
+++ b/src/components/Tabs/README.md
@@ -75,51 +75,47 @@ Where possible, follow this pattern when writing tabs.
 Use for most cases, especially when the number of tabs may be more than three.
 
 ```jsx
-class TabsExample extends React.Component {
-  state = {
-    selected: 0,
-  };
+function TabsExample() {
+  const [selected, setSelected] = useState(0);
 
-  handleTabChange = (selectedTabIndex) => {
-    this.setState({selected: selectedTabIndex});
-  };
+  const handleTabChange = useCallback(
+    (selectedTabIndex) => setSelected(selectedTabIndex),
+    [],
+  );
 
-  render() {
-    const {selected} = this.state;
-    const tabs = [
-      {
-        id: 'all-customers',
-        content: 'All',
-        accessibilityLabel: 'All customers',
-        panelID: 'all-customers-content',
-      },
-      {
-        id: 'accepts-marketing',
-        content: 'Accepts marketing',
-        panelID: 'accepts-marketing-content',
-      },
-      {
-        id: 'repeat-customers',
-        content: 'Repeat customers',
-        panelID: 'repeat-customers-content',
-      },
-      {
-        id: 'prospects',
-        content: 'Prospects',
-        panelID: 'prospects-content',
-      },
-    ];
+  const tabs = [
+    {
+      id: 'all-customers',
+      content: 'All',
+      accessibilityLabel: 'All customers',
+      panelID: 'all-customers-content',
+    },
+    {
+      id: 'accepts-marketing',
+      content: 'Accepts marketing',
+      panelID: 'accepts-marketing-content',
+    },
+    {
+      id: 'repeat-customers',
+      content: 'Repeat customers',
+      panelID: 'repeat-customers-content',
+    },
+    {
+      id: 'prospects',
+      content: 'Prospects',
+      panelID: 'prospects-content',
+    },
+  ];
 
-    return (
-      <Card>
-        <Tabs tabs={tabs} selected={selected} onSelect={this.handleTabChange}>
-          <Card.Section title={tabs[selected].content}>
-            <p>Tab {selected} selected</p>
-          </Card.Section>
-        </Tabs>
-      </Card>
-    );
-  }
+  return (
+    <Card>
+      <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
+        <Card.Section title={tabs[selected].content}>
+          <p>Tab {selected} selected</p>
+        </Card.Section>
+      </Tabs>
+    </Card>
+  );
 }
 ```
 
@@ -140,47 +136,37 @@ class TabsExample extends React.Component {
 Use when tabs contain a few (2 or 3) items within a narrow column.
 
 ```jsx
-class FittedTabsExample extends React.Component {
-  state = {
-    selected: 0,
-  };
+function FittedTabsExample() {
+  const [selected, setSelected] = useState(0);
 
-  handleTabChange = (selectedTabIndex) => {
-    this.setState({selected: selectedTabIndex});
-  };
+  const handleTabChange = useCallback(
+    (selectedTabIndex) => setSelected(selectedTabIndex),
+    [],
+  );
 
-  render() {
-    const {selected} = this.state;
+  const tabs = [
+    {
+      id: 'all-customers-fitted',
+      content: 'All',
+      accessibilityLabel: 'All customers',
+      panelID: 'all-customers-fitted-content',
+    },
+    {
+      id: 'accepts-marketing-fitted',
+      content: 'Accepts marketing',
+      panelID: 'accepts-marketing-fitted-Ccontent',
+    },
+  ];
 
-    const tabs = [
-      {
-        id: 'all-customers-fitted',
-        content: 'All',
-        accessibilityLabel: 'All customers',
-        panelID: 'all-customers-fitted-content',
-      },
-      {
-        id: 'accepts-marketing-fitted',
-        content: 'Accepts marketing',
-        panelID: 'accepts-marketing-fitted-Ccontent',
-      },
-    ];
-
-    return (
-      <Card>
-        <Tabs
-          tabs={tabs}
-          selected={selected}
-          onSelect={this.handleTabChange}
-          fitted
-        >
-          <Card.Section title={tabs[selected].content}>
-            <p>Tab {selected} selected</p>
-          </Card.Section>
-        </Tabs>
-      </Card>
-    );
-  }
+  return (
+    <Card>
+      <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange} fitted>
+        <Card.Section title={tabs[selected].content}>
+          <p>Tab {selected} selected</p>
+        </Card.Section>
+      </Tabs>
+    </Card>
+  );
 }
 ```
 


### PR DESCRIPTION
### WHY are these changes introduced?

Convert examples to hooks

### WHAT is this pull request doing?

Converting SettingToggle, Sheet, and Tabs class-based examples to hooks

### STILL TO DO

I'm making quite a few pr's converting examples to hooks so I anticipate lots of `unreleased.md` conflicts, so I'll add the entry before I merge.

```
- Converted `SettingToggle`, `Sheet`, and `Tabs` examples to functional components ([#2134](https://github.com/Shopify/polaris-react/pull/2134))
```

### How to 🎩

Make sure the behavior of the example mirrors the style guide 

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)
