### PR TITLE
[Migration guide] Improve part about using translations in AppProvider

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,9 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Updated the `AppProvider` section in the Polaris [v3 to v4 migration guide](https://github.com/Shopify/polaris-react/blob/master/documentation/guides/migrating-from-v3-to-v4.md) ([#2312](https://github.com/Shopify/polaris-react/pull/2312))
+- Updated the `Using translations` section in the [AppProvider README](https://github.com/Shopify/polaris-react/blob/master/src/components/AppProvider/README.md#using-translations) ([#2312](https://github.com/Shopify/polaris-react/pull/2312))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/documentation/guides/migrating-from-v3-to-v4.md
+++ b/documentation/guides/migrating-from-v3-to-v4.md
@@ -73,9 +73,10 @@ Polaris now supports multiple languages and ships with [many translations](https
 
 // new
 import translations from '@shopify/polaris/locales/en.json';
-
 <AppProvider i18n={translations}>
 ```
+
+If you use [`@shopify/react-i18n`](https://github.com/Shopify/quilt/tree/master/packages/react-i18n) and want to dynamically load translations based on a provided locale, see the [AppProvider README](https://github.com/Shopify/polaris-react/blob/master/src/components/AppProvider/README.md#using-translations) for more information.
 
 ### Autocomplete <a name="polaris-autocomplete"></a>
 

--- a/src/components/AppProvider/README.md
+++ b/src/components/AppProvider/README.md
@@ -430,13 +430,48 @@ function AppProviderWithAllThemeKeysExample() {
 
 Translations are provided in the locales folder. When using Polaris, you are able to import translations from all languages supported by the core Shopify product and consume them through the `i18n` prop.
 
+If a project has only one locale, then you can pass the JSON content from the locale file into `AppProvider`.
+
 ```jsx
+import AppProvider from '@shopify/polaris';
 // en.json is English. Replace with fr.json for French, etc
 import translations from '@shopify/polaris/locales/en.json';
 
-ReactDOM.render(
-  <AppProvider i18n={translations}>{/* App content */}</AppProvider>,
-);
+function App() {
+  return <AppProvider i18n={translations}>{/* App content */}</AppProvider>;
+}
+```
+
+If a project supports multiple locales, then load them dynamically using [`@shopify/react-i18n`](https://github.com/Shopify/quilt/tree/master/packages/react-i18n#translation). This ensures that you load only the translations you need.
+
+```jsx
+import AppProvider from '@shopify/polaris';
+// en.json is English. Replace with fr.json for French, etc
+import translations from '@shopify/polaris/locales/en.json';
+import {useI18n} from '@shopify/react-i18n';
+
+function App() {
+  const [i18n] = useI18n({
+    id: 'Polaris',
+    fallback: translations,
+    translations(locale) {
+      return import(
+        /* webpackChunkName: "Polaris-i18n-[request]", webpackMode: "lazy-once" */ `@shopify/polaris/locales/${locale}.json`
+      ).then((dictionary) => dictionary && dictionary.default);
+    },
+  });
+
+  // i18n.translations is an array of translation dictionaries, where the first
+  // dictionary is the desired language, and the second is the fallback.
+  // AppProvider however expects that the first dictionary is the fallback
+  // and the second is the desired language. Thus we need to reverse the array
+  // to ensure the dictionaries are in the order desired by AppProvider
+  return (
+    <AppProvider i18n={i18n.translations.reverse()}>
+      {/* App content */}
+    </AppProvider>
+  );
+}
 ```
 
 ---


### PR DESCRIPTION
### WHY are these changes introduced?
Current migration docs didn't provide clear explanation what kind of `translations` should be used while migrating `<AppProvider>`.  I saw migration examples in different projects - in total, around 4-5 options what developers passed into translations. It wasn't clear which option is correct one. I saw other people looking for examples with translations and being confused what approach to take and what each approach means.

### WHAT is this pull request doing?
I'm describing options what to put into `translations` and for what case each option is sutable.

### How to 🎩
Is it the right place to put it? Maybe this info should be rather in README of `AppProvider`, and in migration guide there will be enough to insert a link to the updated `AppProvider` docs?  In case if this info is okay/needed in your opinion in the first place.

