### PR TITLE
[Modal] Convert modal to function

### DIFF
--- a/UNRELEASED-v5.md
+++ b/UNRELEASED-v5.md
@@ -24,4 +24,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Code quality
 
+- Converted `Modal` to a functional component ([#2376](https://github.com/Shopify/polaris-react/pull/2376))
+
 ### Deprecations

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -213,7 +213,3 @@ export const Modal: React.FunctionComponent<ModalProps> & {
 };
 
 Modal.Section = Section;
-
-// Use named export once withAppProvider is refactored away
-// eslint-disable-next-line import/no-default-export
-// export default Modal;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {TransitionGroup} from '@material-ui/react-transition-group';
 import {write} from '@shopify/javascript-utilities/fastdom';
 import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
@@ -64,178 +64,156 @@ export interface ModalProps extends FooterProps {
 }
 type CombinedProps = ModalProps & WithAppProviderProps;
 
-interface State {
-  iframeHeight: number;
-}
-
 const getUniqueID = createUniqueIDFactory('modal-header');
 
-class Modal extends React.Component<CombinedProps, State> {
-  static Section = Section;
+const Modal: React.FunctionComponent<CombinedProps> & {
+  Section: typeof Section;
+} = function Modal({
+  children,
+  title,
+  src,
+  iFrameName,
+  open,
+  instant,
+  sectioned,
+  loading,
+  large,
+  limitHeight,
+  footer,
+  primaryAction,
+  secondaryActions,
+  polaris: {intl},
+  onScrolledToBottom,
+  activator,
+  onClose,
+  onIFrameLoad,
+  onTransitionEnd,
+}: CombinedProps) {
+  const [iframeHeight, setIframeHeight] = useState(IFRAME_LOADING_HEIGHT);
 
-  state: State = {
-    iframeHeight: IFRAME_LOADING_HEIGHT,
-  };
+  const headerId = getUniqueID();
+  const activatorRef = React.useRef<HTMLDivElement>(null);
+  const iframeTitle = intl.translate('Polaris.Modal.iFrameTitle');
 
-  private headerId = getUniqueID();
-  private activatorRef = React.createRef<HTMLDivElement>();
-
-  render() {
-    const {
-      children,
-      title,
-      src,
-      iFrameName,
-      open,
-      instant,
-      sectioned,
-      loading,
-      large,
-      limitHeight,
-      footer,
-      primaryAction,
-      secondaryActions,
-      polaris: {intl},
-      onScrolledToBottom,
-      activator,
-      onClose,
-    } = this.props;
-
-    const {iframeHeight} = this.state;
-
-    const iframeTitle = intl.translate('Polaris.Modal.iFrameTitle');
-
-    let dialog: React.ReactNode;
-    let backdrop: React.ReactNode;
-    if (open) {
-      const footerMarkup =
-        !footer && !primaryAction && !secondaryActions ? null : (
-          <Footer
-            primaryAction={primaryAction}
-            secondaryActions={secondaryActions}
-          >
-            {footer}
-          </Footer>
-        );
-
-      const content = sectioned
-        ? wrapWithComponent(children, Section, {})
-        : children;
-
-      const body = loading ? (
-        <div className={styles.Spinner}>
-          <Spinner />
-        </div>
-      ) : (
-        content
-      );
-
-      const bodyMarkup = src ? (
-        <iframe
-          name={iFrameName}
-          title={iframeTitle}
-          src={src}
-          className={styles.IFrame}
-          onLoad={this.handleIFrameLoad}
-          style={{height: `${iframeHeight}px`}}
-        />
-      ) : (
-        <Scrollable
-          shadow
-          className={styles.Body}
-          onScrolledToBottom={onScrolledToBottom}
+  let dialog: React.ReactNode;
+  let backdrop: React.ReactNode;
+  if (open) {
+    const footerMarkup =
+      !footer && !primaryAction && !secondaryActions ? null : (
+        <Footer
+          primaryAction={primaryAction}
+          secondaryActions={secondaryActions}
         >
-          {body}
-        </Scrollable>
+          {footer}
+        </Footer>
       );
 
-      const headerMarkup = title ? (
-        <Header id={this.headerId} onClose={onClose} testID="ModalHeader">
-          {title}
-        </Header>
-      ) : (
-        <CloseButton
-          onClick={onClose}
-          title={false}
-          testID="ModalCloseButton"
-        />
-      );
+    const content = sectioned
+      ? wrapWithComponent(children, Section, {})
+      : children;
 
-      const labelledBy = title ? this.headerId : undefined;
-
-      dialog = (
-        <Dialog
-          instant={instant}
-          labelledBy={labelledBy}
-          onClose={onClose}
-          onEntered={this.handleEntered}
-          onExited={this.handleExited}
-          large={large}
-          limitHeight={limitHeight}
-        >
-          {headerMarkup}
-          <div className={styles.BodyWrapper}>{bodyMarkup}</div>
-          {footerMarkup}
-        </Dialog>
-      );
-
-      backdrop = <Backdrop />;
-    }
-
-    const animated = !instant;
-
-    return (
-      <WithinContentContext.Provider value>
-        <div ref={this.activatorRef}>{activator}</div>
-        <Portal idPrefix="modal">
-          <TransitionGroup appear={animated} enter={animated} exit={animated}>
-            {dialog}
-          </TransitionGroup>
-          {backdrop}
-        </Portal>
-      </WithinContentContext.Provider>
+    const body = loading ? (
+      <div className={styles.Spinner}>
+        <Spinner />
+      </div>
+    ) : (
+      content
     );
+
+    const bodyMarkup = src ? (
+      <iframe
+        name={iFrameName}
+        title={iframeTitle}
+        src={src}
+        className={styles.IFrame}
+        onLoad={handleIFrameLoad}
+        style={{height: `${iframeHeight}px`}}
+      />
+    ) : (
+      <Scrollable
+        shadow
+        className={styles.Body}
+        onScrolledToBottom={onScrolledToBottom}
+      >
+        {body}
+      </Scrollable>
+    );
+
+    const headerMarkup = title ? (
+      <Header id={headerId} onClose={onClose} testID="ModalHeader">
+        {title}
+      </Header>
+    ) : (
+      <CloseButton onClick={onClose} title={false} testID="ModalCloseButton" />
+    );
+
+    const labelledBy = title ? headerId : undefined;
+
+    dialog = (
+      <Dialog
+        instant={instant}
+        labelledBy={labelledBy}
+        onClose={onClose}
+        onEntered={handleEntered}
+        onExited={handleExited}
+        large={large}
+        limitHeight={limitHeight}
+      >
+        {headerMarkup}
+        <div className={styles.BodyWrapper}>{bodyMarkup}</div>
+        {footerMarkup}
+      </Dialog>
+    );
+
+    backdrop = <Backdrop />;
   }
 
-  private handleEntered = () => {
-    const {onTransitionEnd} = this.props;
+  const animated = !instant;
+
+  return (
+    <WithinContentContext.Provider value>
+      <div ref={activatorRef}>{activator}</div>
+      <Portal idPrefix="modal">
+        <TransitionGroup appear={animated} enter={animated} exit={animated}>
+          {dialog}
+        </TransitionGroup>
+        {backdrop}
+      </Portal>
+    </WithinContentContext.Provider>
+  );
+
+  function handleEntered() {
     if (onTransitionEnd) {
       onTransitionEnd();
     }
-  };
+  }
 
-  private handleExited = () => {
-    this.setState({
-      iframeHeight: IFRAME_LOADING_HEIGHT,
-    });
+  function handleExited() {
+    setIframeHeight(IFRAME_LOADING_HEIGHT);
 
-    const activator = this.activatorRef.current;
+    const activator = activatorRef.current;
     if (activator) {
       write(() => focusFirstFocusableNode(activator));
     }
-  };
+  }
 
-  private handleIFrameLoad = (evt: React.SyntheticEvent<HTMLIFrameElement>) => {
+  function handleIFrameLoad(evt: React.SyntheticEvent<HTMLIFrameElement>) {
     const iframe = evt.target as HTMLIFrameElement;
     if (iframe && iframe.contentWindow) {
       try {
-        this.setState({
-          iframeHeight: iframe.contentWindow.document.body.scrollHeight,
-        });
+        setIframeHeight(iframe.contentWindow.document.body.scrollHeight);
       } catch {
-        this.setState({
-          iframeHeight: DEFAULT_IFRAME_CONTENT_HEIGHT,
-        });
+        setIframeHeight(DEFAULT_IFRAME_CONTENT_HEIGHT);
       }
     }
-
-    const {onIFrameLoad} = this.props;
 
     if (onIFrameLoad != null) {
       onIFrameLoad(evt);
     }
-  };
-}
+  }
+};
+
+Modal.Section = Section;
 
 // Use named export once withAppProvider is refactored away
 // eslint-disable-next-line import/no-default-export

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -102,9 +102,9 @@ export const Modal: React.FunctionComponent<ModalProps> & {
   const handleExited = useCallback(() => {
     setIframeHeight(IFRAME_LOADING_HEIGHT);
 
-    const activator = activatorRef.current;
-    if (activator) {
-      write(() => focusFirstFocusableNode(activator));
+    const activatorElement = activatorRef.current;
+    if (activatorElement) {
+      write(() => focusFirstFocusableNode(activatorElement));
     }
   }, []);
 

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -658,7 +658,7 @@ function ModalExample() {
 
   const handleClose = useCallback(() => {
     setActive(false);
-    button.current.querySelector('button').focus();
+    requestAnimationFrame(() => button.current.querySelector('button').focus());
   }, []);
 
   return (

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -1,3 +1,3 @@
-import Modal, {ModalProps} from './Modal';
+import {Modal, ModalProps} from './Modal';
 
 export {Modal, ModalProps};

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -7,7 +7,7 @@ import {
 } from 'test-utilities/legacy';
 import {Badge, Button, Spinner, Portal, Scrollable} from 'components';
 import {Footer, Dialog} from '../components';
-import Modal from '../Modal';
+import {Modal} from '../Modal';
 
 import {WithinContentContext} from '../../../utilities/within-content-context';
 
@@ -337,9 +337,17 @@ describe('<Modal>', () => {
       expect(modal.find(Button).exists()).toBe(true);
     });
 
+    it('does not throw an error when no activator is passed in', () => {
+      const modal = mountWithAppProvider(<Modal onClose={noop} open />);
+
+      expect(() => {
+        modal.setProps({open: false});
+      }).not.toThrow();
+    });
+
     it('focuses the activator when the modal is closed', () => {
       const modal = mountWithAppProvider(
-        <Modal onClose={noop} open instant activator={<Button />} />,
+        <Modal onClose={noop} open activator={<Button />} />,
       );
 
       modal.setProps({open: false});


### PR DESCRIPTION
### WHY are these changes introduced?

Opening this new PR since the old one https://github.com/Shopify/polaris-react/pull/2341 was closed when the `v5.0.0` branch was deleted.

Part of https://github.com/Shopify/polaris-react/issues/1995

### WHAT is this pull request doing?

Some notable changes,

- The activator now uses `useRef` instead of `createRef`.
- The external activator example needs to call `requestAnimationFrame` when focusing the button.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)
