### PR TITLE
Updated monochrome example

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -28,6 +28,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Updated the monochrome example in `Link` with a color to inherit ([#2163](https://github.com/Shopify/polaris-react/pull/2163))
 - Converted `Autocomplete`, `Banner`, and `ChoiceList` examples to functional components ([#2127](https://github.com/Shopify/polaris-react/pull/2127))
 - Converted `Collapsible`, `ColorPicker`, and `DataTable` examples to functional components ([#2128](https://github.com/Shopify/polaris-react/pull/2128))
 - Converted `Modal`, `OptionList`, and `Popover` examples to functional components ([#2131](https://github.com/Shopify/polaris-react/pull/2131))

--- a/src/components/Link/README.md
+++ b/src/components/Link/README.md
@@ -89,9 +89,11 @@ Use for text links in larger spans of text.
 Use for text links that are the same color as the surrounding text.
 
 ```jsx
-<Link monochrome url="https://help.shopify.com/manual">
-  fulfilling orders
-</Link>
+<div style={{color: '#108043'}}>
+  <Link monochrome url="https://help.shopify.com/manual">
+    fulfilling orders
+  </Link>
+</div>
 ```
 
 ### Monochrome link in a banner


### PR DESCRIPTION
### WHY are these changes introduced?

The example is missing a color to inherit

### How to 🎩

Check the example in a deployment

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
