### PR TITLE
Button.scss: replace rem(-8px) with negative spacing(tight)

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -131,7 +131,7 @@ $spinner-size: rem(20px);
 
 .plain {
   @include recolor-icon(color('blue'));
-  margin: (-1 * $vertical-padding) rem(-8px);
+  margin: (-1 * $vertical-padding) (-1 * spacing(tight));
   padding-left: spacing(tight);
   padding-right: spacing(tight);
   background: transparent;


### PR DESCRIPTION
Hi, I think [this commit](https://github.com/Shopify/polaris-react/commit/0bcc667eff97ac876c9357a220d4f3cc3f37909c#diff-0e3048f5198ef82f45d63fb7f3707384) forgot to replace that rem(-8px) with a negative spacing(tight).
