### PR TITLE
[Color system] Flatten interaction states

### DIFF
--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -48,32 +48,60 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   border-radius: 0;
 
   &.active {
-    @include state(active);
+    background-image: linear-gradient(
+      rgba(179, 188, 245, 0.1),
+      rgba(179, 188, 245, 0.1)
+    );
   }
 
   &:active {
-    @include state(active);
+    background-image: linear-gradient(
+      rgba(179, 188, 245, 0.1),
+      rgba(179, 188, 245, 0.1)
+    );
 
     &:hover {
-      @include state(active, hover);
+      background-image: linear-gradient(
+          rgba(179, 188, 245, 0.1),
+          rgba(179, 188, 245, 0.1)
+        ),
+        linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
 
       // stylelint-disable-next-line selector-max-specificity
       &:focus {
-        @include state(active, hover, focused);
+        box-shadow: inset 0.2rem 0 0 color('indigo');
+        background-image: linear-gradient(
+            rgba(179, 188, 245, 0.1),
+            rgba(179, 188, 245, 0.1)
+          ),
+          linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3)),
+          linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
       }
     }
   }
 
   &:hover {
-    @include state(hover);
+    background-image: linear-gradient(
+      rgba(223, 227, 232, 0.3),
+      rgba(223, 227, 232, 0.3)
+    );
 
     &:focus {
-      @include state(hover, focused);
+      box-shadow: inset 0.2rem 0 0 color('indigo');
+      background-image: linear-gradient(
+          rgba(223, 227, 232, 0.3),
+          rgba(223, 227, 232, 0.3)
+        ),
+        linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
     }
   }
 
   &:focus {
-    @include state(focused);
+    box-shadow: inset 0.2rem 0 0 color('indigo');
+    background-image: linear-gradient(
+      rgba(223, 227, 232, 0.3),
+      rgba(223, 227, 232, 0.3)
+    );
   }
 
   &.destructive {
@@ -81,39 +109,63 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
     color: color('red', 'dark');
 
     &:active {
-      @include state(active-destructive);
+      background-image: linear-gradient(
+        rgba(220, 56, 37, 0.03),
+        rgba(220, 56, 37, 0.03)
+      );
 
       // stylelint-disable-next-line selector-max-specificity
       &:hover {
-        @include state(active-destructive, hover-destructive);
+        background-image: linear-gradient(
+            rgba(220, 56, 37, 0.03),
+            rgba(220, 56, 37, 0.03)
+          ),
+          linear-gradient(rgba(251, 234, 229, 0.4), rgba(251, 234, 229, 0.4));
 
         // stylelint-disable-next-line selector-max-specificity, max-nesting-depth
         &:focus {
-          @include state(
-            active-destructive,
-            hover-destructive,
-            focused-destructive
-          );
+          box-shadow: inset 0.2rem 0 0 color('red');
+          background-image: linear-gradient(
+              rgba(220, 56, 37, 0.03),
+              rgba(220, 56, 37, 0.03)
+            ),
+            linear-gradient(rgba(251, 234, 229, 0.4), rgba(251, 234, 229, 0.4)),
+            linear-gradient(rgba(251, 234, 229, 0.4), rgba(251, 234, 229, 0.4));
         }
       }
     }
 
     &:hover {
-      @include state(hover-destructive);
+      background-image: linear-gradient(
+        rgba(251, 234, 229, 0.4),
+        rgba(251, 234, 229, 0.4)
+      );
 
       // stylelint-disable-next-line selector-max-specificity
       &:focus {
-        @include state(hover-destructive, focused-destructive);
+        box-shadow: inset 0.2rem 0 0 color('red');
+        background-image: linear-gradient(
+            rgba(251, 234, 229, 0.4),
+            rgba(251, 234, 229, 0.4)
+          ),
+          linear-gradient(rgba(251, 234, 229, 0.4), rgba(251, 234, 229, 0.4));
       }
     }
 
     &:focus {
-      @include state(focused-destructive);
+      box-shadow: inset 0.2rem 0 0 color('red');
+      background-image: linear-gradient(
+        rgba(251, 234, 229, 0.4),
+        rgba(251, 234, 229, 0.4)
+      );
     }
   }
 
   &.disabled {
-    @include state(disabled);
+    background-image: linear-gradient(
+      rgba(249, 250, 251, 1),
+      rgba(249, 250, 251, 1)
+    );
     color: color('ink', 'lightest');
     pointer-events: none;
 

--- a/src/components/Filters/Filters.scss
+++ b/src/components/Filters/Filters.scss
@@ -85,12 +85,19 @@ $list-filters-footer-height: rem(70px);
 
   &:hover {
     cursor: pointer;
-    @include state(hover);
+    background-image: linear-gradient(
+      rgba(223, 227, 232, 0.3),
+      rgba(223, 227, 232, 0.3)
+    );
   }
 
   &:focus {
     outline: none;
-    @include state(focused);
+    box-shadow: inset 0.2rem 0 0 color('indigo');
+    background-image: linear-gradient(
+      rgba(223, 227, 232, 0.3),
+      rgba(223, 227, 232, 0.3)
+    );
   }
 }
 

