### PR TITLE
[TrapFocus] Focus should stay within the container

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -30,6 +30,7 @@
 - Fixed `merge` mutating its arguments ([#2317](https://github.com/Shopify/polaris-react/pull/2317))
 - Updated `Card` footer actions to be right aligned by default again ([#2407](https://github.com/Shopify/polaris-react/pull/2407))
 - Fixed the `EmptyState` styles conditional on the `imageContained` prop not being applied ([#2477](https://github.com/Shopify/polaris-react/pull/2477))
+- Fixed `TrapFocus` to keep focus within the container ([#2397](https://github.com/Shopify/polaris-react/pull/2397))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -30,7 +30,7 @@
 - Fixed `merge` mutating its arguments ([#2317](https://github.com/Shopify/polaris-react/pull/2317))
 - Updated `Card` footer actions to be right aligned by default again ([#2407](https://github.com/Shopify/polaris-react/pull/2407))
 - Fixed the `EmptyState` styles conditional on the `imageContained` prop not being applied ([#2477](https://github.com/Shopify/polaris-react/pull/2477))
-- Fixed `TrapFocus` to keep focus within the container ([#2397](https://github.com/Shopify/polaris-react/pull/2397))
+- Fixed `TrapFocus` to keep focus within the container when tabbing past the last element ([#2397](https://github.com/Shopify/polaris-react/pull/2397))
 
 ### Documentation
 

--- a/src/components/Focus/Focus.tsx
+++ b/src/components/Focus/Focus.tsx
@@ -1,3 +1,7 @@
+/*
+`Focus` will automatically focus the first focusable element that it finds in it's children when it is mounted, unless the user specified an `autoFocus` element.
+*/
+
 import React from 'react';
 import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
 import isEqual from 'lodash/isEqual';

--- a/src/components/Focus/Focus.tsx
+++ b/src/components/Focus/Focus.tsx
@@ -1,7 +1,3 @@
-/*
-`Focus` will automatically focus the first focusable element that it finds in it's children when it is mounted, unless the user specified an `autoFocus` element.
-*/
-
 import React from 'react';
 import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
 import isEqual from 'lodash/isEqual';

--- a/src/components/Focus/README_INTERNAL.md
+++ b/src/components/Focus/README_INTERNAL.md
@@ -1,0 +1,3 @@
+# <Focus>
+
+`Focus` will automatically focus the first focusable element that it finds in it's children when it is mounted, unless the user specified an `autoFocus` element.

--- a/src/components/Focus/tests/Focus.test.tsx
+++ b/src/components/Focus/tests/Focus.test.tsx
@@ -32,7 +32,7 @@ describe('<Focus />', () => {
     expect(input).toBe(document.activeElement);
   });
 
-  it('will not focus the first focusable node is the `disabled` is true', () => {
+  it('will not focus the first focusable node if `disabled` is true', () => {
     const focus = mountWithAppProvider(
       <FocusTestWrapper disabled>
         <input />

--- a/src/components/TrapFocus/README_INTERNAL.md
+++ b/src/components/TrapFocus/README_INTERNAL.md
@@ -1,0 +1,9 @@
+# <TrapFocus>
+
+A component which allows you to trap keyboard focus inside of a container.
+
+TrapFocus internally employs `Focus` to focus it's first focusable child on mount.
+
+Whenever a `blur` event occurs that would take the user outside the trap, we reset to the first focusable child.
+
+If you want to cease trapping focus, simply cease rendering the trap.

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -93,7 +93,7 @@ export class TrapFocus extends React.PureComponent<TrapFocusProps, State> {
       event.preventDefault();
 
       if (event.srcElement === findFirstFocusableNode(focusTrapWrapper)) {
-        return focusLastFocusableNode(focusTrapWrapper);
+        return write(() => focusLastFocusableNode(focusTrapWrapper));
       }
       const firstNode = findFirstFocusableNode(focusTrapWrapper) as HTMLElement;
       write(() => focusFirstFocusableNode(firstNode));

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -82,8 +82,8 @@ export class TrapFocus extends React.PureComponent<TrapFocusProps, State> {
     const {focusTrapWrapper} = this;
     const {trapping = true} = this.props;
 
-    if (currentTarget == null || trapping === false) {
-      // return;
+    if (trapping === false) {
+      return;
     }
 
     if (

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -1,13 +1,3 @@
-/*
-A component which allows you to trap keyboard focus inside of a container.
-
-TrapFocus internally employs `Focus` to focus it's first focusable child on mount.
-
-Whenever a `blur` event occurs that would take the user outside the trap, we reset to the first focusable child.
-
-If you want to cease trapping focus, simply cease rendering the trap.
-*/
-
 import React from 'react';
 import {
   focusFirstFocusableNode,

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -54,7 +54,7 @@ export class TrapFocus extends React.PureComponent<TrapFocusProps, State> {
 
     return (
       <Focus disabled={this.shouldDisable} root={this.focusTrapWrapper}>
-        <div ref={this.setFocusTrapWrapper} style={{background: 'salmon'}}>
+        <div ref={this.setFocusTrapWrapper}>
           <EventListener event="focusout" handler={this.handleBlur} />
           {children}
         </div>
@@ -79,26 +79,20 @@ export class TrapFocus extends React.PureComponent<TrapFocusProps, State> {
 
   private handleBlur = (event: FocusEvent) => {
     const {relatedTarget: currentTarget} = event;
-    const {focusTrapWrapper} = this; // the div around the modal
+    const {focusTrapWrapper} = this;
     const {trapping = true} = this.props;
 
     if (currentTarget == null || trapping === false) {
-      // do nothing
       // return;
     }
 
-    // if we have declared a container
-    // and the currently selected element is outside of that container
-    // and the current target has no parent with the `data-polaris-overlay` property
     if (
       focusTrapWrapper &&
-      !focusTrapWrapper.contains(currentTarget as HTMLElement) // &&
-      // !closest(currentTarget as HTMLElement, '[data-polaris-overlay]')
+      !focusTrapWrapper.contains(currentTarget as HTMLElement)
     ) {
       event.preventDefault();
 
       if (event.srcElement === findFirstFocusableNode(focusTrapWrapper)) {
-        // !!
         return focusLastFocusableNode(focusTrapWrapper);
       }
       const firstNode = findFirstFocusableNode(focusTrapWrapper) as HTMLElement;

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {closest} from '@shopify/javascript-utilities/dom';
 import {
   focusFirstFocusableNode,
   findFirstFocusableNode,
@@ -68,7 +69,7 @@ export class TrapFocus extends React.PureComponent<TrapFocusProps, State> {
   };
 
   private handleBlur = (event: FocusEvent) => {
-    const {relatedTarget: currentTarget} = event;
+    const {relatedTarget} = event;
     const {focusTrapWrapper} = this;
     const {trapping = true} = this.props;
 
@@ -78,7 +79,9 @@ export class TrapFocus extends React.PureComponent<TrapFocusProps, State> {
 
     if (
       focusTrapWrapper &&
-      !focusTrapWrapper.contains(currentTarget as HTMLElement)
+      !focusTrapWrapper.contains(relatedTarget as HTMLElement) &&
+      (!relatedTarget ||
+        !closest(relatedTarget as HTMLElement, '[data-polaris-overlay]'))
     ) {
       event.preventDefault();
 


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-react/issues/795

### WHAT is this pull request doing?

This PR is fixing `TrapFocus` so that focus remains within a designated container.

The focus flow on each press of tab works like,

> focus container -> focus first element -> focus second element(last element) -> focus first element -> focus second element -> etc

Instead of returning focus back to the container.
 
<kbd>![1](https://user-images.githubusercontent.com/22782157/68225788-f45b3d00-ffbe-11e9-8a39-aca956397a70.gif)</kbd>

### How to 🎩

Use Storybook. Open up a modal and press tab. Once you reach the last element, the next tab should focus the first element in the modal.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
