### PR TITLE
Remove unused items from withAppProvider

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -27,6 +27,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Migrated `DateSelector` to use hooks instead of withAppProvider ([#2193](https://github.com/Shopify/polaris-react/pull/2193))
 - Migrated `Toast` to use hooks ([#2222](https://github.com/Shopify/polaris-react/pull/2222))
+- Removed `link`, `theme` and `scrollLockManager` from the object returned by withAppProvider as nothing consumes them any more ([#2277](https://github.com/Shopify/polaris-react/pull/2277))
 
 ### Deprecations
 

--- a/src/utilities/tests/with-app-provider.test.tsx
+++ b/src/utilities/tests/with-app-provider.test.tsx
@@ -17,7 +17,7 @@ describe('withAppProvider', () => {
       consoleSpy.mockRestore();
     };
     expect(fn).toThrow(
-      `No Theme was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.`,
+      `No i18n was provided. Your application must be wrapped in an <AppProvider> component. See https://polaris.shopify.com/components/structure/app-provider for implementation instructions.`,
     );
   });
 });

--- a/src/utilities/with-app-provider.tsx
+++ b/src/utilities/with-app-provider.tsx
@@ -1,19 +1,13 @@
 import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 import {useI18n} from './i18n';
-import {useLink} from './link';
-import {useScrollLockManager} from './scroll-lock-manager';
-import {useTheme} from './theme';
 import {useStickyManager} from './sticky-manager';
 import {useAppBridge} from './app-bridge';
 import {useMediaQuery} from './media-query';
 
 export interface WithAppProviderProps {
   polaris: {
-    link: ReturnType<typeof useLink>;
-    theme: ReturnType<typeof useTheme>;
     intl: ReturnType<typeof useI18n>;
-    scrollLockManager: ReturnType<typeof useScrollLockManager>;
     stickyManager: ReturnType<typeof useStickyManager>;
     appBridge: ReturnType<typeof useAppBridge>;
     mediaQuery: ReturnType<typeof useMediaQuery>;
@@ -26,10 +20,7 @@ export function withAppProvider<OwnProps>() {
   ) {
     const WithAppProvider: React.FunctionComponent<OwnProps> = (props) => {
       const polaris: WithAppProviderProps['polaris'] = {
-        link: useLink(),
-        theme: useTheme(),
         intl: useI18n(),
-        scrollLockManager: useScrollLockManager(),
         stickyManager: useStickyManager(),
         appBridge: useAppBridge(),
         mediaQuery: useMediaQuery(),


### PR DESCRIPTION


### WHY are these changes introduced?

Simplifying withAppProvider, stopping it doing work that is no longer required

### WHAT is this pull request doing?

Removes `link`, `theme` and `scrollLockManager` from the object returned by withAppProvider as nothing consumes them any more

### How to 🎩

 check tests and type check pass.