### PR TITLE
🐛[Sass] Fix recolor-icon mixin

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Doesn't render `MenuActions` if no actions are passed to an `actionGroups` item inside `Page` ([2266](https://github.com/Shopify/polaris-react/pull/2266))### Documentation
+- Fixed `recolor-icon` Sass mixin to properly scope `$secondary-color` to the child `svg` ([#2298](https://github.com/Shopify/polaris-react/pull/2298))
 
 ### Development workflow
 

--- a/src/styles/shared/_icons.scss
+++ b/src/styles/shared/_icons.scss
@@ -5,16 +5,16 @@
 @mixin recolor-icon($fill-color, $secondary-color: null, $filter-color: null) {
   svg {
     fill: $fill-color;
+
+    @if $secondary-color != null {
+      color: $secondary-color;
+    }
   }
 
   @if $filter-color != null {
     img {
       filter: $filter-color;
     }
-  }
-
-  @if $secondary-color != null {
-    color: $secondary-color;
   }
 }
 


### PR DESCRIPTION
This PR safely moves `color: $secondary-color` into the `svg` block alongside `fill: $primary-color`.

Previously, the mixin was expected to be used like so:

```scss
.Component {
  color: blue;
  // more styles for the component
  @include recolor-icon(red, green);
}
```

Within the `recolor-icon` mixin, `fill` was scoped to to the `svg` selector... but `color` was outside of it. This meant that in the above example, my `color: blue` will get overridden with `green`, when really my intention is to have `.Component` use `blue` text, while making the primary color of the icon `red` and the secondary color of the icon `green`.