### PR TITLE
[Card] Improve standards compliance via flex-start

### DIFF
--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -83,7 +83,7 @@
 
 .Footer {
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   padding: 0 spacing() spacing();
 
   @include page-content-when-not-fully-condensed {


### PR DESCRIPTION
### WHY are these changes introduced?

PostCSS throws warnings about this, which blocks sewing-kit compilation:

```
ModuleWarning: Module Warning (from ./node_modules/postcss-loader/src/index.js):
Warning

(1:1639) start value has mixed support, consider using flex-start instead
    at Object.emitWarning (node_modules/@shopify/sewing-kit/node_modules/webpack/lib/NormalModule.js:158:6)
    at result.warnings.forEach (node_modules/postcss-loader/src/index.js:146:16)
    at Array.forEach (<anonymous>)
    at postcss.process.then (node_modules/postcss-loader/src/index.js:145:27)
```
