### PR TITLE
[DataTable] Add ability to control location of Totals row

### DIFF
--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -136,11 +136,11 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
       condensed && styles.condensed,
     );
 
+    const headingMarkup = <tr>{headings.map(this.renderHeadings)}</tr>;
+
     const totalsMarkup = totals ? (
       <tr>{totals.map(this.renderTotals)}</tr>
     ) : null;
-
-    const headingMarkup = <tr>{headings.map(this.renderHeadings)}</tr>;
 
     const bodyMarkup = rows.map(this.defaultRenderRow);
 

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -144,18 +144,12 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
 
     const bodyMarkup = rows.map(this.defaultRenderRow);
 
-    let footerMarkup;
+    const footerMarkup = footerContent ? (
+      <div className={styles.Footer}>{footerContent}</div>
+    ) : null;
 
-    if (footerContent) {
-      footerMarkup = footerTotals ? (
-        <div className={styles.Footer}>
-          {footerContent}
-          {totalsMarkup}
-        </div>
-      ) : (
-        <div className={styles.Footer}>{footerContent}</div>
-      );
-    }
+    const headerTotalsMarkup = !footerTotals ? totalsMarkup : null;
+    const footerTotalsMarkup = footerTotals ? totalsMarkup : null;
 
     return (
       <div className={wrapperClassName}>
@@ -177,9 +171,10 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
             <table className={styles.Table} ref={this.table}>
               <thead>
                 {headingMarkup}
-                {totalsMarkup}
+                {headerTotalsMarkup}
               </thead>
               <tbody>{bodyMarkup}</tbody>
+              {footerTotalsMarkup}
             </table>
           </div>
           {footerMarkup}

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -144,20 +144,18 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
 
     const bodyMarkup = rows.map(this.defaultRenderRow);
 
-    const footerMarkup = footerContent ? (
-      <div className={styles.Footer}>{footerContent}</div>
-    ) : null;
+    let footerMarkup;
 
-    // if (footerContent) {
-    //   const footerMarkup = footerTotals ? (
-
-    //   ) : (
-    //     <div className={styles.footer}
-    //     //<div className={styles.Footer}>{footerContent}</div>
-    //   )
-    // }
-
-    // if (footer)
+    if (footerContent) {
+      footerMarkup = footerTotals ? (
+        <div className={styles.Footer}>
+          {footerContent}
+          {totalsMarkup}
+        </div>
+      ) : (
+        <div className={styles.Footer}>{footerContent}</div>
+      );
+    }
 
     return (
       <div className={wrapperClassName}>

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -32,6 +32,8 @@ export interface DataTableProps {
   headings: string[];
   /** List of numeric column totals, highlighted in the table’s header below column headings. Use empty strings as placeholders for columns with no total. */
   totals?: TableData[];
+  /** Placement of totals row within table, true for t */
+  footerTotals?: boolean;
   /** Lists of data points which map to table body rows. */
   rows: TableData[][];
   /** Truncate content in first column instead of wrapping.
@@ -116,7 +118,7 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
   }
 
   render() {
-    const {headings, totals, rows, footerContent} = this.props;
+    const {headings, totals, footerTotals, rows, footerContent} = this.props;
     const {
       condensed,
       columnVisibilityData,
@@ -134,17 +136,28 @@ class DataTable extends React.PureComponent<CombinedProps, DataTableState> {
       condensed && styles.condensed,
     );
 
-    const headingMarkup = <tr>{headings.map(this.renderHeadings)}</tr>;
-
     const totalsMarkup = totals ? (
       <tr>{totals.map(this.renderTotals)}</tr>
     ) : null;
+
+    const headingMarkup = <tr>{headings.map(this.renderHeadings)}</tr>;
 
     const bodyMarkup = rows.map(this.defaultRenderRow);
 
     const footerMarkup = footerContent ? (
       <div className={styles.Footer}>{footerContent}</div>
     ) : null;
+
+    // if (footerContent) {
+    //   const footerMarkup = footerTotals ? (
+
+    //   ) : (
+    //     <div className={styles.footer}
+    //     //<div className={styles.Footer}>{footerContent}</div>
+    //   )
+    // }
+
+    // if (footer)
 
     return (
       <div className={wrapperClassName}>


### PR DESCRIPTION
#### TL;DR: 
Added a prop to DataTable which allows control over placement of the Totals row.

### Why are these changes introduced?

Addresses #2100 

Currently the DataTable component displays the `Totals` row at the top of the table which is defintely a valid place to display that information but in some cases it makes more sense from a UX perspective to have that information at the bottom of the table. This creates the visual flow as your eye goes down each column and subconsciously starts to add up the different values. Having the option in Polaris to do both will make the component more flexible and allow devs and designers alike to customize it to fit the context that it's being implemented in.

### What is this pull request doing?

This PR introduces an additional optional prop to the `DataTable` component called _footerTotals_ (could definitely find a better name) that, when set to true will place the existing Totals row and it's data supplied in other props at the bottom of the data table. Introducing these changes this way makes them backwards compatible with existing implementations of the DataTable because if the prop hasn't been supplied then then the default behaviour will be preserved.

#### Default rendering:

```jsx
<DataTable
  columnContentTypes={[
    'text',
    'numeric',
    'numeric',
    'numeric',
    'numeric',
  ]}
  headings={[
    'Product',
    'Price',
    'SKU Number',
    'Net quantity',
    'Net sales',
  ]}
  rows={rows}
  totals={['', '', '', 255, '$155,830.00']}
/>
```
![image](https://user-images.githubusercontent.com/42747959/65606610-341f1580-df79-11e9-8d34-44c56944f3c9.png)

#### With footerTotals rendering:

```jsx
<DataTable
  columnContentTypes={[
    'text',
    'numeric',
    'numeric',
    'numeric',
    'numeric',
  ]}
  headings={[
    'Product',
    'Price',
    'SKU Number',
    'Net quantity',
    'Net sales',
  ]}
  rows={rows}
  totals={['', '', '', 255, '$155,830.00']}
  footerTotals
/>
```

![image](https://user-images.githubusercontent.com/42747959/65606744-6af52b80-df79-11e9-84e5-9e23be7ea90f.png)

If you have any suggestions for a better prop name than footerTotals 🦶🔢, let me know 😂