### PR TITLE
[RenderAfterMount][useMounted] Add utilities

### DIFF
--- a/src/components/AfterInitialMount/AfterInitialMount.tsx
+++ b/src/components/AfterInitialMount/AfterInitialMount.tsx
@@ -1,0 +1,14 @@
+import React, {ReactNode} from 'react';
+import {useIsAfterInitialMount} from '../../utilities/use-is-after-initial-mount';
+
+interface Props {
+  children?: ReactNode;
+  fallback?: ReactNode;
+}
+
+export function AfterInitialMount({children, fallback = null}: Props) {
+  const isMounted = useIsAfterInitialMount();
+  const content = isMounted ? children : fallback;
+
+  return <React.Fragment>{content}</React.Fragment>;
+}

--- a/src/components/AfterInitialMount/index.ts
+++ b/src/components/AfterInitialMount/index.ts
@@ -1,0 +1,1 @@
+export {AfterInitialMount} from './AfterInitialMount';

--- a/src/components/AfterInitialMount/test/AfterInitialMount.test.tsx
+++ b/src/components/AfterInitialMount/test/AfterInitialMount.test.tsx
@@ -1,0 +1,42 @@
+import React, {useEffect} from 'react';
+import {mount} from 'test-utilities';
+import {AfterInitialMount} from '../AfterInitialMount';
+
+describe('AfterInitialMount', () => {
+  it('renders fallback before mounting', () => {
+    const spy = jest.fn();
+
+    function Fallback() {
+      spy();
+      return null;
+    }
+
+    mount(<AfterInitialMount fallback={<Fallback />} />);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders children after mounting', () => {
+    const fallbackSpy = jest.fn();
+
+    function Fallback() {
+      useEffect(() => {
+        fallbackSpy(true);
+      }, []);
+
+      return null;
+    }
+
+    function Children() {
+      return null;
+    }
+
+    const afterInitialMount = mount(
+      <AfterInitialMount fallback={<Fallback />}>
+        <Children />
+      </AfterInitialMount>,
+    );
+
+    expect(fallbackSpy).toHaveBeenCalledWith(true);
+    expect(afterInitialMount).toContainReactComponent(Children);
+  });
+});

--- a/src/utilities/tests/use-is-after-initial-mount.test.tsx
+++ b/src/utilities/tests/use-is-after-initial-mount.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {mount} from 'test-utilities';
+import {useIsAfterInitialMount} from '../use-is-after-initial-mount';
+
+describe('useIsAfterInitialMount', () => {
+  it('starts off false', () => {
+    let isAfterInitialMountValue: boolean | undefined;
+    function Component() {
+      const isAfterInitialMount = useIsAfterInitialMount();
+      // eslint-disable-next-line shopify/jest/no-if
+      if (isAfterInitialMountValue === undefined)
+        isAfterInitialMountValue = !isAfterInitialMount;
+      return null;
+    }
+
+    mount(<Component />);
+
+    expect(isAfterInitialMountValue).toBe(true);
+  });
+
+  it('is true after mount', () => {
+    let isAfterInitialMountValue: boolean | undefined;
+    function Component() {
+      isAfterInitialMountValue = useIsAfterInitialMount();
+      return null;
+    }
+
+    mount(<Component />);
+
+    expect(isAfterInitialMountValue).toBe(true);
+  });
+});

--- a/src/utilities/use-is-after-initial-mount.ts
+++ b/src/utilities/use-is-after-initial-mount.ts
@@ -1,0 +1,11 @@
+import {useState, useEffect} from 'react';
+
+export function useIsAfterInitialMount() {
+  const [isAfterInitialMount, setIsAfterInitialMount] = useState(false);
+
+  useEffect(() => {
+    setIsAfterInitialMount(true);
+  }, []);
+
+  return isAfterInitialMount;
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Adding two small utilities that'll help with code that needs to be separated from server/client.

### WHAT is this pull request doing?

Adding `RenderAfterMount` and `useMounted`

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
