### PR TITLE
[ColorPicker] Add fix for Windows high contrast mode

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -24,7 +24,6 @@
 - Fixed an issue with the `Filters` component where the `aria-expanded` attribute was `undefined` on mount ([#2589]https://github.com/Shopify/polaris-react/pull/2589)
 - Fixed `TrapFocus` from tabbing out of the container ([#2555](https://github.com/Shopify/polaris-react/pull/2555))
 - Fixed `PositionedOverlay` not correctly getting its position when aligned to the right of the activator ([#2587](https://github.com/Shopify/polaris-react/pull/2587))
-- Fix colour not appearing in main colour picker when in Windows high contrast mode ([#2399](https://github.com/Shopify/polaris-react/pull/2399))
 - Fix colour not appearing in main `ColorPicker` panel when in Windows high contrast mode ([#2399](https://github.com/Shopify/polaris-react/pull/2399))
 
 ### Documentation

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -25,6 +25,7 @@
 - Fixed `TrapFocus` from tabbing out of the container ([#2555](https://github.com/Shopify/polaris-react/pull/2555))
 - Fixed `PositionedOverlay` not correctly getting its position when aligned to the right of the activator ([#2587](https://github.com/Shopify/polaris-react/pull/2587))
 - Fix colour not appearing in main colour picker when in Windows high contrast mode ([#2399](https://github.com/Shopify/polaris-react/pull/2399))
+- Fix colour not appearing in main `ColorPicker` panel when in Windows high contrast mode ([#2399](https://github.com/Shopify/polaris-react/pull/2399))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -24,6 +24,7 @@
 - Fixed an issue with the `Filters` component where the `aria-expanded` attribute was `undefined` on mount ([#2589]https://github.com/Shopify/polaris-react/pull/2589)
 - Fixed `TrapFocus` from tabbing out of the container ([#2555](https://github.com/Shopify/polaris-react/pull/2555))
 - Fixed `PositionedOverlay` not correctly getting its position when aligned to the right of the activator ([#2587](https://github.com/Shopify/polaris-react/pull/2587))
+- Fix colour not appearing in main colour picker when in Windows high contrast mode ([#2399](https://github.com/Shopify/polaris-react/pull/2399))
 
 ### Documentation
 

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -61,6 +61,10 @@ export class ColorPicker extends React.PureComponent<ColorPickerProps, State> {
     const draggerX = clamp(saturation * pickerSize, 0, pickerSize);
     const draggerY = clamp(pickerSize - brightness * pickerSize, 0, pickerSize);
 
+    const backgroundStyle = this.isWindowsHighContrast()
+      ? {background: `linear-gradient(to top, ${colorString}, ${colorString})`}
+      : {backgroundColor: colorString};
+
     const alphaSliderMarkup = allowAlpha ? (
       <AlphaPicker
         alpha={alpha}
@@ -76,10 +80,7 @@ export class ColorPicker extends React.PureComponent<ColorPickerProps, State> {
         onMouseDown={this.handlePickerDrag}
       >
         <div ref={this.setColorNode} className={styles.MainColor}>
-          <div
-            className={styles.ColorLayer}
-            style={{backgroundColor: colorString}}
-          />
+          <div className={styles.ColorLayer} style={backgroundStyle} />
           <Slidable
             onChange={this.handleDraggerMove}
             draggerX={draggerX}
@@ -130,5 +131,13 @@ export class ColorPicker extends React.PureComponent<ColorPickerProps, State> {
   ) => {
     // prevents external elements from being selected
     event.preventDefault();
+  };
+
+  private isWindowsHighContrast = () => {
+    try {
+      return window.matchMedia('(-ms-high-contrast: active)').matches;
+    } catch (err) {
+      return false;
+    }
   };
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/278

The main colorpicker window values do not display correctly in Windows High Contrast in Edge.

### WHAT is this pull request doing?

This PR adds a different `background` style to the main `ColorPicker` window if it detects that the browser is in Windows high contrast mode.

<details><summary>Before</summary>
<img src="https://user-images.githubusercontent.com/1462085/42604058-9b9f489c-8525-11e8-90de-d705956e247c.png">
</details><br>

<details><summary>After</summary>
<img src="https://screenshot.click/05-29-qheip-rjmqo.png">
</details><br>


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->

cc @dpersing @mirualves 