### PR TITLE
Use words rather than icons for storybook contexts

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,6 +1,6 @@
 // The order of these imports defines the order of the tabs in the addons panel
-import '@storybook/addon-contexts/register';
 import '@storybook/addon-viewport/register';
 import '@storybook/addon-actions/register';
 import '@storybook/addon-notes/register';
 import '@storybook/addon-a11y/register';
+import '@storybook/addon-contexts/register';

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -48,26 +48,24 @@ function StrictModeToggle({isStrict = false, children}) {
 addDecorator(
   withContexts([
     {
-      icon: 'dashboard',
       title: 'Strict Mode',
       components: [StrictModeToggle],
       params: [
-        {name: 'React Strict Mode On', default: true, props: {isStrict: true}},
-        {name: 'React Strict Mode Off', props: {isStrict: false}},
+        {name: 'Disabled', props: {isStrict: false}},
+        {name: 'Enabled', default: true, props: {isStrict: true}},
       ],
     },
     {
-      icon: 'paintbrush',
-      title: 'Themes',
+      title: 'Global Theming',
       components: [AppProvider],
       params: [
         {
-          name: 'Global Theming Disabled',
+          name: 'Disabled',
           default: true,
           props: {i18n: enTranslations},
         },
         {
-          name: 'Global Theming Enabled - Light Mode',
+          name: 'Enabled - Light Mode',
           props: {
             i18n: enTranslations,
             features: {
@@ -77,7 +75,7 @@ addDecorator(
           },
         },
         {
-          name: 'Global Theming Enabled - Dark Mode',
+          name: 'Enabled - Dark Mode',
           props: {
             i18n: enTranslations,
             features: {unstableGlobalTheming: true},


### PR DESCRIPTION
### WHY are these changes introduced?

Mystery meat navigation is silly, lets used words rather than icons

### WHAT is this pull request doing?

Removes icons, use words for context switching

### How to 🎩

 Open storybook, see the new "Strict Mode" and "Global Theming" toggles as words rather than wondering what the paintbrush and speedometer icons are for