### PR TITLE
[Color system] Add tests for adding and removing styles

### DIFF
--- a/src/components/Portal/tests/Portal.test.tsx
+++ b/src/components/Portal/tests/Portal.test.tsx
@@ -96,15 +96,24 @@ describe('<Portal />', () => {
     }).not.toThrow();
   });
 
-  it('renders okay with new theme context', () => {
-    expect(() => {
-      mountWithAppProvider(<Portal />, {
-        features: {unstableGlobalTheming: true},
-        theme: {
-          // eslint-disable-next-line babel/camelcase
-          UNSTABLE_colors: {surface: '#000000'},
-        },
-      });
-    }).not.toThrow();
+  it('sets CSS custom properties on the portal node', () => {
+    const setSpy = jest.spyOn(Element.prototype, 'setAttribute');
+    const portal = mountWithAppProvider(<Portal />, {
+      features: {unstableGlobalTheming: true},
+      theme: {
+        // eslint-disable-next-line babel/camelcase
+        UNSTABLE_colors: {surface: '#000000'},
+      },
+    });
+    expect(setSpy).toHaveBeenCalledWith(
+      'style',
+      portal.context().UNSTABLE_cssCustomProperties,
+    );
+  });
+
+  it('removes CSS custom properties from the portal node', () => {
+    const removeSpy = jest.spyOn(Element.prototype, 'removeAttribute');
+    mountWithAppProvider(<Portal />);
+    expect(removeSpy).toHaveBeenCalledWith('style');
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Adds a couple more tests for work done in #2306 and #2327 which expect that we are adding and removing the CSS custom property styles to and from the portal node. 

### WHAT is this pull request doing?

By spying on the `Element` prototype we can get access to instance methods.
