### PR TITLE
[Connected] Preventing loss of TextField focus caused by shifting DOM position

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed loss of focus on TextField when changing connectedRight/connectedLeft content while user is typing ([#2170](https://github.com/Shopify/polaris-react/pull/2170))
 - Fixed `type` for clearButton ([#2060](https://github.com/Shopify/polaris-react/pull/2060))
 - Prevented the `onSelect` prop of `Tabs` from changing scroll position ([#2196](https://github.com/Shopify/polaris-react/pull/2196))
 - Fixed 200ms visual delay when activating `Popover` ([#2209](https://github.com/Shopify/polaris-react/pull/2209))

--- a/src/components/Connected/Connected.tsx
+++ b/src/components/Connected/Connected.tsx
@@ -13,10 +13,6 @@ export interface ConnectedProps {
 }
 
 export function Connected({children, left, right}: ConnectedProps) {
-  if (left == null && right == null) {
-    return <React.Fragment>{children}</React.Fragment>;
-  }
-
   const leftConnectionMarkup = left ? (
     <Item position={ItemPosition.Left}>{left}</Item>
   ) : null;

--- a/src/components/Connected/tests/Connected.test.tsx
+++ b/src/components/Connected/tests/Connected.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {mountWithApp} from 'test-utilities';
+
+import {Connected} from '../Connected';
+import {Item, ItemPosition} from '../components';
+
+describe('<Connected />', () => {
+  describe('<Item />', () => {
+    it('wraps children in an Item component', async () => {
+      const expectedContent = 'foo';
+      const connected = await mountWithApp(
+        <Connected>{expectedContent}</Connected>,
+      );
+
+      expect(
+        connected.find(Item, {position: ItemPosition.Primary}),
+      ).toContainReactText(expectedContent);
+    });
+
+    it('includes `rightConnected` markup in an Item component', async () => {
+      const rightConnectedContent = 'foo';
+      const connected = await mountWithApp(
+        <Connected right={rightConnectedContent} />,
+      );
+
+      expect(
+        connected.find(Item, {position: ItemPosition.Right}),
+      ).toContainReactText(rightConnectedContent);
+    });
+
+    it('includes `leftConnected` markup in an Item component', async () => {
+      const leftConnectedContent = 'foo';
+      const connected = await mountWithApp(
+        <Connected left={leftConnectedContent} />,
+      );
+
+      expect(
+        connected.find(Item, {position: ItemPosition.Left}),
+      ).toContainReactText(leftConnectedContent);
+    });
+
+    it('`leftConnected` and `rightConnected` are not mutually exclusive', async () => {
+      const rightConnectedContent = 'rightfoo';
+      const leftConnectedContent = 'leftfoo';
+      const connected = await mountWithApp(
+        <Connected right={rightConnectedContent} left={leftConnectedContent} />,
+      );
+
+      expect(
+        connected.find(Item, {position: ItemPosition.Right}),
+      ).toContainReactText(rightConnectedContent);
+
+      expect(
+        connected.find(Item, {position: ItemPosition.Left}),
+      ).toContainReactText(leftConnectedContent);
+    });
+  });
+});

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {ReactElement} from 'react';
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {InlineError, Labelled, Connected, Select} from 'components';
 import {mountWithApp} from 'test-utilities';
@@ -1026,33 +1026,17 @@ describe('<TextField />', () => {
       );
       const connectedChild = textField
         .find(Connected)
-        .find('div')
-        .first();
+        .prop('children') as ReactElement;
 
-      connectedChild.simulate('click');
+      expect(textField.getDOMNode().querySelector('input')).not.toBe(
+        document.activeElement,
+      );
+
+      connectedChild.props.onClick({});
 
       expect(textField.getDOMNode().querySelector('input')).toBe(
         document.activeElement,
       );
-    });
-
-    it('applies focus variant style `onFocus`', () => {
-      const textField = mountWithAppProvider(
-        <TextField label="TextField" onChange={noop} />,
-      );
-      let connectedInteriorWrapper = textField
-        .find(Connected)
-        .find('div')
-        .first();
-
-      connectedInteriorWrapper.simulate('focus');
-
-      connectedInteriorWrapper = textField
-        .find(Connected)
-        .find('div')
-        .first();
-
-      expect(connectedInteriorWrapper.hasClass('focus')).toBe(true);
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes: https://github.com/Shopify/polaris-react/issues/2169
Fixes: https://github.com/Shopify/online-store-web/issues/4181

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Ensuring that the `Connected` component always returns fragments at the same DOM depth so as not to cause a `TextField`'s `input` field to unmount and lose focus.

<details>
  <summary>Introducing a "Search" button (`connectedRight`) while typing causes a loss of focus</summary>
  <img src="https://user-images.githubusercontent.com/70582/65271515-5208f800-daeb-11e9-9ba9-769cb7368cd6.gif">
</details>

<details>
  <summary>Ensuring maintained focus by always returning a TextField at the same depth in the DOM (what this PR does)</summary>
  <img src="https://user-images.githubusercontent.com/70582/65271664-9dbba180-daeb-11e9-93dc-33c159471fcb.gif">
</details>

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->