### PR TITLE
[WIP] Modify resource list filter padding

### DIFF
--- a/src/components/ResourceList/ResourceList.scss
+++ b/src/components/ResourceList/ResourceList.scss
@@ -17,7 +17,7 @@ $item-wrapper-loading-height: rem(64px);
 
 .FiltersWrapper {
   padding: resource-list(header-padding-small)
-    resource-list(header-padding-small) spacing();
+    resource-list(header-padding-small) spacing(tight);
 
   @include breakpoint-after(resource-list(breakpoint-small)) {
     padding: spacing();

--- a/src/components/ResourceList/_variables.scss
+++ b/src/components/ResourceList/_variables.scss
@@ -1,7 +1,7 @@
 $resource-list-variables: (
   breakpoint-small: 458px,
   header-min-height: rem(56px),
-  header-padding-small: rem(12px),
+  header-padding-small: rem(16px),
   header-vertical-padding: rem(10px),
   button-min-height: control-height(),
   header-content-min-height: control-height(),


### PR DESCRIPTION
Done some initial work to make spacing consistent (16px). It looks like the mobile version needs some massaging (remove the filter and notice the space should be `base` instead of `tight`) 

### WHY are these changes introduced?

Let's make sure this element is consistent with all other mobile spacing. Input may need to be reduced in size to account for save button falling off the right hand side.

### WHAT is this pull request doing?
Changes the padding around the component from 12px to 16px.

**Before**
<img width="395" alt="CleanShot 2019-10-08 at 15 26 09@2x" src="https://user-images.githubusercontent.com/970304/66426508-f93cc900-e9df-11e9-9dab-90023f2ce226.png">
☝️  Notice the padding around the input is 12px, and there's additional space under the grey filter component.

**After**
<img width="343" alt="CleanShot 2019-10-08 at 15 26 59@2x" src="https://user-images.githubusercontent.com/970304/66426556-170a2e00-e9e0-11e9-9a9c-273619f5548b.png">
☝️ Notice the padding around the input is now 16px

**Needs massaging**
<img width="340" alt="CleanShot 2019-10-08 at 15 27 46@2x" src="https://user-images.githubusercontent.com/970304/66426601-343efc80-e9e0-11e9-9646-ce27b525860d.png">
☝️ Now the padding under the input without a filter is too small (should be `base`, while currently it's `tight`).

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
