### PR TITLE
Add vertical adjustment to `OptionList` control items

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Add vertical adjustment to `OptionList` control items ([#1310](https://github.com/Shopify/polaris-react/pull/1310))
 - Fixed `actionGroups` to only render `MenuActions` when actions are provided in the `Page` ([#2266](https://github.com/Shopify/polaris-react/pull/2266))
 - Fixed `PositionedOverlay` incorrectly calculating `Topbar.UserMenu` `Popover` width ([#1692](https://github.com/Shopify/polaris-react/pull/1692))
 - Fixed `recolor-icon` Sass mixin to properly scope `$secondary-color` to the child `svg` ([#2298](https://github.com/Shopify/polaris-react/pull/2298))

--- a/src/components/Choice/Choice.scss
+++ b/src/components/Choice/Choice.scss
@@ -4,7 +4,7 @@ $control-size: rem(16px);
 
 // Need to push the control down just a little to have it appear
 // vertically centered with the label.
-$control-vertical-adjustment: 2px;
+$control-vertical-adjustment: rem(2px);
 
 .Choice {
   display: inline-flex;

--- a/src/components/OptionList/components/Option/Option.scss
+++ b/src/components/OptionList/components/Option/Option.scss
@@ -2,6 +2,7 @@
 
 $min-height: control-height();
 $control-size: rem(16px);
+$control-vertical-adjustment: rem(2px);
 
 .Option {
   @include unstyled-button;
@@ -32,7 +33,7 @@ $control-size: rem(16px);
 .Label,
 .SingleSelectOption {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   width: 100%;
   padding: spacing(tight) spacing();
 }
@@ -43,6 +44,7 @@ $control-size: rem(16px);
   flex-shrink: 0;
   width: $control-size;
   height: $control-size;
+  margin-top: $control-vertical-adjustment;
   margin-right: spacing(tight);
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Inconsistent alignment of controls between `OptionList` and `ChoiceList` items. In `OptionList` items are center-aligned which causes things to look off when the items wrap.

Fixes #1310 

### WHAT is this pull request doing?

Adds vertical adjustment to `OptionList` control items

| Before       | After |
| ------------- |:-------------:|
| ![Screen Shot 2019-10-17 at 11 12 18 AM](https://user-images.githubusercontent.com/8629173/67022980-0c325600-f0d0-11e9-9eab-990d84642bd2.png) | ![Screen Shot 2019-10-17 at 11 11 49 AM](https://user-images.githubusercontent.com/8629173/67022939-fe7cd080-f0cf-11e9-9f9c-38bb65fac03e.png) |

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';
import {Page, Card, OptionList, ChoiceList} from '../src';

export function Playground() {
  const [selected, setSelected] = useState(['hidden']);

  const handleChange = useCallback((value) => setSelected(value), []);

  return (
    <Page title="Playground">
      <Card>
        <OptionList
          title="Inventory Location"
          onChange={setSelected}
          options={[
            {
              value: 'byward_market',
              label:
                'Currently, items that are two lines have the checkboxes vertically aligned to the middle of the text. They should be aligned to the top to be consistent with ChoiceList.',
            },
            {
              value: 'centretown',
              label:
                'Our color usage guidelines indicate that the color Indigo should be used to signify active/highlighted states. Indigo is active and should be shown to indicate active states.',
            },
            {value: 'hintonburg', label: 'Hintonburg'},
            {value: 'westboro', label: 'Westboro'},
            {value: 'downtown', label: 'Downtown'},
          ]}
          selected={selected}
          allowMultiple
        />
      </Card>

      <Card sectioned>
        <ChoiceList
          allowMultiple
          title="While the customer is checking out"
          choices={[
            {
              label:
                'Use the shipping address as the billing address by default',
              value: 'shipping',
              helpText:
                'Reduces the number of fields required to check out. The billing address can still be edited.',
            },
            {
              label:
                'Currently, items that are two lines have the checkboxes vertically aligned to the middle of the text. They should be aligned to the top to be consistent with ChoiceList.',
              value: 'confirmation',
              helpText:
                'Customers must review their order details before purchasing.',
            },
          ]}
          selected={selected}
          onChange={handleChange}
        />
      </Card>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
