### PR TITLE
Fix bug that introduced a race condition in consumers

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,9 @@
 - Prevented scrolling to `Popover` content in development ([#2403](https://github.com/Shopify/polaris-react/pull/2403))
 - Fixed an issue which caused HSL colors to not display in Edge ([#2418](https://github.com/Shopify/polaris-react/pull/2418))
 - Fixed an issue where the dropzone component jumped from an extra-large layout to a layout based on the width of its container ([#2412](https://github.com/Shopify/polaris-react/pull/2412))
+- Fixed an issue which caused HSL colors to not display in Edge ((#2418)[https://github.com/Shopify/polaris-react/pull/2418])
+- Fixed an issue where the dropzone component jumped from an extra-large layout to a layout based on the width of it's container ([#2412](https://github.com/Shopify/polaris-react/pull/2412))
+- Fixed a race condition in DatePicker ([#2373](https://github.com/Shopify/polaris-react/pull/2373))
 
 ### Documentation
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -65,10 +65,17 @@ export function DatePicker({
   const i18n = useI18n();
   const [hoverDate, setHoverDate] = useState<Date | undefined>(undefined);
   const [focusDate, setFocusDate] = useState<Date | undefined>(undefined);
+  const [newRange, setNewRange] = useState<Range | undefined>(undefined);
 
   useEffect(() => {
     setFocusDate(undefined);
   }, [selected]);
+
+  useEffect(() => {
+    if (newRange) {
+      onChange(newRange);
+    }
+  }, [newRange, onChange]);
 
   const handleFocus = useCallback((date: Date) => {
     setFocusDate(date);
@@ -85,16 +92,13 @@ export function DatePicker({
     [onMonthChange],
   );
 
-  const handleDateSelection = useCallback(
-    (range: Range) => {
-      const {end} = range;
+  const handleDateSelection = useCallback((range: Range) => {
+    const {end} = range;
 
-      setHoverDate(end);
-      setFocusDate(new Date(end));
-      onChange(range);
-    },
-    [onChange],
-  );
+    setHoverDate(end);
+    setFocusDate(new Date(end));
+    setNewRange(range);
+  }, []);
 
   const handleMonthChangeClick = useCallback(
     (month: Months, year: Year) => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #2333 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

See https://github.com/Shopify/polaris-react/pull/2089#discussion_r322790348

When I converted DatePicker to a functional component using hooks, I decided to simplify the code a bit as well. Since our tests and examples for the DatePicker are not thorough, this introduced a race condition that was hard to test locally. The only browser that triggered this condition consistently was Firefox, and only when also using the `Month` component.

This fixes that by waiting until state changes have resolved to trigger the callback

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

`yarn run build-consumer web` and check out the analytics page on FF, as per the original issue