--- a/src/components/OptionList/components/Option/Option.scss
+++ b/src/components/OptionList/components/Option/Option.scss
@@ -13,7 +13,10 @@ $control-vertical-adjustment: rem(2px);
   cursor: pointer;
 
   &:hover {
-    @include state(hover);
+    background-image: linear-gradient(
+      rgba(223, 227, 232, 0.3),
+      rgba(223, 227, 232, 0.3)
+    );
   }
 }
 
@@ -49,15 +52,27 @@ $control-vertical-adjustment: rem(2px);
 }
 
 .focused {
-  @include state(focused);
+  box-shadow: inset 0.2rem 0 0 color('indigo');
+  background-image: linear-gradient(
+    rgba(223, 227, 232, 0.3),
+    rgba(223, 227, 232, 0.3)
+  );
 
   &:hover {
-    @include state(focused, hover);
+    box-shadow: inset 0.2rem 0 0 color('indigo');
+    background-image: linear-gradient(
+        rgba(223, 227, 232, 0.3),
+        rgba(223, 227, 232, 0.3)
+      ),
+      linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
   }
 }
 
 .disabled {
-  @include state(disabled);
+  background-image: linear-gradient(
+    rgba(249, 250, 251, 1),
+    rgba(249, 250, 251, 1)
+  );
 
   .Media {
     @include recolor-icon(color('ink', 'lightest'), color('white'));
@@ -65,19 +80,36 @@ $control-vertical-adjustment: rem(2px);
 }
 
 .select {
-  @include state(selected);
+  background-image: linear-gradient(
+    rgba(179, 188, 245, 0.15),
+    rgba(179, 188, 245, 0.15)
+  );
 
   &.focused {
-    @include state(selected, focused);
+    box-shadow: inset 0.2rem 0 0 color('indigo');
+    background-image: linear-gradient(
+        rgba(179, 188, 245, 0.15),
+        rgba(179, 188, 245, 0.15)
+      ),
+      linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
 
     &:hover {
-      @include state(selected, focused, hover);
+      box-shadow: inset 0.2rem 0 0 color('indigo');
+      background-image: linear-gradient(
+          rgba(179, 188, 245, 0.15),
+          rgba(179, 188, 245, 0.15)
+        ),
+        linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3)),
+        linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
     }
   }
 }
 
 .active {
-  @include state(active);
+  background-image: linear-gradient(
+    rgba(179, 188, 245, 0.1),
+    rgba(179, 188, 245, 0.1)
+  );
 }
 
 .Media {

--- a/src/components/ResourceItem/ResourceItem.scss
+++ b/src/components/ResourceItem/ResourceItem.scss
@@ -40,7 +40,10 @@ $resource-list-item-variables: (
   cursor: pointer;
 
   &:hover {
-    @include state(hover);
+    background-image: linear-gradient(
+      rgba(223, 227, 232, 0.3),
+      rgba(223, 227, 232, 0.3)
+    );
 
     &:not(.persistActions) {
       // stylelint-disable-next-line selector-max-specificity
@@ -57,39 +60,78 @@ $resource-list-item-variables: (
   }
 
   &:active {
-    @include state(active);
+    background-image: linear-gradient(
+      rgba(179, 188, 245, 0.1),
+      rgba(179, 188, 245, 0.1)
+    );
   }
 }
 
 .selected {
-  @include state(selected);
+  background-image: linear-gradient(
+    rgba(179, 188, 245, 0.15),
+    rgba(179, 188, 245, 0.15)
+  );
 
   &.focused {
-    @include state(selected, focused);
+    box-shadow: inset 0.2rem 0 0 color('indigo');
+    background-image: linear-gradient(
+        rgba(179, 188, 245, 0.15),
+        rgba(179, 188, 245, 0.15)
+      ),
+      linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
 
     &:hover {
-      @include state(selected, focused, hover);
+      box-shadow: inset 0.2rem 0 0 color('indigo');
+      background-image: linear-gradient(
+          rgba(179, 188, 245, 0.15),
+          rgba(179, 188, 245, 0.15)
+        ),
+        linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3)),
+        linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
     }
   }
 
   &:hover {
-    @include state(selected, hover);
+    background-image: linear-gradient(
+        rgba(179, 188, 245, 0.15),
+        rgba(179, 188, 245, 0.15)
+      ),
+      linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
   }
 
   &:active {
-    @include state(selected, active);
+    background-image: linear-gradient(
+        rgba(179, 188, 245, 0.15),
+        rgba(179, 188, 245, 0.15)
+      ),
+      linear-gradient(rgba(179, 188, 245, 0.1), rgba(179, 188, 245, 0.1));
   }
 }
 
 .focused {
-  @include state(focused);
+  box-shadow: inset 0.2rem 0 0 color('indigo');
+  background-image: linear-gradient(
+    rgba(223, 227, 232, 0.3),
+    rgba(223, 227, 232, 0.3)
+  );
 
   &:hover {
-    @include state(focused, hover);
+    box-shadow: inset 0.2rem 0 0 color('indigo');
+    background-image: linear-gradient(
+        rgba(223, 227, 232, 0.3),
+        rgba(223, 227, 232, 0.3)
+      ),
+      linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
   }
 
   &:active {
-    @include state(focused, active);
+    box-shadow: inset 0.2rem 0 0 color('indigo');
+    background-image: linear-gradient(
+        rgba(223, 227, 232, 0.3),
+        rgba(223, 227, 232, 0.3)
+      ),
+      linear-gradient(rgba(179, 188, 245, 0.1), rgba(179, 188, 245, 0.1));
   }
 }
 

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -140,28 +140,53 @@ $focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
   cursor: pointer;
 
   &:active {
-    @include state(active);
+    background-image: linear-gradient(
+      rgba(179, 188, 245, 0.1),
+      rgba(179, 188, 245, 0.1)
+    );
 
     &:hover {
-      @include state(active, hover);
+      background-image: linear-gradient(
+          rgba(179, 188, 245, 0.1),
+          rgba(179, 188, 245, 0.1)
+        ),
+        linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
 
       // stylelint-disable-next-line selector-max-specificity
       &:focus {
-        @include state(active, hover, focused);
+        box-shadow: inset 0.2rem 0 0 color('indigo');
+        background-image: linear-gradient(
+            rgba(179, 188, 245, 0.1),
+            rgba(179, 188, 245, 0.1)
+          ),
+          linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3)),
+          linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
       }
     }
   }
 
   &:hover {
-    @include state(hover);
+    background-image: linear-gradient(
+      rgba(223, 227, 232, 0.3),
+      rgba(223, 227, 232, 0.3)
+    );
 
     &:focus {
-      @include state(hover, focused);
+      box-shadow: inset 0.2rem 0 0 color('indigo');
+      background-image: linear-gradient(
+          rgba(223, 227, 232, 0.3),
+          rgba(223, 227, 232, 0.3)
+        ),
+        linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
     }
   }
 
   &:focus {
-    @include state(focused);
+    box-shadow: inset 0.2rem 0 0 color('indigo');
+    background-image: linear-gradient(
+      rgba(223, 227, 232, 0.3),
+      rgba(223, 227, 232, 0.3)
+    );
   }
 
   &::-moz-focus-inner {
@@ -198,7 +223,11 @@ $focus-state-box-shadow-color: rgba(92, 106, 196, 0.8);
 
       @media (-ms-high-contrast: active) {
         @include recolor-icon(color('black'));
-        @include state(active, hover);
+        background-image: linear-gradient(
+            rgba(179, 188, 245, 0.1),
+            rgba(179, 188, 245, 0.1)
+          ),
+          linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3));
         border-bottom-color: ms-high-contrast-color('selected-text-background');
       }
     }


### PR DESCRIPTION
### WHY are these changes introduced?

Address #2197. Flattens the output from the `state` mixin to make it possible to implement CSS var overrides and fallbacks in a sane way. 

### WHAT is this pull request doing?

Find and replaces the `state` uses with the raw output based on arguments.