### PR TITLE
[Banner] Remove period in example link

### DIFF
--- a/src/components/Banner/README.md
+++ b/src/components/Banner/README.md
@@ -248,7 +248,7 @@ Make all banners dismissible, unless they contain critical information or an imp
 <Banner onDismiss={() => {}}>
   <p>
     Use your finance report to get detailed information about your business.{' '}
-    <Link url="">Let us know what you think.</Link>
+    <Link url="">Let us know what you think</Link>
   </p>
 </Banner>
 ```
@@ -490,7 +490,7 @@ Banners inside of cards render with less spacing and a pared-back design to fit 
     <Banner onDismiss={() => {}}>
       <p>
         Use your finance report to get detailed information about your business.{' '}
-        <Link url="">Let us know what you think.</Link>
+        <Link url="">Let us know what you think</Link>
       </p>
     </Banner>
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

There is an extra period in the link of the [Dismissible banner example](https://www.chromaui.com/component?appId=5d559397bae39100201eedc1&name=All%20Components%7CBanner&buildNumber=857&specName=Dismissible%20Banner).

![Screen Shot 2019-09-24 at 11 21 02 AM](https://user-images.githubusercontent.com/85783/65538998-6e2ae180-debd-11e9-9088-d73df176b048.png)

![Screen Shot 2019-09-24 at 11 20 51 AM](https://user-images.githubusercontent.com/85783/65539000-6ff4a500-debd-11e9-9e50-507035043f25.png)


### WHAT is this pull request doing?

Removes the period in those links.

### 🎩 checklist

* [N/A] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [N/A] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [N/A] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [N/A] Updated the component's `README.md` with documentation changes
* [N/A] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->