### PR TITLE
[TextField] Should always have an aria-labelledby property

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,4 +14,6 @@
 
 ### Code quality
 
+- Changed `aria-labelledby` to always exist on `TextField` ([#2401](https://github.com/Shopify/polaris-react/pull/2401))
+
 ### Deprecations

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -356,9 +356,7 @@ export function TextField({
     labelledBy.push(`${id}Suffix`);
   }
 
-  if (labelledBy.length) {
-    labelledBy.unshift(labelID(id));
-  }
+  labelledBy.unshift(labelID(id));
 
   const inputClassName = classNames(
     styles.Input,
@@ -393,7 +391,7 @@ export function TextField({
     pattern,
     type: inputType,
     'aria-describedby': describedBy.length ? describedBy.join(' ') : undefined,
-    'aria-labelledby': labelledBy.length ? labelledBy.join(' ') : undefined,
+    'aria-labelledby': labelledBy.join(' '),
     'aria-invalid': Boolean(error),
     'aria-owns': ariaOwns,
     'aria-activedescendant': ariaActiveDescendant,

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -59,6 +59,15 @@ describe('<TextField />', () => {
     expect(input.prop('prefix')).toBeUndefined();
   });
 
+  it('always has an `aria-labelledby` property', () => {
+    const textField = mountWithAppProvider(
+      <TextField label="TextField" onChange={noop} />,
+    );
+    const property = textField.find('input').prop('aria-labelledby');
+
+    expect(property).not.toHaveLength(0);
+  });
+
   describe('onChange()', () => {
     it('is called with the new value', () => {
       const spy = jest.fn();


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-react/issues/795

### WHY are these changes introduced?

If the text field does not have a `prefix` or `suffix`, then it doesn't have an `aria-labelledby` value. Since `label` is a required prop on TextField, we will always have an id to link to.

### WHAT is this pull request doing?

Removing the check for an empty array since the labelledby property should have a value regardless if the `TextField` has a prefix or suffix.

### How to 🎩

- Open up Storybook
- Go to the "Modal with primary action" example
- Inspect the modal's TextField
- The TextField should have an `aria-labelledby` matching the label element.

![image](https://user-images.githubusercontent.com/22782157/68237460-27a8c680-ffd5-11e9-9ceb-f54852a4586e.png)

- Notice the label's id `PolarisTextField2Label` on the input.

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
