### PR TITLE
[Stack] Fix min-width issue on Stack.Item

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed issue with `Stack` where a `Stack.Item` was not getting a minimum width ([2273](https://github.com/Shopify/polaris-react/pull/2273))
+
 ### Documentation
 
 - Added accessibility documentation for the drop zone component ([#2243](https://github.com/Shopify/polaris-react/pull/2243))

--- a/src/components/Stack/Stack.scss
+++ b/src/components/Stack/Stack.scss
@@ -105,6 +105,7 @@
 
 .Item {
   flex: 0 1 auto;
+  min-width: 0;
 }
 
 .Item-fill {

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -680,32 +680,34 @@ function SeparateValidationErrorExample() {
     : '';
 
   const formGroupMarkup = (
-    <Stack wrap={false} alignment="leading" spacing="tight">
+    <Stack wrap={false} alignment="leading" spacing="loose">
       <Stack.Item fill>
-        <Stack distribution="fill" spacing="tight">
-          <Select
-            labelHidden
-            label="Collection rule type"
-            options={['Product type']}
-            value={selectTypeValue}
-            onChange={handleSelectTypeChange}
-          />
-          <Select
-            labelHidden
-            label="Collection rule condition"
-            options={['is equal to']}
-            value={selectConditionValue}
-            onChange={handleSelectConditionChange}
-          />
-          <TextField
-            labelHidden
-            label="Collection rule content"
-            error={isInvalid}
-            id={textFieldID}
-            value={textFieldValue}
-            onChange={handleTextFieldValueChange}
-          />
-        </Stack>
+        <FormLayout>
+          <FormLayout.Group condensed>
+            <Select
+              labelHidden
+              label="Collection rule type"
+              options={['Product type']}
+              value={selectTypeValue}
+              onChange={handleSelectTypeChange}
+            />
+            <Select
+              labelHidden
+              label="Collection rule condition"
+              options={['is equal to']}
+              value={selectConditionValue}
+              onChange={handleSelectConditionChange}
+            />
+            <TextField
+              labelHidden
+              label="Collection rule content"
+              error={isInvalid}
+              id={textFieldID}
+              value={textFieldValue}
+              onChange={handleTextFieldValueChange}
+            />
+          </FormLayout.Group>
+        </FormLayout>
         <div style={{marginTop: '4px'}}>
           <InlineError message={errorMessage} fieldID={textFieldID} />
         </div>


### PR DESCRIPTION
### WHY are these changes introduced?

In fixing this issue https://github.com/Shopify/polaris-react/issues/1707 we removed min-width thinking it wasn't needed. Turns out it is. 

fixes: https://github.com/Shopify/polaris-react/issues/2260

### WHAT is this pull request doing?

Simply bringing back the min-width so that the flex-items takes the space it requires.

We do still have an issue where if `textOverflow: 'ellipsis',` is used on the child of the flex item, overflow is a little off. In which case its probably best to write flexbox for this edge case.

This fixed the bigger issue of the column not appearing.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {AppProvider, Page, Layout, Card, Stack} from '../src';

export function Playground() {
  return (
    <Page title="Playground" narrowWidth>
      <Layout sectioned>
        <Card title="Broken 1" sectioned>
          <Stack>
            <div
              style={{
                overflow: 'hidden',
                whiteSpace: 'nowrap',
                textOverflow: 'ellipsis',
              }}
            >
              This should cause hello to wrap and also make sure that my text
              does not overflow my container. The ellipsis is spilling into the
              margin of the card however.
            </div>
            <div>
              <p>This line should wrap</p>
            </div>
          </Stack>
        </Card>
        <Card title="Broken 2" sectioned>
          <Stack alignment="center" wrap={false}>
            <div
              style={{
                overflow: 'hidden',
                whiteSpace: 'nowrap',
                textOverflow: 'ellipsis',
              }}
            >
              This should cause hello to still be visible and my content to be
              overflow hidden when I reach my container width. However, hello is
              hidden entirely and the ellipsis is spilling into the card margin.
            </div>
            <div>
              <p>hello world</p>
            </div>
          </Stack>
        </Card>
      </Layout>
    </Page>
  );
}


```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
