### PR TITLE
Removing z-index on icons

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Removed the need for z-indexes in `Icon` ([#2207](https://github.com/Shopify/polaris-react/pull/2207))
+
 ### Bug fixes
 
 - Fixed `type` for clearButton ([#2060](https://github.com/Shopify/polaris-react/pull/2060))

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -1,10 +1,5 @@
 @import '../../styles/common';
 
-$stacking-order: (
-  backdrop: 1,
-  icon: 2,
-);
-
 .Icon {
   display: block;
   height: rem(20px);
@@ -20,10 +15,9 @@ $stacking-order: (
   align-items: center;
   margin: spacing(extra-tight);
 
-  &::after {
+  &::before {
     content: '';
     position: absolute;
-    z-index: z-index(backdrop, $stacking-order);
     top: -1 * spacing(extra-tight);
     bottom: -1 * spacing(extra-tight);
     left: -1 * spacing(extra-tight);
@@ -68,7 +62,7 @@ $stacking-order: (
 .colorInkLighter {
   @include color-icon('ink', 'lighter');
 
-  &::after {
+  &::before {
     background-color: color('sky');
   }
 }
@@ -80,7 +74,7 @@ $stacking-order: (
 .colorInk {
   @include color-icon('ink');
 
-  &::after {
+  &::before {
     background-color: color('sky');
   }
 }
@@ -100,7 +94,7 @@ $stacking-order: (
 .colorBlueDark {
   @include color-icon('blue', 'dark');
 
-  &::after {
+  &::before {
     background-color: color('blue', 'light');
   }
 }
@@ -140,7 +134,7 @@ $stacking-order: (
 .colorTeal {
   @include color-icon('teal');
 
-  &::after {
+  &::before {
     background-color: color('white');
   }
 }
@@ -148,7 +142,7 @@ $stacking-order: (
 .colorTealDark {
   @include color-icon('teal', 'dark');
 
-  &::after {
+  &::before {
     background-color: color('teal', 'light');
   }
 }
@@ -164,7 +158,7 @@ $stacking-order: (
 .colorGreen {
   @include color-icon('green');
 
-  &::after {
+  &::before {
     background-color: color('green', 'lighter');
   }
 }
@@ -172,7 +166,7 @@ $stacking-order: (
 .colorGreenDark {
   @include color-icon('green', 'dark');
 
-  &::after {
+  &::before {
     background-color: color('green', 'light');
   }
 }
@@ -188,7 +182,7 @@ $stacking-order: (
 .colorYellowDark {
   @include color-icon('yellow', 'dark');
 
-  &::after {
+  &::before {
     background-color: color('yellow', 'light');
   }
 }
@@ -212,7 +206,7 @@ $stacking-order: (
 .colorRedDark {
   @include color-icon('red', 'dark');
 
-  &::after {
+  &::before {
     background-color: color('red', 'light');
   }
 }
@@ -224,7 +218,6 @@ $stacking-order: (
 .Svg,
 .Img {
   position: relative;
-  z-index: z-index(icon, $stacking-order);
   display: block;
   width: 100%;
   max-width: 100%;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Currently we apply a z-index to icons to allow for them to sit above the backdrop when using one. This causes strange issues in consumers because it means icons get an arbitrary z-index of 2, lifting them over things that they shouldn't be.

### WHAT is this pull request doing?

This removes the z-indexes and instead changes the `::after` used for the backdrop to be a `::before` which naturally stacks correctly without a z-index.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Ideally any regressions here will be caught by percy, but poking around in the playground to see if you can find any holes in this approach would be useful.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [NA] Updated the component's `README.md` with documentation changes
* [NA] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [NA] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)
