### PR TITLE
Add useLazyRef hook

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -45,6 +45,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Code quality
 
+- Added `useLazyRef` hook to use while building components ([#2166](https://github.com/Shopify/polaris-react/pull/2166))
 - Migrated `FilterCreator` to use hooks instead of withAppProvider ([#2156](https://github.com/Shopify/polaris-react/pull/2156))
 - Created a custom error for lack of context providers ([#2136](https://github.com/Shopify/polaris-react/pull/2136))
 - Migrated `ContextualSaveBar` to use hooks instead of `withAppProvider` ([#2091](https://github.com/Shopify/polaris-react/pull/2091))

--- a/src/utilities/tests/use-lazy-ref.test.tsx
+++ b/src/utilities/tests/use-lazy-ref.test.tsx
@@ -1,0 +1,37 @@
+import React, {useEffect, useState} from 'react';
+import {mount} from 'test-utilities';
+import {useLazyRef} from '../use-lazy-ref';
+
+describe('useLazyRef', () => {
+  it('returns a ref object', () => {
+    const spy = jest.fn();
+
+    function MockComponent() {
+      const lazyValue = useLazyRef(() => true);
+      spy(lazyValue);
+      return null;
+    }
+
+    mount(<MockComponent />);
+    expect(spy).toHaveBeenCalledWith({current: true});
+  });
+
+  it('only calls initialValue once', () => {
+    const spy = jest.fn();
+
+    function MockComponent() {
+      const [, setFooState] = useState(false);
+
+      useEffect(() => {
+        setFooState(true);
+      }, []);
+
+      useLazyRef(spy);
+
+      return null;
+    }
+
+    mount(<MockComponent />);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utilities/use-lazy-ref.ts
+++ b/src/utilities/use-lazy-ref.ts
@@ -1,0 +1,22 @@
+import {useRef, MutableRefObject} from 'react';
+
+const UNIQUE_IDENTIFIER = Symbol('unique_identifier');
+
+/**
+ * useLazyRef provides a lazy initial value, similar to lazy
+ * initial state the initialValue is the value used during
+ * initialization and disregarded after that.
+ * @param initialValue - A function that will return the initial
+ * value and be disregarded after that
+ * @returns MutableRefObject<T> - Returns a ref object with the
+ * results from invoking initial value
+ */
+export function useLazyRef<T>(initialValue: () => T) {
+  const lazyRef = useRef<T | Symbol>(UNIQUE_IDENTIFIER);
+
+  if (lazyRef.current === UNIQUE_IDENTIFIER) {
+    lazyRef.current = initialValue();
+  }
+
+  return lazyRef as MutableRefObject<T>;
+}


### PR DESCRIPTION
### WHY are these changes introduced?

@beefchimi and I added this while working on #2105, I broke this out of the other PR so we can take our time working on 2105 and use this hook in the meantime.

It'll allow for lazy initialization of refs, see jsdocs for a little more information

### WHAT is this pull request doing?

* Adding hook + jsdoc
* Adding tests

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
