### PR TITLE
[Button] add support for split disclosure button

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,23 +4,6 @@
 
 ### Enhancements
 
-- Added `hideTags` prop to `Filters` ([#2573](https://github.com/Shopify/polaris-react/pull/2573))
-- Added `searchResultsOverlayVisible` prop to `TopBar` which adds a translucent background to the search dismissal overlay when results are displayed ([#2440](https://github.com/Shopify/polaris-react/pull/2440))
-- Added `external` prop to `ResourceList` ([#2408](https://github.com/Shopify/polaris-react/pull/2408))
-- Added `onMouseEnter` and `onTouchStart` props to `Button` ([#2409](https://github.com/Shopify/polaris-react/pull/2409))
-- Added `ariaHaspopup` prop to `Popover` ([#2248](https://github.com/Shopify/polaris-react/pull/2248))
-- Fixed an accessibility issue where the `Form` implicit submit was still accessible via keyboard ([#2447](https://github.com/Shopify/polaris-react/pull/2447))
-- Moved `Button` styles from the `Buttongroup` CSS file to the `Button` CSS file ([#2441](https://github.com/Shopify/polaris-react/pull/2441))
-- Added `footerActionAlignment` prop to control `<Card>` footer action alignment, defaults to `'right'`
-- Improved contrast of `MessageIndicator` with a border ([#2428](https://github.com/Shopify/polaris-react/pull/2428))
-- Removed the need for z-indexes in `Icon` ([#2207](https://github.com/Shopify/polaris-react/pull/2207))
-- Added `features` prop to `AppProvider` ([#2204](https://github.com/Shopify/polaris-react/pull/2204))
-- Added support for using `EmptyState` in a content context ([#1570](https://github.com/Shopify/polaris-react/pull/1570))
-- `Page` no longer renders navigation or actions in print mode ([#2469](https://github.com/Shopify/polaris-react/pull/2469))
-- Migrated `Dropzone` to a functional component and reduce complexity ([#2360](https://github.com/Shopify/polaris-react/pull/2360))
-- Added `fluidContent` prop to `Popover` ([#2494](https://github.com/Shopify/polaris-react/pull/2494))
-- Add `external` prop to `ResourceList` [#2408](https://github.com/Shopify/polaris-react/pull/2408)
-- Add `onMouseEnter` and `onTouchStart` props to `Button` ([#2409](https://github.com/Shopify/polaris-react/pull/2409))
 - Added a split variant to `Button` ([#2329](https://github.com/Shopify/polaris-react/pull/2329))
 
 ### Bug fixes

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,25 @@
 
 ### Enhancements
 
+- Added `hideTags` prop to `Filters` ([#2573](https://github.com/Shopify/polaris-react/pull/2573))
+- Added `searchResultsOverlayVisible` prop to `TopBar` which adds a translucent background to the search dismissal overlay when results are displayed ([#2440](https://github.com/Shopify/polaris-react/pull/2440))
+- Added `external` prop to `ResourceList` ([#2408](https://github.com/Shopify/polaris-react/pull/2408))
+- Added `onMouseEnter` and `onTouchStart` props to `Button` ([#2409](https://github.com/Shopify/polaris-react/pull/2409))
+- Added `ariaHaspopup` prop to `Popover` ([#2248](https://github.com/Shopify/polaris-react/pull/2248))
+- Fixed an accessibility issue where the `Form` implicit submit was still accessible via keyboard ([#2447](https://github.com/Shopify/polaris-react/pull/2447))
+- Moved `Button` styles from the `Buttongroup` CSS file to the `Button` CSS file ([#2441](https://github.com/Shopify/polaris-react/pull/2441))
+- Added `footerActionAlignment` prop to control `<Card>` footer action alignment, defaults to `'right'`
+- Improved contrast of `MessageIndicator` with a border ([#2428](https://github.com/Shopify/polaris-react/pull/2428))
+- Removed the need for z-indexes in `Icon` ([#2207](https://github.com/Shopify/polaris-react/pull/2207))
+- Added `features` prop to `AppProvider` ([#2204](https://github.com/Shopify/polaris-react/pull/2204))
+- Added support for using `EmptyState` in a content context ([#1570](https://github.com/Shopify/polaris-react/pull/1570))
+- `Page` no longer renders navigation or actions in print mode ([#2469](https://github.com/Shopify/polaris-react/pull/2469))
+- Migrated `Dropzone` to a functional component and reduce complexity ([#2360](https://github.com/Shopify/polaris-react/pull/2360))
+- Added `fluidContent` prop to `Popover` ([#2494](https://github.com/Shopify/polaris-react/pull/2494))
+- Add `external` prop to `ResourceList` [#2408](https://github.com/Shopify/polaris-react/pull/2408)
+- Add `onMouseEnter` and `onTouchStart` props to `Button` ([#2409](https://github.com/Shopify/polaris-react/pull/2409))
+- Added a split variant to `Button` ([#2329](https://github.com/Shopify/polaris-react/pull/2329))
+
 ### Bug fixes
 
 ### Documentation

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Načítání"
+      "spinnerAccessibilityLabel": "Načítání",
+      "connectedDisclosureAccessibilityLabel": "Související akce"
     },
     "Common": {
       "checkbox": "zaškrtávací políčko",

--- a/locales/da.json
+++ b/locales/da.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Indlæser"
+      "spinnerAccessibilityLabel": "Indlæser",
+      "connectedDisclosureAccessibilityLabel": "Relaterede handlinger"
     },
     "Common": {
       "checkbox": "afkrydsningsfelt",

--- a/locales/de.json
+++ b/locales/de.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Wird geladen"
+      "spinnerAccessibilityLabel": "Wird geladen",
+      "connectedDisclosureAccessibilityLabel": "Ähnliche Aktionen"
     },
     "Common": {
       "checkbox": "Kontrollkästchen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -25,7 +25,8 @@
     },
 
     "Button": {
-      "spinnerAccessibilityLabel": "Loading"
+      "spinnerAccessibilityLabel": "Loading",
+      "connectedDisclosureAccessibilityLabel": "Related actions"
     },
 
     "Common": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Cargando"
+      "spinnerAccessibilityLabel": "Cargando",
+      "connectedDisclosureAccessibilityLabel": "Acciones relacionadas"
     },
     "Common": {
       "checkbox": "casilla de verificación",

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Ladataan"
+      "spinnerAccessibilityLabel": "Ladataan",
+      "connectedDisclosureAccessibilityLabel": "Aiheeseen liittyvät toimenpiteet"
     },
     "Common": {
       "checkbox": "valintaruutu",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Chargement"
+      "spinnerAccessibilityLabel": "Chargement",
+      "connectedDisclosureAccessibilityLabel": "Actions associées"
     },
     "Common": {
       "checkbox": "case à cocher",

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "लोड हो रहा है"
+      "spinnerAccessibilityLabel": "लोड हो रहा है",
+      "connectedDisclosureAccessibilityLabel": "संबंधित कार्रवाइयाँ"
     },
     "Common": {
       "checkbox": "चेकबॉक्स",

--- a/locales/it.json
+++ b/locales/it.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Caricamento"
+      "spinnerAccessibilityLabel": "Caricamento",
+      "connectedDisclosureAccessibilityLabel": "Azioni correlate"
     },
     "Common": {
       "checkbox": "casella di spunta",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "読み込んでいます"
+      "spinnerAccessibilityLabel": "読み込んでいます",
+      "connectedDisclosureAccessibilityLabel": "関連したアクション"
     },
     "Common": {
       "checkbox": "チェックボックス",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "로드 중"
+      "spinnerAccessibilityLabel": "로드 중",
+      "connectedDisclosureAccessibilityLabel": "관련 작업"
     },
     "Common": {
       "checkbox": "확인란",

--- a/locales/ms.json
+++ b/locales/ms.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Memuatkan"
+      "spinnerAccessibilityLabel": "Memuatkan",
+      "connectedDisclosureAccessibilityLabel": "Tindakan yang berkaitan"
     },
     "Common": {
       "checkbox": "kotak semak",

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Laster inn"
+      "spinnerAccessibilityLabel": "Laster inn",
+      "connectedDisclosureAccessibilityLabel": "Relaterte handlinger"
     },
     "Common": {
       "checkbox": "avmerkingsboks",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Laden"
+      "spinnerAccessibilityLabel": "Laden",
+      "connectedDisclosureAccessibilityLabel": "Gerelateerde acties"
     },
     "Common": {
       "checkbox": "selectievakje",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Ładowanie"
+      "spinnerAccessibilityLabel": "Ładowanie",
+      "connectedDisclosureAccessibilityLabel": "Powiązane czynności"
     },
     "Common": {
       "checkbox": "pole wyboru",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Carregando"
+      "spinnerAccessibilityLabel": "Carregando",
+      "connectedDisclosureAccessibilityLabel": "Ações relacionadas"
     },
     "Common": {
       "checkbox": "caixa de seleção",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Carregar"
+      "spinnerAccessibilityLabel": "Carregar",
+      "connectedDisclosureAccessibilityLabel": "Ações relacionadas"
     },
     "Common": {
       "checkbox": "caixa de verificação",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Laddar"
+      "spinnerAccessibilityLabel": "Laddar",
+      "connectedDisclosureAccessibilityLabel": "Relaterade åtgärder"
     },
     "Common": {
       "checkbox": "kryssruta",

--- a/locales/th.json
+++ b/locales/th.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "กำลังโหลด"
+      "spinnerAccessibilityLabel": "กำลังโหลด",
+      "connectedDisclosureAccessibilityLabel": "การดำเนินการที่เกี่ยวข้อง"
     },
     "Common": {
       "checkbox": "ช่องทำเครื่องหมาย",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "Yükleniyor"
+      "spinnerAccessibilityLabel": "Yükleniyor",
+      "connectedDisclosureAccessibilityLabel": "İlgili işlemler"
     },
     "Common": {
       "checkbox": "onay kutusu",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "正在加载"
+      "spinnerAccessibilityLabel": "正在加载",
+      "connectedDisclosureAccessibilityLabel": "相关操作"
     },
     "Common": {
       "checkbox": "复选框",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -22,7 +22,8 @@
       }
     },
     "Button": {
-      "spinnerAccessibilityLabel": "載入中"
+      "spinnerAccessibilityLabel": "載入中",
+      "connectedDisclosureAccessibilityLabel": "相關動作"
     },
     "Common": {
       "checkbox": "核取方塊",

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -180,7 +180,7 @@ $stacking-order: (
   @include recolor-icon(color('white'));
 
   &.globalTheming {
-    @include recolor-icon(var(--p-icon-on-branded));
+    @include recolor-icon(var(--p-button-text));
   }
 
   &.disabled {
@@ -217,6 +217,10 @@ $stacking-order: (
       $destructive-pressed-darkest
     );
   }
+
+  &.globalTheming {
+    @include recolor-icon(var(--p-button-text));
+  }
 }
 
 .outline {
@@ -229,7 +233,6 @@ $stacking-order: (
 
 .destructive.outline {
   @include button-outline(color('red'));
-  @include recolor-icon(color('red', 'dark'));
 
   &.pressed {
     @include button-outline(
@@ -671,7 +674,19 @@ $stacking-order: (
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 
-  &:focus {
+  // Because the outline border color has a 40% opacity, the left border appears darker than the rest of the borders because they are layered over one another. Reducing the opacity to zero for the connected disclosure when not focused gives us the expected border color.
+  &.outline:not(:focus) {
+    border-left-color: rgba(color('ink', 'lighter'), 0);
+  }
+
+  &:focus,
+  &:active {
     z-index: z-index(focused, $stacking-order);
+  }
+
+  &.globalTheming {
+    margin-left: rem(1px);
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
   }
 }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -63,11 +63,26 @@ $partial-button-filled-pressed-box-shadow: inset 0 0 0 0 transparent,
   }
 }
 
+$stacking-order: (
+  segment: 10,
+  focused: 20,
+);
+
 .Button {
   @include button-base;
 
   &.disabled {
     @include base-button-disabled;
+  }
+
+  &.connectedDisclosure {
+    z-index: z-index(segment, $stacking-order);
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+
+    &:focus {
+      z-index: z-index(focused, $stacking-order);
+    }
   }
 }
 // stylelint-disable selector-max-combinators
@@ -643,4 +658,20 @@ $partial-button-filled-pressed-box-shadow: inset 0 0 0 0 transparent,
 
 .DisclosureIconFacingUp {
   transform: rotate(-180deg);
+}
+
+.ConnectedDisclosureWrapper {
+  display: flex;
+  align-items: center;
+}
+
+.ConnectedDisclosure {
+  z-index: z-index(segment, $stacking-order);
+  margin-left: -(border-width());
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+
+  &:focus {
+    z-index: z-index(focused, $stacking-order);
+  }
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -242,6 +242,7 @@ export function Button({
       connectedDisclosure.disabled && styles.disabled,
       styles.iconOnly,
       styles.ConnectedDisclosure,
+      unstableGlobalTheming && styles.globalTheming,
     );
 
     const defaultLabel = i18n.translate(

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,20 +1,22 @@
-import React, {useRef} from 'react';
+import React, {useRef, useState, useCallback} from 'react';
 import {CaretDownMinor} from '@shopify/polaris-icons';
+
 import {classNames, variationName} from '../../utilities/css';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 import {useFeatures} from '../../utilities/features';
 import {useI18n} from '../../utilities/i18n';
 import {UnstyledLink} from '../UnstyledLink';
 import {Icon} from '../Icon';
-import {IconProps} from '../../types';
+import {IconProps, ConnectedDisclosure} from '../../types';
 import {Spinner} from '../Spinner';
+import {Popover} from '../Popover';
+import {ActionList} from '../ActionList';
+
 import styles from './Button.scss';
 
-type Size = 'slim' | 'medium' | 'large';
-
-type TextAlign = 'left' | 'right' | 'center';
-
-type IconSource = IconProps['source'];
+export type Size = 'slim' | 'medium' | 'large';
+export type TextAlign = 'left' | 'right' | 'center';
+export type IconSource = IconProps['source'];
 
 export interface ButtonProps {
   /** The content to display inside the button */
@@ -69,6 +71,8 @@ export interface ButtonProps {
    * Tells screen reader the element is pressed
    */
   ariaPressed?: boolean;
+  /** Disclosure button connected right of the button. Toggles a popover action list. */
+  connectedDisclosure?: ConnectedDisclosure;
   /** Callback when clicked */
   onClick?(): void;
   /** Callback when button becomes focussed */
@@ -121,6 +125,7 @@ export function Button({
   textAlign,
   fullWidth,
   pressed,
+  connectedDisclosure,
 }: ButtonProps) {
   const {unstableGlobalTheming = false} = useFeatures();
   const hasGivenDeprecationWarning = useRef(false);
@@ -152,6 +157,7 @@ export function Button({
     textAlign && styles[variationName('textAlign', textAlign)],
     fullWidth && styles.fullWidth,
     icon && children == null && styles.iconOnly,
+    connectedDisclosure && styles.connectedDisclosure,
   );
 
   const disclosureIcon = (
@@ -216,9 +222,71 @@ export function Button({
     );
 
   const type = submit ? 'submit' : 'button';
+  const ariaPressedStatus = pressed !== undefined ? pressed : ariaPressed;
+
+  const [disclosureActive, setDisclosureActive] = useState(false);
+  const toggleDisclosureActive = useCallback(() => {
+    setDisclosureActive((disclosureActive) => !disclosureActive);
+  }, []);
+
+  let connectedDisclosureMarkup;
+
+  if (connectedDisclosure) {
+    const connectedDisclosureClassName = classNames(
+      styles.Button,
+      primary && styles.primary,
+      outline && styles.outline,
+      size && size !== DEFAULT_SIZE && styles[variationName('size', size)],
+      textAlign && styles[variationName('textAlign', textAlign)],
+      destructive && styles.destructive,
+      connectedDisclosure.disabled && styles.disabled,
+      styles.iconOnly,
+      styles.ConnectedDisclosure,
+    );
+
+    const defaultLabel = i18n.translate(
+      'Polaris.Button.connectedDisclosureAccessibilityLabel',
+    );
+
+    const {
+      disabled,
+      accessibilityLabel: disclosureLabel = defaultLabel,
+    } = connectedDisclosure;
+
+    const connectedDisclosureActivator = (
+      <button
+        type="button"
+        className={connectedDisclosureClassName}
+        disabled={disabled}
+        aria-label={disclosureLabel}
+        onClick={toggleDisclosureActive}
+        onMouseUp={handleMouseUpByBlurring}
+      >
+        <IconWrapper>
+          <Icon source={CaretDownMinor} />
+        </IconWrapper>
+      </button>
+    );
+
+    connectedDisclosureMarkup = (
+      <Popover
+        active={disclosureActive}
+        onClose={toggleDisclosureActive}
+        activator={connectedDisclosureActivator}
+        preferredAlignment="right"
+      >
+        <ActionList
+          items={connectedDisclosure.actions}
+          onActionAnyItem={toggleDisclosureActive}
+        />
+      </Popover>
+    );
+  }
+
+  let buttonMarkup;
 
   if (url) {
-    return isDisabled ? (
+    buttonMarkup = isDisabled ? (
       // Render an `<a>` so toggling disabled/enabled state changes only the
       // `href` attribute instead of replacing the whole element.
       // eslint-disable-next-line jsx-a11y/anchor-is-valid
@@ -243,34 +311,41 @@ export function Button({
         {content}
       </UnstyledLink>
     );
+  } else {
+    buttonMarkup = (
+      <button
+        id={id}
+        type={type}
+        onClick={onClick}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onKeyDown={onKeyDown}
+        onKeyUp={onKeyUp}
+        onKeyPress={onKeyPress}
+        onMouseUp={handleMouseUpByBlurring}
+        onMouseEnter={onMouseEnter}
+        onTouchStart={onTouchStart}
+        className={className}
+        disabled={isDisabled}
+        aria-label={accessibilityLabel}
+        aria-controls={ariaControls}
+        aria-expanded={ariaExpanded}
+        aria-pressed={ariaPressedStatus}
+        role={loading ? 'alert' : undefined}
+        aria-busy={loading ? true : undefined}
+      >
+        {content}
+      </button>
+    );
   }
 
-  const ariaPressedStatus = pressed !== undefined ? pressed : ariaPressed;
-
-  return (
-    <button
-      id={id}
-      type={type}
-      onClick={onClick}
-      onFocus={onFocus}
-      onBlur={onBlur}
-      onKeyDown={onKeyDown}
-      onKeyUp={onKeyUp}
-      onKeyPress={onKeyPress}
-      onMouseUp={handleMouseUpByBlurring}
-      onMouseEnter={onMouseEnter}
-      onTouchStart={onTouchStart}
-      className={className}
-      disabled={isDisabled}
-      aria-label={accessibilityLabel}
-      aria-controls={ariaControls}
-      aria-expanded={ariaExpanded}
-      aria-pressed={ariaPressedStatus}
-      role={loading ? 'alert' : undefined}
-      aria-busy={loading ? true : undefined}
-    >
-      {content}
-    </button>
+  return connectedDisclosureMarkup ? (
+    <div className={styles.ConnectedDisclosureWrapper}>
+      {buttonMarkup}
+      {connectedDisclosureMarkup}
+    </div>
+  ) : (
+    buttonMarkup
   );
 }
 

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -263,7 +263,7 @@ Use for plain or monochrome buttons that could have a long length and should be 
 
 Buttons are sometimes used as a toggle for other parts of the user interface.
 
-````jsx
+```jsx
 function PressedButton() {
   const [isFirstButtonActive, setIsFirstButtonActive] = useState(true);
 
@@ -290,11 +290,11 @@ function PressedButton() {
 }
 ```
 
-### Button with disclosure
+### Plain disclosure button
 
 <!-- example-for: web -->
 
-Use to denote something that can be progressively disclosed to the user on click.
+Use to indicate that more content can be disclosed on click, like text in a collapsible.
 
 ```jsx
 function DisclosureButtion() {
@@ -330,7 +330,7 @@ Use when there is only one primary action but other related actions can be taken
 >
   Save
 </Button>
-````
+```
 
 ### Disabled state
 

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -263,7 +263,7 @@ Use for plain or monochrome buttons that could have a long length and should be 
 
 Buttons are sometimes used as a toggle for other parts of the user interface.
 
-```jsx
+````jsx
 function PressedButton() {
   const [isFirstButtonActive, setIsFirstButtonActive] = useState(true);
 
@@ -313,6 +313,24 @@ function DisclosureButtion() {
   );
 }
 ```
+
+### Split button
+
+<!-- example-for: web -->
+
+Use when there is only one primary action but other related actions can be taken.
+
+```jsx
+<Button
+  primary
+  connectedDisclosure={{
+    accessibilityLabel: 'Other save actions',
+    actions: [{content: 'Save as draft'}],
+  }}
+>
+  Save
+</Button>
+````
 
 ### Disabled state
 

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import {PlusMinor} from '@shopify/polaris-icons';
+import {PlusMinor, CaretDownMinor} from '@shopify/polaris-icons';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
-import {UnstyledLink, Icon, Spinner} from 'components';
+import {UnstyledLink, Icon, Spinner, ActionList, Popover} from 'components';
 import {Button} from '../Button';
+
+import en from '../../../../locales/en.json';
 
 describe('<Button />', () => {
   describe('url', () => {
@@ -215,6 +217,117 @@ describe('<Button />', () => {
       expect(button.find('button').prop('aria-pressed')).toBeTruthy();
 
       warningSpy.mockRestore();
+    });
+  });
+
+  describe('connectedDisclosure', () => {
+    it('connects a disclosure icon button to the button', () => {
+      const disclosure = {
+        actions: [
+          {
+            content: 'Save and mark as ordered',
+          },
+        ],
+      };
+
+      const button = mountWithAppProvider(
+        <Button connectedDisclosure={disclosure} />,
+      );
+
+      expect(button.find('button')).toHaveLength(2);
+
+      const disclosureButton = button.find('button').at(1);
+
+      expect(disclosureButton.find(Icon).props().source).toBe(CaretDownMinor);
+    });
+
+    it('sets a custom aria-label on the disclosure button when accessibilityLabel is provided', () => {
+      const connectedDisclosureLabel = 'More save actions';
+      const disclosure = {
+        accessibilityLabel: connectedDisclosureLabel,
+        actions: [
+          {
+            content: 'Save and mark as ordered',
+          },
+        ],
+      };
+
+      const button = mountWithAppProvider(
+        <Button connectedDisclosure={disclosure} />,
+      );
+
+      const disclosureButton = button.find('button').at(1);
+      const disclosureButtonProps = disclosureButton.props();
+
+      expect(disclosureButtonProps['aria-label']).toBe(
+        connectedDisclosureLabel,
+      );
+    });
+
+    it('sets a default aria-label on the disclosure button when accessibilityLabel is not provided', () => {
+      const connectedDisclosureLabel =
+        en.Polaris.Button.connectedDisclosureAccessibilityLabel;
+
+      const disclosure = {
+        actions: [
+          {
+            content: 'Save and mark as ordered',
+          },
+        ],
+      };
+
+      const button = mountWithAppProvider(
+        <Button connectedDisclosure={disclosure} />,
+      );
+
+      const disclosureButton = button.find('button').at(1);
+      const disclosureButtonProps = disclosureButton.props();
+
+      expect(disclosureButtonProps['aria-label']).toBe(
+        connectedDisclosureLabel,
+      );
+    });
+
+    it('disables the disclosure button when disabled is true', () => {
+      const disclosure = {
+        disabled: true,
+        actions: [
+          {
+            content: 'Save and mark as ordered',
+          },
+        ],
+      };
+
+      const button = mountWithAppProvider(
+        <Button connectedDisclosure={disclosure} />,
+      );
+
+      const disclosureButton = button.find('button').at(1);
+
+      expect(disclosureButton.props().disabled).toBe(true);
+    });
+
+    it('renders an ActionList with the actions set', () => {
+      const actions = [
+        {
+          content: 'Save and mark as ordered',
+        },
+      ];
+
+      const disclosure = {actions};
+
+      const button = mountWithAppProvider(
+        <Button connectedDisclosure={disclosure} />,
+      );
+
+      const disclosureButton = button.find('button').at(1);
+      disclosureButton.simulate('click');
+
+      const actionList = button.find(Popover).find(ActionList);
+
+      expect(actionList.prop('items')).toStrictEqual(
+        expect.arrayContaining(actions),
+      );
     });
   });
 

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -203,6 +203,7 @@
   border-color: rgba($outline-color, 0.4);
   box-shadow: none;
   color: darken($outline-color, 20%);
+  @include recolor-icon(darken($outline-color, 20%));
 
   &:hover {
     background: rgba($outline-color, 0.05);
@@ -248,7 +249,8 @@
     &.destructive {
       background: transparent;
       box-shadow: 0 0 0 border-width('base') var(--p-border-critical);
-      color: var(--p-link-critical);
+      color: var(--p-critical-link);
+      @include recolor-icon(var(--p-icon-critical));
 
       &:hover {
         box-shadow: 0 0 0 border-width('base') var(--p-border-critical);

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,7 +129,7 @@ export interface BaseCallbackAction {
 export interface CallbackAction extends BaseCallbackAction {}
 
 export interface DisableableAction extends Action {
-  /** Should the action be disabled */
+  /** Whether or not the action is disabled */
   disabled?: boolean;
 }
 
@@ -200,6 +200,17 @@ export interface MenuGroupDescriptor extends BadgeAction {
   details?: React.ReactNode;
   /** Callback when any action takes place */
   onActionAnyItem?: ActionListItemDescriptor['onAction'];
+}
+
+export interface ConnectedDisclosure {
+  /** Visually hidden label for the connected disclosure button.
+   * @default 'Related actions'
+   */
+  accessibilityLabel?: string;
+  /** Whether or not the disclosure is disabled */
+  disabled?: boolean;
+  /** List of actions */
+  actions: ActionListItemDescriptor[];
 }
 
 export enum Key {


### PR DESCRIPTION
### WHY are these changes introduced?

There is currently no way to expose merchants to related primary actions in the `ContextualSaveBar` or `Page` `Header` because they only support a single primary action. For example, if the primary action is to save a resource like an order, but you can also save the order as a draft. 

### WHAT is this pull request doing?

This PR adds support for a split button variant. This is the same UX as the split button you are probably familiar with in Gmail. It renders a disclosure button connected right which toggles a popover action list with related actions.

| Split button | Split button with disclosure active |
|---|---|
|<img width="180" alt="Screen Shot 2019-10-18 at 4 33 15 PM" src="https://user-images.githubusercontent.com/18447883/67127048-81805280-f1c6-11e9-8f65-691222a35d70.png">|<img width="219" alt="Screen Shot 2019-10-18 at 4 33 46 PM" src="https://user-images.githubusercontent.com/18447883/67126459-1bdf9680-f1c5-11e9-9ae5-dcbd52b835b4.png">|

<details>
<summary>Other UX considered</summary>

Another possible UX could be that the action list acts as a way to choose which action the primary button renders. You may be familiar with that type of split button if you've ever created a draft PR here on GitHub. The currently selected action has a selected state in the action list. Clicking a related action closes the popover and updates the primary action to be that clicked action. 

cc @ShaniqueS @mirualves 

| Initial primary action | Related primary action selected |
|---|---|
|<img width="318" alt="Primary action" src="https://user-images.githubusercontent.com/18447883/67126779-eab39600-f1c5-11e9-9985-ed633281c5fc.png">|<img width="318" alt="Primary action updated to selected related action" src="https://user-images.githubusercontent.com/18447883/67126780-eab39600-f1c5-11e9-8d95-ba96e892969e.png">|

</details>


|| Split button variants |
|---|---|
|Current|<img width="696" alt="Screen Shot 2019-12-05 at 6 04 33 PM" src="https://user-images.githubusercontent.com/18447883/70281898-2e6c5a00-178a-11ea-9e4a-0f025e06025e.png">|
|Light mode|<img width="685" alt="Screen Shot 2019-12-05 at 6 04 44 PM" src="https://user-images.githubusercontent.com/18447883/70281964-5e1b6200-178a-11ea-8270-8c6b9daea810.png">|
|Dark mode|<img width="686" alt="Screen Shot 2019-12-05 at 6 04 54 PM" src="https://user-images.githubusercontent.com/18447883/70281973-64a9d980-178a-11ea-80a9-3448b4f5fda4.png">|


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

#### To tophat in Chroma deployment

- <a href="https://www.chromaui.com/component?appId=5d559397bae39100201eedc1&name=All%20Components%7CButton&buildNumber=1624&specName=Split%20Button" target="_blank" rel="noopener noreferrer">Click to view the split button example in a new tab</a>

#### To tophat locally
- `git checkout button-connectedSegment && dev up && yarn dev`
  - A new tab or window with the Storybook examples will open automatically 
- Open `polaris-react` in your text editor and copy/paste the Playground code collapsed below into `/playground/Playground.tsx`
  - Click "Playground" in the left navigation of the Storybook to view the playground

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Card, ButtonGroup, Button} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Card sectioned>
        <ButtonGroup>
          <Button
            onClick={() => console.log('Draft purchase order saved')}
            primary
            connectedDisclosure={{
              actions: [
                {
                  content: 'Save and mark as ordered',
                  onAction: () => console.log('PO saved and marked as ordered'),
                },
              ],
            }}
          >
            Primary
          </Button>
          <Button
            onClick={() => console.log('Draft purchase order saved')}
            connectedDisclosure={{
              actions: [
                {
                  content: 'Save and mark as ordered',
                  onAction: () => console.log('PO saved and marked as ordered'),
                },
              ],
            }}
          >
            Basic
          </Button>
          <Button
            outline
            onClick={() => console.log('Draft purchase order saved')}
            connectedDisclosure={{
              actions: [
                {
                  content: 'Save and mark as ordered',
                  onAction: () => console.log('PO saved and marked as ordered'),
                },
              ],
            }}
          >
            Outline
          </Button>
          <Button
            destructive
            onClick={() => console.log('Draft purchase order saved')}
            connectedDisclosure={{
              actions: [
                {
                  destructive: true,
                  content: 'Save and mark as ordered',
                  onAction: () => console.log('PO saved and marked as ordered'),
                },
              ],
            }}
          >
            Destructive
          </Button>
          <Button
            outline
            destructive
            onClick={() => console.log('Draft purchase order saved')}
            connectedDisclosure={{
              actions: [
                {
                  destructive: true,
                  content: 'Save and mark as ordered',
                  onAction: () => console.log('PO saved and marked as ordered'),
                },
              ],
            }}
          >
            Destructive
          </Button>
        </ButtonGroup>
      </Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
