### PR TITLE
[Page][SkeletonPage] Combine interfaces

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@
 ### Documentation
 
 - Added a details page and kitchen sink example to Storybook ([#2402](https://github.com/Shopify/polaris-react/pull/2402))
+- Combined the interface used by `Page` so the types can be parsed ([#2358](https://github.com/Shopify/polaris-react/pull/2358))
 
 ### Development workflow
 

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -33,16 +33,13 @@ export interface PageProps extends HeaderProps {
    * @see {@link https://polaris.shopify.com/components/structure/page#section-use-in-an-embedded-application|Shopify Page Component docs}
    * */
   forceRender?: boolean;
-}
-
-export interface DeprecatedProps {
   /** Decreases the maximum layout width. Intended for single-column layouts
    * @deprecated As of release 4.0, replaced by {@link https://polaris.shopify.com/components/structure/page#props-narrow-width}
    */
   singleColumn?: boolean;
 }
 
-export type ComposedProps = PageProps & DeprecatedProps & WithAppProviderProps;
+export type ComposedProps = PageProps & WithAppProviderProps;
 
 const APP_BRIDGE_PROPS: (keyof PageProps)[] = [
   'title',
@@ -205,4 +202,4 @@ class Page extends React.PureComponent<ComposedProps, never> {
 
 // Use named export once withAppProvider is refactored away
 // eslint-disable-next-line import/no-default-export
-export default withAppProvider<PageProps & DeprecatedProps>()(Page);
+export default withAppProvider<PageProps>()(Page);

--- a/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/src/components/SkeletonPage/SkeletonPage.tsx
@@ -23,16 +23,11 @@ export interface SkeletonPageProps {
   breadcrumbs?: boolean;
   /** The child elements to render in the skeleton page. */
   children?: React.ReactNode;
-}
-
-interface DeprecatedProps {
   /** Decreases the maximum layout width. Intended for single-column layouts
    * @deprecated As of release 4.0, replaced by {@link https://polaris.shopify.com/components/feedback-indicators/skeleton-page#props-narrow-width}
    */
   singleColumn?: boolean;
 }
-
-export type CombinedProps = SkeletonPageProps & DeprecatedProps;
 
 export function SkeletonPage({
   children,
@@ -43,7 +38,7 @@ export function SkeletonPage({
   secondaryActions,
   title = '',
   breadcrumbs,
-}: CombinedProps) {
+}: SkeletonPageProps) {
   if (singleColumn) {
     // eslint-disable-next-line no-console
     console.warn(


### PR DESCRIPTION
### WHY are these changes introduced?

The parser will only read the interface `{Component}Props` so we need to combine the props and deprecated props interface

