### PR TITLE
Ensuring tabs collapse in small screens on <iOS 13

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed tabs that don't wrap correctly on small screens in pre-iOS 13 Safari ([#2232](https://github.com/Shopify/polaris-react/pull/2232))
 - Fixed `BulkActions` checkbox losing on selection focus ([#2138](https://github.com/Shopify/polaris-react/pull/2138))
 - Moved rendering of the portal component’s node within the node created by the theme provider component to enable theming through CSS Custom Properties ([#2224](https://github.com/Shopify/polaris-react/pull/2224))
 

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -7,6 +7,7 @@ $focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
 
 .Tabs {
   display: flex;
+  flex-wrap: wrap;
   margin: 0;
   padding: 0;
   border-bottom: border();
@@ -14,6 +15,8 @@ $focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
 }
 
 .fitted {
+  flex-wrap: nowrap;
+
   .TabContainer {
     flex: 1 1 100%;
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes: https://github.com/Shopify/polaris-react/issues/1677
Fixes: https://github.com/Shopify/online-store-web/issues/4667

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Causes `<Tabs />` component to collapse correctly on small screens in pre-iOS 13 versions of Safari. The screenshots go back to iOS 11 but it fixes the issue all the way back to iOS 9. (The tabs don't render properly in iOS 8.)

| Before        | After           |
| ------------- |:-------------:|
|<img width="745" alt="Screen Shot 2019-10-03 at 1 55 28 PM" src="https://user-images.githubusercontent.com/70582/66152132-d0cf5c00-e5e6-11e9-9e34-72680b76121b.png">|<img width="750" alt="Screen Shot 2019-10-03 at 1 55 47 PM" src="https://user-images.githubusercontent.com/70582/66152133-d0cf5c00-e5e6-11e9-8c14-0bba538a36f0.png">|
|<img width="748" alt="Screen Shot 2019-10-03 at 1 56 30 PM" src="https://user-images.githubusercontent.com/70582/66152134-d167f280-e5e6-11e9-8e25-3c61d9e77b66.png">|<img width="752" alt="Screen Shot 2019-10-03 at 1 56 46 PM" src="https://user-images.githubusercontent.com/70582/66152135-d167f280-e5e6-11e9-99a1-86cf9dac87fc.png">|
|<img width="748" alt="Screen Shot 2019-10-03 at 1 58 28 PM" src="https://user-images.githubusercontent.com/70582/66152136-d167f280-e5e6-11e9-88a4-650ee4a8e15b.png">|<img width="749" alt="Screen Shot 2019-10-03 at 2 06 17 PM" src="https://user-images.githubusercontent.com/70582/66152199-feb4a080-e5e6-11e9-9c39-de9789241598.png">|


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
