### PR TITLE
Assign the result of useI18n consistently

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -44,7 +44,7 @@ export function Badge({
   progress,
   size = DEFAULT_SIZE,
 }: BadgeProps) {
-  const intl = useI18n();
+  const i18n = useI18n();
 
   const className = classNames(
     styles.Badge,
@@ -56,17 +56,17 @@ export function Badge({
   let progressMarkup;
   switch (progress) {
     case PROGRESS_LABELS.incomplete:
-      progressMarkup = intl.translate(
+      progressMarkup = i18n.translate(
         'Polaris.Badge.PROGRESS_LABELS.incomplete',
       );
       break;
     case PROGRESS_LABELS.partiallyComplete:
-      progressMarkup = intl.translate(
+      progressMarkup = i18n.translate(
         'Polaris.Badge.PROGRESS_LABELS.partiallyComplete',
       );
       break;
     case PROGRESS_LABELS.complete:
-      progressMarkup = intl.translate('Polaris.Badge.PROGRESS_LABELS.complete');
+      progressMarkup = i18n.translate('Polaris.Badge.PROGRESS_LABELS.complete');
       break;
   }
 
@@ -79,19 +79,19 @@ export function Badge({
   let statusMarkup;
   switch (status) {
     case STATUS_LABELS.info:
-      statusMarkup = intl.translate('Polaris.Badge.STATUS_LABELS.info');
+      statusMarkup = i18n.translate('Polaris.Badge.STATUS_LABELS.info');
       break;
     case STATUS_LABELS.success:
-      statusMarkup = intl.translate('Polaris.Badge.STATUS_LABELS.success');
+      statusMarkup = i18n.translate('Polaris.Badge.STATUS_LABELS.success');
       break;
     case STATUS_LABELS.warning:
-      statusMarkup = intl.translate('Polaris.Badge.STATUS_LABELS.warning');
+      statusMarkup = i18n.translate('Polaris.Badge.STATUS_LABELS.warning');
       break;
     case STATUS_LABELS.attention:
-      statusMarkup = intl.translate('Polaris.Badge.STATUS_LABELS.attention');
+      statusMarkup = i18n.translate('Polaris.Badge.STATUS_LABELS.attention');
       break;
     case STATUS_LABELS.new:
-      statusMarkup = intl.translate('Polaris.Badge.STATUS_LABELS.new');
+      statusMarkup = i18n.translate('Polaris.Badge.STATUS_LABELS.new');
       break;
   }
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -109,7 +109,7 @@ export function Button({
   textAlign,
   fullWidth,
 }: ButtonProps) {
-  const intl = useI18n();
+  const i18n = useI18n();
 
   const isDisabled = disabled || loading;
 
@@ -156,7 +156,7 @@ export function Button({
       <Spinner
         size="small"
         color={spinnerColor}
-        accessibilityLabel={intl.translate(
+        accessibilityLabel={i18n.translate(
           'Polaris.Button.spinnerAccessibilityLabel',
         )}
       />

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -38,7 +38,7 @@ export function Cell({
   defaultSortDirection = 'ascending',
   onSort,
 }: CellProps) {
-  const {translate} = useI18n();
+  const i18n = useI18n();
   const numeric = contentType === 'numeric';
   const className = classNames(
     styles.Cell,
@@ -63,7 +63,7 @@ export function Cell({
   const oppositeDirection =
     sortDirection === 'ascending' ? 'descending' : 'ascending';
 
-  const sortAccessibilityLabel = translate(
+  const sortAccessibilityLabel = i18n.translate(
     'Polaris.DataTable.sortAccessibilityLabel',
     {direction: sorted ? oppositeDirection : direction},
   );

--- a/src/components/DataTable/components/Navigation/Navigation.tsx
+++ b/src/components/DataTable/components/Navigation/Navigation.tsx
@@ -24,7 +24,7 @@ export function Navigation({
   navigateTableLeft,
   navigateTableRight,
 }: NavigationProps) {
-  const {translate} = useI18n();
+  const i18n = useI18n();
 
   const pipMarkup = columnVisibilityData.map((column, index) => {
     const className = classNames(
@@ -35,13 +35,15 @@ export function Navigation({
     return <div className={className} key={`pip-${index}`} />;
   });
 
-  const leftA11yLabel = translate('Polaris.DataTable.navAccessibilityLabel', {
-    direction: 'left',
-  });
+  const leftA11yLabel = i18n.translate(
+    'Polaris.DataTable.navAccessibilityLabel',
+    {direction: 'left'},
+  );
 
-  const rightA11yLabel = translate('Polaris.DataTable.navAccessibilityLabel', {
-    direction: 'right',
-  });
+  const rightA11yLabel = i18n.translate(
+    'Polaris.DataTable.navAccessibilityLabel',
+    {direction: 'right'},
+  );
 
   return (
     <div className={styles.Navigation}>

--- a/src/components/DatePicker/components/Month/Month.tsx
+++ b/src/components/DatePicker/components/Month/Month.tsx
@@ -60,7 +60,7 @@ export function Month({
   year,
   weekStartsOn,
 }: MonthProps) {
-  const intl = useI18n();
+  const i18n = useI18n();
 
   const isInHoveringRange = allowRange ? hoveringDateIsInRange : () => false;
   const now = new Date();
@@ -73,7 +73,7 @@ export function Month({
   const weekdays = getWeekdaysOrdered(weekStartsOn).map((weekday) => (
     <Weekday
       key={weekday}
-      title={intl.translate(
+      title={i18n.translate(
         `Polaris.DatePicker.daysAbbreviated.${weekdayName(weekday)}`,
       )}
       current={current && new Date().getDay() === weekday}
@@ -126,7 +126,7 @@ export function Month({
   return (
     <div role="grid" className={styles.Month}>
       <div className={className}>
-        {intl.translate(`Polaris.DatePicker.months.${monthName(month)}`)} {year}
+        {i18n.translate(`Polaris.DatePicker.months.${monthName(month)}`)} {year}
       </div>
       <div role="rowheader" className={styles.WeekHeadings}>
         {weekdays}

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -21,12 +21,16 @@ export interface FileUploadProps {
 }
 
 export function FileUpload(props: FileUploadProps) {
-  const {translate} = useI18n();
+  const i18n = useI18n();
   const {size, type, focused, disabled} = useContext(DropZoneContext);
   const suffix = capitalize(type);
   const {
-    actionTitle = translate(`Polaris.DropZone.FileUpload.actionTitle${suffix}`),
-    actionHint = translate(`Polaris.DropZone.FileUpload.actionHint${suffix}`),
+    actionTitle = i18n.translate(
+      `Polaris.DropZone.FileUpload.actionTitle${suffix}`,
+    ),
+    actionHint = i18n.translate(
+      `Polaris.DropZone.FileUpload.actionHint${suffix}`,
+    ),
   } = props;
 
   const imageClasses = classNames(

--- a/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/DiscardConfirmationModal.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/DiscardConfirmationModal.tsx
@@ -14,15 +14,15 @@ export function DiscardConfirmationModal({
   onDiscard,
   onCancel,
 }: DiscardConfirmationModalProps) {
-  const intl = useI18n();
+  const i18n = useI18n();
 
   return (
     <Modal
-      title={intl.translate('Polaris.DiscardConfirmationModal.title')}
+      title={i18n.translate('Polaris.DiscardConfirmationModal.title')}
       open={open}
       onClose={onCancel}
       primaryAction={{
-        content: intl.translate(
+        content: i18n.translate(
           'Polaris.DiscardConfirmationModal.primaryAction',
         ),
         destructive: true,
@@ -30,7 +30,7 @@ export function DiscardConfirmationModal({
       }}
       secondaryActions={[
         {
-          content: intl.translate(
+          content: i18n.translate(
             'Polaris.DiscardConfirmationModal.secondaryAction',
           ),
           onAction: onCancel,
@@ -38,7 +38,7 @@ export function DiscardConfirmationModal({
       ]}
       sectioned
     >
-      {intl.translate('Polaris.DiscardConfirmationModal.message')}
+      {i18n.translate('Polaris.DiscardConfirmationModal.message')}
     </Modal>
   );
 }

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -20,12 +20,12 @@ const COLORS_WITH_BACKDROPS = [
 interface Props extends IconProps {}
 
 export function Icon({source, color, backdrop, accessibilityLabel}: Props) {
-  const intl = useI18n();
+  const i18n = useI18n();
 
   if (color && backdrop && COLORS_WITH_BACKDROPS.indexOf(color) < 0) {
     // eslint-disable-next-line no-console
     console.warn(
-      intl.translate('Polaris.Icon.backdropWarning', {
+      i18n.translate('Polaris.Icon.backdropWarning', {
         color,
         colorsWithBackDrops: COLORS_WITH_BACKDROPS.join(', '),
       }),

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -32,11 +32,11 @@ export function Link({
   id,
   monochrome,
 }: LinkProps) {
-  const intl = useI18n();
+  const i18n = useI18n();
   let childrenMarkup = children;
 
   if (external && typeof children === 'string') {
-    const iconLabel = intl.translate(
+    const iconLabel = i18n.translate(
       'Polaris.Common.newWindowAccessibilityHint',
     );
 

--- a/src/components/Modal/components/CloseButton/CloseButton.tsx
+++ b/src/components/Modal/components/CloseButton/CloseButton.tsx
@@ -13,7 +13,7 @@ export interface CloseButtonProps {
 }
 
 export function CloseButton({title = true, onClick}: CloseButtonProps) {
-  const intl = useI18n();
+  const i18n = useI18n();
 
   const className = classNames(
     styles.CloseButton,
@@ -24,7 +24,7 @@ export function CloseButton({title = true, onClick}: CloseButtonProps) {
     <button
       onClick={onClick}
       className={className}
-      aria-label={intl.translate('Polaris.Common.close')}
+      aria-label={i18n.translate('Polaris.Common.close')}
     >
       <Icon source={MobileCancelMajorMonotone} color="inkLighter" />
     </button>

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -83,7 +83,7 @@ export function Item({
   matchPaths,
   excludePaths,
 }: ItemProps) {
-  const intl = useI18n();
+  const i18n = useI18n();
   const {isNavigationCollapsed} = useMediaQuery();
   const {location, onNavigationDismiss} = useContext(NavigationContext);
   const [expanded, setExpanded] = useState(false);
@@ -116,7 +116,7 @@ export function Item({
   if (isNew) {
     badgeMarkup = (
       <Badge status="new" size="small">
-        {intl.translate('Polaris.Badge.STATUS_LABELS.new')}
+        {i18n.translate('Polaris.Badge.STATUS_LABELS.new')}
       </Badge>
     );
   } else if (typeof badge === 'string') {

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -60,12 +60,12 @@ export function Pagination({
   accessibilityLabel,
   label,
 }: PaginationProps) {
-  const intl = useI18n();
+  const i18n = useI18n();
 
   const node: React.RefObject<HTMLElement> = React.createRef();
 
   const navLabel =
-    accessibilityLabel || intl.translate('Polaris.Pagination.pagination');
+    accessibilityLabel || i18n.translate('Polaris.Pagination.pagination');
 
   const className = classNames(styles.Pagination, plain && styles.plain);
 
@@ -81,7 +81,7 @@ export function Pagination({
       className={previousClassName}
       url={previousURL}
       onMouseUp={handleMouseUpByBlurring}
-      aria-label={intl.translate('Polaris.Pagination.previous')}
+      aria-label={i18n.translate('Polaris.Pagination.previous')}
       id="previousURL"
     >
       <Icon source={ArrowLeftMinor} />
@@ -92,7 +92,7 @@ export function Pagination({
       type="button"
       onMouseUp={handleMouseUpByBlurring}
       className={previousClassName}
-      aria-label={intl.translate('Polaris.Pagination.previous')}
+      aria-label={i18n.translate('Polaris.Pagination.previous')}
       disabled={!hasPrevious}
     >
       <Icon source={ArrowLeftMinor} />
@@ -104,7 +104,7 @@ export function Pagination({
       className={nextClassName}
       url={nextURL}
       onMouseUp={handleMouseUpByBlurring}
-      aria-label={intl.translate('Polaris.Pagination.next')}
+      aria-label={i18n.translate('Polaris.Pagination.next')}
       id="nextURL"
     >
       <Icon source={ArrowRightMinor} />
@@ -115,7 +115,7 @@ export function Pagination({
       type="button"
       onMouseUp={handleMouseUpByBlurring}
       className={nextClassName}
-      aria-label={intl.translate('Polaris.Pagination.next')}
+      aria-label={i18n.translate('Polaris.Pagination.next')}
       disabled={!hasNext}
     >
       <Icon source={ArrowRightMinor} />

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -19,14 +19,14 @@ export interface ProgressBarProps {
 }
 
 export function ProgressBar({progress = 0, size = 'medium'}: ProgressBarProps) {
-  const intl = useI18n();
+  const i18n = useI18n();
 
   const className = classNames(
     styles.ProgressBar,
     size && styles[variationName('size', size)],
   );
 
-  const warningMessage = intl.translate(
+  const warningMessage = i18n.translate(
     progress < 0
       ? 'Polaris.ProgressBar.negativeWarningMessage'
       : 'Polaris.ProgressBar.exceedWarningMessage',

--- a/src/components/ResourceList/components/FilterControl/FilterControl.tsx
+++ b/src/components/ResourceList/components/FilterControl/FilterControl.tsx
@@ -42,12 +42,12 @@ export function FilterControl({
     'Deprecation: <FilterControl /> is deprecated. Use <Filters /> instead.',
   );
 
-  const intl = useI18n();
+  const i18n = useI18n();
   const {selectMode, resourceName} = React.useContext(ResourceListContext);
 
   const filterResourceName = resourceName || {
-    singular: intl.translate('Polaris.ResourceList.defaultItemSingular'),
-    plural: intl.translate('Polaris.ResourceList.defaultItemPlural'),
+    singular: i18n.translate('Polaris.ResourceList.defaultItemSingular'),
+    plural: i18n.translate('Polaris.ResourceList.defaultItemPlural'),
   };
 
   const handleAddFilter = React.useCallback(
@@ -106,7 +106,7 @@ export function FilterControl({
 
   const textFieldLabel = placeholder
     ? placeholder
-    : intl.translate('Polaris.ResourceList.FilterControl.textFieldLabel', {
+    : i18n.translate('Polaris.ResourceList.FilterControl.textFieldLabel', {
         resourceNamePlural: filterResourceName.plural.toLocaleLowerCase(),
       });
 
@@ -223,13 +223,13 @@ export function FilterControl({
       if (filter.key === appliedFilter.key) {
         const filterLabelKey = `Polaris.ResourceList.DateSelector.FilterLabelForValue.${appliedFilter.value}`;
 
-        return intl.translationKeyExists(filterLabelKey)
-          ? intl.translate(filterLabelKey)
+        return i18n.translationKeyExists(filterLabelKey)
+          ? i18n.translate(filterLabelKey)
           : appliedFilter.value;
       }
 
       if (appliedFilter.key === filter.maxKey) {
-        return intl.translate(
+        return i18n.translate(
           'Polaris.ResourceList.DateSelector.FilterLabelForValue.on_or_before',
           {
             date: formatDateForLabelDisplay(appliedFilter.value),
@@ -238,7 +238,7 @@ export function FilterControl({
       }
 
       if (appliedFilter.key === filter.minKey) {
-        return intl.translate(
+        return i18n.translate(
           'Polaris.ResourceList.DateSelector.FilterLabelForValue.on_or_after',
           {
             date: formatDateForLabelDisplay(appliedFilter.value),

--- a/src/components/ResourceList/components/FilterControl/components/FilterCreator/FilterCreator.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterCreator/FilterCreator.tsx
@@ -37,7 +37,7 @@ export function FilterCreator({
   const [selectedFilterValue, setSelectedFilterValue] = useState<
     AppliedFilter['value']
   >();
-  const {translate} = useI18n();
+  const i18n = useI18n();
   const node = useRef<HTMLButtonElement>(null);
 
   const canAddFilter = Boolean(
@@ -124,7 +124,7 @@ export function FilterCreator({
       disabled={disabled}
       onFocus={handleButtonFocus}
     >
-      {translate('Polaris.ResourceList.FilterCreator.filterButtonLabel')}
+      {i18n.translate('Polaris.ResourceList.FilterCreator.filterButtonLabel')}
     </Button>
   );
 
@@ -149,7 +149,9 @@ export function FilterCreator({
       disabled={!canAddFilter}
       testID="FilterCreator-AddFilterButton"
     >
-      {translate('Polaris.ResourceList.FilterCreator.addFilterButtonLabel')}
+      {i18n.translate(
+        'Polaris.ResourceList.FilterCreator.addFilterButtonLabel',
+      )}
     </Button>
   ) : null;
 
@@ -164,11 +166,11 @@ export function FilterCreator({
       <Form onSubmit={handleAddFilter}>
         <FormLayout>
           <Select
-            label={translate(
+            label={i18n.translate(
               'Polaris.ResourceList.FilterCreator.showAllWhere',
               {resourceNamePlural: resourceName.plural.toLocaleLowerCase()},
             )}
-            placeholder={translate(
+            placeholder={i18n.translate(
               'Polaris.ResourceList.FilterCreator.selectFilterKeyPlaceholder',
             )}
             options={filterOptions}

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -31,13 +31,13 @@ export function Spinner({
   color = 'teal',
   accessibilityLabel,
 }: SpinnerProps) {
-  const intl = useI18n();
+  const i18n = useI18n();
 
   if (size === 'large' && COLORS_FOR_LARGE_SPINNER.indexOf(color) < 0) {
     if (process.env.NODE_ENV === 'development') {
       // eslint-disable-next-line no-console
       console.warn(
-        intl.translate('Polaris.Spinner.warningMessage', {
+        i18n.translate('Polaris.Spinner.warningMessage', {
           color,
           size,
           colors: COLORS_FOR_LARGE_SPINNER.join(', '),

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -16,9 +16,9 @@ export interface TagProps {
 }
 
 export function Tag({children, disabled = false, onRemove}: TagProps) {
-  const intl = useI18n();
+  const i18n = useI18n();
   const className = classNames(disabled && styles.disabled, styles.Tag);
-  const ariaLabel = intl.translate('Polaris.Tag.ariaLabel', {children});
+  const ariaLabel = i18n.translate('Polaris.Tag.ariaLabel', {children});
 
   return (
     <span className={className}>

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -160,7 +160,7 @@ export function TextField({
   onFocus,
   onBlur,
 }: TextFieldProps) {
-  const intl = useI18n();
+  const i18n = useI18n();
   const [height, setHeight] = useState<number | null>(null);
   const [focus, setFocus] = useState(Boolean(focused));
   const [isMounted, setIsMounted] = useState(false);
@@ -209,7 +209,7 @@ export function TextField({
   ) : null;
 
   const characterCount = normalizedValue.length;
-  const characterCountLabel = intl.translate(
+  const characterCountLabel = i18n.translate(
     maxLength
       ? 'Polaris.TextField.characterCountWithMaxLength'
       : 'Polaris.TextField.characterCount',
@@ -247,7 +247,7 @@ export function TextField({
         disabled={disabled}
       >
         <VisuallyHidden>
-          {intl.translate('Polaris.Common.clear')}
+          {i18n.translate('Polaris.Common.clear')}
         </VisuallyHidden>
         <Icon source={CircleCancelMinor} color="inkLightest" />
       </button>


### PR DESCRIPTION
### WHY are these changes introduced?

Consistency in naming things

We use the following interchangably:
- `const i18n = useI18n();`
- `const intl = useI18n();`
- `const {translate} = useI18n();`

### WHAT is this pull request doing?

The commit standardizes us to always use `const i18n = useI18n();`

### How to 🎩

confirm tests and type-check pass