### PR TITLE
Sewing-kit bump

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -69,6 +69,18 @@
   },
   "overrides": [
     {
+      "files": ["src/**/*.{ts,tsx}"],
+      "extends": ["plugin:shopify/typescript-type-checking"],
+      "parserOptions": {
+        "project": "./tsconfig.json"
+      },
+      "rules": {
+        "@typescript-eslint/prefer-readonly": "off",
+        "@typescript-eslint/no-unnecessary-condition": "off",
+        "@typescript-eslint/unbound-method": "off"
+      }
+    },
+    {
       "files": ["**/*.test.{ts,tsx}"],
       "rules": {
         "jest/no-truthy-falsy": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -62,7 +62,8 @@
         "allow": [
           "UNSTABLE_Color",
           "UNSTABLE_colors",
-          "UNSTABLE_cssCustomProperties"
+          "UNSTABLE_cssCustomProperties",
+          "UNSTABLE_telemetry"
         ]
       }
     ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -55,14 +55,23 @@
     "jsx-a11y/mouse-events-have-key-events": "off",
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
-    "jsx-a11y/no-noninteractive-element-to-interactive-role": "off"
+    "jsx-a11y/no-noninteractive-element-to-interactive-role": "off",
+    "@typescript-eslint/camelcase": [
+      "error",
+      {
+        "allow": [
+          "UNSTABLE_Color",
+          "UNSTABLE_colors",
+          "UNSTABLE_cssCustomProperties"
+        ]
+      }
+    ]
   },
   "overrides": [
     {
       "files": ["**/*.test.{ts,tsx}"],
       "rules": {
         "jest/no-truthy-falsy": "off",
-        "shopify/jsx-no-hardcoded-content": "off",
         "shopify/no-ancestor-directory-import": "off"
       }
     },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,14 @@
 // Place your settings in this file to overwrite default and user settings.
 {
   "css.validate": false,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
+  "eslint.autoFixOnSave": true,
   "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
+    {"language": "javascript", "autoFix": true},
+    {"language": "javascriptreact", "autoFix": true},
+    {"language": "typescript", "autoFix": true},
+    {"language": "typescriptreact", "autoFix": true}
   ],
   "files.exclude": {
     "**/.DS_Store": true,
@@ -27,7 +29,6 @@
   },
   "javascript.validate.enable": false,
   "jest.autoEnable": false,
-  "prettier.eslintIntegration": true,
   "prettier.stylelintIntegration": true,
   "scss.validate": false,
   "search.exclude": {

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@
 ### Development workflow
 
 - Enabled maintainers running `yarn dev` to hide [`yarn splash`](https://github.com/Shopify/polaris-react/tree/master/scripts/splash) reports from the console by running `DISABLE_SPLASH=1 yarn dev` ([#2372](https://github.com/Shopify/polaris-react/pull/2372))
+- Updated to sewing-kit 0.112.0 and eslint 6 and updated vscode config to use the eslint plugin to format js/ts files ((#2369)[https://github.com/Shopify/polaris-react/pull/2369])
 
 ### Dependency upgrades
 

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@percy/storybook": "^3.2.0",
     "@shopify/jest-dom-mocks": "^2.1.1",
     "@shopify/react-testing": "^1.7.8",
-    "@shopify/sewing-kit": "^0.111.0",
+    "@shopify/sewing-kit": "^0.112.0",
     "@storybook/addon-a11y": "^5.2.4",
     "@storybook/addon-actions": "^5.2.4",
     "@storybook/addon-console": "^1.2.1",
@@ -161,9 +161,6 @@
   "peerDependencies": {
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
-  },
-  "resolutions": {
-    "typescript-eslint-parser": "npm:@typescript-eslint/parser@1.10.2"
   },
   "files": [
     "esnext",

--- a/scripts/pa11y.js
+++ b/scripts/pa11y.js
@@ -39,6 +39,7 @@ async function runPa11y() {
   ];
 
   await browsers.forEach(async (instance) => {
+    // eslint-disable-next-line require-atomic-updates
     instance.page = await instance.browser.newPage();
   });
 

--- a/scripts/splash/index.tsx
+++ b/scripts/splash/index.tsx
@@ -202,7 +202,7 @@ const App = () => {
           <Color dim>
             <Box width={3}>💡</Box>
             <Box>
-              Tip: to disable these reports, run{' '}
+              Tip: to disable these reports, run
               <Text bold>DISABLE_SPLASH=1 yarn dev</Text>
             </Box>
           </Color>

--- a/scripts/splash/index.tsx
+++ b/scripts/splash/index.tsx
@@ -203,7 +203,7 @@ const App = () => {
             <Box width={3}>💡</Box>
             <Box>
               Tip: to disable these reports, run
-              <Text bold>DISABLE_SPLASH=1 yarn dev</Text>
+              <Text bold> DISABLE_SPLASH=1 yarn dev</Text>
             </Box>
           </Color>
         </Box>

--- a/scripts/splash/index.tsx
+++ b/scripts/splash/index.tsx
@@ -81,7 +81,7 @@ const Components = ({components, status}) => (
   <React.Fragment>
     {status === 'loading' && (
       <Box marginLeft={4} marginBottom={1}>
-        ⏳{'  '}Please wait during compilation… Beep boop beep 🤖
+        ⏳ Please wait during compilation… Beep boop beep 🤖
       </Box>
     )}
 

--- a/scripts/splash/treebuilder.ts
+++ b/scripts/splash/treebuilder.ts
@@ -3,15 +3,15 @@ import * as ts from 'typescript';
 import glob from 'glob';
 import cmd from 'node-cmd';
 
-type Node = {
+interface Node {
   fileName: string;
   dependsOn: Node[];
   dependedOnBy: Node[];
-};
+}
 
-type GraphType = {
+interface GraphType {
   [name: string]: Node;
-};
+}
 
 const graph: GraphType = {};
 

--- a/src/components/AccountConnection/tests/AccountConnection.test.tsx
+++ b/src/components/AccountConnection/tests/AccountConnection.test.tsx
@@ -28,7 +28,7 @@ describe('<AccountConnection />', () => {
     it('is shown on the card when provided', () => {
       const TermsOfService = () => (
         <p>
-          By clicking <strong>Connect</strong>, you agree to accept Sample App’s{' '}
+          By clicking <strong>Connect</strong>, you agree to accept Sample App’s
           terms and conditions. You’ll pay a commission rate of 15% on sales
           made through Sample App.
         </p>

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -42,7 +42,6 @@ export interface AppProviderProps extends AppBridgeOptions {
   features?: Features;
   /** Inner content of the application */
   children?: React.ReactNode;
-  // eslint-disable-next-line babel/camelcase
   UNSTABLE_telemetry?: TelemetryObject;
 }
 
@@ -100,7 +99,6 @@ export class AppProvider extends React.Component<AppProviderProps, State> {
     });
   }
 
-  /* eslint-disable babel/camelcase */
   render() {
     const {
       theme = {},
@@ -132,5 +130,4 @@ export class AppProvider extends React.Component<AppProviderProps, State> {
       </FeaturesContext.Provider>
     );
   }
-  /* eslint-enable babel/camelcase */
 }

--- a/src/components/AppProvider/tests/AppProvider.test.tsx
+++ b/src/components/AppProvider/tests/AppProvider.test.tsx
@@ -16,7 +16,7 @@ describe('<AppProvider />', () => {
   });
 
   it('updates context when props change', () => {
-    const Child: React.SFC<{}> = () => {
+    const Child: React.SFC = () => {
       return useContext(LinkContext) ? <div id="child" /> : null;
     };
     const LinkComponent = () => <div />;

--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -17,7 +17,7 @@ export interface AutocompleteProps {
   /** The selected options */
   selected: string[];
   /** The text field component attached to the list of options */
-  textField: React.ReactElement<any>;
+  textField: React.ReactElement;
   /** The preferred direction to open the popover */
   preferredPosition?: PreferredPosition;
   /** Title of the list of options */

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -31,7 +31,7 @@ export interface ComboBoxProps {
   /** The selected options */
   selected: string[];
   /** The text field component attached to the list of options */
-  textField: React.ReactElement<any>;
+  textField: React.ReactElement;
   /** The preferred direction to open the popover */
   preferredPosition?: PreferredPosition;
   /** Title of the list of options */

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -152,7 +152,7 @@ describe('<Banner />', () => {
 
   describe('context', () => {
     it('passes the within banner context', () => {
-      const Child: React.SFC<{}> = (_props) => {
+      const Child: React.SFC = (_props) => {
         return (
           <BannerContext.Consumer>
             {(BannerContext) => {

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -10,7 +10,7 @@ import styles from './Breadcrumbs.scss';
 
 export interface BreadcrumbsProps {
   /** Collection of breadcrumbs */
-  breadcrumbs: Array<CallbackAction | LinkAction>;
+  breadcrumbs: (CallbackAction | LinkAction)[];
 }
 
 export class Breadcrumbs extends React.PureComponent<BreadcrumbsProps, never> {

--- a/src/components/Choice/Choice.tsx
+++ b/src/components/Choice/Choice.tsx
@@ -12,7 +12,7 @@ export interface ChoiceProps {
   /**	Label for the choice */
   label: React.ReactNode;
   /** Whether the associated form control is disabled */
-  disabled?: Boolean;
+  disabled?: boolean;
   /** Display an error message */
   error?: Error | boolean;
   /** Visually hide the label */

--- a/src/components/Choice/tests/Choice.test.tsx
+++ b/src/components/Choice/tests/Choice.test.tsx
@@ -82,8 +82,8 @@ describe('<Choice />', () => {
       <Choice id="MyChoice" label="Label" />,
     );
     const label = element.find('label');
-    for (let i = 0; i < blockLevelElements.length; i++) {
-      expect(label.find(blockLevelElements[i])).toHaveLength(0);
+    for (const blockLevelElement of blockLevelElements) {
+      expect(label.find(blockLevelElement)).toHaveLength(0);
     }
   });
 });

--- a/src/components/ChoiceList/ChoiceList.tsx
+++ b/src/components/ChoiceList/ChoiceList.tsx
@@ -136,7 +136,7 @@ export function ChoiceList({
 function noop() {}
 
 function choiceIsSelected({value}: Choice, selected: string[]) {
-  return selected.indexOf(value) >= 0;
+  return selected.includes(value);
 }
 
 function updateSelectedChoices(

--- a/src/components/Connected/tests/Connected.test.tsx
+++ b/src/components/Connected/tests/Connected.test.tsx
@@ -6,20 +6,18 @@ import {Item, ItemPosition} from '../components';
 
 describe('<Connected />', () => {
   describe('<Item />', () => {
-    it('wraps children in an Item component', async () => {
+    it('wraps children in an Item component', () => {
       const expectedContent = 'foo';
-      const connected = await mountWithApp(
-        <Connected>{expectedContent}</Connected>,
-      );
+      const connected = mountWithApp(<Connected>{expectedContent}</Connected>);
 
       expect(
         connected.find(Item, {position: ItemPosition.Primary}),
       ).toContainReactText(expectedContent);
     });
 
-    it('includes `rightConnected` markup in an Item component', async () => {
+    it('includes `rightConnected` markup in an Item component', () => {
       const rightConnectedContent = 'foo';
-      const connected = await mountWithApp(
+      const connected = mountWithApp(
         <Connected right={rightConnectedContent} />,
       );
 
@@ -28,21 +26,19 @@ describe('<Connected />', () => {
       ).toContainReactText(rightConnectedContent);
     });
 
-    it('includes `leftConnected` markup in an Item component', async () => {
+    it('includes `leftConnected` markup in an Item component', () => {
       const leftConnectedContent = 'foo';
-      const connected = await mountWithApp(
-        <Connected left={leftConnectedContent} />,
-      );
+      const connected = mountWithApp(<Connected left={leftConnectedContent} />);
 
       expect(
         connected.find(Item, {position: ItemPosition.Left}),
       ).toContainReactText(leftConnectedContent);
     });
 
-    it('`leftConnected` and `rightConnected` are not mutually exclusive', async () => {
+    it('`leftConnected` and `rightConnected` are not mutually exclusive', () => {
       const rightConnectedContent = 'rightfoo';
       const leftConnectedContent = 'leftfoo';
-      const connected = await mountWithApp(
+      const connected = mountWithApp(
         <Connected right={rightConnectedContent} left={leftConnectedContent} />,
       );
 

--- a/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -7,9 +7,6 @@ import {ContextualSaveBarProps, useFrame} from '../../utilities/frame';
 // crashing if we write `ContextualSaveBar extends React.Component<ContextualSaveBarProps>`
 export interface ContextualSaveBarProps extends ContextualSaveBarProps {}
 
-// This does have a display name, but the linting has a bug in it
-// https://github.com/yannickcr/eslint-plugin-react/issues/2324
-// eslint-disable-next-line react/display-name
 export const ContextualSaveBar = React.memo(function ContextualSaveBar({
   message,
   saveAction,

--- a/src/components/DatePicker/components/Month/Month.tsx
+++ b/src/components/DatePicker/components/Month/Month.tsx
@@ -27,7 +27,7 @@ export interface MonthProps {
   year: Year;
   disableDatesBefore?: Date;
   disableDatesAfter?: Date;
-  allowRange?: Boolean;
+  allowRange?: boolean;
   weekStartsOn: Weekdays;
   onChange?(date: Range): void;
   onHover?(hoverEnd: Date): void;
@@ -82,7 +82,7 @@ export function Month({
   ));
 
   function handleDateClick(selectedDate: Date) {
-    onChange(getNewRange(allowRange && selected, selectedDate));
+    onChange(getNewRange(allowRange ? selected : undefined, selectedDate));
   }
 
   function renderWeek(day: Date, dayIndex: number) {

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -499,7 +499,7 @@ class DropZone extends React.Component<CombinedProps, State> {
 
     const fileList = getDataTransferFiles(event);
 
-    if (event.target && this.dragTargets.indexOf(event.target) === -1) {
+    if (event.target && !this.dragTargets.includes(event.target)) {
       this.dragTargets.push(event.target);
     }
 

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -482,7 +482,7 @@ function fireEvent({
   element: ReactWrapper<any, any>;
   eventType?: string;
   spy?: jest.Mock;
-  testFiles?: Array<Object>;
+  testFiles?: object[];
 }) {
   if (spy) {
     spy.mockReset();

--- a/src/components/DropZone/utils/index.ts
+++ b/src/components/DropZone/utils/index.ts
@@ -36,9 +36,9 @@ function accepts(file: File, acceptedFiles: string | string[] | undefined) {
 
     return acceptedFilesArray.some((type) => {
       const validType = type.trim();
-      if (validType.charAt(0) === '.') {
+      if (validType.startsWith('.')) {
         return fileName.toLowerCase().endsWith(validType.toLowerCase());
-      } else if (/\/\*$/.test(validType)) {
+      } else if (validType.endsWith('/*')) {
         // This is something like a image/* mime type
         return baseMimeType === validType.replace(/\/.*$/, '');
       }

--- a/src/components/ExceptionList/ExceptionList.tsx
+++ b/src/components/ExceptionList/ExceptionList.tsx
@@ -9,8 +9,8 @@ import styles from './ExceptionList.scss';
 
 export type Description =
   | string
-  | React.ReactElement<any>
-  | (string | React.ReactElement<any>)[];
+  | React.ReactElement
+  | (string | React.ReactElement)[];
 
 export interface Item {
   /** Set the color of the icon and title for the given item. */

--- a/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.tsx
@@ -185,9 +185,7 @@ export class ConnectedFilterControl extends React.Component<
     return actionsToReturn;
   }
 
-  private activatorButtonFrom(
-    action: PopoverableAction,
-  ): React.ReactElement<any> {
+  private activatorButtonFrom(action: PopoverableAction): React.ReactElement {
     return (
       <Button
         onClick={action.onAction}
@@ -200,7 +198,7 @@ export class ConnectedFilterControl extends React.Component<
     );
   }
 
-  private popoverFrom(actions: PopoverableAction[]): React.ReactElement<any>[] {
+  private popoverFrom(actions: PopoverableAction[]): React.ReactElement[] {
     return actions.map((action) => {
       return (
         <Item key={action.key}>

--- a/src/components/Frame/components/ToastManager/ToastManager.tsx
+++ b/src/components/Frame/components/ToastManager/ToastManager.tsx
@@ -17,9 +17,6 @@ export interface ToastManagerProps {
   toastMessages: (ToastPropsWithID)[];
 }
 
-// This does have a display name, but the linting has a bug in it
-// https://github.com/yannickcr/eslint-plugin-react/issues/2324
-// eslint-disable-next-line react/display-name
 export const ToastManager = memo(function ToastManager({
   toastMessages,
 }: ToastManagerProps) {

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -32,7 +32,7 @@ export function Icon({source, color, backdrop, accessibilityLabel}: Props) {
   }, [source, telemetry]);
   /* eslint-enable babel/camelcase */
 
-  if (color && backdrop && COLORS_WITH_BACKDROPS.indexOf(color) < 0) {
+  if (color && backdrop && !COLORS_WITH_BACKDROPS.includes(color)) {
     // eslint-disable-next-line no-console
     console.warn(
       i18n.translate('Polaris.Icon.backdropWarning', {

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -24,13 +24,12 @@ export function Icon({source, color, backdrop, accessibilityLabel}: Props) {
   const i18n = useI18n();
   const telemetry = useTelemetry();
 
-  /* eslint-disable babel/camelcase */
   useEffect(() => {
     telemetry.produce('polaris_icons_usage/1.0', {
+      // eslint-disable-next-line @typescript-eslint/camelcase
       icon_source: parseSource(source),
     });
   }, [source, telemetry]);
-  /* eslint-enable babel/camelcase */
 
   if (color && backdrop && !COLORS_WITH_BACKDROPS.includes(color)) {
     // eslint-disable-next-line no-console

--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -5,9 +5,6 @@ import {useAppBridge} from '../../utilities/app-bridge';
 
 export interface LoadingProps {}
 
-// This does have a display name, but the linting has a bug in it
-// https://github.com/yannickcr/eslint-plugin-react/issues/2324
-// eslint-disable-next-line react/display-name
 export const Loading = React.memo(function Loading() {
   const appBridgeLoading = useRef<AppBridgeLoading.Loading>();
   const appBridge = useAppBridge();

--- a/src/components/Loading/tests/Loading.test.tsx
+++ b/src/components/Loading/tests/Loading.test.tsx
@@ -65,7 +65,7 @@ describe('<Loading />', () => {
   });
 });
 
-function mountWithAppBridge(element: React.ReactElement<any>) {
+function mountWithAppBridge(element: React.ReactElement) {
   const appBridge = {};
   const loading = mountWithAppProvider(element, {appBridge});
   return {loading, appBridge};

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -375,7 +375,7 @@ class Modal extends React.Component<CombinedProps, State> {
     const srcPayload: {url?: string; path?: string} = {};
 
     if (src != null) {
-      if (src.match('^https?://')) {
+      if (/^https?:\/\//.test(src)) {
         srcPayload.url = src;
       } else {
         srcPayload.path = src;

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -514,7 +514,7 @@ describe('<Modal>', () => {
   });
 });
 
-function mountWithAppBridge(element: React.ReactElement<any>) {
+function mountWithAppBridge(element: React.ReactElement) {
   const appBridge = {};
   const modal = mountWithAppProvider(element, {appBridge});
 

--- a/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -463,7 +463,7 @@ function itemForLocation(location: string, overrides: Partial<ItemProps> = {}) {
 }
 
 function mountWithNavigationProvider(
-  node: React.ReactElement<any>,
+  node: React.ReactElement,
   context: React.ContextType<typeof NavigationContext> = {location: ''},
 ) {
   return mountWithAppProvider(

--- a/src/components/Navigation/components/Section/tests/Section.test.tsx
+++ b/src/components/Navigation/components/Section/tests/Section.test.tsx
@@ -257,7 +257,7 @@ describe('<Navigation.Section />', () => {
 });
 
 function mountWithNavigationProvider(
-  node: React.ReactElement<any>,
+  node: React.ReactElement,
   context: React.ContextType<typeof NavigationContext> = {location: ''},
 ) {
   return mountWithAppProvider(

--- a/src/components/Navigation/tests/Navigation.test.tsx
+++ b/src/components/Navigation/tests/Navigation.test.tsx
@@ -12,7 +12,7 @@ describe('<Navigation />', () => {
 
   describe('context', () => {
     it('passes location context', () => {
-      const Child: React.SFC<{}> = (_props) => {
+      const Child: React.SFC = (_props) => {
         return (
           <NavigationContext.Consumer>
             {({location}) => {
@@ -39,7 +39,7 @@ describe('<Navigation />', () => {
     });
 
     it('has a child with contentContext', () => {
-      const Child: React.SFC<{}> = (_props) => {
+      const Child: React.SFC = (_props) => {
         return (
           <WithinContentContext.Consumer>
             {(withinContentContainer) => {

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -57,7 +57,7 @@ describe('<Page />', () => {
     animationFrame.restore();
   });
 
-  describe('forceRender renders children in page', () => {
+  it('forceRender renders children in page', () => {
     const {
       createSpy: titleBarCreateSpy,
       restore: restoreTitleBarCreateMock,

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -445,7 +445,7 @@ describe('<Page />', () => {
 
 function noop() {}
 
-function mountWithAppBridge(element: React.ReactElement<any>) {
+function mountWithAppBridge(element: React.ReactElement) {
   const appBridge = {};
   const page = mountWithAppProvider(element, {appBridge});
   return {page, appBridge};

--- a/src/components/PolarisTestProvider/PolarisTestProvider.tsx
+++ b/src/components/PolarisTestProvider/PolarisTestProvider.tsx
@@ -36,7 +36,7 @@ type MediaQueryContextType = NonNullable<
  * this is the type of the options object. These values are customizable when
  * you call the app
  */
-export type WithPolarisTestProviderOptions = {
+export interface WithPolarisTestProviderOptions {
   // Contexts provided by AppProvider
   i18n?: TranslationDictionary | TranslationDictionary[];
   appBridge?: AppBridgeOptions;
@@ -46,7 +46,7 @@ export type WithPolarisTestProviderOptions = {
   features?: Features;
   // Contexts provided by Frame
   frame?: Partial<FrameContextType>;
-};
+}
 
 export interface PolarisTestProviderProps
   extends WithPolarisTestProviderOptions {

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -20,7 +20,7 @@ export interface PopoverProps {
   /** Show or hide the Popover */
   active: boolean;
   /** The element to activate the Popover */
-  activator: React.ReactElement<any>;
+  activator: React.ReactElement;
   /**
    * The element type to wrap the activator with
    * @default 'div'

--- a/src/components/Popover/components/Pane/tests/Pane.test.tsx
+++ b/src/components/Popover/components/Pane/tests/Pane.test.tsx
@@ -6,14 +6,14 @@ import {Section} from '../../Section';
 
 describe('<Pane />', () => {
   describe('fixed', () => {
-    it('does not render content in a Scrollable when set to true', async () => {
+    it('does not render content in a Scrollable when set to true', () => {
       const Children = () => (
         <TextContainer>
           <p>Text</p>
         </TextContainer>
       );
 
-      const popoverPane = await mountWithAppProvider(
+      const popoverPane = mountWithAppProvider(
         <Pane fixed>
           <Children />
         </Pane>,
@@ -22,14 +22,14 @@ describe('<Pane />', () => {
       expect(popoverPane.find(Scrollable)).toHaveLength(0);
     });
 
-    it('renders content in a Scrollable when set to false', async () => {
+    it('renders content in a Scrollable when set to false', () => {
       const Children = () => (
         <TextContainer>
           <p>Text</p>
         </TextContainer>
       );
 
-      const popoverPane = await mountWithAppProvider(
+      const popoverPane = mountWithAppProvider(
         <Pane fixed={false}>
           <Children />
         </Pane>,
@@ -38,14 +38,14 @@ describe('<Pane />', () => {
       expect(popoverPane.find(Scrollable)).toHaveLength(1);
     });
 
-    it('renders content in a Scrollable when unset', async () => {
+    it('renders content in a Scrollable when unset', () => {
       const Children = () => (
         <TextContainer>
           <p>Text</p>
         </TextContainer>
       );
 
-      const popoverPane = await mountWithAppProvider(
+      const popoverPane = mountWithAppProvider(
         <Pane>
           <Children />
         </Pane>,
@@ -56,14 +56,14 @@ describe('<Pane />', () => {
   });
 
   describe('sectioned', () => {
-    it('renders children in a Section when set to true', async () => {
+    it('renders children in a Section when set to true', () => {
       const Children = () => (
         <TextContainer>
           <p>Text</p>
         </TextContainer>
       );
 
-      const popoverPane = await mountWithAppProvider(
+      const popoverPane = mountWithAppProvider(
         <Pane sectioned>
           <Children />
         </Pane>,
@@ -72,14 +72,14 @@ describe('<Pane />', () => {
       expect(popoverPane.find(Section)).toHaveLength(1);
     });
 
-    it('does not render content in a Section when set to false', async () => {
+    it('does not render content in a Section when set to false', () => {
       const Children = () => (
         <TextContainer>
           <p>Text</p>
         </TextContainer>
       );
 
-      const popoverPane = await mountWithAppProvider(
+      const popoverPane = mountWithAppProvider(
         <Pane sectioned={false}>
           <Children />
         </Pane>,
@@ -88,14 +88,14 @@ describe('<Pane />', () => {
       expect(popoverPane.find(Section)).toHaveLength(0);
     });
 
-    it('does not render content in a Section when unset', async () => {
+    it('does not render content in a Section when unset', () => {
       const Children = () => (
         <TextContainer>
           <p>Text</p>
         </TextContainer>
       );
 
-      const popoverPane = await mountWithAppProvider(
+      const popoverPane = mountWithAppProvider(
         <Pane>
           <Children />
         </Pane>,
@@ -106,7 +106,7 @@ describe('<Pane />', () => {
   });
 
   describe('onScrolledToBottom', () => {
-    it('is set on the Scrollable when provided', async () => {
+    it('is set on the Scrollable when provided', () => {
       const onScrolledToBottom = jest.fn();
       const Children = () => (
         <TextContainer>
@@ -114,7 +114,7 @@ describe('<Pane />', () => {
         </TextContainer>
       );
 
-      const popoverPane = await mountWithAppProvider(
+      const popoverPane = mountWithAppProvider(
         <Pane onScrolledToBottom={onScrolledToBottom}>
           <Children />
         </Pane>,

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -35,7 +35,6 @@ export class Portal extends React.PureComponent<PortalProps, State> {
     this.portalNode.setAttribute(portal.props[0], this.portalId);
 
     if (this.context != null) {
-      /* eslint-disable babel/camelcase */
       const {UNSTABLE_cssCustomProperties} = this.context;
       if (UNSTABLE_cssCustomProperties != null) {
         this.portalNode.setAttribute('style', UNSTABLE_cssCustomProperties);
@@ -57,7 +56,6 @@ export class Portal extends React.PureComponent<PortalProps, State> {
       } else {
         this.portalNode.removeAttribute('style');
       }
-      /* eslint-enable babel/camelcase */
     }
     if (!prevState.isMounted && this.state.isMounted) {
       onPortalCreated();

--- a/src/components/Portal/tests/Portal.test.tsx
+++ b/src/components/Portal/tests/Portal.test.tsx
@@ -102,7 +102,6 @@ describe('<Portal />', () => {
     const portal = mountWithAppProvider(<Portal />, {
       features: {unstableGlobalTheming: true},
       theme: {
-        // eslint-disable-next-line babel/camelcase
         UNSTABLE_colors: {surface: '#000000'},
       },
     });

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -714,11 +714,8 @@ class ResourceList extends React.Component<CombinedProps, State> {
     newlySelectedItems = [...new Set([...newlySelectedItems, ...selectedIds])];
 
     if (!selected) {
-      for (let i = 0; i < selectedIds.length; i++) {
-        newlySelectedItems.splice(
-          newlySelectedItems.indexOf(selectedIds[i]),
-          1,
-        );
+      for (const selectedId of selectedIds) {
+        newlySelectedItems.splice(newlySelectedItems.indexOf(selectedId), 1);
       }
     }
 

--- a/src/components/ResourceList/components/FilterControl/components/DateSelector/DateSelector.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/DateSelector/DateSelector.tsx
@@ -35,9 +35,6 @@ export enum DateFilterOption {
   OnOrAfter = 'on_or_after',
 }
 
-// This does have a display name, but the linting has a bug in it
-// https://github.com/yannickcr/eslint-plugin-react/issues/2324
-// eslint-disable-next-line react/display-name
 export const DateSelector = memo(function DateSelector({
   filterValue,
   filterKey,

--- a/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
+++ b/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
@@ -227,7 +227,7 @@ describe('<ResourcePicker />', () => {
 
 function noop() {}
 
-function mountWithAppBridge(element: React.ReactElement<any>) {
+function mountWithAppBridge(element: React.ReactElement) {
   const appBridge = {};
   const resourcePicker = mountWithAppProvider(element, {appBridge});
 

--- a/src/components/Scrollable/tests/Scrollable.test.tsx
+++ b/src/components/Scrollable/tests/Scrollable.test.tsx
@@ -30,7 +30,7 @@ describe('<Scrollable />', () => {
   });
 
   it('provides scrollToPosition callback to children', () => {
-    const Child: React.SFC<{}> = (_) => (
+    const Child: React.SFC = (_) => (
       <ScrollableContext.Consumer>
         {(scrollToPosition) => {
           return scrollToPosition ? <div /> : null;

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -39,7 +39,7 @@ export function Spinner({
   const i18n = useI18n();
   const isAfterInitialMount = useIsAfterInitialMount();
 
-  if (size === 'large' && COLORS_FOR_LARGE_SPINNER.indexOf(color) < 0) {
+  if (size === 'large' && !COLORS_FOR_LARGE_SPINNER.includes(color)) {
     if (process.env.NODE_ENV === 'development') {
       // eslint-disable-next-line no-console
       console.warn(

--- a/src/components/Sticky/Sticky.tsx
+++ b/src/components/Sticky/Sticky.tsx
@@ -7,7 +7,7 @@ import {
 
 interface State {
   isSticky: boolean;
-  style: Object;
+  style: object;
 }
 
 export type StickyProps = {

--- a/src/components/Sticky/tests/Sticky.test.tsx
+++ b/src/components/Sticky/tests/Sticky.test.tsx
@@ -41,6 +41,6 @@ function functionItem(isSticky: boolean) {
   if (isSticky === false) {
     return <h1>it worked!</h1>;
   } else {
-    return <h2> {'it didn’t'} </h2>;
+    return <h2>it didn’t work</h2>;
   }
 }

--- a/src/components/Tabs/components/Item/Item.tsx
+++ b/src/components/Tabs/components/Item/Item.tsx
@@ -14,7 +14,7 @@ export interface ItemProps {
 }
 
 export class Item extends React.PureComponent<ItemProps, never> {
-  private focusedNode: HTMLElement | React.ReactElement<any> | null = null;
+  private focusedNode: HTMLElement | React.ReactElement | null = null;
 
   componentDidMount() {
     const {focusedNode} = this;
@@ -67,9 +67,7 @@ export class Item extends React.PureComponent<ItemProps, never> {
     return <li>{markup}</li>;
   }
 
-  private setFocusedNode = (
-    node: HTMLElement | React.ReactElement<any> | null,
-  ) => {
+  private setFocusedNode = (node: HTMLElement | React.ReactElement | null) => {
     this.focusedNode = node;
   };
 }

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -133,7 +133,7 @@ describe('<Tabs />', () => {
 
   describe('selected', () => {
     let getElementById: jest.SpyInstance;
-    let panelStub: {focus: jest.Mock<any>};
+    let panelStub: {focus: jest.Mock};
 
     beforeEach(() => {
       panelStub = {focus: jest.fn()};

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -438,7 +438,7 @@ export function TextField({
   function handleKeyPress(event: React.KeyboardEvent) {
     const {key, which} = event;
     const numbersSpec = /[\d.eE+-]$/;
-    if (type !== 'number' || which === Key.Enter || key.match(numbersSpec)) {
+    if (type !== 'number' || which === Key.Enter || numbersSpec.test(key)) {
       return;
     }
     event.preventDefault();

--- a/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -14,7 +14,7 @@ describe('<ThemeProvider />', () => {
   });
 
   it('passes context', () => {
-    const Child: React.SFC<{}> = (_props) => {
+    const Child: React.SFC = (_props) => {
       return (
         <ThemeContext.Consumer>
           {(polarisTheme) => {

--- a/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -144,7 +144,6 @@ describe('<ThemeProvider />', () => {
     );
 
     function Child() {
-      // eslint-disable-next-line babel/camelcase
       const {UNSTABLE_cssCustomProperties} = useTheme();
       expect(UNSTABLE_cssCustomProperties).toBeTruthy();
       return null;
@@ -159,7 +158,6 @@ describe('<ThemeProvider />', () => {
     );
 
     function Child() {
-      // eslint-disable-next-line babel/camelcase
       const {UNSTABLE_cssCustomProperties} = useTheme();
       expect(UNSTABLE_cssCustomProperties).toBeUndefined();
       return null;

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -13,9 +13,6 @@ import {useAppBridge} from '../../utilities/app-bridge';
 // crashing if we write `ComposedProps = ToastProps & WithAppProviderProps`
 export interface ToastProps extends ToastProps {}
 
-// This does have a display name, but the linting has a bug in it
-// https://github.com/yannickcr/eslint-plugin-react/issues/2324
-// eslint-disable-next-line react/display-name
 export const Toast = React.memo(function Toast(props: ToastProps) {
   const id = useUniqueId('Toast');
   const appBridgeToast = useRef<AppBridgeToast.Toast>();

--- a/src/components/Toast/tests/Toast.test.tsx
+++ b/src/components/Toast/tests/Toast.test.tsx
@@ -109,7 +109,7 @@ describe('<Toast />', () => {
 
 function noop() {}
 
-function mountWithAppBridge(element: React.ReactElement<any>) {
+function mountWithAppBridge(element: React.ReactElement) {
   const appBridge = {};
   const toast = mountWithAppProvider(element, {appBridge});
 

--- a/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/src/components/UnstyledLink/UnstyledLink.tsx
@@ -7,11 +7,7 @@ import {useLink, LinkLikeComponentProps} from '../../utilities/link';
 // but the props explorer isn't smart enough to work that out
 export interface UnstyledLinkProps extends LinkLikeComponentProps {}
 
-// This does have a display name, but the linting has a bug in it
-// https://github.com/yannickcr/eslint-plugin-react/issues/2324
-// eslint-disable-next-line react/display-name
 export const UnstyledLink = React.memo(
-  // eslint-disable-next-line react/display-name
   React.forwardRef<unknown, UnstyledLinkProps>(function UnstyledLink(
     props,
     _ref,
@@ -29,3 +25,8 @@ export const UnstyledLink = React.memo(
     );
   }),
 );
+
+// Wrapping forwardRef in a memo means the component does not get a name set
+// So we have to do it ourselves
+// https://github.com/facebook/react/issues/16722
+UnstyledLink.displayName = 'Memoised(UnstyledLink)';

--- a/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/src/components/UnstyledLink/UnstyledLink.tsx
@@ -7,6 +7,10 @@ import {useLink, LinkLikeComponentProps} from '../../utilities/link';
 // but the props explorer isn't smart enough to work that out
 export interface UnstyledLinkProps extends LinkLikeComponentProps {}
 
+// Wrapping forwardRef in a memo gets a name set since
+// https://github.com/facebook/react/issues/16722
+// but eslint-plugin-react doesn't know that just yet
+// eslint-disable-next-line react/display-name
 export const UnstyledLink = React.memo(
   React.forwardRef<unknown, UnstyledLinkProps>(function UnstyledLink(
     props,
@@ -25,8 +29,3 @@ export const UnstyledLink = React.memo(
     );
   }),
 );
-
-// Wrapping forwardRef in a memo means the component does not get a name set
-// So we have to do it ourselves
-// https://github.com/facebook/react/issues/16722
-UnstyledLink.displayName = 'Memoised(UnstyledLink)';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line babel/camelcase
 export {UNSTABLE_Color} from './utilities/theme';
 
 export type Color =
@@ -318,8 +317,8 @@ export interface GeneralObject {
 }
 
 export type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends Array<infer U>
-    ? Array<DeepPartial<U>>
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? DeepPartial<U>[]
     : T[P] extends ReadonlyArray<infer U>
     ? ReadonlyArray<DeepPartial<U>>
     : DeepPartial<T[P]>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,8 +60,8 @@ export type AppBridgeTarget = 'ADMIN_PATH' | 'REMOTE' | 'APP';
 
 export type Error =
   | string
-  | React.ReactElement<any>
-  | (string | React.ReactElement<any>)[];
+  | React.ReactElement
+  | (string | React.ReactElement)[];
 
 export interface BaseAction {
   /** A unique identifier for the action */

--- a/src/utilities/app-bridge/tests/app-bridge.test.ts
+++ b/src/utilities/app-bridge/tests/app-bridge.test.ts
@@ -2,7 +2,7 @@ import * as appBridge from '@shopify/app-bridge';
 import {createAppBridge, setClientInterfaceHook} from '../app-bridge';
 
 describe('createAppBridge()', () => {
-  const createAppSpy: jest.SpyInstance<any> = jest.spyOn(appBridge, 'default');
+  const createAppSpy: jest.SpyInstance = jest.spyOn(appBridge, 'default');
 
   afterEach(() => {
     createAppSpy.mockReset();

--- a/src/utilities/color-transformers.ts
+++ b/src/utilities/color-transformers.ts
@@ -253,6 +253,7 @@ export function hslToString(hslColor: HSLAColor | string) {
 }
 
 function rgbToObject(color: string): RGBAColor {
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
   const colorMatch = color.match(/\(([^)]+)\)/);
 
   if (!colorMatch) {
@@ -280,6 +281,7 @@ const rbgStringToHsla: (color: string) => HSLAColor = compose(
 );
 
 function hslToObject(color: string): HSLAColor {
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
   const colorMatch = color.match(/\(([^)]+)\)/);
 
   if (!colorMatch) {

--- a/src/utilities/get.ts
+++ b/src/utilities/get.ts
@@ -11,6 +11,7 @@ export function get<T>(
 
   const keys = Array.isArray(keypath) ? keypath : getKeypath(keypath);
   let acc = obj;
+  // eslint-disable-next-line @typescript-eslint/prefer-for-of
   for (let i = 0; i < keys.length; i++) {
     const val = acc[keys[i]];
     if (val === undefined) return defaultValue;

--- a/src/utilities/media-query/context.tsx
+++ b/src/utilities/media-query/context.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-type MediaQueryContextType = {
+export interface MediaQueryContextType {
   isNavigationCollapsed: boolean;
-};
+}
 
 export const MediaQueryContext = React.createContext<
   MediaQueryContextType | undefined

--- a/src/utilities/pluck-deep.ts
+++ b/src/utilities/pluck-deep.ts
@@ -6,8 +6,7 @@ export function pluckDeep(obj: {[key: string]: any} | null, key: string): any {
   }
 
   const keys = Object.keys(obj);
-  for (let i = 0; i < keys.length; i++) {
-    const currKey = keys[i];
+  for (const currKey of keys) {
     if (currKey === key) {
       return obj[key];
     }

--- a/src/utilities/tests/merge.test.ts
+++ b/src/utilities/tests/merge.test.ts
@@ -6,6 +6,7 @@ describe('merge', () => {
   });
 
   it('does not merge prototypes', () => {
+    // eslint-disable-next-line @typescript-eslint/no-extraneous-class
     class Obj {}
     (Obj.prototype as any).prototypeVal = 'val';
     expect(merge(new Obj(), {})).toStrictEqual({});

--- a/src/utilities/tests/with-app-provider.test.tsx
+++ b/src/utilities/tests/with-app-provider.test.tsx
@@ -8,7 +8,7 @@ describe('withAppProvider', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => {});
 
-    const Child: React.SFC<{}> = (_props) => <div />;
+    const Child: React.SFC = (_props) => <div />;
 
     const WrappedComponent = withAppProvider<any>()(Child);
 

--- a/src/utilities/theme/color-adjustments.ts
+++ b/src/utilities/theme/color-adjustments.ts
@@ -1,6 +1,5 @@
 import {ColorAdjustments} from './types';
 
-/* eslint-disable babel/camelcase */
 // eslint-disable-next-line shopify/typescript/prefer-pascal-case-enums
 export enum UNSTABLE_Color {
   Surface = '#FAFAFA',
@@ -13,7 +12,7 @@ export enum UNSTABLE_Color {
   Warning = '#FFC453',
   Highlight = '#59D0C2',
   Success = '#008060',
-} /* eslint-enable babel/camelcase */
+}
 
 export const colorAdjustments: ColorAdjustments = {
   surface: {baseColor: 'surface', light: {}, dark: {}},

--- a/src/utilities/theme/index.ts
+++ b/src/utilities/theme/index.ts
@@ -4,7 +4,6 @@ export {useTheme} from './hooks';
 
 export {Theme, ThemeConfig, CustomPropertiesLike} from './types';
 
-// eslint-disable-next-line babel/camelcase
 export {UNSTABLE_Color} from './color-adjustments';
 
 export {buildCustomProperties, buildThemeContext} from './utils';

--- a/src/utilities/theme/tests/utils.test.ts
+++ b/src/utilities/theme/tests/utils.test.ts
@@ -49,7 +49,6 @@ describe('needsVariant', () => {
   });
 });
 
-/* eslint-disable babel/camelcase */
 describe('buildCustomProperties', () => {
   const legacyCustomProperties = {
     '--top-bar-background': '#eeeeee',
@@ -806,4 +805,3 @@ describe('buildThemeContext', () => {
     ).toStrictEqual({logo: {}, UNSTABLE_cssCustomProperties: 'foo:bar'});
   });
 });
-/* eslint-enable babel/camelcase */

--- a/src/utilities/theme/types.ts
+++ b/src/utilities/theme/types.ts
@@ -1,4 +1,4 @@
-export type ThemeLogo = {
+export interface ThemeLogo {
   /** Provides a path for a logo used on a dark background */
   topBarSource?: string;
   /** Provides a path for a logo used on a light background */
@@ -9,7 +9,7 @@ export type ThemeLogo = {
   accessibilityLabel?: string;
   /** Number of pixels wide the logo image is */
   width?: number;
-};
+}
 
 // The value that is passed into the ThemeProvider
 export interface ThemeConfig {
@@ -19,7 +19,6 @@ export interface ThemeConfig {
     /** Sets the background color of the top bar component. Complimentary and typography colors are determined programmatically */
     topBar?: Record<string, string>;
   };
-  // eslint-disable-next-line babel/camelcase
   UNSTABLE_colors?: {
     surface?: string;
     onSurface?: string;
@@ -39,7 +38,6 @@ export type CustomPropertiesLike = Record<string, string>;
 export interface Theme {
   /** Sets the logo for the top bar and contextual save bar components*/
   logo?: ThemeLogo;
-  // eslint-disable-next-line babel/camelcase
   UNSTABLE_cssCustomProperties?: string;
 }
 

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -13,11 +13,7 @@ import {createLightColor} from '../color-manipulation';
 import {compose} from '../compose';
 import {needsVariantList} from './config';
 import {ThemeConfig, Theme, CustomPropertiesLike} from './types';
-import {
-  colorAdjustments,
-  // eslint-disable-next-line babel/camelcase
-  UNSTABLE_Color,
-} from './color-adjustments';
+import {colorAdjustments, UNSTABLE_Color} from './color-adjustments';
 
 export function buildCustomProperties(
   themeConfig: ThemeConfig,
@@ -35,7 +31,6 @@ export function buildThemeContext(
   const {logo} = themeConfig;
   return {
     logo,
-    // eslint-disable-next-line babel/camelcase
     UNSTABLE_cssCustomProperties: toString(cssCustomProperties),
   };
 }
@@ -60,7 +55,6 @@ function hexToHsluvObj(hex: string) {
   };
 }
 
-/* eslint-disable babel/camelcase */
 export function buildColors(theme: ThemeConfig) {
   const colors = {
     surface: UNSTABLE_Color.Surface,
@@ -105,7 +99,6 @@ export function buildColors(theme: ThemeConfig) {
     ...overrides(),
   });
 }
-/* eslint-enable babel/camelcase */
 
 function overrides() {
   return {
@@ -255,11 +248,11 @@ function parseColors([baseName, colors]: [
 ]): string[][] {
   const keys = Object.keys(colors);
   const colorPairs = [];
-  for (let i = 0; i < keys.length; i++) {
-    colorPairs.push([constructColorName(baseName, keys[i]), colors[keys[i]]]);
+  for (const key of keys) {
+    colorPairs.push([constructColorName(baseName, key), colors[key]]);
 
     if (needsVariant(baseName)) {
-      const hslColor = colorToHsla(colors[keys[i]]);
+      const hslColor = colorToHsla(colors[key]);
 
       if (typeof hslColor === 'string') {
         return colorPairs;
@@ -268,9 +261,9 @@ function parseColors([baseName, colors]: [
       const rgbColor = hslToRgb(hslColor);
 
       if (isLight(rgbColor)) {
-        colorPairs.push(...setTheme(hslColor, baseName, keys[i], 'light'));
+        colorPairs.push(...setTheme(hslColor, baseName, key, 'light'));
       } else {
-        colorPairs.push(...setTheme(hslColor, baseName, keys[i], 'dark'));
+        colorPairs.push(...setTheme(hslColor, baseName, key, 'dark'));
       }
     }
   }

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -183,7 +183,7 @@ function buildLegacyColors(theme?: ThemeConfig): CustomPropertiesLike {
 }
 
 export function needsVariant(name: string) {
-  return needsVariantList.indexOf(name) !== -1;
+  return needsVariantList.includes(name);
 }
 
 const lightenToString: (

--- a/src/utilities/unique-id/tests/hooks.test.tsx
+++ b/src/utilities/unique-id/tests/hooks.test.tsx
@@ -133,7 +133,10 @@ describe('useUniqueId', () => {
   });
 
   it('updates the ID if the overridden ID changes', () => {
-    type HasPropProps = {info: string; idOverride?: string};
+    interface HasPropProps {
+      info: string;
+      idOverride?: string;
+    }
     const HasProp = ({info, idOverride}: HasPropProps) => (
       <div id={useUniqueId('', idOverride)} title={info} />
     );

--- a/src/utilities/use-lazy-ref.ts
+++ b/src/utilities/use-lazy-ref.ts
@@ -12,7 +12,7 @@ const UNIQUE_IDENTIFIER = Symbol('unique_identifier');
  * results from invoking initial value
  */
 export function useLazyRef<T>(initialValue: () => T) {
-  const lazyRef = useRef<T | Symbol>(UNIQUE_IDENTIFIER);
+  const lazyRef = useRef<T | symbol>(UNIQUE_IDENTIFIER);
 
   if (lazyRef.current === UNIQUE_IDENTIFIER) {
     lazyRef.current = initialValue();

--- a/tests/matchers/index.ts
+++ b/tests/matchers/index.ts
@@ -1,6 +1,7 @@
 import {toBeDisabled} from './props';
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
     interface Matchers<R> {
       toBeDisabled(): void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,18 +71,18 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@>=7.1.0", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.4.3", "@babel/core@^7.4.4", "@babel/core@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.0.tgz#9b00f73554edd67bebc86df8303ef678be3d7b48"
-  integrity sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==
+"@babel/core@>=7.1.0", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.4.3", "@babel/core@^7.5.5", "@babel/core@^7.6.0":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.4.tgz#6ebd9fe00925f6c3e177bb726a188b5f578088ff"
+  integrity sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==
   dependencies:
     "@babel/code-frame" "^7.5.5"
-    "@babel/generator" "^7.6.0"
-    "@babel/helpers" "^7.6.0"
-    "@babel/parser" "^7.6.0"
+    "@babel/generator" "^7.6.4"
+    "@babel/helpers" "^7.6.2"
+    "@babel/parser" "^7.6.4"
     "@babel/template" "^7.6.0"
-    "@babel/traverse" "^7.6.0"
-    "@babel/types" "^7.6.0"
+    "@babel/traverse" "^7.6.3"
+    "@babel/types" "^7.6.3"
     convert-source-map "^1.1.0"
     debug "^4.1.0"
     json5 "^2.1.0"
@@ -102,7 +102,7 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/generator@^7.4.0", "@babel/generator@^7.6.0", "@babel/generator@^7.6.3":
+"@babel/generator@^7.4.0", "@babel/generator@^7.6.3", "@babel/generator@^7.6.4":
   version "7.6.4"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.4.tgz#a4f8437287bf9671b07f483b76e3bb731bc97671"
   integrity sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==
@@ -287,13 +287,13 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.2.0"
 
-"@babel/helpers@^7.4.3", "@babel/helpers@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.6.0.tgz#21961d16c6a3c3ab597325c34c465c0887d31c6e"
-  integrity sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==
+"@babel/helpers@^7.4.3", "@babel/helpers@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.6.2.tgz#681ffe489ea4dcc55f23ce469e58e59c1c045153"
+  integrity sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==
   dependencies:
     "@babel/template" "^7.6.0"
-    "@babel/traverse" "^7.6.0"
+    "@babel/traverse" "^7.6.2"
     "@babel/types" "^7.6.0"
 
 "@babel/highlight@^7.0.0":
@@ -317,7 +317,7 @@
     node-environment-flags "^1.0.5"
     v8flags "^3.1.1"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.3", "@babel/parser@^7.4.3", "@babel/parser@^7.6.0", "@babel/parser@^7.6.3":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.3", "@babel/parser@^7.4.3", "@babel/parser@^7.6.0", "@babel/parser@^7.6.3", "@babel/parser@^7.6.4":
   version "7.6.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.4.tgz#cb9b36a7482110282d5cb6dd424ec9262b473d81"
   integrity sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==
@@ -990,7 +990,7 @@
     "@babel/parser" "^7.6.0"
     "@babel/types" "^7.6.0"
 
-"@babel/traverse@>=7.0.0", "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.6.0":
+"@babel/traverse@>=7.0.0", "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.6.2", "@babel/traverse@^7.6.3":
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.3.tgz#66d7dba146b086703c0fb10dd588b7364cec47f9"
   integrity sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==
@@ -1402,15 +1402,15 @@
   dependencies:
     browserslist "^4.6.3"
 
-"@shopify/fail-on-unexpected-module-shaking-plugin@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@shopify/fail-on-unexpected-module-shaking-plugin/-/fail-on-unexpected-module-shaking-plugin-1.0.7.tgz#6abcdb23a9073aa146997b82db1d00aa6515ba39"
-  integrity sha512-mIHX+pZEO3eef5C8m5/hCEh8pD9j8guXhKFnJ44A3o5N+VdvdhHYGeUtTjAU7L/J+QSdDYK6pN4XnQoORBpAfg==
+"@shopify/fail-on-unexpected-module-shaking-plugin@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@shopify/fail-on-unexpected-module-shaking-plugin/-/fail-on-unexpected-module-shaking-plugin-1.0.8.tgz#0e1776881c22c7596b5c14c90e5b35bb1b2f77fb"
+  integrity sha512-J/vjxI2uKMPIYW39lW7hJFXqnwMdgJevPwd4swvc2rPkJmS9OfksOOo2HbwHS1eDXKrKVo7b2Rkq29npkDuL4A==
 
-"@shopify/find-duplicate-dependencies-plugin@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@shopify/find-duplicate-dependencies-plugin/-/find-duplicate-dependencies-plugin-1.1.3.tgz#59f8646345aa225e8ec33de1dd58efd380ce7fa0"
-  integrity sha512-KQU8DVU382ZW7tB7AypdF/NlUOZOcZjKTxceFZdvKOr8h6T6zxHqIHg7XKPEPIEwdDZXqVqcEJQhYn2qSeeu0w==
+"@shopify/find-duplicate-dependencies-plugin@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@shopify/find-duplicate-dependencies-plugin/-/find-duplicate-dependencies-plugin-1.1.4.tgz#60e53230d93307b027dead6c56c24c7ee4985ee0"
+  integrity sha512-fcXSOvxK5aDESyyiXRwwogROzZS+tQJzqFgur5lBmxeYNdQaGB7JBf0zdNy24b6Ldi2fZn5LogWgeHgegHEu5A==
 
 "@shopify/images@^2.0.0":
   version "2.0.0"
@@ -1488,30 +1488,30 @@
     jest-matcher-utils "^24.5.0"
     react-reconciler "^0.20.2"
 
-"@shopify/sewing-kit@^0.111.0":
-  version "0.111.0"
-  resolved "https://registry.yarnpkg.com/@shopify/sewing-kit/-/sewing-kit-0.111.0.tgz#70432eea5f25fcbce6058b2218fd59b540012831"
-  integrity sha512-IH9mh6JiHY7q5AAyXR0KJUhZgQQX5cYg5gHCj3mGTys/+k5gz5sHwdVE3Qkj7K3avobVFHCoExfAtnZ1QFFRJA==
+"@shopify/sewing-kit@^0.112.0":
+  version "0.112.0"
+  resolved "https://registry.yarnpkg.com/@shopify/sewing-kit/-/sewing-kit-0.112.0.tgz#ae7a27cc91f44addd6be9062b9cc96396537369c"
+  integrity sha512-pqjCmMypjgkY1pgAMC8cxHTPb84zldYrlbMbdp+GtZbGCLmLHAj03K3H89vib0xOtccC/jtAG1HnYpFf4W9b8Q==
   dependencies:
-    "@babel/core" "^7.4.4"
+    "@babel/core" "^7.5.5"
     "@shopify/async" ">1.2.0 <3.0.0"
     "@shopify/babel-plugin-convert-empty-typescript-file-to-es-module" "^0.1.1"
     "@shopify/browserslist-config" "^1.0.0"
     "@shopify/build-targets" "^2.0.1"
-    "@shopify/fail-on-unexpected-module-shaking-plugin" "^1.0.7"
-    "@shopify/find-duplicate-dependencies-plugin" "^1.1.3"
+    "@shopify/fail-on-unexpected-module-shaking-plugin" "^1.0.8"
+    "@shopify/find-duplicate-dependencies-plugin" "^1.1.4"
     "@shopify/images" "^2.0.0"
     "@shopify/polyfills" "^1.0.1"
     "@shopify/react-server-webpack-plugin" "^2.1.14"
     "@shopify/typescript-configs" "^2.0.0"
     "@shopify/webpack-asset-metadata-plugin" "^1.3.0"
-    "@shopify/webpack-asset-sri-hash-verification-plugin" "^1.0.3"
+    "@shopify/webpack-asset-sri-hash-verification-plugin" "^1.0.4"
     "@shopify/webpack-ignore-typescript-export-warnings-plugin" "^1.0.2"
     "@shopify/webpack-no-react-jsx-loader" "^1.0.3"
     "@shopify/webpack-no-typescript-ts-loader" "^1.0.3"
     "@shopify/webpack-persisted-graphql-plugin" "^1.0.2"
     "@shopify/webpack-react-loadable-plugin" "^1.0.4"
-    "@shopify/webpack-runtime-sri-verification-plugin" "^1.0.6"
+    "@shopify/webpack-runtime-sri-verification-plugin" "^1.0.7"
     "@shopify/webpack-section-focus-loader" "^1.0.2"
     "@svgr/webpack" "^4.2.0"
     "@types/graphql" "^14.2.3"
@@ -1531,8 +1531,8 @@
     core-js "^2.5.0"
     css-loader "^1.0.1"
     element-dataset "^2.2.6"
-    eslint "^5.15.0"
-    eslint-plugin-shopify "30.0.1"
+    eslint "^6.5.1"
+    eslint-plugin-shopify "31.0.0"
     express "^4.16.3"
     file-loader "^2.0.0"
     fs-extra "^7.0.1"
@@ -1590,7 +1590,7 @@
     ts-loader "^5.3.0"
     url-loader "~1.1.2"
     webpack "~4.41.0"
-    webpack-bundle-analyzer "^3.4.1"
+    webpack-bundle-analyzer "^3.6.0"
     webpack-dev-middleware "^3.4.0"
     webpack-dev-server "^3.3.1"
     webpack-filter-warnings-plugin "^1.2.0"
@@ -1629,10 +1629,10 @@
     "@shopify/integrity-sha-utils" "^1.0.3"
     browserslist "^4.6.3"
 
-"@shopify/webpack-asset-sri-hash-verification-plugin@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@shopify/webpack-asset-sri-hash-verification-plugin/-/webpack-asset-sri-hash-verification-plugin-1.0.3.tgz#9db435ad6808c9adc11bfb59a5466850a17b179c"
-  integrity sha512-UBOBJ/ZSHhEnMWCnsDeP6Lkh/VVbgs7saRjh2g0zNYokPjF2yrwF+s+XPU03NW57e954SnL5UYVE3/72OaarSw==
+"@shopify/webpack-asset-sri-hash-verification-plugin@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@shopify/webpack-asset-sri-hash-verification-plugin/-/webpack-asset-sri-hash-verification-plugin-1.0.4.tgz#ae09eb13628a77a5e3b58d0aba56e4fd25504ad8"
+  integrity sha512-Dx9rVwjAyEW1qwAy0t129iWRB4uv8+znxtjAu62pTpsplzv/+YtHAobA9sJylb8Qc4ZRKwr1U4UtCGwsIFHfDA==
 
 "@shopify/webpack-ignore-typescript-export-warnings-plugin@^1.0.2":
   version "1.0.2"
@@ -1661,10 +1661,10 @@
   dependencies:
     "@shopify/integrity-sha-utils" "^1.0.3"
 
-"@shopify/webpack-runtime-sri-verification-plugin@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@shopify/webpack-runtime-sri-verification-plugin/-/webpack-runtime-sri-verification-plugin-1.0.6.tgz#de24ddfe082f5ea981646b355aecf454bc08d301"
-  integrity sha512-jGCZTmMCcOj/Ap/uzBinQAsRWT0+cQnJzAYuasfiNYSpZj3gvw97+m4VY+9untsXfd1lMpgvdYtdfCGXtwtoUg==
+"@shopify/webpack-runtime-sri-verification-plugin@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@shopify/webpack-runtime-sri-verification-plugin/-/webpack-runtime-sri-verification-plugin-1.0.7.tgz#ee818398d6e94ab7c93cfdb2fc573d2685469e02"
+  integrity sha512-IrHa4gFfF/p+qvy/8mh7CUJFxcl61QsAQKm2ZRhdUvo/Fz9GKa3upfta1YrVkinBHRz6NMYmyI4sWpxUXogrig==
 
 "@shopify/webpack-section-focus-loader@^1.0.2":
   version "1.0.2"
@@ -2338,11 +2338,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
-"@types/json5@^0.0.29":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
-  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
-
 "@types/lodash@^4.14.138", "@types/lodash@^4.14.65":
   version "4.14.138"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.138.tgz#34f52640d7358230308344e579c15b378d91989e"
@@ -2496,13 +2491,25 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/experimental-utils@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-1.10.2.tgz#cd548c03fc1a2b3ba5c136d1599001a1ede24215"
-  integrity sha512-Hf5lYcrnTH5Oc67SRrQUA7KuHErMvCf5RlZsyxXPIT6AXa8fKTyfFO6vaEnUmlz48RpbxO4f0fY3QtWkuHZNjg==
+"@typescript-eslint/eslint-plugin@^2.3.3":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.5.0.tgz#101d96743ce3365b3223df73d641078c9b775903"
+  integrity sha512-ddrJZxp5ns1Lh5ofZQYk3P8RyvKfyz/VcRR4ZiJLHO/ljnQAO8YvTfj268+WJOOadn99mvDiqJA65+HAKoeSPA==
   dependencies:
-    "@typescript-eslint/typescript-estree" "1.10.2"
-    eslint-scope "^4.0.0"
+    "@typescript-eslint/experimental-utils" "2.5.0"
+    eslint-utils "^1.4.2"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^2.0.1"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/experimental-utils@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.5.0.tgz#383a97ded9a7940e5053449f6d73995e782b8fb1"
+  integrity sha512-UgcQGE0GKJVChyRuN1CWqDW8Pnu7+mVst0aWrhiyuUD1J9c+h8woBdT4XddCvhcXDodTDVIfE3DzGHVjp7tUeQ==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.5.0"
+    eslint-scope "^5.0.0"
 
 "@typescript-eslint/experimental-utils@^1.13.0":
   version "1.13.0"
@@ -2513,13 +2520,15 @@
     "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-scope "^4.0.0"
 
-"@typescript-eslint/typescript-estree@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.10.2.tgz#8403585dd74b6cfb6f78aa98b6958de158b5897b"
-  integrity sha512-Kutjz0i69qraOsWeI8ETqYJ07tRLvD9URmdrMoF10bG8y8ucLmPtSxROvVejWvlJUGl2et/plnMiKRDW+rhEhw==
+"@typescript-eslint/parser@^2.3.3":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.5.0.tgz#858030ddd808fbbe88e03f42e5971efaccb8218a"
+  integrity sha512-9UBMiAwIDWSl79UyogaBdj3hidzv6exjKUx60OuZuFnJf56tq/UMpdPcX09YmGqE8f4AnAueYtBxV8IcAT3jdQ==
   dependencies:
-    lodash.unescape "4.0.1"
-    semver "5.5.0"
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.5.0"
+    "@typescript-eslint/typescript-estree" "2.5.0"
+    eslint-visitor-keys "^1.1.0"
 
 "@typescript-eslint/typescript-estree@1.13.0":
   version "1.13.0"
@@ -2528,6 +2537,17 @@
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
+
+"@typescript-eslint/typescript-estree@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.5.0.tgz#40ada624d6217ef092a3a79ed30d947ad4f212ce"
+  integrity sha512-AXURyF8NcA3IsnbjNX1v9qbwa0dDoY9YPcKYR2utvMHoUcu3636zrz0gRWtVAyxbPCkhyKuGg6WZIyi2Fc79CA==
+  dependencies:
+    debug "^4.1.1"
+    glob "^7.1.4"
+    is-glob "^4.0.1"
+    lodash.unescape "4.0.1"
+    semver "^6.3.0"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -2723,10 +2743,10 @@ acorn-globals@^4.1.0, acorn-globals@^4.3.2:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
-acorn-jsx@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
-  integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
+acorn-jsx@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.1.0.tgz#294adb71b57398b0680015f0a38c563ee1db5384"
+  integrity sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==
 
 acorn-walk@^6.0.1, acorn-walk@^6.1.1:
   version "6.1.1"
@@ -2827,7 +2847,7 @@ ajv@6.5.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.1.0, ajv@^6.10.2, ajv@^6.5.5, ajv@^6.9.1:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5, ajv@^6.9.1:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
   integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
@@ -3471,17 +3491,17 @@ babel-core@7.0.0-bridge.0:
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
 
-babel-eslint@10.0.2:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.2.tgz#182d5ac204579ff0881684b040560fdcc1558456"
-  integrity sha512-UdsurWPtgiPgpJ06ryUnuaSXC2s0WoSZnQmEpbAH65XZSdwowgN5MvyP7e88nW07FYXv72erVtpBkxyDVKhH1Q==
+babel-eslint@10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
+  integrity sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/parser" "^7.0.0"
     "@babel/traverse" "^7.0.0"
     "@babel/types" "^7.0.0"
-    eslint-scope "3.7.1"
     eslint-visitor-keys "^1.0.0"
+    resolve "^1.12.0"
 
 babel-helper-evaluate-path@^0.5.0:
   version "0.5.0"
@@ -4794,6 +4814,13 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+  dependencies:
+    restore-cursor "^3.1.0"
+
 cli-table3@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"
@@ -5871,11 +5898,6 @@ deep-object-diff@^1.1.0:
   resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
   integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
 
-deepmerge@^2.0.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
-  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
-
 default-gateway@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-4.2.0.tgz#167104c7500c2115f6dd69b0a536bb8ed720552b"
@@ -6349,6 +6371,11 @@ emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -6576,15 +6603,6 @@ eslint-import-resolver-node@^0.3.2:
     debug "^2.6.9"
     resolve "^1.5.0"
 
-eslint-import-resolver-typescript@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-1.1.1.tgz#e6d42172b95144ef16610fe104ef38340edea591"
-  integrity sha512-jqSfumQ+H5y3FUJ6NjRkbOQSUOlbBucGTN3ELymOtcDBbPjVdm/luvJuCfCaIXGh8sEF26ma1qVdtDgl9ndhUg==
-  dependencies:
-    debug "^4.0.1"
-    resolve "^1.4.0"
-    tsconfig-paths "^3.6.0"
-
 eslint-module-utils@2.4.1, eslint-module-utils@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz#7b4675875bf96b0dbf1b21977456e5bb1f5e018c"
@@ -6616,10 +6634,10 @@ eslint-plugin-eslint-comments@3.1.2:
     escape-string-regexp "^1.0.5"
     ignore "^5.0.5"
 
-eslint-plugin-graphql@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-graphql/-/eslint-plugin-graphql-3.0.3.tgz#9ecdaf5ea8397973e29cea9dbf860420694e9df0"
-  integrity sha512-hHwLyxSkC5rkakJ/SNTWwOswPdVhvfyMCnEOloevrLQIOHUNVIQBg1ljCaRe9C40HdzgcGUFUdG5BHLCKm8tuw==
+eslint-plugin-graphql@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-graphql/-/eslint-plugin-graphql-3.1.0.tgz#ccf0d3c61961f6307170ac565c1fb0902dd4f11f"
+  integrity sha512-87HGS00aeBqGFiQZQGzSPzk1D59w+124F8CRIDATh3LJqce5RCTuUI4tcIqPeyY95YPBCIKwISksWUuA0nrgNw==
   dependencies:
     graphql-config "^2.0.1"
     lodash "^4.11.1"
@@ -6641,10 +6659,10 @@ eslint-plugin-import@2.18.2:
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
 
-eslint-plugin-jest@22.13.6:
-  version "22.13.6"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.13.6.tgz#85630e7709fe1ecbe0099956590af32d5e157448"
-  integrity sha512-wn3n9Djj+Dyi8AS1kvGOXpzUJfs9SJYhoZxIb49y4cwHRPaSgDHzSJPZX3sliZ3k8l6bYVeEGW76QvvqoOjSEw==
+eslint-plugin-jest@22.15.2:
+  version "22.15.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.15.2.tgz#e3c10d9391f787744e31566f69ebb70c3a98e398"
+  integrity sha512-p4NME9TgXIt+KgpxcXyNBvO30ZKxwFAO1dJZBc2OGfDnXVEtPwEyNs95GSr6RIE3xLHdjd8ngDdE2icRRXrbxg==
   dependencies:
     "@typescript-eslint/experimental-utils" "^1.13.0"
 
@@ -6687,59 +6705,59 @@ eslint-plugin-promise@4.2.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a"
   integrity sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==
 
-eslint-plugin-react-hooks@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
-  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
+eslint-plugin-react-hooks@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.2.0.tgz#078264e9e388da6929ace09d6abe92c85963aff4"
+  integrity sha512-jSlnBjV2cmyIeL555H/FbvuSbQ1AtpHjLMHuPrQnt1eVA6lX8yufdygh7AArI2m8ct7ChHGx2uOaCuxq2MUn6g==
 
-eslint-plugin-react@7.14.3:
-  version "7.14.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz#911030dd7e98ba49e1b2208599571846a66bdf13"
-  integrity sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==
+eslint-plugin-react@7.15.1:
+  version "7.15.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.15.1.tgz#db5f8ed66c6ba46922518f08e1df9dac52ccaa49"
+  integrity sha512-YotSItgMPwLGlr3df44MGVyXnHkmKcpkHTzpte3QwJtocr3nFqCXCuoxFZeBtnT8RHdj038NlTvam3dcAFrMcA==
   dependencies:
     array-includes "^3.0.3"
     doctrine "^2.1.0"
     has "^1.0.3"
-    jsx-ast-utils "^2.1.0"
+    jsx-ast-utils "^2.2.1"
     object.entries "^1.1.0"
     object.fromentries "^2.0.0"
     object.values "^1.1.0"
     prop-types "^15.7.2"
-    resolve "^1.10.1"
+    resolve "^1.12.0"
 
-eslint-plugin-shopify@30.0.1:
-  version "30.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-shopify/-/eslint-plugin-shopify-30.0.1.tgz#d284a30c15654d3b73b7ae6f76686d345069fa0d"
-  integrity sha512-nCnkMAtqmqYCYqixgwQwy/P/xrBdjacg9MjJWPqgfRY9zZM+ZD7dgR5udiS4h4Ht/na6ro8RUVx4rLGS9BJ9Fw==
+eslint-plugin-shopify@31.0.0:
+  version "31.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-shopify/-/eslint-plugin-shopify-31.0.0.tgz#e1ec99aba8220bc6fea37c65a196ddcaf28796f2"
+  integrity sha512-jn5OUC5OuIuYKIXOi21R0io7FpH7bVWzJdXc0yUmZ5BMzYsNtqgqZhA9jSaZiKo+23hRLbbJgSxvheBt2lz7LA==
   dependencies:
-    babel-eslint "10.0.2"
+    "@typescript-eslint/eslint-plugin" "^2.3.3"
+    "@typescript-eslint/parser" "^2.3.3"
+    babel-eslint "10.0.3"
     common-tags "^1.8.0"
     eslint-config-prettier "6.0.0"
-    eslint-import-resolver-typescript "^1.1.1"
     eslint-module-utils "2.4.1"
     eslint-plugin-babel "5.3.0"
     eslint-plugin-eslint-comments "3.1.2"
-    eslint-plugin-graphql "3.0.3"
+    eslint-plugin-graphql "3.1.0"
     eslint-plugin-import "2.18.2"
-    eslint-plugin-jest "22.13.6"
+    eslint-plugin-jest "22.15.2"
     eslint-plugin-jsx-a11y "6.2.3"
     eslint-plugin-node "9.1.0"
     eslint-plugin-prettier "3.1.0"
     eslint-plugin-promise "4.2.1"
-    eslint-plugin-react "7.14.3"
-    eslint-plugin-react-hooks "^1.6.0"
-    eslint-plugin-sort-class-members "1.5.0"
+    eslint-plugin-react "7.15.1"
+    eslint-plugin-react-hooks "^2.0.1"
+    eslint-plugin-sort-class-members "1.6.0"
     eslint-plugin-typescript "0.14.0"
     merge "1.2.1"
     pascal-case "^2.0.1"
     pkg-dir "4.2.0"
     pluralize "^8.0.0"
-    typescript-eslint-parser "20.0.0"
 
-eslint-plugin-sort-class-members@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.5.0.tgz#71c66d89f902ddd31b04acd4cff7c86141db3389"
-  integrity sha512-LgseO8RQTJ1PJcnSlMNuSGIHHaJhSH+CUQE2jbsSVmKETwaW+tJLBNTHX7laTobXugrjvF6A+7RccxEKJY3t/A==
+eslint-plugin-sort-class-members@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.6.0.tgz#64228d527f5d8e315e8249765417be218404353f"
+  integrity sha512-7+FEtnxeK0vtoPERAU7gtxpr//NsYYrPvMoDRIoqP6u999xbY7Lpgjr9KmalfXIOTuVxvRNgK7vJhAGVRi/z4A==
 
 eslint-plugin-typescript@0.14.0:
   version "0.14.0"
@@ -6753,14 +6771,6 @@ eslint-rule-composer@^0.3.0:
   resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
   integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
-eslint-scope@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
-  integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
-  dependencies:
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
-
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -6769,73 +6779,82 @@ eslint-scope@^4.0.0, eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.0, eslint-utils@^1.3.1:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
-  integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
+eslint-scope@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
+  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
   dependencies:
-    eslint-visitor-keys "^1.0.0"
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
-eslint-visitor-keys@^1.0.0:
+eslint-utils@^1.3.0, eslint-utils@^1.3.1, eslint-utils@^1.4.2, eslint-utils@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
+  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^5.15.0:
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
-  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
+eslint@^6.5.1:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.6.0.tgz#4a01a2fb48d32aacef5530ee9c5a78f11a8afd04"
+  integrity sha512-PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    ajv "^6.9.1"
+    ajv "^6.10.0"
     chalk "^2.1.0"
     cross-spawn "^6.0.5"
     debug "^4.0.1"
     doctrine "^3.0.0"
-    eslint-scope "^4.0.3"
-    eslint-utils "^1.3.1"
-    eslint-visitor-keys "^1.0.0"
-    espree "^5.0.1"
+    eslint-scope "^5.0.0"
+    eslint-utils "^1.4.3"
+    eslint-visitor-keys "^1.1.0"
+    espree "^6.1.2"
     esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
-    glob "^7.1.2"
+    glob-parent "^5.0.0"
     globals "^11.7.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^6.2.2"
-    js-yaml "^3.13.0"
+    inquirer "^7.0.0"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.17.11"
+    lodash "^4.17.14"
     minimatch "^3.0.4"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.2"
     progress "^2.0.0"
     regexpp "^2.0.1"
-    semver "^5.5.1"
-    strip-ansi "^4.0.0"
-    strip-json-comments "^2.0.1"
+    semver "^6.1.2"
+    strip-ansi "^5.2.0"
+    strip-json-comments "^3.0.1"
     table "^5.2.3"
     text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
 
 esm@^3.2.25:
   version "3.2.25"
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
   integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
-espree@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
-  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+espree@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.1.2.tgz#6c272650932b4f91c3714e5e7b5f5e2ecf47262d"
+  integrity sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==
   dependencies:
-    acorn "^6.0.7"
-    acorn-jsx "^5.0.0"
-    eslint-visitor-keys "^1.0.0"
+    acorn "^7.1.0"
+    acorn-jsx "^5.1.0"
+    eslint-visitor-keys "^1.1.0"
 
 esprima@^3.1.3:
   version "3.1.3"
@@ -7346,6 +7365,13 @@ figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
   integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+figures@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.1.0.tgz#4b198dd07d8d71530642864af2d45dd9e459c4ec"
+  integrity sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==
   dependencies:
     escape-string-regexp "^1.0.5"
 
@@ -7943,6 +7969,13 @@ glob-parent@^3.0.0, glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
+
+glob-parent@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
+  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  dependencies:
+    is-glob "^4.0.1"
 
 glob-stream@^5.3.2:
   version "5.3.5"
@@ -9131,7 +9164,7 @@ inquirer@6.2.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inquirer@6.2.2, inquirer@^6.2.0, inquirer@^6.2.2:
+inquirer@6.2.2, inquirer@^6.2.0:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
   integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
@@ -9148,6 +9181,25 @@ inquirer@6.2.2, inquirer@^6.2.0, inquirer@^6.2.2:
     rxjs "^6.4.0"
     string-width "^2.1.0"
     strip-ansi "^5.0.0"
+    through "^2.3.6"
+
+inquirer@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.0.tgz#9e2b032dde77da1db5db804758b8fea3a970519a"
+  integrity sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^2.4.2"
+    cli-cursor "^3.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.15"
+    mute-stream "0.0.8"
+    run-async "^2.2.0"
+    rxjs "^6.4.0"
+    string-width "^4.1.0"
+    strip-ansi "^5.1.0"
     through "^2.3.6"
 
 internal-ip@^4.3.0:
@@ -9440,6 +9492,11 @@ is-fullwidth-code-point@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
 is-function@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
@@ -9471,10 +9528,10 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
-  integrity sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=
+is-glob@^4.0.0, is-glob@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -10270,7 +10327,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.9.0:
+js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.13.1, js-yaml@^3.9.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -10461,7 +10518,7 @@ jssha@^2.1.0:
   resolved "https://registry.yarnpkg.com/jssha/-/jssha-2.3.1.tgz#147b2125369035ca4b2f7d210dc539f009b3de9a"
   integrity sha1-FHshJTaQNcpLL30hDcU58Amz3po=
 
-jsx-ast-utils@^2.1.0, jsx-ast-utils@^2.2.1:
+jsx-ast-utils@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz#4d4973ebf8b9d2837ee91a8208cc66f3a2776cfb"
   integrity sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==
@@ -11562,6 +11619,11 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
+
+mute-stream@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 nan@^2.12.1, nan@^2.13.2:
   version "2.13.2"
@@ -14766,10 +14828,10 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
-  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
 
@@ -14786,6 +14848,14 @@ restore-cursor@^2.0.0:
   integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
   dependencies:
     onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+  dependencies:
+    onetime "^5.1.0"
     signal-exit "^3.0.2"
 
 ret@~0.1.10:
@@ -15127,7 +15197,7 @@ semver@^4.0.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
   integrity sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=
 
-semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -15900,6 +15970,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.1.0.tgz#ba846d1daa97c3c596155308063e075ed1c99aff"
+  integrity sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^5.2.0"
+
 string.prototype.matchall@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-3.0.1.tgz#5a9e0b64bcbeb336aa4814820237c2006985646d"
@@ -16063,7 +16142,12 @@ strip-indent@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
-strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
+  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
+
+strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -16728,21 +16812,17 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
   integrity sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA==
 
-tsconfig-paths@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.6.0.tgz#f14078630d9d6e8b1dc690c1fc0cfb9cd0663891"
-  integrity sha512-mrqQIP2F4e03aMTCiPdedCIT300//+q0ET53o5WqqtQjmEICxP9yfz/sHTpPqXpssuJEzODsEzJaLRaf5J2X1g==
-  dependencies:
-    "@types/json5" "^0.0.29"
-    deepmerge "^2.0.1"
-    json5 "^1.0.1"
-    minimist "^1.2.0"
-    strip-bom "^3.0.0"
-
-tslib@^1, tslib@^1.7.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1, tslib@^1.7.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -16805,16 +16885,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-typescript-eslint-parser@20.0.0, "typescript-eslint-parser@npm:@typescript-eslint/parser@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.10.2.tgz#36cfe8c6bf1b6c1dd81da56f88c8588f4b1a852b"
-  integrity sha512-xWDWPfZfV0ENU17ermIUVEVSseBBJxKfqBcRCMZ8nAjJbfA5R7NWMZmFFHYnars5MjK4fPjhu4gwQv526oZIPQ==
-  dependencies:
-    "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "1.10.2"
-    "@typescript-eslint/typescript-estree" "1.10.2"
-    eslint-visitor-keys "^1.0.0"
 
 typescript@~3.5.1:
   version "3.5.1"
@@ -17184,6 +17254,11 @@ uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
 
+v8-compile-cache@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
+  integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
+
 v8flags@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.3.tgz#fc9dc23521ca20c5433f81cc4eb9b3033bb105d8"
@@ -17439,7 +17514,7 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webpack-bundle-analyzer@^3.4.1:
+webpack-bundle-analyzer@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.6.0.tgz#39b3a8f829ca044682bc6f9e011c95deb554aefd"
   integrity sha512-orUfvVYEfBMDXgEKAKVvab5iQ2wXneIEorGNsyuOyVYpjYrI7CUOhhXNDd3huMwQ3vNNWWlGP+hzflMFYNzi2g==


### PR DESCRIPTION
### WHY are these changes introduced?

This updates our eslint version to 6 and our eslint-plugin-shopify
version to v31, which includes support for the new @typescript-eslint
parser so we can get rid of that resolution hack.


### WHAT is this pull request doing?

Updates sewing-kit and updates code to adhere to updated rules.

This also changes our vscode config so that the prettier extension no longer formats our `{js,ts}x?` files on save and instead this is handled by the eslint extension, this is because the prettier extension doesn't play nice with eslint 6 (as it uses prettier-eslint under the hood which doesn't like eslint6: https://github.com/prettier/prettier-eslint/pull/236) and its future roadmap will remove support for running eslint formatting (https://github.com/prettier/prettier-vscode/issues/958).


### How to 🎩

linting and tests pass

After doing a `yarn install` restart VSCode and ensure that format on save still works for various file types:
- JS files
- JSX files (don't think we have any of these but whatevs)
- TS files
- TSX files (these 4 have changes to their behaviour as they're now using the eslint extension to format rather than the prettier extension
- scss files (this has no changes but nice to regression test)
- md files (this has no changes but nice to regression test)