### PR TITLE
Use generics for typing UnstyleLink's forwardRef

### DIFF
--- a/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/src/components/UnstyledLink/UnstyledLink.tsx
@@ -11,9 +11,9 @@ export const UnstyledLink = React.memo(
   // This does have a display name, but the linting has a bug in it
   // https://github.com/yannickcr/eslint-plugin-react/issues/2324
   // eslint-disable-next-line react/display-name
-  React.forwardRef(function UnstyledLink(
-    props: UnstyledLinkProps,
-    _ref: React.RefObject<unknown>,
+  React.forwardRef<unknown, UnstyledLinkProps>(function UnstyledLink(
+    props,
+    _ref,
   ) {
     const LinkComponent = useLink();
     if (LinkComponent) {


### PR DESCRIPTION
### WHY are these changes introduced?

Slightly simpler code

### WHAT is this pull request doing?

Use generics for typing React.forwardRef