### PR TITLE
[Breadcrumbs] Pass accessibilityLabel through to rendered components

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `BulkActions` checkbox losing on selection focus ([#2138](https://github.com/Shopify/polaris-react/pull/2138))
 - Moved rendering of the portal component’s node within the node created by the theme provider component to enable theming through CSS Custom Properties ([#2224](https://github.com/Shopify/polaris-react/pull/2224))
 - Fixed bug which caused the `Popover` overlay to remain in the DOM if it was updated during exiting ([#2246](https://github.com/Shopify/polaris-react/pull/2246))
+- Fixed `Breadcrumbs` to use `accessibilityLabel` prop when passed in ([#2254](https://github.com/Shopify/polaris-react/pull/2254))
 
 ### Documentation
 

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -39,6 +39,7 @@ export class Breadcrumbs extends React.PureComponent<BreadcrumbsProps, never> {
           url={breadcrumb.url}
           className={styles.Breadcrumb}
           onMouseUp={handleMouseUpByBlurring}
+          aria-label={breadcrumb.accessibilityLabel}
         >
           {contentMarkup}
         </UnstyledLink>
@@ -49,6 +50,7 @@ export class Breadcrumbs extends React.PureComponent<BreadcrumbsProps, never> {
           onClick={breadcrumb.onAction}
           onMouseUp={handleMouseUpByBlurring}
           type="button"
+          aria-label={breadcrumb.accessibilityLabel}
         >
           {contentMarkup}
         </button>

--- a/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
@@ -20,6 +20,25 @@ describe('<Breadcrumbs />', () => {
 
       expect(breadcrumbs.find('a')).toHaveLength(1);
     });
+
+    it('passes the accessibilityLabel through to <a> tag', () => {
+      const linkBreadcrumbs: LinkAction[] = [
+        {
+          content: 'Products',
+          url: 'https://shopify.com',
+          target: 'REMOTE',
+          accessibilityLabel: 'Go to Products',
+        },
+      ];
+
+      const breadcrumbs = mountWithAppProvider(
+        <Breadcrumbs breadcrumbs={linkBreadcrumbs} />,
+      );
+
+      expect(breadcrumbs.find('a').prop('aria-label')).toStrictEqual(
+        'Go to Products',
+      );
+    });
   });
 
   describe('onAction()', () => {
@@ -36,6 +55,24 @@ describe('<Breadcrumbs />', () => {
       );
 
       expect(breadcrumbs.find('button')).toHaveLength(1);
+    });
+
+    it('passes accessibilityLabel through to <button> tag', () => {
+      const callbackBreadcrumbs: CallbackAction[] = [
+        {
+          content: 'Products',
+          onAction: noop,
+          accessibilityLabel: 'Go to Products',
+        },
+      ];
+
+      const breadcrumbs = mountWithAppProvider(
+        <Breadcrumbs breadcrumbs={callbackBreadcrumbs} />,
+      );
+
+      expect(breadcrumbs.find('button').prop('aria-label')).toStrictEqual(
+        'Go to Products',
+      );
     });
 
     it('triggers the callback function when clicked', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/2251

The `Breadcrumbs` component that is rendered on `Page` accepts the `accessibilityLabel` prop. However when we pass a value in, it doesn't get rendered.

### WHAT is this pull request doing?

This PR is passing the value given in `accessibilityLabel` down to the rendered <a> tag or <button> tag.

![image](https://user-images.githubusercontent.com/9055413/66349291-858ab580-e926-11e9-8c4b-2f4355ee2d20.png)
```tsx
<Page breadcrumbs={[{content: 'Go back', url: '#', accessibilityLabel: 'Go back to some page'}]} title="Playground" />
```

![image](https://user-images.githubusercontent.com/9055413/66349421-def2e480-e926-11e9-9267-bca67e7f7698.png)
```tsx
<Page breadcrumbs={[{content: 'Go back', onAction: () => {}, accessibilityLabel: 'Go back to some page'}]} title="Playground" />
```

## <!-- ℹ️ Delete the following for small / trivial changes -->

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
