### PR TITLE
[RangeSlider] Fix example spacing; specify dual range slider example as web only

### DIFF
--- a/src/components/RangeSlider/README.md
+++ b/src/components/RangeSlider/README.md
@@ -116,7 +116,7 @@ Error messages should:
 
 ### Default range slider
 
-Use range sliders where merchants may need to select a percentage between `0 — 100`.
+Use when a single value between `0 and 100` needs to be selected.
 
 ```jsx
 function RangeSliderExample() {
@@ -128,7 +128,7 @@ function RangeSliderExample() {
   );
 
   return (
-    <Card sectioned>
+    <Card sectioned title="Background color">
       <RangeSlider
         label="Opacity percentage"
         value={rangeValue}
@@ -152,15 +152,15 @@ function RangeSliderExample() {
 
 <!-- /content-for -->
 
-### More precise range control
+### Min and max range control
 
 <!-- example-for: web -->
 
-For a more precise value, you can define a `min` and `max` range, as well as the amount with which the slider will be incremented.
+Use when a single value needs to be selected from a number range with a specific minimum and maximum.
 
 ```jsx
 function RangeSliderWithPreciseRangeControlExample() {
-  const [rangeValue, setRangeValue] = useState(5);
+  const [rangeValue, setRangeValue] = useState(0);
 
   const handleRangeSliderChange = useCallback(
     (value) => setRangeValue(value),
@@ -168,12 +168,43 @@ function RangeSliderWithPreciseRangeControlExample() {
   );
 
   return (
-    <Card sectioned>
+    <Card sectioned title="Navigation branding">
       <RangeSlider
+        output
         label="Logo offset"
-        min={-10}
-        max={10}
-        step={5}
+        min={-20}
+        max={20}
+        value={rangeValue}
+        onChange={handleRangeSliderChange}
+      />
+    </Card>
+  );
+}
+```
+
+### Step incremented range control
+
+<!-- example-for: web -->
+
+Use when a single value of a specific increment needs to be selected from a range of numbers.
+
+```jsx
+function RangeSliderWithPreciseRangeControlExample() {
+  const [rangeValue, setRangeValue] = useState(4);
+
+  const handleRangeSliderChange = useCallback(
+    (value) => setRangeValue(value),
+    [],
+  );
+
+  return (
+    <Card sectioned title="Navigation branding">
+      <RangeSlider
+        output
+        label="Logo offset"
+        min={-20}
+        max={20}
+        step={4}
         value={rangeValue}
         onChange={handleRangeSliderChange}
       />
@@ -186,7 +217,9 @@ function RangeSliderWithPreciseRangeControlExample() {
 
 <!-- example-for: web -->
 
-Because a range slider can also output a `label` and `helpText`, the height of the overall component can vary. `prefix` and `suffix` props allow you to pass in a React element to be placed before or after the rendered `input`, allowing for perfect vertical alignment and easier stylistic control.
+Use when the start or end of the range input benefits from additional content.
+
+The height of the range slider component varies based on the presence or absense of props like `label` and `helpText`. Setting a React element on the `prefix` and `suffix` props is supported to enable control of spacing and alignment.
 
 ```jsx
 function RangeSliderWithPrefixAndSuffixExample() {
@@ -203,8 +236,9 @@ function RangeSliderWithPrefixAndSuffixExample() {
   };
 
   return (
-    <Card sectioned>
+    <Card sectioned title="Text color">
       <RangeSlider
+        output
         label="Hue color mix"
         min={0}
         max={360}
@@ -220,7 +254,9 @@ function RangeSliderWithPrefixAndSuffixExample() {
 
 ### Dual thumb range slider
 
-Use a dual thumb range slider when merchants need to select a range of values.
+<!-- example-for: web -->
+
+Use when two values need to be selected from a range of numbers.
 
 ```jsx
 function DualThumbRangeSliderExample() {
@@ -286,19 +322,20 @@ function DualThumbRangeSliderExample() {
     intermediateTextFieldValue[0] === rangeValue[0]
       ? rangeValue[0]
       : intermediateTextFieldValue[0];
+
   const upperTextFieldValue =
     intermediateTextFieldValue[1] === rangeValue[1]
       ? rangeValue[1]
       : intermediateTextFieldValue[1];
 
   return (
-    <Card sectioned>
-      <div style={{marginTop: '20px'}} onKeyDown={handleEnterKeyPress}>
+    <Card sectioned title="Minimum requirements">
+      <div onKeyDown={handleEnterKeyPress}>
         <RangeSlider
+          output
           label="Money spent is between"
           value={rangeValue}
           prefix={prefix}
-          output
           min={min}
           max={max}
           step={step}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2221 

`RangeSlider` has animated tooltips for the current `value` when `output` is `true`. The tooltips in the dual range slider example get cut off unless they have enough space within the `Card` since `Card` hides `overflow` content. Right now this is accomplished by adding `margin-top` to the event listening `div` that wraps the input, but this looks strange.

### WHAT is this pull request doing?

- [X] Updates the `Card` wrapping each example to have a `title` so that the `output` tooltips have enough space when present. 
- [X] Updates the example content to align with our guidelines.
- [X] Fixes the dual range slider example content being visible in the iOS and Android tabs of the component page in the style guide.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Play with each of the `RangeSlider` examples in the [Chroma deployment](https://www.chromaui.com/component?appId=5d559397bae39100201eedc1&name=All%20Components%7CRange%20slider&buildNumber=1079) to ensure that the spacing is consistent, card contents do not overflow, and example descriptions make sense.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
