### PR TITLE
[a11y] Add empty state component a11y docs 

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Added accessibility documentation for the empty state component ([#2244](https://github.com/Shopify/polaris-react/pull/2244))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -204,3 +204,31 @@ Use to provide additional but non-critical context for a new product or feature.
 - To learn more about illustrations for empty states, [read the illustration guidelines](https://polaris.shopify.com/design/illustrations)
 - To create page-level layout, [use the layout component](https://polaris.shopify.com/components/structure/layout)
 - To highlight a Shopify feature, [use the callout card component](https://polaris.shopify.com/components/structure/callout-card)
+
+---
+
+## Accessibility
+
+<!-- content-for: android -->
+
+See Material Design and development documentation about accessibility for Android:
+
+- [Accessible design on Android](https://material.io/design/usability/accessibility.html)
+- [Accessible development on Android](https://developer.android.com/guide/topics/ui/accessibility/)
+
+<!-- /content-for -->
+
+<!-- content-for: ios -->
+
+See Apple’s Human Interface Guidelines and API documentation about accessibility for iOS:
+
+- [Accessible design on iOS](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/accessibility/)
+- [Accessible development on iOS](https://developer.apple.com/accessibility/ios/)
+
+<!-- /content-for -->
+
+<!-- content-for: web -->
+
+Empty state illustrations are implemented as decorative images, so they use an empty `alt` attribute and are skipped by technologies like screen readers.
+
+<!-- /content-for -->


### PR DESCRIPTION
### WHY are these changes introduced?

Adds accessibility guidance for the empty state component, to appear in `polaris-react` docs and in the style guide.

## WHAT is this pull request doing?

* [X] Adds accessibility documentation for the empty state component (web only)
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide` to get the changes that support the accessibility section.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples and props:
  * https://polaris.myshopify.io/components/actions/account-connection (web only)
  * https://polaris.myshopify.io/components/actions/setting-toggle (web only)

### Screenshots

![Screenshot of the empty state web only accessibility section](https://screenshot.click/04-02-52ybf-125g0.jpg)

FYI @dpersing ❤️ 