### PR TITLE
[i18n] Add new beta and future supported languages

### DIFF
--- a/translation.yml
+++ b/translation.yml
@@ -1,5 +1,28 @@
 source_language: en
-target_languages: [de, es, fr, hi, it, ja, ms, nl, pt-BR, zh-CN, zh-TW]
+target_languages:
+  [
+    cs,
+    da,
+    de,
+    es,
+    fi,
+    fr,
+    hi,
+    it,
+    ja,
+    ko,
+    ms,
+    nb,
+    nl,
+    pl,
+    pt-BR,
+    pt-PT,
+    sv,
+    th,
+    tr,
+    zh-CN,
+    zh-TW,
+  ]
 components:
   - name: 'default'
     scheme: react


### PR DESCRIPTION
### WHY are these changes introduced?

Since the initial support of internationalization at Shopify, seven more languages have since been added to the beta: `da` (Danish), `ko` (Korean),`nb` (Norwegian), `pt-PT` (Portuguese), `th` (Thai), `tr` (Turkish), and `sv` (Swedish). There are also two additional languages Shopify will be supporting in the future: `cs` (Czech) and `pl` (Polish). 

(Shout out to @beefchimi and @tleunen for bringing this to our attention!)

### WHAT is this pull request doing?

Updating our `translation.yml` with the latest list of supported languages so that the translation platform keeps our locales in sync with what the product supports.

