### PR TITLE
[Color system] fix default topbar colors

### DIFF
--- a/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -56,8 +56,8 @@ describe('<ThemeProvider />', () => {
     expect(wrapper.find('div').props().style).toStrictEqual(
       expect.objectContaining({
         '--top-bar-background': '#00848e',
-        '--top-bar-background-lighter': '#f9fafb',
-        '--top-bar-color': '#1d9ba4',
+        '--top-bar-background-lighter': '#1d9ba4',
+        '--top-bar-color': '#f9fafb',
       }),
     );
   });

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -259,7 +259,7 @@ function buildLegacyColors(theme?: ThemeConfig): CustomPropertiesLike {
   const colors =
     theme && theme.colors && theme.colors.topBar
       ? theme.colors.topBar
-      : {background: '#00848e', backgroundLighter: '#f9fafb', color: '#1d9ba4'};
+      : {background: '#00848e', backgroundLighter: '#1d9ba4', color: '#f9fafb'};
 
   const colorKey = 'topBar';
   const colorKeys = Object.keys(colors);


### PR DESCRIPTION
During https://github.com/Shopify/polaris-react/pull/2225, I made a mistake and inverted the default colors for the TopBar. This wasn't caught in VRT since we don't have an example just using the default colors.

|before|after|
|-|-|
|<img width="1083" alt="Screen Shot 2019-10-04 at 10 22 09 AM" src="https://user-images.githubusercontent.com/1403188/66215102-e0a37a80-e690-11e9-88d8-a3bc317d91f3.png">|<img width="1088" alt="Screen Shot 2019-10-04 at 10 22 22 AM" src="https://user-images.githubusercontent.com/1403188/66215122-e6995b80-e690-11e9-923d-a5ff5744330e.png">|