### PR TITLE
[Page] Allow for non-primary page action

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,7 +19,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `Modal` setting an invalid `id` on `aria-labelledby` when no `title` is set ([#2115](https://github.com/Shopify/polaris-react/pull/2115))
 - Fixed error warnings in `Card` and `RollupActions` tests ([#2125](https://github.com/Shopify/polaris-react/pull/2125))
 - Added default accessibility label from `ResourceItem` ([#2097](https://github.com/Shopify/polaris-react/pull/2097))
-- Allow for non-primary action in the `Header` actions ([#2137](https://github.com/Shopify/polaris-react/pull/2137))
+- Reverted `Page.primaryAction` forcing `primary` to be `true` ([#2137](https://github.com/Shopify/polaris-react/pull/2137))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `Modal` setting an invalid `id` on `aria-labelledby` when no `title` is set ([#2115](https://github.com/Shopify/polaris-react/pull/2115))
 - Fixed error warnings in `Card` and `RollupActions` tests ([#2125](https://github.com/Shopify/polaris-react/pull/2125))
 - Added default accessibility label from `ResourceItem` ([#2097](https://github.com/Shopify/polaris-react/pull/2097))
+- Allow for non-primary action in the `Header` actions ([#2137](https://github.com/Shopify/polaris-react/pull/2137))
 
 ### Documentation
 

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -114,11 +114,13 @@ export class Header extends React.PureComponent<HeaderProps, State> {
       />
     );
 
+    const primary =
+      primaryAction &&
+      (primaryAction.primary === undefined ? true : primaryAction.primary);
+
     const primaryActionMarkup = primaryAction ? (
       <div className={styles.PrimaryActionWrapper}>
-        {buttonsFrom(primaryAction, {
-          primary: true,
-        })}
+        {buttonsFrom(primaryAction, {primary})}
       </div>
     ) : null;
 

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -87,7 +87,7 @@ describe('<Header />', () => {
   });
 
   describe('primaryAction', () => {
-    it('renders a button based on the given action', () => {
+    it('renders a `primary` button based on the given action', () => {
       const primaryAction: HeaderPrimaryAction = {
         content: 'Click me!',
       };
@@ -97,6 +97,20 @@ describe('<Header />', () => {
       );
 
       const expectedButton = buttonsFrom(primaryAction, {primary: true});
+      expect(header.contains(expectedButton)).toBeTruthy();
+    });
+
+    it('renders a regular button based on the given action when primary is set to false', () => {
+      const primaryAction: HeaderPrimaryAction = {
+        content: 'Click me!',
+        primary: false,
+      };
+
+      const header = mountWithAppProvider(
+        <Header {...mockProps} primaryAction={primaryAction} />,
+      );
+
+      const expectedButton = buttonsFrom(primaryAction, {primary: false});
       expect(header.contains(expectedButton)).toBeTruthy();
     });
   });


### PR DESCRIPTION
### WHY are these changes introduced?

We are bringing back the ability to have a non-primary/indigo button as the pages primary actions. We previously made the decision to remove this ability but there are use cases that having a non-indigo button does make sense.

### WHAT is this pull request doing?

Making the default button indigo/primary but allowing the ability to make it a regular button.



## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Paste the code below in the playground and toggle primary key of the primaryAction.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page
      breadcrumbs={[{content: 'Products'}]}
      title="Product reviews"
      primaryAction={{
        content: 'Save',
        disabled: true,
        primary: false,
      }}
      secondaryActions={[{content: 'Duplicate'}, {content: 'Upgrade'}]}
      actionGroups={[
        {
          title: 'Promote',
          actions: [
            {
              content: 'Share on Facebook',
            },
            {
              content: 'Share on Pinterest',
            },
          ],
        },
      ]}
    >
      <p>Page content</p>
    </Page>
  );
}


```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
