### PR TITLE
Move color adjustments to JSON file

### DIFF
--- a/src/utilities/theme/colorAdjustments.json
+++ b/src/utilities/theme/colorAdjustments.json
@@ -1,0 +1,546 @@
+{
+  "SURFACE": {"baseColor": "surface", "light": {}, "dark": {}},
+  "SURFACE_BACKGROUND": {
+    "baseColor": "surface",
+    "light": {"lightness": 98},
+    "dark": {"lightness": 7}
+  },
+  "SURFACE_FOREGROUND": {
+    "baseColor": "surface",
+    "light": {"lightness": 100},
+    "dark": {"lightness": 13}
+  },
+  "SURFACE_FOREGROUND_SUBDUED": {
+    "baseColor": "surface",
+    "light": {"lightness": 90},
+    "dark": {"lightness": 10}
+  },
+  "SURFACE_INVERSE": {
+    "baseColor": "surface",
+    "light": {"lightness": 0},
+    "dark": {"lightness": 100}
+  },
+  "SURFACE_HOVERED": {
+    "baseColor": "surface",
+    "light": {"lightness": 93},
+    "dark": {"lightness": 20}
+  },
+  "SURFACE_PRESSED": {
+    "baseColor": "surface",
+    "light": {"lightness": 86},
+    "dark": {"lightness": 27}
+  },
+  "ON_SURFACE": {"baseColor": "onSurface", "light": {}, "dark": {}},
+  "ACTION_ON_INVERSE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 76},
+    "dark": {"lightness": 36}
+  },
+  "ACTION_ON_SURFACE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 36},
+    "dark": {"lightness": 76}
+  },
+  "ACTION_DISABLED_ON_INVERSE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 66},
+    "dark": {"lightness": 46}
+  },
+  "ACTION_DISABLED_ON_SURFACE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 46},
+    "dark": {"lightness": 66}
+  },
+  "ACTION_HOVERED_ON_INVERSE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 86},
+    "dark": {"lightness": 26}
+  },
+  "ACTION_HOVERED_ON_SURFACE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 26},
+    "dark": {"lightness": 86}
+  },
+  "ACTION_PRESSED_ON_INVERSE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 96},
+    "dark": {"lightness": 16}
+  },
+  "ACTION_PRESSED_ON_SURFACE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 16},
+    "dark": {"lightness": 96}
+  },
+  "DIVIDER_ON_INVERSE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 80},
+    "dark": {"lightness": 75}
+  },
+  "DIVIDER_ON_SURFACE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 75},
+    "dark": {"lightness": 80}
+  },
+  "DIVIDER_DISABLED_ON_INVERSE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 70},
+    "dark": {"lightness": 95}
+  },
+  "DIVIDER_DISABLED_ON_SURFACE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 95},
+    "dark": {"lightness": 70}
+  },
+  "DIVIDER_SUBDUED_ON_INVERSE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 75},
+    "dark": {"lightness": 85}
+  },
+  "DIVIDER_SUBDUED_ON_SURFACE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 85},
+    "dark": {"lightness": 75}
+  },
+  "ICON_ON_INVERSE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 98},
+    "dark": {"lightness": 18}
+  },
+  "ICON_ON_SURFACE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 18},
+    "dark": {"lightness": 98}
+  },
+  "ICON_DISABLED_ON_INVERSE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 75},
+    "dark": {"lightness": 68}
+  },
+  "ICON_DISABLED_ON_SURFACE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 68},
+    "dark": {"lightness": 75}
+  },
+  "ICON_SUBDUED_ON_INVERSE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 88},
+    "dark": {"lightness": 43}
+  },
+  "ICON_SUBDUED_ON_SURFACE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 43},
+    "dark": {"lightness": 88}
+  },
+  "TEXT_ON_INVERSE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 100},
+    "dark": {"lightness": 13}
+  },
+  "TEXT_ON_SURFACE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 13},
+    "dark": {"lightness": 100}
+  },
+  "TEXT_DISABLED_ON_INVERSE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 80},
+    "dark": {"lightness": 63}
+  },
+  "TEXT_DISABLED_ON_SURFACE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 63},
+    "dark": {"lightness": 80}
+  },
+  "TEXT_SUBDUED_ON_INVERSE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 90},
+    "dark": {"lightness": 38}
+  },
+  "TEXT_SUBDUED_ON_SURFACE": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 38},
+    "dark": {"lightness": 90}
+  },
+  "ACTION_ON_DARK": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 76},
+    "dark": {"lightness": 76}
+  },
+  "ACTION_ON_LIGHT": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 36},
+    "dark": {"lightness": 36}
+  },
+  "ACTION_DISABLED_ON_DARK": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 66},
+    "dark": {"lightness": 66}
+  },
+  "ACTION_DISABLED_ON_LIGHT": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 46},
+    "dark": {"lightness": 46}
+  },
+  "ACTION_HOVERED_ON_DARK": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 86},
+    "dark": {"lightness": 86}
+  },
+  "ACTION_HOVERED_ON_LIGHT": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 26},
+    "dark": {"lightness": 26}
+  },
+  "ACTION_PRESSED_ON_DARK": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 96},
+    "dark": {"lightness": 96}
+  },
+  "ACTION_PRESSED_ON_LIGHT": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 16},
+    "dark": {"lightness": 16}
+  },
+  "DIVIDER_ON_DARK": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 80},
+    "dark": {"lightness": 80}
+  },
+  "DIVIDER_ON_LIGHT": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 75},
+    "dark": {"lightness": 75}
+  },
+  "DIVIDER_DISABLED_ON_DARK": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 70},
+    "dark": {"lightness": 70}
+  },
+  "DIVIDER_DISABLED_ON_LIGHT": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 95},
+    "dark": {"lightness": 95}
+  },
+  "DIVIDER_SUBDUED_ON_DARK": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 75},
+    "dark": {"lightness": 75}
+  },
+  "DIVIDER_SUBDUED_ON_LIGHT": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 85},
+    "dark": {"lightness": 85}
+  },
+  "ICON_ON_DARK": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 98},
+    "dark": {"lightness": 98}
+  },
+  "ICON_ON_LIGHT": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 18},
+    "dark": {"lightness": 18}
+  },
+  "ICON_DISABLED_ON_DARK": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 75},
+    "dark": {"lightness": 75}
+  },
+  "ICON_DISABLED_ON_LIGHT": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 68},
+    "dark": {"lightness": 68}
+  },
+  "ICON_SUBDUED_ON_DARK": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 88},
+    "dark": {"lightness": 88}
+  },
+  "ICON_SUBDUED_ON_LIGHT": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 43},
+    "dark": {"lightness": 43}
+  },
+  "TEXT_ON_DARK": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 100},
+    "dark": {"lightness": 100}
+  },
+  "TEXT_ON_LIGHT": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 13},
+    "dark": {"lightness": 13}
+  },
+  "TEXT_DISABLED_ON_DARK": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 80},
+    "dark": {"lightness": 80}
+  },
+  "TEXT_DISABLED_ON_LIGHT": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 63},
+    "dark": {"lightness": 63}
+  },
+  "TEXT_SUBDUED_ON_DARK": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 90},
+    "dark": {"lightness": 90}
+  },
+  "TEXT_SUBDUED_ON_LIGHT": {
+    "baseColor": "onSurface",
+    "light": {"lightness": 38},
+    "dark": {"lightness": 38}
+  },
+  "INTERACTIVE": {"baseColor": "interactive", "light": {}, "dark": {}},
+  "INTERACTIVE_ACTION": {
+    "baseColor": "interactive",
+    "light": {"lightness": 44},
+    "dark": {"lightness": 56}
+  },
+  "INTERACTIVE_ACTION_DISABLED": {
+    "baseColor": "interactive",
+    "light": {"lightness": 58},
+    "dark": {"lightness": 42}
+  },
+  "INTERACTIVE_ACTION_HOVERED": {
+    "baseColor": "interactive",
+    "light": {"lightness": 37},
+    "dark": {"lightness": 63}
+  },
+  "INTERACTIVE_ACTION_SUBDUED": {
+    "baseColor": "interactive",
+    "light": {"lightness": 51},
+    "dark": {"lightness": 49}
+  },
+  "INTERACTIVE_ACTION_PRESSED": {
+    "baseColor": "interactive",
+    "light": {"lightness": 31},
+    "dark": {"lightness": 69}
+  },
+  "INTERACTIVE_FOCUS": {
+    "baseColor": "interactive",
+    "light": {"lightness": 58},
+    "dark": {"lightness": 42}
+  },
+  "INTERACTIVE_SELECTED": {
+    "baseColor": "interactive",
+    "light": {"lightness": 96},
+    "dark": {"lightness": 4}
+  },
+  "INTERACTIVE_SELECTED_HOVERED": {
+    "baseColor": "interactive",
+    "light": {"lightness": 89},
+    "dark": {"lightness": 11}
+  },
+  "INTERACTIVE_SELECTED_PRESSED": {
+    "baseColor": "interactive",
+    "light": {"lightness": 82},
+    "dark": {"lightness": 18}
+  },
+  "NEUTRAL": {"baseColor": "neutral", "light": {}, "dark": {}},
+  "NEUTRAL_ACTION_DISABLED": {
+    "baseColor": "neutral",
+    "light": {"lightness": 94},
+    "dark": {"lightness": 13}
+  },
+  "NEUTRAL_ACTION": {
+    "baseColor": "neutral",
+    "light": {"lightness": 92},
+    "dark": {"lightness": 22}
+  },
+  "NEUTRAL_ACTION_HOVERED": {
+    "baseColor": "neutral",
+    "light": {"lightness": 86},
+    "dark": {"lightness": 29}
+  },
+  "NEUTRAL_ACTION_PRESSED": {
+    "baseColor": "neutral",
+    "light": {"lightness": 76},
+    "dark": {"lightness": 39}
+  },
+  "BRANDED": {"baseColor": "branded", "light": {}, "dark": {}},
+  "BRANDED_ACTION": {
+    "baseColor": "branded",
+    "light": {"lightness": 25},
+    "dark": {"lightness": 25}
+  },
+  "BRANDED_ACTION_DISABLED": {
+    "baseColor": "branded",
+    "light": {"lightness": 32},
+    "dark": {"lightness": 32}
+  },
+  "BRANDED_ACTION_HOVERED": {
+    "baseColor": "branded",
+    "light": {"lightness": 22},
+    "dark": {"lightness": 22}
+  },
+  "BRANDED_ACTION_PRESSED": {
+    "baseColor": "branded",
+    "light": {"lightness": 15},
+    "dark": {"lightness": 15}
+  },
+  "ICON_ON_BRANDED": {
+    "baseColor": "branded",
+    "light": {"lightness": 98},
+    "dark": {"lightness": 98}
+  },
+  "ICON_SUBDUED_ON_BRANDED": {
+    "baseColor": "branded",
+    "light": {"lightness": 88},
+    "dark": {"lightness": 88}
+  },
+  "TEXT_ON_BRANDED": {
+    "baseColor": "branded",
+    "light": {"lightness": 100},
+    "dark": {"lightness": 100}
+  },
+  "TEXT_SUBDUED_ON_BRANDED": {
+    "baseColor": "branded",
+    "light": {"lightness": 90},
+    "dark": {"lightness": 90}
+  },
+  "BRANDED_SELECTED": {
+    "baseColor": "branded",
+    "light": {"lightness": 95, "saturation": 30},
+    "dark": {"lightness": 5, "saturation": 30}
+  },
+  "BRANDED_SELECTED_HOVERED": {
+    "baseColor": "branded",
+    "light": {"lightness": 81, "saturation": 22},
+    "dark": {"lightness": 19, "saturation": 22}
+  },
+  "BRANDED_SELECTED_PRESSED": {
+    "baseColor": "branded",
+    "light": {"lightness": 74, "saturation": 22},
+    "dark": {"lightness": 26, "saturation": 22}
+  },
+  "CRITICAL": {"baseColor": "critical", "light": {}, "dark": {}},
+  "CRITICAL_DIVIDER": {
+    "baseColor": "critical",
+    "light": {"lightness": 52},
+    "dark": {"lightness": 48}
+  },
+  "CRITICAL_ICON": {
+    "baseColor": "critical",
+    "light": {"lightness": 52},
+    "dark": {"lightness": 48}
+  },
+  "CRITICAL_SURFACE": {
+    "baseColor": "critical",
+    "light": {"lightness": 88},
+    "dark": {"lightness": 12}
+  },
+  "CRITICAL_SURFACE_SUBDUED": {
+    "baseColor": "critical",
+    "light": {"lightness": 98},
+    "dark": {"lightness": 12}
+  },
+  "CRITICAL_TEXT": {
+    "baseColor": "critical",
+    "light": {"lightness": 30},
+    "dark": {"lightness": 70}
+  },
+  "CRITICAL_ACTION_DISABLED": {
+    "baseColor": "critical",
+    "light": {"lightness": 59},
+    "dark": {"lightness": 41}
+  },
+  "CRITICAL_ACTION": {
+    "baseColor": "critical",
+    "light": {"lightness": 52},
+    "dark": {"lightness": 48}
+  },
+  "CRITICAL_ACTION_HOVERED": {
+    "baseColor": "critical",
+    "light": {"lightness": 45},
+    "dark": {"lightness": 55}
+  },
+  "CRITICAL_ACTION_SUBDUED": {
+    "baseColor": "critical",
+    "light": {"lightness": 38},
+    "dark": {"lightness": 62}
+  },
+  "CRITICAL_ACTION_PRESSED": {
+    "baseColor": "critical",
+    "light": {"lightness": 31},
+    "dark": {"lightness": 69}
+  },
+  "WARNING": {"baseColor": "warning", "light": {}, "dark": {}},
+  "WARNING_DIVIDER": {
+    "baseColor": "warning",
+    "light": {"lightness": 66},
+    "dark": {"lightness": 34}
+  },
+  "WARNING_ICON": {
+    "baseColor": "warning",
+    "light": {"lightness": 66},
+    "dark": {"lightness": 34}
+  },
+  "WARNING_SURFACE": {
+    "baseColor": "warning",
+    "light": {"lightness": 88},
+    "dark": {"lightness": 12}
+  },
+  "WARNING_SURFACE_SUBDUED": {
+    "baseColor": "warning",
+    "light": {"lightness": 98},
+    "dark": {"lightness": 12}
+  },
+  "WARNING_TEXT": {
+    "baseColor": "warning",
+    "light": {"lightness": 30},
+    "dark": {"lightness": 70}
+  },
+  "HIGHLIGHT": {"baseColor": "highlight", "light": {}, "dark": {}},
+  "HIGHLIGHT_DIVIDER": {
+    "baseColor": "highlight",
+    "light": {"lightness": 58},
+    "dark": {"lightness": 42}
+  },
+  "HIGHLIGHT_ICON": {
+    "baseColor": "highlight",
+    "light": {"lightness": 58},
+    "dark": {"lightness": 42}
+  },
+  "HIGHLIGHT_SURFACE": {
+    "baseColor": "highlight",
+    "light": {"lightness": 88},
+    "dark": {"lightness": 12}
+  },
+  "HIGHLIGHT_SURFACE_SUBDUED": {
+    "baseColor": "highlight",
+    "light": {"lightness": 98},
+    "dark": {"lightness": 12}
+  },
+  "HIGHLIGHT_TEXT": {
+    "baseColor": "highlight",
+    "light": {"lightness": 98},
+    "dark": {"lightness": 2}
+  },
+  "SUCCESS": {"baseColor": "success", "light": {}, "dark": {}},
+  "SUCCESS_DIVIDER": {
+    "baseColor": "success",
+    "light": {"lightness": 25},
+    "dark": {"lightness": 35}
+  },
+  "SUCCESS_ICON": {
+    "baseColor": "success",
+    "light": {"lightness": 25},
+    "dark": {"lightness": 35}
+  },
+  "SUCCESS_SURFACE": {
+    "baseColor": "success",
+    "light": {"lightness": 88},
+    "dark": {"lightness": 12}
+  },
+  "SUCCESS_SURFACE_SUBDUED": {
+    "baseColor": "success",
+    "light": {"lightness": 98},
+    "dark": {"lightness": 12}
+  },
+  "SUCCESS_TEXT": {
+    "baseColor": "success",
+    "light": {"lightness": 15},
+    "dark": {"lightness": 85}
+  }
+}

