### PR TITLE
Fixing fullWidth section on Card

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed 200ms visual delay when activating `Popover` ([#2209](https://github.com/Shopify/polaris-react/pull/2209))
 - Fixed `ResourceList` `Item` deselect ([#1952](https://github.com/Shopify/polaris-react/pull/1952))
 - Fixed `Subheading`’s `font-weight` ([#2218](https://github.com/Shopify/polaris-react/pull/2218))
+- Fixed `fullWidth` `CardSection`s when contained in a page with a `Nav` ([#2227](https://github.com/Shopify/polaris-react/pull/2227))
 
 ### Documentation
 

--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -43,7 +43,11 @@
 }
 
 .Section-fullWidth {
-  padding: spacing(loose) spacing(none);
+  padding: spacing() spacing(none);
+
+  @include page-content-when-not-fully-condensed {
+    padding: spacing(loose) spacing(none);
+  }
 }
 
 .Section-subdued {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2226

This fixes `fullWidth` `Card.Section`s not appearing full width when a Nav is present.

### WHAT is this pull request doing?

This adds a padding override inside the page breakpoint as well as fixing the default padding.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Add a `Card` with a `fullWidth` `Card.Section` to a page that also has a `Frame` and a `Nav`

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)