### PR TITLE
[a11y] Add drop zone component a11y docs and edit description

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Added accessibility documentation for the drop zone component ([#2243](https://github.com/Shopify/polaris-react/pull/2243))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -506,7 +506,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-The drop zone component builds on the native HTML `<input type=”upload”>` element by including a `<button>` as well as a drag and drop area.
+The drop zone component builds on the native HTML `<input type="upload">` element. It includes a  visual`<button>` as well as a drag and drop area that can receive keyboard focus.
 
 ### Keyboard support
 

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -506,7 +506,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-The drop zone component builds on the native HTML `<input type="upload">` element. It includes a  visual`<button>` as well as a drag and drop area that can receive keyboard focus.
+The drop zone component builds on the native HTML `<input type="upload">` element. It includes a visual`<button>` as well as a drag and drop area that can receive keyboard focus.
 
 ### Keyboard support
 

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -16,7 +16,7 @@ keywords:
 
 # Drop zone
 
-The drop zone component lets merchants upload files by dragging and dropping files into an area on a page.
+The drop zone component lets users upload files by dragging and dropping the files into an area on a page, or activating a button.
 
 ---
 
@@ -481,3 +481,38 @@ Use file upload with the drop zone component to let merchants select files for u
 
 - To provide context to upload errors when they occur, use the [banner component](https://polaris.shopify.com/components/feedback-indicators/banner)
 - To provide feedback during file upload, use the [spinner component](https://polaris.shopify.com/components/feedback-indicators/spinner)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+The drop zone component builds on the native HTML `<input type=”upload”>` element by including a `<button>` as well as a drag and drop area.
+
+### Keyboard support
+
+To upload a file with the keyboard, merchants interact with the “Add file” button.
+
+- To give the button keyboard focus, use the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
+- To activate the button, use the <kbd>enter</kbd>/<kbd>return</kbd> or <kbd>space</kbd> keys
+
+<!-- /content-for -->

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -512,7 +512,7 @@ The drop zone component builds on the native HTML `<input type="upload">` elemen
 
 To upload a file with the keyboard, merchants interact with the “Add file” button.
 
-- To give the button keyboard focus, use the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
+- To give the input keyboard focus, use the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
 - To activate the button, use the <kbd>enter</kbd>/<kbd>return</kbd> or <kbd>space</kbd> keys
 
 <!-- /content-for -->

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -513,6 +513,6 @@ The drop zone component builds on the native HTML `<input type="upload">` elemen
 To upload a file with the keyboard, merchants interact with the “Add file” button.
 
 - To give the input keyboard focus, use the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
-- To activate the button, use the <kbd>enter</kbd>/<kbd>return</kbd> or <kbd>space</kbd> keys
+- To activate the input, use the <kbd>enter</kbd>/<kbd>return</kbd> or <kbd>space</kbd> keys
 
 <!-- /content-for -->

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -510,7 +510,7 @@ The drop zone component builds on the native HTML `<input type="upload">` elemen
 
 ### Keyboard support
 
-To upload a file with the keyboard, merchants interact with the “Add file” button.
+To upload a file with the keyboard, merchants can interact with the drag-and-drop region.
 
 - To give the input keyboard focus, use the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
 - To activate the input, use the <kbd>enter</kbd>/<kbd>return</kbd> or <kbd>space</kbd> keys


### PR DESCRIPTION
### WHY are these changes introduced?

- Adds accessibility guidance for the drop zone component, to appear in `polaris-react` docs and in the style guide.
- Edits the drop zone component description

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the drop zone component (web only)
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide` to get the changes that support the accessibility section.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props:
  * https://polaris.myshopify.io/components/actions/account-connection (web only)
  * https://polaris.myshopify.io/components/actions/setting-toggle (web only)

### Screenshots

![Screenshot of the new description for the drop zone component](https://screenshot.click/04-48-dlj7q-7ybsn.jpg)

![Screenshot of the drop zone web only accessibility guidelines](https://screenshot.click/04-48-b4i67-lrzen.jpg)


FYI @dpersing ❤️ 