### PR TITLE
[TextField] Replace “e.g.” with “Example:”

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Documentation
 
 - Converted `Form`, `Frame`, and `Loading` examples to functional components ([#2130](https://github.com/Shopify/polaris-react/pull/2130))
+- Replaced Latin abbreviations with English words in Text field content guidelines ([#2192](https://github.com/Shopify/polaris-react/pull/2192))
 
 ### Development workflow
 

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -97,17 +97,18 @@ input. Field placeholder text should:
 
 - Be used only for supplementary information because the text has low contrast and is not visible when text is entered
 - Be written as examples instead of instructions
-- Include “e.g.” before an example
+- Include “Example:” before an example
 
 <!-- usagelist -->
 
 #### Do
 
-- e.g. FALLSALE
+- Example: FALLSALE
 
 #### Don’t
 
 - Name your discount code
+- e.g. FALLSALE
 
 <!-- end -->
 
@@ -424,7 +425,7 @@ function PlaceholderExample() {
       label="Shipping zone name"
       value={textFieldValue}
       onChange={handleTextFieldChange}
-      placeholder="e.g. North America, Europe"
+      placeholder="Example: North America, Europe"
     />
   );
 }


### PR DESCRIPTION
There is an initiative to eliminate Latin abbreviations, and part of that work includes replacing `e.g.` with `Example:`.