### PR TITLE
[Color system] set theme css custom properties on portal node

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added `pressed` state to `Button` ([#2148](https://github.com/Shopify/polaris-react/pull/2148))
+- Added CSS custom properties to `Portal` container ([#2306](https://github.com/Shopify/polaris-react/pull/2306))
 
 ### Bug fixes
 

--- a/src/components/PolarisTestProvider/PolarisTestProvider.tsx
+++ b/src/components/PolarisTestProvider/PolarisTestProvider.tsx
@@ -5,6 +5,7 @@ import {
   ThemeContext,
   ThemeConfig,
   buildThemeContext,
+  buildCustomProperties,
 } from '../../utilities/theme';
 import {MediaQueryContext} from '../../utilities/media-query';
 import {
@@ -82,7 +83,11 @@ export function PolarisTestProvider({
   // I'm not that worried about it
   const appBridgeApp = appBridge as React.ContextType<typeof AppBridgeContext>;
 
-  const mergedTheme = buildThemeContext(theme);
+  const {unstableGlobalTheming = false} = features;
+  const customProperties = unstableGlobalTheming
+    ? buildCustomProperties(theme, unstableGlobalTheming)
+    : undefined;
+  const mergedTheme = buildThemeContext(theme, customProperties);
 
   const mergedFrame = createFrameContext(frame);
 

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -35,10 +35,10 @@ export class Portal extends React.PureComponent<PortalProps, State> {
 
     if (this.context != null) {
       /* eslint-disable babel/camelcase */
-      const {UNSTABLE_cssCustomProperties} = this.context;
+      const {UNSTABLE_cssCustomProperties = {}} = this.context;
       this.portalNode.setAttribute(
         'style',
-        toString(UNSTABLE_cssCustomProperties || {}),
+        toString(UNSTABLE_cssCustomProperties),
       );
     }
     document.body.appendChild(this.portalNode);
@@ -49,10 +49,10 @@ export class Portal extends React.PureComponent<PortalProps, State> {
     const {onPortalCreated = noop} = this.props;
 
     if (this.context != null) {
-      const {UNSTABLE_cssCustomProperties} = this.context;
+      const {UNSTABLE_cssCustomProperties = {}} = this.context;
       this.portalNode.setAttribute(
         'style',
-        toString(UNSTABLE_cssCustomProperties || {}),
+        toString(UNSTABLE_cssCustomProperties),
         /* eslint-enable babel/camelcase */
       );
     }

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {createPortal} from 'react-dom';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
-import {ThemeContext, CustomPropertiesLike} from '../../utilities/theme';
+import {ThemeContext} from '../../utilities/theme';
 
 export interface PortalProps {
   children?: React.ReactNode;
@@ -35,11 +35,8 @@ export class Portal extends React.PureComponent<PortalProps, State> {
 
     if (this.context != null) {
       /* eslint-disable babel/camelcase */
-      const {UNSTABLE_cssCustomProperties = {}} = this.context;
-      this.portalNode.setAttribute(
-        'style',
-        toString(UNSTABLE_cssCustomProperties),
-      );
+      const {UNSTABLE_cssCustomProperties = ''} = this.context;
+      this.portalNode.setAttribute('style', UNSTABLE_cssCustomProperties);
     }
     document.body.appendChild(this.portalNode);
     this.setState({isMounted: true});
@@ -49,10 +46,10 @@ export class Portal extends React.PureComponent<PortalProps, State> {
     const {onPortalCreated = noop} = this.props;
 
     if (this.context != null) {
-      const {UNSTABLE_cssCustomProperties = {}} = this.context;
+      const {UNSTABLE_cssCustomProperties = ''} = this.context;
       this.portalNode.setAttribute(
         'style',
-        toString(UNSTABLE_cssCustomProperties),
+        UNSTABLE_cssCustomProperties,
         /* eslint-enable babel/camelcase */
       );
     }
@@ -73,9 +70,3 @@ export class Portal extends React.PureComponent<PortalProps, State> {
 }
 
 function noop() {}
-
-function toString(obj: CustomPropertiesLike) {
-  return Object.entries(obj)
-    .map((pair) => pair.join(':'))
-    .join(';');
-}

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {createPortal} from 'react-dom';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
+import {ThemeContext} from '../../utilities/theme';
 
 export interface PortalProps {
   children?: React.ReactNode;
@@ -16,6 +17,7 @@ const getUniqueID = createUniqueIDFactory('portal-');
 
 export class Portal extends React.PureComponent<PortalProps, State> {
   static defaultProps = {idPrefix: ''};
+  static contextType = ThemeContext;
 
   state: State = {isMounted: false};
 
@@ -27,14 +29,26 @@ export class Portal extends React.PureComponent<PortalProps, State> {
       : getUniqueID();
 
   componentDidMount() {
+    // eslint-disable-next-line babel/camelcase
+    const {UNSTABLE_cssCustomProperties} = this.context;
     this.portalNode = document.createElement('div');
     this.portalNode.setAttribute('data-portal-id', this.portalId);
+    this.portalNode.setAttribute(
+      'style',
+      JSON.stringify(UNSTABLE_cssCustomProperties),
+    );
     document.body.appendChild(this.portalNode);
     this.setState({isMounted: true});
   }
 
   componentDidUpdate(_: PortalProps, prevState: State) {
     const {onPortalCreated = noop} = this.props;
+    // eslint-disable-next-line babel/camelcase
+    const {UNSTABLE_cssCustomProperties} = this.context;
+    this.portalNode.setAttribute(
+      'style',
+      JSON.stringify(UNSTABLE_cssCustomProperties),
+    );
     if (!prevState.isMounted && this.state.isMounted) {
       onPortalCreated();
     }

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -35,7 +35,9 @@ export class Portal extends React.PureComponent<PortalProps, State> {
     this.portalNode.setAttribute('data-portal-id', this.portalId);
     this.portalNode.setAttribute(
       'style',
-      JSON.stringify(UNSTABLE_cssCustomProperties),
+      Object.entries(UNSTABLE_cssCustomProperties)
+        .map((pair) => pair.join(':'))
+        .join(';'),
     );
     document.body.appendChild(this.portalNode);
     this.setState({isMounted: true});
@@ -47,7 +49,9 @@ export class Portal extends React.PureComponent<PortalProps, State> {
     const {UNSTABLE_cssCustomProperties} = this.context;
     this.portalNode.setAttribute(
       'style',
-      JSON.stringify(UNSTABLE_cssCustomProperties),
+      Object.entries(UNSTABLE_cssCustomProperties)
+        .map((pair) => pair.join(':'))
+        .join(';'),
     );
     if (!prevState.isMounted && this.state.isMounted) {
       onPortalCreated();

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {createPortal} from 'react-dom';
 import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
-import {ThemeContext} from '../../utilities/theme';
+import {ThemeContext, CustomPropertiesLike} from '../../utilities/theme';
 
 export interface PortalProps {
   children?: React.ReactNode;
@@ -35,9 +35,7 @@ export class Portal extends React.PureComponent<PortalProps, State> {
     this.portalNode.setAttribute('data-portal-id', this.portalId);
     this.portalNode.setAttribute(
       'style',
-      Object.entries(UNSTABLE_cssCustomProperties)
-        .map((pair) => pair.join(':'))
-        .join(';'),
+      toString(UNSTABLE_cssCustomProperties),
     );
     document.body.appendChild(this.portalNode);
     this.setState({isMounted: true});
@@ -49,9 +47,7 @@ export class Portal extends React.PureComponent<PortalProps, State> {
     const {UNSTABLE_cssCustomProperties} = this.context;
     this.portalNode.setAttribute(
       'style',
-      Object.entries(UNSTABLE_cssCustomProperties)
-        .map((pair) => pair.join(':'))
-        .join(';'),
+      toString(UNSTABLE_cssCustomProperties),
     );
     if (!prevState.isMounted && this.state.isMounted) {
       onPortalCreated();
@@ -70,3 +66,9 @@ export class Portal extends React.PureComponent<PortalProps, State> {
 }
 
 function noop() {}
+
+function toString(obj: CustomPropertiesLike) {
+  return Object.entries(obj)
+    .map((pair) => pair.join(':'))
+    .join(';');
+}

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -18,6 +18,7 @@ const getUniqueID = createUniqueIDFactory('portal-');
 export class Portal extends React.PureComponent<PortalProps, State> {
   static defaultProps = {idPrefix: ''};
   static contextType = ThemeContext;
+  context!: React.ContextType<typeof ThemeContext>;
 
   state: State = {isMounted: false};
 
@@ -29,26 +30,32 @@ export class Portal extends React.PureComponent<PortalProps, State> {
       : getUniqueID();
 
   componentDidMount() {
-    // eslint-disable-next-line babel/camelcase
-    const {UNSTABLE_cssCustomProperties} = this.context;
     this.portalNode = document.createElement('div');
     this.portalNode.setAttribute('data-portal-id', this.portalId);
-    this.portalNode.setAttribute(
-      'style',
-      toString(UNSTABLE_cssCustomProperties),
-    );
+
+    if (this.context != null) {
+      /* eslint-disable babel/camelcase */
+      const {UNSTABLE_cssCustomProperties} = this.context;
+      this.portalNode.setAttribute(
+        'style',
+        toString(UNSTABLE_cssCustomProperties || {}),
+      );
+    }
     document.body.appendChild(this.portalNode);
     this.setState({isMounted: true});
   }
 
   componentDidUpdate(_: PortalProps, prevState: State) {
     const {onPortalCreated = noop} = this.props;
-    // eslint-disable-next-line babel/camelcase
-    const {UNSTABLE_cssCustomProperties} = this.context;
-    this.portalNode.setAttribute(
-      'style',
-      toString(UNSTABLE_cssCustomProperties),
-    );
+
+    if (this.context != null) {
+      const {UNSTABLE_cssCustomProperties} = this.context;
+      this.portalNode.setAttribute(
+        'style',
+        toString(UNSTABLE_cssCustomProperties || {}),
+        /* eslint-enable babel/camelcase */
+      );
+    }
     if (!prevState.isMounted && this.state.isMounted) {
       onPortalCreated();
     }

--- a/src/components/Portal/tests/Portal.test.tsx
+++ b/src/components/Portal/tests/Portal.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {mount} from 'enzyme';
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Portal} from '../Portal';
 
@@ -87,5 +88,23 @@ describe('<Portal />', () => {
 
     mountWithAppProvider(<PortalParent />);
     expect(handlePortalCreated).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders okay when theme context is undefined', () => {
+    expect(() => {
+      mount(<Portal />);
+    }).not.toThrow();
+  });
+
+  it('renders okay with new theme context', () => {
+    expect(() => {
+      mountWithAppProvider(<Portal />, {
+        features: {unstableGlobalTheming: true},
+        theme: {
+          // eslint-disable-next-line babel/camelcase
+          UNSTABLE_colors: {surface: '#000000'},
+        },
+      });
+    }).not.toThrow();
   });
 });

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -24,8 +24,12 @@ export function ThemeProvider({
     [unstableGlobalTheming, themeConfig],
   );
   const theme = useMemo(
-    () => buildThemeContext(themeConfig, customProperties),
-    [themeConfig, customProperties],
+    () =>
+      buildThemeContext(
+        themeConfig,
+        unstableGlobalTheming ? customProperties : undefined,
+      ),
+    [customProperties, themeConfig, unstableGlobalTheming],
   );
 
   // We want these values to be `null` instead of `undefined` when not set.

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -19,10 +19,13 @@ export function ThemeProvider({
   children,
 }: ThemeProviderProps) {
   const {unstableGlobalTheming = false} = useFeatures();
-  const theme = useMemo(() => buildThemeContext(themeConfig), [themeConfig]);
   const customProperties = useMemo(
     () => buildCustomProperties(themeConfig, unstableGlobalTheming),
     [unstableGlobalTheming, themeConfig],
+  );
+  const theme = useMemo(
+    () => buildThemeContext(themeConfig, customProperties),
+    [themeConfig, customProperties],
   );
 
   // We want these values to be `null` instead of `undefined` when not set.

--- a/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {ThemeProvider} from '../ThemeProvider';
-import {ThemeContext} from '../../../utilities/theme';
+import {ThemeContext, useTheme} from '../../../utilities/theme';
 
 describe('<ThemeProvider />', () => {
   it('mounts', () => {
@@ -134,5 +134,36 @@ describe('<ThemeProvider />', () => {
         '--p-surface-background': 'hsl(0, 0%, 98%, 1)',
       }),
     );
+  });
+
+  it('sets color system properties in context when global theming is enabled', () => {
+    mountWithAppProvider(
+      <ThemeProvider theme={{}}>
+        <Child />
+      </ThemeProvider>,
+      {features: {unstableGlobalTheming: true}},
+    );
+
+    function Child() {
+      // eslint-disable-next-line babel/camelcase
+      const {UNSTABLE_cssCustomProperties} = useTheme();
+      expect(UNSTABLE_cssCustomProperties).toBeTruthy();
+      return null;
+    }
+  });
+
+  it('does not set color system properties in context by default', () => {
+    mountWithAppProvider(
+      <ThemeProvider theme={{}}>
+        <Child />
+      </ThemeProvider>,
+    );
+
+    function Child() {
+      // eslint-disable-next-line babel/camelcase
+      const {UNSTABLE_cssCustomProperties} = useTheme();
+      expect(UNSTABLE_cssCustomProperties).toBeUndefined();
+      return null;
+    }
   });
 });

--- a/src/utilities/theme/index.ts
+++ b/src/utilities/theme/index.ts
@@ -2,7 +2,7 @@ export {ThemeContext} from './context';
 
 export {useTheme} from './hooks';
 
-export {Theme, ThemeConfig} from './types';
+export {Theme, ThemeConfig, CustomPropertiesLike} from './types';
 
 export {
   buildCustomProperties,

--- a/src/utilities/theme/tests/utils.test.ts
+++ b/src/utilities/theme/tests/utils.test.ts
@@ -716,7 +716,7 @@ describe('buildThemeContext', () => {
   it('reduces theme config down to a theme', () => {
     expect(
       buildThemeContext({colors: {}, logo: {}}, {foo: 'bar'}),
-    ).toStrictEqual({logo: {}, UNSTABLE_cssCustomProperties: {foo: 'bar'}});
+    ).toStrictEqual({logo: {}, UNSTABLE_cssCustomProperties: 'foo:bar'});
   });
 });
 /* eslint-enable babel/camelcase */

--- a/src/utilities/theme/tests/utils.test.ts
+++ b/src/utilities/theme/tests/utils.test.ts
@@ -711,10 +711,12 @@ describe('buildColors', () => {
     });
   });
 });
-/* eslint-enable babel/camelcase */
 
 describe('buildThemeContext', () => {
   it('reduces theme config down to a theme', () => {
-    expect(buildThemeContext({colors: {}, logo: {}})).toStrictEqual({logo: {}});
+    expect(
+      buildThemeContext({colors: {}, logo: {}}, {foo: 'bar'}),
+    ).toStrictEqual({logo: {}, UNSTABLE_cssCustomProperties: {foo: 'bar'}});
   });
 });
+/* eslint-enable babel/camelcase */

--- a/src/utilities/theme/types.ts
+++ b/src/utilities/theme/types.ts
@@ -33,10 +33,12 @@ export interface ThemeConfig {
   };
 }
 
+export type CustomPropertiesLike = Record<string, string>;
+
 // The value that is stored in the ThemeContext
 export interface Theme {
   /** Sets the logo for the top bar and contextual save bar components*/
   logo?: ThemeLogo;
+  // eslint-disable-next-line babel/camelcase
+  UNSTABLE_cssCustomProperties?: CustomPropertiesLike;
 }
-
-export type CustomPropertiesLike = Record<string, string>;

--- a/src/utilities/theme/types.ts
+++ b/src/utilities/theme/types.ts
@@ -40,5 +40,5 @@ export interface Theme {
   /** Sets the logo for the top bar and contextual save bar components*/
   logo?: ThemeLogo;
   // eslint-disable-next-line babel/camelcase
-  UNSTABLE_cssCustomProperties?: CustomPropertiesLike;
+  UNSTABLE_cssCustomProperties?: string;
 }

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -22,8 +22,21 @@ export function buildThemeContext(
   cssCustomProperties?: CustomPropertiesLike,
 ): Theme {
   const {logo} = themeConfig;
-  // eslint-disable-next-line babel/camelcase
-  return {logo, UNSTABLE_cssCustomProperties: cssCustomProperties};
+  return {
+    logo,
+    // eslint-disable-next-line babel/camelcase
+    UNSTABLE_cssCustomProperties: toString(cssCustomProperties),
+  };
+}
+
+function toString(obj?: CustomPropertiesLike) {
+  if (obj) {
+    return Object.entries(obj)
+      .map((pair) => pair.join(':'))
+      .join(';');
+  } else {
+    return undefined;
+  }
 }
 
 /* eslint-disable babel/camelcase */

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -17,9 +17,13 @@ export function buildCustomProperties(
     : buildLegacyColors(themeConfig);
 }
 
-export function buildThemeContext(themeConfig: ThemeConfig): Theme {
+export function buildThemeContext(
+  themeConfig: ThemeConfig,
+  cssCustomProperties: CustomPropertiesLike,
+): Theme {
   const {logo} = themeConfig;
-  return {logo};
+  // eslint-disable-next-line babel/camelcase
+  return {logo, UNSTABLE_cssCustomProperties: cssCustomProperties};
 }
 
 /* eslint-disable babel/camelcase */

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -19,7 +19,7 @@ export function buildCustomProperties(
 
 export function buildThemeContext(
   themeConfig: ThemeConfig,
-  cssCustomProperties: CustomPropertiesLike,
+  cssCustomProperties?: CustomPropertiesLike,
 ): Theme {
   const {logo} = themeConfig;
   // eslint-disable-next-line babel/camelcase


### PR DESCRIPTION
Co-authored-by: Tim Layton <tim.layton@shopify.com>

### WHY are these changes introduced?

This PR enables components rendered in a `Portal` to be themed using the generated CSS custom properties. Otherwise components rendered in a `Portal` are out of scope (rendered outside of the `ThemeProvider`) and do not have access to the CSS custom properties.

#2224 was the first attempt at solving this issue which moved the `Portal` container within the `ThemeProvider`. But this broke `Popover` positioning if an app had a positioned wrapper (e.g `position: relative; top: 50px`, see #2302) and was reverted in #2305.

### WHAT is this pull request doing?

1. Adds the generated CSS custom properties used for global theming to the theme context
1. Sets the CSS custom properties on the `Portal` container

- [x] 🎩 