--- a/src/utilities/theme/tests/utils.test.ts
+++ b/src/utilities/theme/tests/utils.test.ts
@@ -7,6 +7,7 @@ import {
   buildThemeContext,
   buildCustomProperties,
   buildColors,
+  snakeCaseToCamelCase,
 } from '../utils';
 
 describe('setTextColor', () => {
@@ -717,6 +718,19 @@ describe('buildThemeContext', () => {
     expect(
       buildThemeContext({colors: {}, logo: {}}, {foo: 'bar'}),
     ).toStrictEqual({logo: {}, UNSTABLE_cssCustomProperties: 'foo:bar'});
+  });
+});
+
+describe('snakeCaseToCamelCase', () => {
+  it('convert convers uppercase snake case correctly', () => {
+    expect(snakeCaseToCamelCase('P_SUCCESS_TEXT')).toStrictEqual(
+      'pSuccessText',
+    );
+  });
+  it('convert convers lowercase snake case correctly', () => {
+    expect(snakeCaseToCamelCase('p_success_text')).toStrictEqual(
+      'pSuccessText',
+    );
   });
 });
 /* eslint-enable babel/camelcase */

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -7,6 +7,7 @@ import {createLightColor} from '../color-manipulation';
 import {compose} from '../compose';
 import {needsVariantList} from './config';
 import {ThemeConfig, Theme, CustomPropertiesLike} from './types';
