### PR TITLE
[package.json] Point homepage field to polaris.shopify.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify <dev@shopify.com>",
-  "homepage": "https://github.com/Shopify/polaris-react#readme",
+  "homepage": "https://polaris.shopify.com/components",
   "repository": "https://github.com/Shopify/polaris-react",
   "bugs": {
     "url": "https://github.com/Shopify/polaris-react/issues"


### PR DESCRIPTION
Makes better use of the "Homepage" link on npm, because as seen in the screenshot below, https://www.npmjs.com/package/@shopify/polaris links to the GitHub repository twice.

<img width="1200" alt="Screen_Shot_2019-10-03_at_2_48_59_PM" src="https://user-images.githubusercontent.com/85783/66166821-3292c480-e5ed-11e9-99ee-10f11a8a2d21.png">
