### PR TITLE
[v5] Drop support for ios9

### DIFF
--- a/UNRELEASED-v5.md
+++ b/UNRELEASED-v5.md
@@ -8,6 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Removed `FilterControl` component ([#2047](https://github.com/Shopify/polaris-react/pull/2047))
 - Removed `AppBridge`, `ResourcePicker` and `Loading`, `Modal`, `Page`, `Toast` App Bridge render delegation ([#2046](https://github.com/Shopify/polaris-react/pull/2046))
+- Drop support for iOS 9 ([#2195](https://github.com/Shopify/polaris-react/pull/2195))
 
 ### Enhancements
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "last 3 opera versions",
     "last 2 edge versions",
     "safari >= 10",
-    "ios >= 9"
+    "ios >= 10"
   ],
   "devDependencies": {
     "@babel/core": "^7.6.0",


### PR DESCRIPTION
### WHY are these changes introduced?

Generally speaking Shopify supports the last three version of browsers. In reality we're a little more lax so sometimes we end up supporting older versions as conditional transpilation using babel-preset-env is pretty easy. Supporting older versions of safari and ios was useful for point-of-sale apps on older hardware that couldn't update to latest.

Earlier this year Shopify publicly dropped support for ios9 and we recently removed transpilation support in [web](https://github.com/Shopify/web/pull/18235). Now it is Polaris's turn.

This drastically decreases our bundle size as we no longer need to transpile several aspects of class syntax, object destructuring and arrow functions.

This shrinks the uncompressed esm build from 614914 bytes to 530242 bytes - A saving
of 85KB or 15%! Gzipped versions are a little more restrained - saving 12KB or 10%.

```
index.es.js v5.0.0 Branch:
Uncompressed 614914
Compressed: 136062

index.es.js drop-ios9 Branch:
Uncompressed: 530242
Compressed: 123251
```

### WHAT is this pull request doing?

Updates our browserlist config (which is then used by babel-preset-env)
