### PR TITLE
[Popover] Fix 200ms visual delay when activating a popover

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixed `type` for clearButton ([#2060](https://github.com/Shopify/polaris-react/pull/2060))
 - Prevented the `onSelect` prop of `Tabs` from changing scroll position ([#2196](https://github.com/Shopify/polaris-react/pull/2196))
+- Fixed 200ms visual delay when activating `Popover` ([#2209](https://github.com/Shopify/polaris-react/pull/2209))
 
 ### Documentation
 

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -19,6 +19,10 @@ $content-max-width: rem(400px);
   transition: opacity duration() easing(in);
 }
 
+.PopoverOverlay-entering {
+  opacity: 1;
+}
+
 .PopoverOverlay-open {
   opacity: 1;
 }

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -85,6 +85,8 @@ export class PopoverOverlay extends React.PureComponent<
   }
 
   componentDidUpdate(oldProps: PopoverOverlayProps) {
+    this.clearTransitionTimeout();
+
     if (this.props.active && !oldProps.active) {
       this.focusContent();
       this.changeTransitionStatus(TransitionStatus.Entering, () => {
@@ -121,6 +123,8 @@ export class PopoverOverlay extends React.PureComponent<
 
     const className = classNames(
       styles.PopoverOverlay,
+      transitionStatus === TransitionStatus.Entering &&
+        styles['PopoverOverlay-entering'],
       transitionStatus === TransitionStatus.Entered &&
         styles['PopoverOverlay-open'],
       transitionStatus === TransitionStatus.Exiting &&

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -154,6 +154,26 @@ describe('<PopoverOverlay />', () => {
     listenerMap.keyup({keyCode: Key.Escape});
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('starts animating in immediately', () => {
+    const popoverOverlay = mountWithAppProvider(
+      <PopoverOverlay
+        active={false}
+        id="PopoverOverlay-1"
+        activator={activator}
+        onClose={noop}
+        fullWidth
+      >
+        {children}
+      </PopoverOverlay>,
+    );
+
+    popoverOverlay.setProps({active: true});
+    popoverOverlay.update();
+    expect(popoverOverlay.find(PositionedOverlay).prop('classNames')).toMatch(
+      /PopoverOverlay-entering/,
+    );
+  });
 });
 
 function noop() {}


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/Shopify/polaris-react/commit/c6d321bcf899c039f7a4078cde2d60649b38d723 created a 200ms visual delay before starting the animation.

#### Before
<img width="1366" alt="Screen Shot 2019-09-27 at 3 04 48 PM" src="https://user-images.githubusercontent.com/344839/65807262-5fa12c00-e142-11e9-91a9-393be0a761c0.png">

#### After
<img width="1161" alt="Screen Shot 2019-09-27 at 3 08 04 PM" src="https://user-images.githubusercontent.com/344839/65807264-6039c280-e142-11e9-9795-1ad0dc693a2b.png">

### WHAT is this pull request doing?

Adds an `entering` class which is added immediately and starts animating the opacity. Also clears the timeouts when the component updates in case subsequent updates are triggered in < 200ms.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
