### PR TITLE
[Popover] Convert Popover to functional component

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,4 +22,6 @@
 
 ### Code quality
 
+- Migrated `Popover` to use hooks ([#2386](https://github.com/Shopify/polaris-react/pull/2386))
+
 ### Deprecations

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -79,8 +79,7 @@ describe('<Popover />', () => {
         onClose={spy}
       />,
     );
-    const activatorWrapper = findByTestID(popover, 'wrapper-component');
-    expect(activatorWrapper.type()).toBe('div');
+    expect(popover.childAt(0).type()).toBe('div');
   });
 
   it('has a span as activatorWrapper when activatorWrapper prop is set to span', () => {
@@ -93,8 +92,7 @@ describe('<Popover />', () => {
         onClose={spy}
       />,
     );
-    const activatorWrapper = findByTestID(popover, 'wrapper-component');
-    expect(activatorWrapper.type()).toBe('span');
+    expect(popover.childAt(0).type()).toBe('span');
   });
 
   it('passes preventAutofocus to PopoverOverlay', () => {


### PR DESCRIPTION
related to: https://github.com/Shopify/polaris-react/issues/1995

### WHY are these changes introduced?

I'm wanting to make use of a hook inside popover for my current project, so I took the opportunity to convert popover to a function components.

### WHAT is this pull request doing?

Functionality remains the same. However there are changes.
1. ComponentDidMount and ComponentDidUpdate bundle into a single useEffect hook.
~2. Use React.createElement to workaround creating jsx typing issue with the WrapperComponent~
~3. Tighten the type of activatorWrapper too so that it may only include strings of element names, e.g. 'button' and 'div' are valid, but not 'fff' or 'Button'~ (breaking change)

thank you for those last two @BPScott!

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';
import {Page, Popover, ActionList, Button} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <PopoverWithActionListExample />
    </Page>
  );
}

function PopoverWithActionListExample() {
  const [popoverActive, setPopoverActive] = useState(false);
  const togglePopoverActive = useCallback(
    () => setPopoverActive((popoverActive) => !popoverActive),
    [],
  );
  const activator = (
    <Button onClick={togglePopoverActive} disclosure>
      More actions
    </Button>
  );
  return (
    <div style={{height: '250px'}}>
      <Popover
        active={popoverActive}
        activator={activator}
        onClose={togglePopoverActive}
      >
        <ActionList items={[{content: 'Import'}, {content: 'Export'}]} />
      </Popover>
    </div>
  );
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
