### PR TITLE
[Modal] Return focus to the button that opened the modal when it closes

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,6 @@
 import React, {forwardRef, useImperativeHandle} from 'react';
 import {CaretDownMinor} from '@shopify/polaris-icons';
+import {FOCUSABLE_SELECTOR} from '@shopify/javascript-utilities/focus';
 import {classNames, variationName} from '../../utilities/css';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 import {useI18n} from '../../utilities/i18n';
@@ -135,7 +136,12 @@ export const Button = forwardRef(function(
 
   useImperativeHandle(ref, () => ({
     focus: () => {
-      buttonRef.current && buttonRef.current.focus();
+      const element = buttonRef.current;
+
+      if (element) {
+        FOCUSABLE_SELECTOR.includes(element.nodeName.toLowerCase()) &&
+          element.focus();
+      }
     },
   }));
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {forwardRef, useImperativeHandle} from 'react';
 import {CaretDownMinor} from '@shopify/polaris-icons';
 import {classNames, variationName} from '../../utilities/css';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
@@ -79,37 +79,42 @@ export interface ButtonProps {
 
 const DEFAULT_SIZE = 'medium';
 
-export function Button({
-  id,
-  url,
-  disabled,
-  loading,
-  children,
-  accessibilityLabel,
-  ariaControls,
-  ariaExpanded,
-  ariaPressed,
-  onClick,
-  onFocus,
-  onBlur,
-  onKeyDown,
-  onKeyPress,
-  onKeyUp,
-  external,
-  download,
-  icon,
-  primary,
-  outline,
-  destructive,
-  disclosure,
-  plain,
-  monochrome,
-  submit,
-  size = DEFAULT_SIZE,
-  textAlign,
-  fullWidth,
-}: ButtonProps) {
+// eslint-disable-next-line react/display-name
+export const Button = forwardRef(function(
+  {
+    id,
+    url,
+    disabled,
+    loading,
+    children,
+    accessibilityLabel,
+    ariaControls,
+    ariaExpanded,
+    ariaPressed,
+    onClick,
+    onFocus,
+    onBlur,
+    onKeyDown,
+    onKeyPress,
+    onKeyUp,
+    external,
+    download,
+    icon,
+    primary,
+    outline,
+    destructive,
+    disclosure,
+    plain,
+    monochrome,
+    submit,
+    size = DEFAULT_SIZE,
+    textAlign,
+    fullWidth,
+  }: ButtonProps,
+  ref,
+) {
   const intl = useI18n();
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
 
   const isDisabled = disabled || loading;
 
@@ -127,6 +132,12 @@ export function Button({
     fullWidth && styles.fullWidth,
     icon && children == null && styles.iconOnly,
   );
+
+  useImperativeHandle(ref, () => ({
+    focus: () => {
+      buttonRef.current && buttonRef.current.focus();
+    },
+  }));
 
   const disclosureIconMarkup = disclosure ? (
     <IconWrapper>
@@ -225,11 +236,12 @@ export function Button({
       aria-pressed={ariaPressed}
       role={loading ? 'alert' : undefined}
       aria-busy={loading ? true : undefined}
+      ref={buttonRef}
     >
       {content}
     </button>
   );
-}
+});
 
 export function IconWrapper({children}: any) {
   return <span className={styles.Icon}>{children}</span>;

--- a/src/components/Focus/Focus.tsx
+++ b/src/components/Focus/Focus.tsx
@@ -16,7 +16,7 @@ export class Focus extends React.PureComponent<FocusProps, never> {
   componentDidUpdate({children: prevChildren, ...restPrevProps}: FocusProps) {
     const {children, ...restProps} = this.props;
 
-    if (isEqual(restProps, restPrevProps)) {
+    if (isEqual(restProps, restPrevProps) || !restPrevProps.root) {
       return;
     }
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -324,7 +324,7 @@ class Modal extends React.Component<CombinedProps, State> {
   private handleOnClose = () => {
     const {openerRef, onClose} = this.props;
 
-    openerRef && openerRef.focus();
+    openerRef && openerRef.current && openerRef.current.focus();
     onClose();
   };
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -77,6 +77,8 @@ export interface ModalProps extends FooterProps {
   onTransitionEnd?(): void;
   /** Callback when the bottom of the modal content is reached */
   onScrolledToBottom?(): void;
+  /** Reference to the element that opens the Modal */
+  openerRef?: React.RefObject<HTMLElement>;
 }
 type CombinedProps = ModalProps & WithAppProviderProps;
 
@@ -215,7 +217,6 @@ class Modal extends React.Component<CombinedProps, State> {
       loading,
       large,
       limitHeight,
-      onClose,
       footer,
       primaryAction,
       secondaryActions,
@@ -272,12 +273,16 @@ class Modal extends React.Component<CombinedProps, State> {
       );
 
       const headerMarkup = title ? (
-        <Header id={this.headerId} onClose={onClose} testID="ModalHeader">
+        <Header
+          id={this.headerId}
+          onClose={this.handleOnClose}
+          testID="ModalHeader"
+        >
           {title}
         </Header>
       ) : (
         <CloseButton
-          onClick={onClose}
+          onClick={this.handleOnClose}
           title={false}
           testID="ModalCloseButton"
         />
@@ -287,7 +292,7 @@ class Modal extends React.Component<CombinedProps, State> {
         <Dialog
           instant={instant}
           labelledBy={this.headerId}
-          onClose={onClose}
+          onClose={this.handleOnClose}
           onEntered={this.handleEntered}
           onExited={this.handleExited}
           large={large}
@@ -315,6 +320,13 @@ class Modal extends React.Component<CombinedProps, State> {
       </WithinContentContext.Provider>
     );
   }
+
+  private handleOnClose = () => {
+    const {openerRef, onClose} = this.props;
+
+    openerRef && openerRef.focus();
+    onClose();
+  };
 
   private handleEntered = () => {
     const {onTransitionEnd} = this.props;


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-react/issues/795

Paired with @AndrewMusgrave 

### WHY are these changes introduced?

When closing a modal, focus is not returned back to the button that originally opened the modal. If the user was navigating with the keyboard, this would be the expected behaviour.

### WHAT is this pull request doing?

The Modal accepts an optional prop for a ref that is added to the button that opens the modal. This ref is created by the user, as you can see in the playground example.

### Still need to:

- [ ] Update unreleased (right before merge)
- [ ] Update documentation (new prop on modal) (also for button?)
- [x] Ensure node is focusable ([popover logic](https://github.com/Shopify/polaris-react/blob/44060b1ef10a346408675af954d48e03ac1286f6/src/components/Popover/Popover.tsx#L119))

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Modal, Button} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <ModalExample />
    </Page>
  );
}

class ModalExample extends React.Component {
  state = {
    active: false,
  };

  private buttonRef = React.createRef();

  render() {
    const {active} = this.state;
    return (
      <div style={{height: '500px'}}>
        <Button onClick={this.handleChange} ref={this.buttonRef}>
          Open
        </Button>

        <Modal
          openerRef={this.buttonRef.current}
          open={active}
          onClose={this.handleChange}
          primaryAction={{
            content: 'Add Instagram',
            onAction: this.handleChange,
          }}
          secondaryActions={[
            {
              content: 'Learn more',
              onAction: this.handleChange,
            },
          ]}
        >
          <Modal.Section>Foo</Modal.Section>
        </Modal>
      </div>
    );
  }

  handleChange = () => {
    this.setState(({active}) => ({active: !active}));
  };
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
