### PR TITLE
[TextField] Fix aria-multiline attribute values

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed an accessibility issue by updating the `aria-multiline` attribute for `TextField` with `multiline` of type number. Replaced positive number values with `true`. ([#2351](https://github.com/Shopify/polaris-react/pull/2351)).
+
 ### Documentation
 
 ### Development workflow

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,7 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
-- Fixed an accessibility issue by updating the `aria-multiline` attribute for `TextField` with `multiline` of type number. Replaced positive number values with `true`. ([#2351](https://github.com/Shopify/polaris-react/pull/2351)).
+- Fixed an accessibility issue with `TextField` `multiline` where `aria-multiline` would be set to an invalid type `number` ([#2351](https://github.com/Shopify/polaris-react/pull/2351))
 
 ### Documentation
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -397,7 +397,7 @@ export function TextField({
     'aria-activedescendant': ariaActiveDescendant,
     'aria-autocomplete': ariaAutocomplete,
     'aria-controls': ariaControls,
-    'aria-multiline': multiline,
+    'aria-multiline': normalizeAriaMultiline(multiline),
   });
 
   return (
@@ -482,5 +482,17 @@ function normalizeAutoComplete(autoComplete?: boolean | string) {
     return 'off';
   } else {
     return autoComplete;
+  }
+}
+
+function normalizeAriaMultiline(multiline?: boolean | number) {
+  if (!multiline) {
+    return false;
+  }
+
+  if (typeof multiline === 'boolean') {
+    return multiline;
+  } else if (typeof multiline === 'number') {
+    return Boolean(multiline > 0);
   }
 }

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -486,13 +486,12 @@ function normalizeAutoComplete(autoComplete?: boolean | string) {
 }
 
 function normalizeAriaMultiline(multiline?: boolean | number) {
-  if (!multiline) {
-    return false;
-  }
-
-  if (typeof multiline === 'boolean') {
-    return multiline;
-  } else if (typeof multiline === 'number') {
-    return Boolean(multiline > 0);
+  switch (typeof multiline) {
+    case 'undefined':
+      return false;
+    case 'boolean':
+      return multiline;
+    case 'number':
+      return Boolean(multiline > 0);
   }
 }

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -958,7 +958,7 @@ describe('<TextField />', () => {
       expect(textField.find('textarea').prop('aria-multiline')).toBe(true);
     });
 
-    it('renders a input element with `aria-multiline` set to false if multiline is equal to 0', () => {
+    it('renders an input element with `aria-multiline` set to false if multiline is equal to 0', () => {
       const textField = mountWithAppProvider(
         <TextField
           label="TextField"
@@ -974,7 +974,7 @@ describe('<TextField />', () => {
       expect(textField.find('input').prop('aria-multiline')).toBe(false);
     });
 
-    it('renders a input element with `aria-multiline` set to false if multiline is undefined', () => {
+    it('renders an input element with `aria-multiline` set to false if multiline is undefined', () => {
       const textField = mountWithAppProvider(
         <TextField
           label="TextField"

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -941,6 +941,53 @@ describe('<TextField />', () => {
         'Aria controls',
       );
     });
+
+    it('renders a textarea element with `aria-multiline` set to true if multiline greater than 0', () => {
+      const textField = mountWithAppProvider(
+        <TextField
+          label="TextField"
+          id="MyField"
+          onChange={noop}
+          multiline={4}
+          ariaOwns="Aria owns"
+          ariaActiveDescendant="Aria active descendant"
+          ariaAutocomplete="Aria autocomplete"
+          ariaControls="Aria controls"
+        />,
+      );
+      expect(textField.find('textarea').prop('aria-multiline')).toBe(true);
+    });
+
+    it('renders a input element with `aria-multiline` set to false if multiline is equal to 0', () => {
+      const textField = mountWithAppProvider(
+        <TextField
+          label="TextField"
+          id="MyField"
+          onChange={noop}
+          multiline={0}
+          ariaOwns="Aria owns"
+          ariaActiveDescendant="Aria active descendant"
+          ariaAutocomplete="Aria autocomplete"
+          ariaControls="Aria controls"
+        />,
+      );
+      expect(textField.find('input').prop('aria-multiline')).toBe(false);
+    });
+
+    it('renders a input element with `aria-multiline` set to false if multiline is undefined', () => {
+      const textField = mountWithAppProvider(
+        <TextField
+          label="TextField"
+          id="MyField"
+          onChange={noop}
+          ariaOwns="Aria owns"
+          ariaActiveDescendant="Aria active descendant"
+          ariaAutocomplete="Aria autocomplete"
+          ariaControls="Aria controls"
+        />,
+      );
+      expect(textField.find('input').prop('aria-multiline')).toBe(false);
+    });
   });
 
   describe('Labelled', () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

Comply with the [WAI-ARIA-1.1 guidelines](https://www.w3.org/TR/wai-aria-1.1/#aria-multiline) by normalizing the `aria-multiline` attribute for `TextField` components that have `multiline: number` prop.

### WHY are these changes introduced?

Fixes #2349 

Automated accessibility tools (e.g. Axe, Lighthouse) currently flag invalid aria-multiline values for TextField when specifying a number value for its multiline prop.

### WHAT is this pull request doing?

| `multiline` prop        | before           | after       |
| ------------- |:-------------:| --------:|
| number > 0    | `aria-multiline={number}` | `aria-multiline={true}`|

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

`<textarea>` with `aria-multiline` will no longer be flagged for invalid aria attributes.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';
import {Page, TextField} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <MultilineFieldExample />
    </Page>
  );
}

function MultilineFieldExample() {
  const [value, setValue] = useState('1776 Barnes Street\nOrlando, FL 32801');

  const handleChange = useCallback((newValue) => setValue(newValue), []);

  return (
    <TextField
      label="Shipping address"
      value={value}
      onChange={handleChange}
      multiline={5}
    />
  );
}
```

</details>

### 🎩 checklist

* [ ] ~Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)~
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide (⚠️ I believe aria-multiline is implicit, not exposed to Polaris users. Not sure if any change in documentation is required).
* [ ] ~For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)~

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