+import colorAdjustmentsJson from './colorAdjustments.json';
 
 export function buildCustomProperties(
   themeConfig: ThemeConfig,
@@ -39,6 +40,12 @@ function toString(obj?: CustomPropertiesLike) {
   }
 }
 
+export function snakeCaseToCamelCase(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/_([a-z])/g, (_match, char) => char.toUpperCase());
+}
+
 /* eslint-disable babel/camelcase */
 // eslint-disable-next-line shopify/typescript/prefer-pascal-case-enums
 export enum UNSTABLE_Color {
@@ -54,207 +61,81 @@ export enum UNSTABLE_Color {
   Success = '#008060',
 }
 
+export interface ColorAdjustments {
+  [x: string]: {
+    baseColor:
+      | 'surface'
+      | 'onSurface'
+      | 'interactive'
+      | 'neutral'
+      | 'branded'
+      | 'critical'
+      | 'warning'
+      | 'highlight'
+      | 'success';
+    light: {
+      hue?: number;
+      saturation?: number;
+      lightness?: number;
+      alpha?: number;
+    };
+    dark: {
+      hue?: number;
+      saturation?: number;
+      lightness?: number;
+      alpha?: number;
+    };
+  };
+}
+
 export function buildColors(theme: ThemeConfig) {
-  const {UNSTABLE_colors = {}} = theme;
-
-  const {
-    surface = UNSTABLE_Color.Surface,
-    onSurface = UNSTABLE_Color.OnSurface,
-    interactive = UNSTABLE_Color.Interactive,
-    neutral = UNSTABLE_Color.Neutral,
-    branded = UNSTABLE_Color.Branded,
-    critical = UNSTABLE_Color.Critical,
-    warning = UNSTABLE_Color.Warning,
-    highlight = UNSTABLE_Color.Highlight,
-    success = UNSTABLE_Color.Success,
-  } = UNSTABLE_colors;
   /* eslint-enable babel/camelcase */
+  const UNSTABLE_colors = {
+    surface: UNSTABLE_Color.Surface,
+    onSurface: UNSTABLE_Color.OnSurface,
+    interactive: UNSTABLE_Color.Interactive,
+    neutral: UNSTABLE_Color.Neutral,
+    branded: UNSTABLE_Color.Branded,
+    critical: UNSTABLE_Color.Critical,
+    warning: UNSTABLE_Color.Warning,
+    highlight: UNSTABLE_Color.Highlight,
+    success: UNSTABLE_Color.Success,
+    ...theme.UNSTABLE_colors,
+  };
 
-  const lightSurface = isLight(hslToRgb(colorToHsla(surface)));
-
-  return {
-    ...customPropertyTransformer({
-      ...surfaceColors(colorToHsla(surface), lightSurface),
-      ...onSurfaceColors(colorToHsla(onSurface), lightSurface),
-      ...interactiveColors(colorToHsla(interactive), lightSurface),
-      ...neutralColors(colorToHsla(neutral), lightSurface),
-      ...brandedColors(colorToHsla(branded), lightSurface),
-      ...criticalColors(colorToHsla(critical), lightSurface),
-      ...warningColors(colorToHsla(warning), lightSurface),
-      ...highlightColors(colorToHsla(highlight), lightSurface),
-      ...successColors(colorToHsla(success), lightSurface),
+  const surfaceColor = colorToHsla(UNSTABLE_colors.surface);
+  const lightSurface = isLight(
+    hslToRgb({
+      hue: surfaceColor.hue,
+      lightness: surfaceColor.lightness,
+      saturation: surfaceColor.saturation,
     }),
+  );
+
+  const allColors: any = {};
+  const colorAdjustments = colorAdjustmentsJson as ColorAdjustments;
+
+  Object.entries(colorAdjustments).forEach(([colorName, colorSettings]) => {
+    const adjustments = colorSettings[lightSurface ? 'light' : 'dark'];
+    const baseColor = colorToHsla(UNSTABLE_colors[colorSettings.baseColor]);
+
+    allColors[snakeCaseToCamelCase(colorName)] = {
+      alpha: baseColor.alpha,
+      hue: baseColor.hue,
+      lightness:
+        adjustments.lightness !== undefined
+          ? setLightness(baseColor, adjustments.lightness).lightness
+          : baseColor.lightness,
+      saturation:
+        adjustments.saturation !== undefined
+          ? setSaturation(baseColor, adjustments.saturation).saturation
+          : baseColor.saturation,
+    };
+  });
+
+  return {
+    ...customPropertyTransformer(allColors),
     ...overrides(),
-  };
-}
-
-function surfaceColors(color: HSLAColor, lightSurface: boolean) {
-  return {
-    surface: color,
-    surfaceBackground: setLightness(color, lightSurface ? 98 : 7),
-    surfaceForeground: setLightness(color, lightSurface ? 100 : 13),
-    surfaceForegroundSubdued: setLightness(color, lightSurface ? 90 : 10),
-    surfaceInverse: setLightness(color, lightSurface ? 0 : 100),
-    surfaceHovered: setLightness(color, lightSurface ? 93 : 20),
-    surfacePressed: setLightness(color, lightSurface ? 86 : 27),
-  };
-}
-
-function onSurfaceColors(color: HSLAColor, lightSurface: boolean) {
-  return {
-    onSurface: color,
-    actionOnDark: setLightness(color, 76),
-    actionOnLight: setLightness(color, 36),
-    actionOnInverse: setLightness(color, lightSurface ? 76 : 36),
-    actionOnSurface: setLightness(color, lightSurface ? 36 : 76),
-    actionDisabledOnDark: setLightness(color, 66),
-    actionDisabledOnLight: setLightness(color, 46),
-    actionDisabledOnInverse: setLightness(color, lightSurface ? 66 : 46),
-    actionDisabledOnSurface: setLightness(color, lightSurface ? 46 : 66),
-    actionHoveredOnDark: setLightness(color, 86),
-    actionHoveredOnLight: setLightness(color, 26),
-    actionHoveredOnInverse: setLightness(color, lightSurface ? 86 : 26),
-    actionHoveredOnSurface: setLightness(color, lightSurface ? 26 : 86),
-    actionPressedOnDark: setLightness(color, 96),
-    actionPressedOnLight: setLightness(color, 16),
-    actionPressedOnInverse: setLightness(color, lightSurface ? 96 : 16),
-    actionPressedOnSurface: setLightness(color, lightSurface ? 16 : 96),
-    dividerOnDark: setLightness(color, 80),
-    dividerOnLight: setLightness(color, 75),
-    dividerOnInverse: setLightness(color, lightSurface ? 80 : 75),
-    dividerOnSurface: setLightness(color, lightSurface ? 75 : 80),
-    dividerDisabledOnDark: setLightness(color, 70),
-    dividerDisabledOnLight: setLightness(color, 95),
-    dividerDisabledOnInverse: setLightness(color, lightSurface ? 70 : 95),
-    dividerDisabledOnSurface: setLightness(color, lightSurface ? 95 : 70),
-    dividerSubduedOnDark: setLightness(color, 75),
-    dividerSubduedOnLight: setLightness(color, 85),
-    dividerSubduedOnInverse: setLightness(color, lightSurface ? 75 : 85),
-    dividerSubduedOnSurface: setLightness(color, lightSurface ? 85 : 75),
-    iconOnDark: setLightness(color, 98),
-    iconOnLight: setLightness(color, 18),
-    iconOnInverse: setLightness(color, lightSurface ? 98 : 18),
-    iconOnSurface: setLightness(color, lightSurface ? 18 : 98),
-    iconDisabledOnDark: setLightness(color, 75),
-    iconDisabledOnLight: setLightness(color, 68),
-    iconDisabledOnInverse: setLightness(color, lightSurface ? 75 : 68),
-    iconDisabledOnSurface: setLightness(color, lightSurface ? 68 : 75),
-    iconSubduedOnDark: setLightness(color, 88),
-    iconSubduedOnLight: setLightness(color, 43),
-    iconSubduedOnInverse: setLightness(color, lightSurface ? 88 : 43),
-    iconSubduedOnSurface: setLightness(color, lightSurface ? 43 : 88),
-    textOnDark: setLightness(color, 100),
-    textOnLight: setLightness(color, 13),
-    textOnInverse: setLightness(color, lightSurface ? 100 : 13),
-    textOnSurface: setLightness(color, lightSurface ? 13 : 100),
-    textDisabledOnDark: setLightness(color, 80),
-    textDisabledOnLight: setLightness(color, 63),
-    textDisabledOnInverse: setLightness(color, lightSurface ? 80 : 63),
-    textDisabledOnSurface: setLightness(color, lightSurface ? 63 : 80),
-    textSubduedOnDark: setLightness(color, 90),
-    textSubduedOnLight: setLightness(color, 38),
-    textSubduedOnInverse: setLightness(color, lightSurface ? 90 : 38),
-    textSubduedOnSurface: setLightness(color, lightSurface ? 38 : 90),
-  };
-}
-
-function interactiveColors(color: HSLAColor, lightSurface: boolean) {
-  return {
-    interactive: color,
-    interactiveAction: setLightness(color, lightSurface ? 44 : 56),
-    interactiveActionDisabled: setLightness(color, lightSurface ? 58 : 42),
-    interactiveActionHovered: setLightness(color, lightSurface ? 37 : 63),
-    interactiveActionSubdued: setLightness(color, lightSurface ? 51 : 49),
-    interactiveActionPressed: setLightness(color, lightSurface ? 31 : 69),
-    interactiveFocus: setLightness(color, lightSurface ? 58 : 42),
-    interactiveSelected: setLightness(color, lightSurface ? 96 : 4),
-    interactiveSelectedHovered: setLightness(color, lightSurface ? 89 : 11),
-    interactiveSelectedPressed: setLightness(color, lightSurface ? 82 : 18),
-  };
-}
-
-function neutralColors(color: HSLAColor, lightSurface: boolean) {
-  return {
-    neutral: color,
-    neutralActionDisabled: setLightness(color, lightSurface ? 94 : 13),
-    neutralAction: setLightness(color, lightSurface ? 92 : 22),
-    neutralActionHovered: setLightness(color, lightSurface ? 86 : 29),
-    neutralActionPressed: setLightness(color, lightSurface ? 76 : 39),
-  };
-}
-
-function brandedColors(color: HSLAColor, lightSurface: boolean) {
-  return {
-    branded: color,
-    brandedAction: setLightness(color, 25),
-    brandedActionDisabled: setLightness(color, 32),
-    brandedActionHovered: setLightness(color, 22),
-    brandedActionPressed: setLightness(color, 15),
-    iconOnBranded: setLightness(color, 98),
-    iconSubduedOnBranded: setLightness(color, 88),
-    textOnBranded: setLightness(color, 100),
-    textSubduedOnBranded: setLightness(color, 90),
-    brandedSelected: setSaturation(
-      setLightness(color, lightSurface ? 95 : 5),
-      30,
-    ),
-    brandedSelectedHovered: setSaturation(
-      setLightness(color, lightSurface ? 81 : 19),
-      22,
-    ),
-    brandedSelectedPressed: setSaturation(
-      setLightness(color, lightSurface ? 74 : 26),
-      22,
-    ),
-  };
-}
-
-function criticalColors(color: HSLAColor, lightSurface: boolean) {
-  return {
-    critical: color,
-    criticalDivider: setLightness(color, lightSurface ? 52 : 48),
-    criticalIcon: setLightness(color, lightSurface ? 52 : 48),
-    criticalSurface: setLightness(color, lightSurface ? 88 : 12),
-    criticalSurfaceSubdued: setLightness(color, lightSurface ? 98 : 12),
-    criticalText: setLightness(color, lightSurface ? 30 : 70),
-    criticalActionDisabled: setLightness(color, lightSurface ? 59 : 41),
-    criticalAction: setLightness(color, lightSurface ? 52 : 48),
-    criticalActionHovered: setLightness(color, lightSurface ? 45 : 55),
-    criticalActionSubdued: setLightness(color, lightSurface ? 38 : 62),
-    criticalActionPressed: setLightness(color, lightSurface ? 31 : 69),
-  };
-}
-
-function warningColors(color: HSLAColor, lightSurface: boolean) {
-  return {
-    warning: color,
-    warningDivider: setLightness(color, lightSurface ? 66 : 34),
-    warningIcon: setLightness(color, lightSurface ? 66 : 34),
-    warningSurface: setLightness(color, lightSurface ? 88 : 12),
-    warningSurfaceSubdued: setLightness(color, lightSurface ? 98 : 12),
-    warningText: setLightness(color, lightSurface ? 30 : 70),
-  };
-}
-
-function highlightColors(color: HSLAColor, lightSurface: boolean) {
-  return {
-    highlight: color,
-    highlightDivider: setLightness(color, lightSurface ? 58 : 42),
-    highlightIcon: setLightness(color, lightSurface ? 58 : 42),
-    highlightSurface: setLightness(color, lightSurface ? 88 : 12),
-    highlightSurfaceSubdued: setLightness(color, lightSurface ? 98 : 12),
-    highlightText: setLightness(color, lightSurface ? 98 : 2),
-  };
-}
-
-function successColors(color: HSLAColor, lightSurface: boolean) {
-  return {
-    success: color,
-    successDivider: setLightness(color, lightSurface ? 25 : 35),
-    successIcon: setLightness(color, lightSurface ? 25 : 35),
-    successSurface: setLightness(color, lightSurface ? 88 : 12),
-    successSurfaceSubdued: setLightness(color, lightSurface ? 98 : 12),
-    successText: setLightness(color, lightSurface ? 15 : 85),
   };
 }
 


### PR DESCRIPTION
**🚩 This is a highly speculative, low-confidence suggestion. Consider it an idea.**

### WHY are these changes introduced?
With the new color system, ~10 colors are inputed and ~100 more are generated. These new colors are adjusted versions of the initial ones. These adjustments are hard-coded into `utils.ts`. It means that the *color factory* and the *color blueprint* are tightly coupled. This makes it hard to introduce new tooling around colors — if you want to play around with colors, your only option is to tweak `utils.ts`.

### WHAT is this pull request doing?
It extracts the adjustments to a separate JSON file. 

Before:

```js
actionOnDark: setLightness(color, 76),
actionOnLight: setLightness(color, 36),
```

After (now in `colorAdjustments.json`):
```js
"ACTION_ON_DARK": {
  "baseColor": "onSurface", // ACTION_ON_DARK is based on onSurface
  "light": {"lightness": 76}, // Apply this modification in light mode
  "dark": {"lightness": 76} // Apply this modification in dark mode
},
"ACTION_ON_LIGHT": {
  "baseColor": "onSurface",
  "light": {"lightness": 36},
  "dark": {"lightness": 36}
},
...
```

Utils.ts reads this file, creates the corresponding colors and returns the same CSS Custom Properties as before. 

### WHAT can we do now?
I can build a separate tool that allows designers (like me or @jessebc) to play with these values. As long as the tool outputs the same JSON file as above, Polaris can use it and generate Custom Properties from it.