### PR TITLE
[TextField] delete irrelevant default numeric-range props, prevent unconditional aria-invalid='false'

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,9 @@
 
 ### Bug fixes
 
+- Fixed `TextField` to no longer render `aria-invalid="false"` ([#2282](https://github.com/Shopify/polaris-react/pull/2282))
+- Fixed `TextField` to only render `min` ,`max` and `step` attributes when explicitly passed ([#2282](https://github.com/Shopify/polaris-react/pull/2282))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -144,11 +144,11 @@ export function TextField({
   name,
   id: idProp,
   role,
-  step = 1,
+  step,
   autoComplete,
-  max = Infinity,
+  max,
   maxLength,
-  min = -Infinity,
+  min,
   minLength,
   pattern,
   spellCheck,
@@ -183,6 +183,11 @@ export function TextField({
 
   const normalizedValue = value != null ? value : '';
   const {unstableGlobalTheming = false} = useFeatures();
+
+  const normalizedStep = step != null ? step : 1;
+  const normalizedMax = max != null ? max : Infinity;
+  const normalizedMin = min != null ? min : -Infinity;
+
   const className = classNames(
     styles.TextField,
     Boolean(normalizedValue) && styles.hasValue,
@@ -268,16 +273,16 @@ export function TextField({
 
       // Making sure the new value has the same length of decimal places as the
       // step / value has.
-      const decimalPlaces = Math.max(dpl(numericValue), dpl(step));
+      const decimalPlaces = Math.max(dpl(numericValue), dpl(normalizedStep));
 
       const newValue = Math.min(
-        Number(max),
-        Math.max(numericValue + steps * step, Number(min)),
+        Number(normalizedMax),
+        Math.max(numericValue + steps * normalizedStep, Number(normalizedMin)),
       );
 
       onChange(String(newValue.toFixed(decimalPlaces)), id);
     },
-    [id, max, min, onChange, step, value],
+    [id, normalizedMax, normalizedMin, onChange, normalizedStep, value],
   );
 
   const handleButtonRelease = useCallback(() => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #2282. I made a single PR because it was one issue, but maybe it should be split in two

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

1. Removes default props for `max`, `min`, `step` so they no longer show up in markup unless explicitly passed
2. Prevents `aria-invalid="false"` from being rendered when there is no error


