### PR TITLE
[Stack] Fix Item proportion when shrinking

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `PositionedOverlay` incorrectly calculating `Topbar.UserMenu` `Popover` width ([#1692](https://github.com/Shopify/polaris-react/pull/1692))
 - Fixed `recolor-icon` Sass mixin to properly scope `$secondary-color` to the child `svg` ([#2298](https://github.com/Shopify/polaris-react/pull/2298))
 - Fixed a regression with the positioning of the `Popover` component ([#2305](https://github.com/Shopify/polaris-react/pull/2305))
+- Fixed Stack Item proportion when shrinking ([#2319](https://github.com/Shopify/polaris-react/pull/2319))
 
 ### Documentation
 

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -350,7 +350,7 @@ function ModalWithPrimaryActionExample() {
         }}
       >
         <Modal.Section>
-          <Stack>
+          <Stack vertical>
             <Stack.Item>
               <TextContainer>
                 <p>

--- a/src/components/Stack/Stack.scss
+++ b/src/components/Stack/Stack.scss
@@ -104,7 +104,7 @@
 }
 
 .Item {
-  flex: 0 1 auto;
+  flex: 0 0 auto;
   min-width: 0;
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

An issue was found with Stack items with display inline content. In case the sibling element is too long the proportions of this Item will not be correct and will possibly overflow.

Here is an example from the Payments Settings page:

<img width="639" alt="Screen Shot 2019-10-17 at 4 16 34 PM" src="https://user-images.githubusercontent.com/2091116/67045517-7365ff80-f0fc-11e9-9955-395717136501.png">


### WHAT is this pull request doing?

Making sure that the Stack Item has the `flex-shrink` role set to 0

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
