### PR TITLE
[ChoiceList] Allow JSX in a choice's label

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Updated `OptionList` section title to match `ActionList` section title ([#2300](https://github.com/Shopify/polaris-react/pull/2300))
 - Added `pressed` state to `Button` ([#2148](https://github.com/Shopify/polaris-react/pull/2148))
 - Added CSS custom properties to `Portal` container ([#2306](https://github.com/Shopify/polaris-react/pull/2306))
+- Updated the type of the `label` prop in `ChoiceList` (nested prop of `choices`) from `string` to `ReactNode` ([#2325](https://github.com/Shopify/polaris-react/pull/2325)).
 
 ### Bug fixes
 

--- a/src/components/ChoiceList/ChoiceList.tsx
+++ b/src/components/ChoiceList/ChoiceList.tsx
@@ -14,7 +14,7 @@ export interface ChoiceDescriptor {
   /** Value of the choice */
   value: string;
   /** Label for the choice */
-  label: string;
+  label: React.ReactNode;
   /** Disable choice */
   disabled?: boolean;
   /** Additional text to aide in use */

--- a/src/components/ChoiceList/tests/ChoiceList.test.tsx
+++ b/src/components/ChoiceList/tests/ChoiceList.test.tsx
@@ -50,6 +50,31 @@ describe('<ChoiceList />', () => {
       });
     });
 
+    it('renders choices with labels containing JSX', () => {
+      const jsxLabel = <b>Two</b>;
+      const ComponentLabel = () => (
+        <React.Fragment>
+          Label <i>one</i>
+        </React.Fragment>
+      );
+
+      choices = [
+        {label: <ComponentLabel />, value: 'one'},
+        {label: jsxLabel, value: 'two'},
+        {...choices[2], helpText: 'Some help text'},
+      ];
+
+      const choiceElements = mountWithAppProvider(
+        <ChoiceList title="Choose a number" selected={[]} choices={choices} />,
+      ).find(RadioButton);
+
+      choiceElements.forEach((choiceElement, index) => {
+        expect(choiceElement.prop('label')).toBe(choices[index].label);
+        expect(choiceElement.prop('value')).toBe(choices[index].value);
+        expect(choiceElement.prop('helpText')).toBe(choices[index].helpText);
+      });
+    });
+
     describe('with valid children property returning node', () => {
       const children = <span>Child</span>;
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

I have a couple of use cases, where I want to increase the font weight of a group of words in a choice's label, in a `<ChoiceList />`. Also, `<Checkbox />` and `<RadioButton />` already allow `ReactNode`s on the `label` prop, while `<ChoiceList />` doesn't. It is also possible in rails.

<img width="190" alt="Screen Shot 2019-10-18 at 11 06 54 AM" src="https://user-images.githubusercontent.com/6439357/67107097-c8a41e80-f199-11e9-9845-942870dc39ac.png">

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Replacing the `string` type of the `label` sub prop by a more permissive `ReactNode` type. Adding tests accordingly.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

You can just play with the `Playground` snippet below ⬇️ 

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {Fragment, useState} from 'react';
import {Page, ChoiceList} from '../src';

const jsxLabel = <b>Two</b>;
const ComponentLabel = () => (
  <Fragment>
    Label <u>one</u>
  </Fragment>
);

const choices = [
  {label: <ComponentLabel />, value: 'one'},
  {label: jsxLabel, value: 'two'},
  {label: 'Three', value: 'three', helpText: 'Some help text'},
];

export function Playground() {
  const [selected, setSelected] = useState('two');
  const changeMePlz = (value: string[]) => setSelected(value[0]);

  return (
    <Page title="Playground">
      <ChoiceList
        title="Choose a number"
        selected={[selected]}
        choices={choices}
        onChange={changeMePlz}
      />
      ,
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [ ] ~Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)~
* [ ] ~Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)~
* [ ] ~Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)~
* [ ] ~Updated the component's `README.md` with documentation changes~
* [ ] ~[Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide~
* [ ] ~For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)~

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
