### PR TITLE
Textfield placeholder clarification

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Clarified usage of the `helpText`, `label`, and `placeholder` props for the `TextField` componnent. ([#2321](https://github.com/Shopify/polaris-react/pull/2321))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -830,32 +830,30 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-### Structure
-
 Screen readers convey information about text fields automatically through native HTML.
 
 - Use the `disabled` prop to add the HTML `disabled` attribute to the text field.
 - Use the `readOnly` prop to add the HTML `readonly` attribute to the text field.
-- If you use the `type` prop, then some assistive technologies adapt the software keyboard to the current task. This helps merchants with mobility, vision, and cognitive issues to enter information more easily.
+- If you use the `type` prop, then some browsers and assistive technologies adapt the software keyboard to the current task. This helps users with mobility, vision, and cognitive issues to enter information more easily.
 
 Use the `id` prop to provide a unique `id` attribute value for the text field. If you don't provide an `id`, then the component generates one automatically. All text fields need to have unique `id` values.
 
 ### Labeling
 
-The `label` prop is required to convey the purpose of the checkbox to all merchants.
+The `label` prop is required to convey the purpose of the checkbox to all users.
 
-If there are separate visual cues that convey the purpose of the text field to sighted merchants, then the label can be visually hidden with the `labelHidden` prop.
+If there are separate visual cues that convey the purpose of the text field to sighted users, then the label can be visually hidden with the `labelHidden` prop.
 
 When you provide help text via the `helpText` prop or an inline error message via the `error` prop, the help or error content is conveyed to screen reader users with the `aria-describedby` attribute. This attribute causes the content to be read along with the label, either immediately or after a short delay.
 
-Use the `placeholder` prop to provide additional instructions. However, don’t rely on placeholders alone since the content isn’t always conveyed to all merchants.
+Use the `placeholder` prop only to provide formatting instructions that aren't essential. [HTML placeholders can be difficult for users to access.](https://www.nngroup.com/articles/form-design-placeholders/) Don’t rely on placeholders to convey important information since the content isn’t always conveyed to all users.
 
 <!-- usageblock -->
 
 #### Do
 
-- Use the label to provide instructions critical to using the text field
-- Use help text and placeholder text to provide additional, non-critical instructions
+- Use the label as the primary way to provide instructions critical to using the text field
+- Use help text as a secondary way to provide additional, non-critical instructions
 
 #### Don’t
 
@@ -867,8 +865,8 @@ Use the placeholder to provide information that’s required to use the text fie
 
 Text fields have standard keyboard support.
 
-- Merchants who rely on the keyboard expect to move focus to each text field using the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
-- If the `type` is set to `number`, then merchants can use the up and down arrow keys to adjust the value typed into the field
+- Users who rely on the keyboard expect to move focus to each text field using the <kbd>tab</kbd> key (or <kbd>shift</kbd> + <kbd>tab</kbd> when tabbing backwards)
+- If the `type` is set to `number`, then users can use the up and down arrow keys to adjust the value typed into the field
 - Using the `disabled` prop will prevent the text field from receive keyboard focus or inputs
 - The `readOnly` prop allows focus on the text field but prevents input or editing
 
@@ -880,7 +878,7 @@ Although you can use the `autoFocus` prop to automatically move focus to the tex
 
 - Use the `ariaControls` and `ariaOwns` props (which implement the `aria-controls` and `aria-owns` attributes) to point to the `id` of the autocomplete list.
 - Use the `ariaAutocomplete` prop to indicate what kind of `aria-autocomplete` input is provided, either `list` or `inline`. Typically, `list` is used.
-- When merchants navigate through the list, the `ariaActiveDescendant` prop indicates which option has programmatic focus so that it can be conveyed to screen reader users.
+- When users navigate through the list, the `ariaActiveDescendant` prop indicates which option has programmatic focus so that it can be conveyed to screen reader users.
 
 To learn more about implementing a text field with autocomplete, see the [autocomplete component](https://polaris.shopify.com/components/forms/autocomplete).
 

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -846,7 +846,7 @@ If there are separate visual cues that convey the purpose of the text field to s
 
 When you provide help text via the `helpText` prop or an inline error message via the `error` prop, the help or error content is conveyed to screen reader users with the `aria-describedby` attribute. This attribute causes the content to be read along with the label, either immediately or after a short delay.
 
-Use the `placeholder` prop only to provide formatting instructions that aren't essential. [HTML placeholders can be difficult for users to access.](https://www.nngroup.com/articles/form-design-placeholders/) Don’t rely on placeholders to convey important information since the content isn’t always conveyed to all users.
+Use the `placeholder` prop only to provide formatting instructions that aren’t essential, as [users may find difficult or impossible to access placeholders](https://www.nngroup.com/articles/form-design-placeholders/).
 
 <!-- usageblock -->
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -35,13 +35,13 @@ export interface BaseProps {
   prefix?: React.ReactNode;
   /** Text to display after value */
   suffix?: React.ReactNode;
-  /** Hint text to display */
+  /** Non-essential hint text to display */
   placeholder?: string;
   /** Initial value for the input */
   value?: string;
-  /** Additional hint text to display */
+  /** Secondary help text to display */
   helpText?: React.ReactNode;
-  /** Label for the input */
+  /** Primary label for the input */
   label: string;
   /** Adds an action to the label */
   labelAction?: Action;

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -35,15 +35,15 @@ export interface BaseProps {
   prefix?: React.ReactNode;
   /** Text to display after value */
   suffix?: React.ReactNode;
-  /** Non-essential hint text to display */
+  /** Non-essential hint text to display in the field */
   placeholder?: string;
   /** Initial value for the input */
   value?: string;
-  /** Secondary help text to display */
+  /** Secondary instruction text that displays below the field */
   helpText?: React.ReactNode;
   /** Primary label for the input */
   label: string;
-  /** Adds an action to the label */
+  /** Adds an action next to the label */
   labelAction?: Action;
   /** Visually hide the label */
   labelHidden?: boolean;

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -39,7 +39,7 @@ export interface BaseProps {
   placeholder?: string;
   /** Initial value for the input */
   value?: string;
-  /** Secondary instruction text that displays below the field */
+  /** Secondary help text to display below the field */
   helpText?: React.ReactNode;
   /** Primary label for the input */
   label: string;


### PR DESCRIPTION
## WHY are these changes introduced?

Clarifies usage for the `helpText`, `label`, and `placeholder` props, to appear in `polaris-react` docs and in the style guide for the `TextField` component.

## WHAT is this pull request doing?

* [X] Updates accessibility documentation and and props descriptions for the text field `README.md`
* [x] Adds an entry to `UNRELEASED.md`

## How to 🎩

1. Check out `master` from `polaris-styleguide` to get the changes that support the accessibility section.
1. In another Terminal tab or window, check out this branch from `polaris-react` and [run the instructions for testing in a consuming project](https://github.com/Shopify/polaris-react/#testing-in-a-consuming-project).
1. In the `polaris-styleguide` tab, run `dev up && dev start`.
1. View changes after examples: https://polaris.myshopify.io/components/forms/text-field