### PR TITLE
Revert "move portal node within theme provider node to enable theming"

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Doesn't render `MenuActions` if no actions are passed to an `actionGroups` item inside `Page` ([2266](https://github.com/Shopify/polaris-react/pull/2266))### Documentation
 - Fixed `recolor-icon` Sass mixin to properly scope `$secondary-color` to the child `svg` ([#2298](https://github.com/Shopify/polaris-react/pull/2298))
+- Fixed a regression with the positioning of the `Popover` component ([#2305](https://github.com/Shopify/polaris-react/pull/2305))
 
 ### Development workflow
 

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {createPortal} from 'react-dom';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
-import {themeProvider} from '../shared';
 
 export interface PortalProps {
   children?: React.ReactNode;
@@ -21,7 +20,6 @@ export class Portal extends React.PureComponent<PortalProps, State> {
   state: State = {isMounted: false};
 
   private portalNode: HTMLElement;
-  private portalContainerNode: HTMLElement | null;
 
   private portalId =
     this.props.idPrefix !== ''
@@ -31,13 +29,7 @@ export class Portal extends React.PureComponent<PortalProps, State> {
   componentDidMount() {
     this.portalNode = document.createElement('div');
     this.portalNode.setAttribute('data-portal-id', this.portalId);
-    this.portalContainerNode = document.querySelector(
-      `${themeProvider.selector}`,
-    );
-    if (this.portalContainerNode != null) {
-      this.portalContainerNode.appendChild(this.portalNode);
-    }
-
+    document.body.appendChild(this.portalNode);
     this.setState({isMounted: true});
   }
 
@@ -49,9 +41,7 @@ export class Portal extends React.PureComponent<PortalProps, State> {
   }
 
   componentWillUnmount() {
-    if (this.portalContainerNode != null) {
-      this.portalContainerNode.removeChild(this.portalNode);
-    }
+    document.body.removeChild(this.portalNode);
   }
 
   render() {

--- a/src/components/Portal/tests/Portal.test.tsx
+++ b/src/components/Portal/tests/Portal.test.tsx
@@ -46,20 +46,15 @@ describe('<Portal />', () => {
   });
 
   describe('DOM node', () => {
-    const appendChildSpy = jest.fn();
-    const removeChildSpy = jest.fn();
-    Object.defineProperty(document, 'querySelector', {
-      value: () => {
-        return {appendChild: appendChildSpy, removeChild: removeChildSpy};
-      },
-    });
     it('gets added to the DOM on mount', () => {
+      const appendChildSpy = jest.spyOn(document.body, 'appendChild');
       mountWithAppProvider(<Portal />);
       expect(appendChildSpy).toHaveBeenCalledWith(expect.any(HTMLDivElement));
       appendChildSpy.mockRestore();
     });
 
     it('gets removed from the DOM when the component unmounts', () => {
+      const removeChildSpy = jest.spyOn(document.body, 'removeChild');
       const portal = mountWithAppProvider(<Portal />);
       portal.unmount();
       expect(removeChildSpy).toHaveBeenCalledWith(expect.any(HTMLDivElement));

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -5,7 +5,6 @@ import {
   buildThemeContext,
   buildCustomProperties,
 } from '../../utilities/theme';
-import {themeProvider} from '../shared';
 import {useFeatures} from '../../utilities/features';
 
 interface ThemeProviderProps {
@@ -38,9 +37,7 @@ export function ThemeProvider({
 
   return (
     <ThemeContext.Provider value={theme}>
-      <div style={customProperties} {...themeProvider.props}>
-        {children}
-      </div>
+      <div style={customProperties}>{children}</div>
     </ThemeContext.Provider>
   );
 }

--- a/src/components/shared.ts
+++ b/src/components/shared.ts
@@ -28,11 +28,6 @@ export const headerCell = {
   selector: '[data-polaris-header-cell]',
 };
 
-export const themeProvider = {
-  props: {'data-polaris-theme-provider': true},
-  selector: '[data-polaris-theme-provider]',
-};
-
 export const DATA_ATTRIBUTE = {
   overlay,
   layer,


### PR DESCRIPTION
This reverts commit d62cff649c1db363efa461b02cf600270394f4e6.

Co-authored-by: Tim Layton <tim.layton@shopify.com>

Closes https://github.com/Shopify/polaris-react/issues/2302