### PR TITLE
Make yarn splash optional

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -116,7 +116,7 @@ module.exports = ({config, mode}) => {
     apply: (compiler) => {
       compiler.hooks.afterEmit.tap('AfterEmitPlugin', (compilation) => {
         process.env.DISABLE_SPLASH ||
-          spawn('yarn splash --storybook', {
+          spawn('yarn splash --show-storybook-tip', {
             shell: true,
             stdio: 'inherit',
           });

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -115,10 +115,11 @@ module.exports = ({config, mode}) => {
   config.plugins.push({
     apply: (compiler) => {
       compiler.hooks.afterEmit.tap('AfterEmitPlugin', (compilation) => {
-        const spawnedProcess = spawn('yarn splash', {
-          shell: true,
-          stdio: 'inherit',
-        });
+        process.env.DISABLE_SPLASH ||
+          spawn('yarn splash', {
+            shell: true,
+            stdio: 'inherit',
+          });
       });
     },
   });

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -116,7 +116,7 @@ module.exports = ({config, mode}) => {
     apply: (compiler) => {
       compiler.hooks.afterEmit.tap('AfterEmitPlugin', (compilation) => {
         process.env.DISABLE_SPLASH ||
-          spawn('yarn splash', {
+          spawn('yarn splash --storybook', {
             shell: true,
             stdio: 'inherit',
           });

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -115,11 +115,10 @@ module.exports = ({config, mode}) => {
   config.plugins.push({
     apply: (compiler) => {
       compiler.hooks.afterEmit.tap('AfterEmitPlugin', (compilation) => {
-        process.env.DISABLE_SPLASH ||
-          spawn('yarn splash --show-storybook-tip', {
-            shell: true,
-            stdio: 'inherit',
-          });
+        spawn('yarn splash --show-disable-tip', {
+          shell: true,
+          stdio: 'inherit',
+        });
       });
     },
   });

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,7 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Development workflow
 
-- Made it possible to prevent [“yarn splash”](https://github.com/Shopify/polaris-react/tree/master/scripts/splash) from automatically running alongside `yarn dev`: `yarn dev-no-splash` or `DISABLE_SPLASH=1 yarn dev` ([#2372](https://github.com/Shopify/polaris-react/pull/2372))
+- Enable developers to hide [`yarn splash`](https://github.com/Shopify/polaris-react/tree/master/scripts/splash) reports when running `yarn dev` by running `DISABLE_SPLASH=1 yarn dev` ([#2372](https://github.com/Shopify/polaris-react/pull/2372))
 
 ### Dependency upgrades
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,7 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Development workflow
 
-- Enable developers to hide [`yarn splash`](https://github.com/Shopify/polaris-react/tree/master/scripts/splash) reports when running `yarn dev` by running `DISABLE_SPLASH=1 yarn dev` ([#2372](https://github.com/Shopify/polaris-react/pull/2372))
+- Enabled maintainers running `yarn dev` to hide [`yarn splash`](https://github.com/Shopify/polaris-react/tree/master/scripts/splash) reports by running `DISABLE_SPLASH=1 yarn dev` ([#2372](https://github.com/Shopify/polaris-react/pull/2372))
 
 ### Dependency upgrades
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Development workflow
 
+- Made running yarn splash along with the storybook optional ([#2372](https://github.com/Shopify/polaris-react/pull/2372))
+
 ### Dependency upgrades
 
 ### Code quality

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,7 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Development workflow
 
-- Enabled maintainers running `yarn dev` to hide [`yarn splash`](https://github.com/Shopify/polaris-react/tree/master/scripts/splash) reports by running `DISABLE_SPLASH=1 yarn dev` ([#2372](https://github.com/Shopify/polaris-react/pull/2372))
+- Enabled maintainers running `yarn dev` to hide [`yarn splash`](https://github.com/Shopify/polaris-react/tree/master/scripts/splash) reports from the console by running `DISABLE_SPLASH=1 yarn dev` ([#2372](https://github.com/Shopify/polaris-react/pull/2372))
 
 ### Dependency upgrades
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,7 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Development workflow
 
-- Made running yarn splash along with the storybook optional ([#2372](https://github.com/Shopify/polaris-react/pull/2372))
+- Made it possible to prevent [“yarn splash”](https://github.com/Shopify/polaris-react/tree/master/scripts/splash) from automatically running alongside `yarn dev`: `yarn dev-no-splash` or `DISABLE_SPLASH=1 yarn dev` ([#2372](https://github.com/Shopify/polaris-react/pull/2372))
 
 ### Dependency upgrades
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "prepublish": "in-publish && yarn run build || :",
     "postpublish": "in-publish && npm-run-all new-version-pr-generator",
     "dev": "npm-run-all copy-polaris-tokens storybook",
+    "dev-no-splash": "DISABLE_SPLASH=1 yarn run dev",
     "test:percy": "yarn run storybook:build && percy-storybook --build_dir build/storybook/static",
     "test:a11y": "yarn run storybook:build && node ./scripts/pa11y.js",
     "start": "serve -l ${PORT} -c .storybook/serve.json",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "prepublish": "in-publish && yarn run build || :",
     "postpublish": "in-publish && npm-run-all new-version-pr-generator",
     "dev": "npm-run-all copy-polaris-tokens storybook",
-    "dev-no-splash": "DISABLE_SPLASH=1 yarn run dev",
     "test:percy": "yarn run storybook:build && percy-storybook --build_dir build/storybook/static",
     "test:a11y": "yarn run storybook:build && node ./scripts/pa11y.js",
     "start": "serve -l ${PORT} -c .storybook/serve.json",

--- a/scripts/splash/README.md
+++ b/scripts/splash/README.md
@@ -12,7 +12,7 @@ It answers the question:
 2. As you run `yarn dev`, `yarn splash` will run in the background. Keep an eye on the terminal to see the splash zone of your changes in the working directory.
 
 💡 Tip: <kbd>command</kbd> + click a file path to open it in your text editor
-💡 Tip: To disable `yarn splash` running inside of `yarn dev` add the environment variable `DISABLE_SPLASH=1` to your environment
+💡 Tip: To disable `yarn splash` when running `yarn dev` either run `yarn dev-no-splash` or add the environment variable `DISABLE_SPLASH=1` to your environment
 
 ## Feedback and bug reports
 

--- a/scripts/splash/README.md
+++ b/scripts/splash/README.md
@@ -11,8 +11,9 @@ It answers the question:
 1. Edit files in `src/`, such as components 🧩 and style sheets 🎨.
 2. As you run `yarn dev`, `yarn splash` will run in the background. Keep an eye on the terminal to see the splash zone of your changes in the working directory.
 
+   💡 Tip: to disable these reports, run `DISABLE_SPLASH=1 yarn dev`
+
 💡 Tip: <kbd>command</kbd> + click a file path to open it in your text editor
-💡 Tip: To disable `yarn splash` when running `yarn dev` either run `yarn dev-no-splash` or add the environment variable `DISABLE_SPLASH=1` to your environment
 
 ## Feedback and bug reports
 

--- a/scripts/splash/README.md
+++ b/scripts/splash/README.md
@@ -12,6 +12,7 @@ It answers the question:
 2. As you run `yarn dev`, `yarn splash` will run in the background. Keep an eye on the terminal to see the splash zone of your changes in the working directory.
 
 💡 Tip: <kbd>command</kbd> + click a file path to open it in your text editor
+💡 Tip: To disable `yarn splash` running inside of `yarn dev` add the environment variable `DISABLE_SPLASH=1` to your environment
 
 ## Feedback and bug reports
 

--- a/scripts/splash/index.tsx
+++ b/scripts/splash/index.tsx
@@ -158,7 +158,8 @@ const App = () => {
           <Box>
             <Box width={3}>💡</Box>
             <Box>
-              Tip: disable <Text bold>yarn splash</Text> setting an environment
+              Tip: disable <Text bold>yarn splash</Text> by running variable{' '}
+              <Text bold>yarn dev-no-splash</Text> or setting an environment
               variable <Text bold>DISABLE_SPLASH=1</Text>
             </Box>
           </Box>

--- a/scripts/splash/index.tsx
+++ b/scripts/splash/index.tsx
@@ -155,6 +155,14 @@ const App = () => {
     <React.Fragment>
       <Box marginBottom={1} flexDirection="column">
         <Box>
+          <Box width={3}>💡</Box>
+          <Box>
+            Tip: disable <Text bold>yarn splash</Text> by running{' '}
+            <Text bold>yarn dev-no-splash</Text> or setting an environment
+            variable <Text bold>DISABLE_SPLASH=1</Text>
+          </Box>
+        </Box>
+        <Box>
           <Box width={3}>💦</Box>
           <Box>
             <Text bold>yarn splash</Text>: Observe the splash zone of a change

--- a/scripts/splash/index.tsx
+++ b/scripts/splash/index.tsx
@@ -4,6 +4,10 @@ import {Box, Text, Color, render} from 'ink';
 import sortBy from 'lodash/sortBy';
 import {getGitStagedFiles, getDependencies} from './treebuilder';
 
+if (process.env.DISABLE_SPLASH) {
+  process.exit(0);
+}
+
 const excludedFileNames = (fileName) =>
   !fileName.includes('test') && !fileName.includes('types');
 
@@ -154,18 +158,6 @@ const App = () => {
   return (
     <React.Fragment>
       <Box marginBottom={1} flexDirection="column">
-        {process.argv.includes('--show-storybook-tip') ? (
-          <Box>
-            <Box width={3}>💡</Box>
-            <Box>
-              Tip: disable <Text bold>yarn splash</Text> by running variable{' '}
-              <Text bold>yarn dev-no-splash</Text> or setting an environment
-              variable <Text bold>DISABLE_SPLASH=1</Text>
-            </Box>
-          </Box>
-        ) : (
-          undefined
-        )}
         <Box>
           <Box width={3}>💦</Box>
           <Box>
@@ -205,6 +197,17 @@ const App = () => {
           </Box>
         </Color>
       </Box>
+      {process.argv.includes('--show-disable-tip') && (
+        <Box>
+          <Color dim>
+            <Box width={3}>💡</Box>
+            <Box>
+              Tip: to disable these reports, run{' '}
+              <Text bold>DISABLE_SPLASH=1 yarn dev</Text>
+            </Box>
+          </Color>
+        </Box>
+      )}
     </React.Fragment>
   );
 };

--- a/scripts/splash/index.tsx
+++ b/scripts/splash/index.tsx
@@ -154,12 +154,11 @@ const App = () => {
   return (
     <React.Fragment>
       <Box marginBottom={1} flexDirection="column">
-        {process.argv.includes('--storybook') ? (
+        {process.argv.includes('--show-storybook-tip') ? (
           <Box>
             <Box width={3}>💡</Box>
             <Box>
-              Tip: disable <Text bold>yarn splash</Text> by running{' '}
-              <Text bold>yarn dev-no-splash</Text> or setting an environment
+              Tip: disable <Text bold>yarn splash</Text> setting an environment
               variable <Text bold>DISABLE_SPLASH=1</Text>
             </Box>
           </Box>

--- a/scripts/splash/index.tsx
+++ b/scripts/splash/index.tsx
@@ -154,14 +154,18 @@ const App = () => {
   return (
     <React.Fragment>
       <Box marginBottom={1} flexDirection="column">
-        <Box>
-          <Box width={3}>💡</Box>
+        {process.argv.includes('--storybook') ? (
           <Box>
-            Tip: disable <Text bold>yarn splash</Text> by running{' '}
-            <Text bold>yarn dev-no-splash</Text> or setting an environment
-            variable <Text bold>DISABLE_SPLASH=1</Text>
+            <Box width={3}>💡</Box>
+            <Box>
+              Tip: disable <Text bold>yarn splash</Text> by running{' '}
+              <Text bold>yarn dev-no-splash</Text> or setting an environment
+              variable <Text bold>DISABLE_SPLASH=1</Text>
+            </Box>
           </Box>
-        </Box>
+        ) : (
+          undefined
+        )}
         <Box>
           <Box width={3}>💦</Box>
           <Box>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Yarn splash can be really noisy at times

### WHAT is this pull request doing?

Enables maintainers running `yarn dev` to hide [`yarn splash`](https://github.com/Shopify/polaris-react/tree/master/scripts/splash) reports from the console by running `DISABLE_SPLASH=1 yarn dev` ([#2372](https://github.com/Shopify/polaris-react/pull/2372))