### PR TITLE
Add CODEOWNERS file to notify them of any public Sass API changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,5 @@
 # to prevent any new helpers from sneaking in.
 /src/styles/foundation @BPScott @danrosenthal @tmlayton
 /src/styles/shared @BPScott @danrosenthal @tmlayton
-/src/styles/_common.scss @BPScott @danrosenthal @tmlayton
 /src/styles/foundation.scss @BPScott @danrosenthal @tmlayton
 /src/styles/shared.scss @BPScott @danrosenthal @tmlayton

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# The public Sass API will be gradually deprecated
+#
+# These people should be aware of any changes made to it
+# to prevent any new helpers from sneaking in.
+/src/styles/foundation @BPScott @danrosenthal @tmlayton
+/src/styles/shared @BPScott @danrosenthal @tmlayton
+/src/styles/_common.scss @BPScott @danrosenthal @tmlayton
+/src/styles/foundation.scss @BPScott @danrosenthal @tmlayton
+/src/styles/shared.scss @BPScott @danrosenthal @tmlayton


### PR DESCRIPTION
The public Sass API is set to be gradually deprecated.

@tmlayton @BPScott and @danrosenthal should be aware of any changes made to it
to prevent any new helpers from sneaking in.

If anyone feels like they should be added to this list, I'll be happy to add them.