### PR TITLE
[Spinner] Fix not being read by screen readers

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added `hasFocusableParent` to `Spinner` ([#2176](https://github.com/Shopify/polaris-react/pull/2176))
+
 ### Bug fixes
 
 - Fixed tabs that don't wrap correctly on small screens in pre-iOS 13 Safari ([#2232](https://github.com/Shopify/polaris-react/pull/2232))

--- a/src/components/Spinner/README.md
+++ b/src/components/Spinner/README.md
@@ -28,7 +28,7 @@ Spinners are used to notify merchants that their action is being processed. For 
 Use to notify merchants that their requested action is being processed.
 
 ```jsx
-<Spinner size="large" color="teal" />
+<Spinner accessibilityLabel="Spinner example" size="large" color="teal" />
 ```
 
 <!-- content-for: android -->
@@ -50,8 +50,92 @@ Use to notify merchants that their requested action is being processed.
 Smaller than the default spinner.
 
 ```jsx
-<Spinner size="small" color="teal" />
+<Spinner accessibilityLabel="Small spinner example" size="small" color="teal" />
 ```
+
+### Spinner with focus management
+
+Use to direct the focus state from the control to the spinner, to the content.
+
+```jsx
+function SpinnerWithFocusManagement() {
+  const tabs = useRef([
+    {
+      id: 'all-customers',
+      content: 'All',
+      accessibilityLabel: 'All customers',
+      panelID: 'all-customers-content',
+    },
+    {
+      id: 'accepts-marketing',
+      content: 'Accepts marketing',
+      panelID: 'accepts-marketing-content',
+    },
+  ]);
+
+  const [selected, setSelected] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [value, setValue] = useState('');
+  const [textFieldFocused, setTextFieldFocused] = useState(false);
+
+  useEffect(() => {
+    setTextFieldFocused(!loading);
+  }, [loading]);
+
+  const handleTabChange = useCallback((selectedTab) => {
+    setLoading(true);
+    setSelected(selectedTab);
+    setTimeout(() => {
+      setValue('');
+      return setLoading(false);
+    }, 1500);
+  }, []);
+
+  const handleUrlChange = useCallback((value) => setValue(value), []);
+
+  const handleSubmit = useCallback((_event) => setValue(''), []);
+
+  const label = selected ? 'Marketing' : 'Customers';
+  const sectionMarkup = loading ? (
+    <Spinner
+      accessibilityLabel="Loading form field"
+      hasFocusableParent={false}
+    />
+  ) : (
+    <Form noValidate onSubmit={handleSubmit}>
+      <FormLayout>
+        <TextField
+          value={value}
+          focused={textFieldFocused}
+          onChange={handleUrlChange}
+          label={label}
+        />
+        <Button submit>Submit</Button>
+      </FormLayout>
+    </Form>
+  );
+
+  return (
+    <Card>
+      <Tabs tabs={tabs.current} selected={selected} onSelect={handleTabChange}>
+        <Card.Section title={tabs.current[selected].content}>
+          {sectionMarkup}
+        </Card.Section>
+      </Tabs>
+    </Card>
+  );
+}
+```
+
+---
+
+## Accessibility
+
+<!-- content-for: web -->
+
+SVGs are often conveyed inconsistently to assistive technologies. The `Spinner` component's accessibility is also highly contextual. When the parent component is focusable, you'll need to set the `hasFocusableParent` prop for the appropriate `role` attribute to be applied.
+
+<!-- /content-for-->
 
 ---
 

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {classNames, variationName} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
 import {Image} from '../Image';
+import {VisuallyHidden} from '../VisuallyHidden';
+import {useIsAfterInitialMount} from '../../utilities/use-is-after-initial-mount';
 import styles from './Spinner.scss';
 import {spinnerLarge, spinnerSmall} from './images';
 
@@ -24,14 +26,18 @@ export interface SpinnerProps {
   size?: Size;
   /** Accessible label for the spinner */
   accessibilityLabel?: string;
+  /** Allows the component to apply the correct accessibility roles based on focus */
+  hasFocusableParent?: boolean;
 }
 
 export function Spinner({
   size = 'large',
   color = 'teal',
   accessibilityLabel,
+  hasFocusableParent,
 }: SpinnerProps) {
   const i18n = useI18n();
+  const isAfterInitialMount = useIsAfterInitialMount();
 
   if (size === 'large' && COLORS_FOR_LARGE_SPINNER.indexOf(color) < 0) {
     if (process.env.NODE_ENV === 'development') {
@@ -57,14 +63,24 @@ export function Spinner({
 
   const spinnerSVG = size === 'large' ? spinnerLarge : spinnerSmall;
 
+  const spanAttributes = {
+    ...(!hasFocusableParent && {role: 'status'}),
+  };
+
+  const accessibilityLabelMarkup = (isAfterInitialMount ||
+    !hasFocusableParent) && (
+    <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>
+  );
+
   return (
-    <Image
-      alt=""
-      source={spinnerSVG}
-      className={className}
-      draggable={false}
-      role="status"
-      aria-label={accessibilityLabel}
-    />
+    <React.Fragment>
+      <Image
+        alt=""
+        source={spinnerSVG}
+        className={className}
+        draggable={false}
+      />
+      <span {...spanAttributes}>{accessibilityLabelMarkup}</span>
+    </React.Fragment>
   );
 }

--- a/src/components/Spinner/tests/Spinner.test.tsx
+++ b/src/components/Spinner/tests/Spinner.test.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {Spinner, Color} from '../Spinner';
 import {Image} from '../../Image';
+import {VisuallyHidden} from '../../VisuallyHidden';
 
 describe('<Spinner />', () => {
   describe('accessibilityLabel', () => {
     it('uses the label as the aria-label for the spinner', () => {
-      const spinner = mountWithAppProvider(
+      const spinner = mountWithApp(
         <Spinner accessibilityLabel="Content is loading" />,
       );
-      expect(spinner.find(Image).prop('aria-label')).toBe('Content is loading');
+      expect(spinner.find(VisuallyHidden)).toContainReactText(
+        'Content is loading',
+      );
     });
   });
 
@@ -38,9 +42,14 @@ describe('<Spinner />', () => {
   });
 
   describe('role', () => {
-    it('sets the role to status to denote advisory information to screen readers', () => {
-      const spinner = mountWithAppProvider(<Spinner />);
-      expect(spinner.find(Image).prop('role')).toBe('status');
+    it('sets the role to status to denote advisory information to screen readers when a live region is not active', () => {
+      const spinner = mountWithApp(<Spinner hasFocusableParent={false} />);
+      expect(spinner).toContainReactComponentTimes('span', 1, {role: 'status'});
+    });
+
+    it('does not set role to status when a live region is active', () => {
+      const spinner = mountWithApp(<Spinner hasFocusableParent />);
+      expect(spinner).not.toContainReactComponent('span', {role: 'status'});
     });
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #791

### Styleguide Screenies

![Screen Shot 2019-09-30 at 2 45 18 PM](https://user-images.githubusercontent.com/24610840/65906858-3f1ae100-e391-11e9-88cf-c3682479d3d4.png)
![Screen Shot 2019-09-30 at 2 45 27 PM](https://user-images.githubusercontent.com/24610840/65906864-40e4a480-e391-11e9-8933-814dab16fa0f.png)

### WHAT is this pull request doing?

* Adding `hasFocusableParent` to spinners public API
* Add a focus management example
* Add tests
* Add accessibility docs section

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

#### With label

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Spinner} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Spinner accessibilityLabel="label here" />
    </Page>
  );
}
```

</details>

#### With focusable parent

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Spinner} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <div tabIndex={0}>
        <Spinner hasFocusableParent accessibilityLabel="label here" />
      </div>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
