### PR TITLE
[useEventListener][useComponentDidMount] Add useComponentDidMount & useEventListener

### DIFF
--- a/src/utilities/tests/use-component-did-mount.test.tsx
+++ b/src/utilities/tests/use-component-did-mount.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {mount} from 'test-utilities';
+import {useComponentDidMount} from '../use-component-did-mount';
+import {useIsAfterInitialMount} from '../use-is-after-initial-mount';
+
+describe('useComponentDidMount', () => {
+  it('invokes your callback after mount', () => {
+    const spy = jest.fn();
+    function Component() {
+      const isAfterInitialMount = useIsAfterInitialMount();
+      useComponentDidMount(() => {
+        spy(isAfterInitialMount);
+      });
+
+      return null;
+    }
+
+    mount(<Component />);
+
+    expect(spy).toHaveBeenCalledWith(true);
+  });
+
+  it('invokes the callback once', () => {
+    const spy = jest.fn();
+    function Component() {
+      useComponentDidMount(spy);
+      return null;
+    }
+
+    const component = mount(<Component />);
+
+    component.setProps({});
+    component.setProps({});
+    component.setProps({});
+    component.setProps({});
+    component.setProps({});
+    component.setProps({});
+
+    component.unmount();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utilities/tests/use-event-listener.test.tsx
+++ b/src/utilities/tests/use-event-listener.test.tsx
@@ -1,0 +1,75 @@
+import React, {useRef, useEffect} from 'react';
+import {mount} from 'test-utilities';
+import {useEventListener} from '../use-event-listener';
+
+describe('useComponentDidMount', () => {
+  let addEventListenerSpy: jest.SpyInstance;
+  let removeEventListenerSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    addEventListenerSpy = jest.spyOn(document, 'addEventListener');
+    removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it('adds event to react refs', () => {
+    const spy = jest.fn();
+    function Component() {
+      const div = useRef<HTMLDivElement>(null);
+
+      useEventListener(div, 'blur', spy);
+
+      useEffect(() => {
+        div.current!.dispatchEvent(new Event('blur'));
+      });
+
+      return <div ref={div} />;
+    }
+
+    mount(<Component />);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes the provided handler when the type of event is triggered', () => {
+    const spy = jest.fn();
+    function Component() {
+      useEventListener(document, 'reset', spy);
+
+      return null;
+    }
+
+    mount(<Component />);
+    document.dispatchEvent(new Event('reset'));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes type, handler and options to the listener', () => {
+    const options = {passive: true};
+    const noop = () => {};
+    function Component() {
+      useEventListener(document, 'reset', noop, options);
+
+      return null;
+    }
+
+    mount(<Component />);
+    expect(addEventListenerSpy).toHaveBeenCalledWith('reset', noop, options);
+  });
+
+  it('removes the event listener when unmounting', () => {
+    function Component() {
+      useEventListener(document, 'reset', () => {});
+
+      return null;
+    }
+
+    const component = mount(<Component />);
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(0);
+    component.unmount();
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utilities/use-component-did-mount.ts
+++ b/src/utilities/use-component-did-mount.ts
@@ -5,7 +5,7 @@ import {useIsAfterInitialMount} from './use-is-after-initial-mount';
 /**
  * Similarly to the lifecycle hook componentDidMount, useComponentDidMount
  * will be invoked after the component has mounted, and only the initial mount.
- * @param callback Defines a callback to use invoked once the component has
+ * @param callback Defines a callback to invoke once the component has
  * initially mounted.
  */
 export function useComponentDidMount(callback: EffectCallback) {

--- a/src/utilities/use-component-did-mount.ts
+++ b/src/utilities/use-component-did-mount.ts
@@ -1,0 +1,19 @@
+import {useRef} from 'react';
+import {EffectCallback} from '../types';
+import {useIsAfterInitialMount} from './use-is-after-initial-mount';
+
+/**
+ * Similarly to the lifecycle hook componentDidMount, useComponentDidMount
+ * will be invoked after the component has mounted, and only the initial mount.
+ * @param callback Defines a callback to use invoked once the component has
+ * initially mounted.
+ */
+export function useComponentDidMount(callback: EffectCallback) {
+  const isAfterInitialMount = useIsAfterInitialMount();
+  const hasInvokedLifeCycle = useRef(false);
+
+  if (isAfterInitialMount && !hasInvokedLifeCycle.current) {
+    hasInvokedLifeCycle.current = true;
+    return callback();
+  }
+}

--- a/src/utilities/use-event-listener.ts
+++ b/src/utilities/use-event-listener.ts
@@ -1,0 +1,22 @@
+import {useEffect, RefObject} from 'react';
+
+/**
+ * Attachs and removes event listeners from the target
+ * @param target Defines a target for the listener to be placed on
+ * @param type Defines the type of event, i.e blur or focus
+ * @param handler Defines a callback to be invoked when the event type occurs
+ * @param options Object that specificies event properties
+ */
+export function useEventListener<K extends keyof WindowEventMap>(
+  target: RefObject<HTMLElement> | Window | Document,
+  type: K,
+  handler: (ev: WindowEventMap[K]) => any,
+  options?: boolean | AddEventListenerOptions,
+) {
+  useEffect(() => {
+    const eventTarget = target && 'current' in target ? target.current : target;
+    if (!eventTarget) return;
+    eventTarget.addEventListener(type, handler, options);
+    return () => eventTarget.removeEventListener(type, handler, options);
+  }, [handler, options, target, type]);
+}


### PR DESCRIPTION
### WHY are these changes introduced?

I needed these while converting dropzone to a functional component

### WHAT is this pull request doing?

* add hooks
* add tests
* add docs

### How to 🎩

* tests
* try to break them in the playground

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
