### PR TITLE
[ResourceList] Fix for the plural resource name when totalItemsCount is greater than 1

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `PositionedOverlay` incorrectly calculating `Topbar.UserMenu` `Popover` width ([#1692](https://github.com/Shopify/polaris-react/pull/1692))
 - Fixed `recolor-icon` Sass mixin to properly scope `$secondary-color` to the child `svg` ([#2298](https://github.com/Shopify/polaris-react/pull/2298))
 - Fixed a regression with the positioning of the `Popover` component ([#2305](https://github.com/Shopify/polaris-react/pull/2305))
+- Fixed an issue with the `ResourceList` component where the plural resource name was not used for `totalItemsCount` ([#2299](https://github.com/Shopify/polaris-react/issues/2299))
 
 ### Documentation
 

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -184,7 +184,8 @@ class ResourceList extends React.Component<CombinedProps, State> {
 
     const itemsCount = items.length;
     const resource =
-      itemsCount === 1 && !loading
+      !loading &&
+      ((!totalItemsCount && itemsCount === 1) || totalItemsCount === 1)
         ? resourceName.singular
         : resourceName.plural;
 

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -244,6 +244,22 @@ describe('<ResourceList />', () => {
         'Showing 2 of 5 products',
       );
     });
+
+    it('prints number of items shown of totalItemsCount plural when totalItemsCount is provided and items is one resource', () => {
+      const resourceList = mountWithAppProvider(
+        <ResourceList
+          items={singleItemNoID}
+          renderItem={renderItem}
+          resourceName={{singular: 'product', plural: 'products'}}
+          showHeader
+          totalItemsCount={5}
+        />,
+      );
+
+      expect(findByTestID(resourceList, 'headerTitleWrapper').text()).toBe(
+        'Showing 1 of 5 products',
+      );
+    });
   });
 
   describe('bulkActionsAccessibilityLabel', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2299 

When the `ResourceList` has only item showing, but a `totalItemsCount` greater than 1, it was using the singular form of the resource name when it should use the plural.

### WHAT is this pull request doing?

Whenever there's a `totalItemsCount` and it's not equal to 1, it will use the plural form of the resource name.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)