### PR TITLE
[a11y] Add date picker component a11y docs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Added accessibility documentation for the date picker component ([#2242](https://github.com/Shopify/polaris-react/pull/2242))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/DatePicker/README.md
+++ b/src/components/DatePicker/README.md
@@ -86,3 +86,39 @@ function DatePickerExample() {
 ![Date picker on iOS](/public_images/components/DatePicker/ios/default@2x.png)
 
 <!-- /content-for -->
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Some users might find interacting with date pickers to be challenging. When you use the [date picker component](/components/forms/text-field), always give users the option to enter the date using a text field component as well.
+
+If you use the date picker within a [popover component](/components/overlays/popover), then use a button to trigger the popover instead of displaying the popover when the text input gets focus. This gives users more control over their experience.
+
+### Keyboard support
+
+- Press the <kbd>tab</kbd> key to move forward and <kbd>shift</kbd> + <kbd>tab</kbd> to move backward through the previous button, next button, and the calendar
+- When focus is in the calendar, move keyboard focus between the dates using the arrow keys
+- To select a date that has focus, press the <kbd>enter</kbd>/<kbd>return</kbd> key
+
+<!-- /content-for -->

--- a/src/components/DatePicker/README.md
+++ b/src/components/DatePicker/README.md
@@ -111,7 +111,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-Some users might find interacting with date pickers to be challenging. When you use the [date picker component](/components/forms/text-field), always give users the option to enter the date using a text field component as well.
+Some users might find interacting with date pickers to be challenging. When you use the date picker component, always give users the option to enter the date using a text field component as well.
 
 If you use the date picker within a [popover component](/components/overlays/popover), then use a button to trigger the popover instead of displaying the popover when the text input gets focus. This gives users more control over their experience.
 


### PR DESCRIPTION
### WHY are these changes introduced?

Adds accessibility guidance for the date picker component, to appear in `polaris-react` docs and in the style guide.

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the date picker component (web only)
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide` to get the changes that support the accessibility section.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props:
  * https://polaris.myshopify.io/components/actions/account-connection (web only)
  * https://polaris.myshopify.io/components/actions/setting-toggle (web only)

### Screenshots

![Screenshot of the date picker web only accessibility section](https://screenshot.click/04-25-9zhxb-5eduz.jpg)

FYI @dpersing ❤️ 