### PR TITLE
[Card][ButtonGroup] Revert change to footer button alignment, add new footerActionAlignment prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@
 - Added `ariaHaspopup` prop to `Popover` ([#2248](https://github.com/Shopify/polaris-react/pull/2248))
 - Fixed an accessibility issue where the `Form` implicit submit was still accessible via keyboard ([#2447](https://github.com/Shopify/polaris-react/pull/2447))
 - Moved `Button` styles from the `Buttongroup` CSS file to the `Button` CSS file ([#2441](https://github.com/Shopify/polaris-react/pull/2441))
+- Added `footerActionAlignment` prop to control `<Card>` footer action alignment, defaults to `'right'`
 
 ### Bug fixes
 
@@ -17,10 +18,10 @@
 - Fixed an issue where the dropzone component jumped from an extra-large layout to a layout based on the width of its container ([#2412](https://github.com/Shopify/polaris-react/pull/2412))
 - Fixed an issue which caused HSL colors to not display in Edge ([#2418](https://github.com/Shopify/polaris-react/pull/2418))
 - Changed Button's `disclosure` prop to be `boolean | "up" | "down"`, allowing greater control over the direction the disclosure caret faces ([#2431](https://github.com/Shopify/polaris-react/pull/2431))
-- Fixed an issue where the dropzone component jumped from an extra-large layout to a layout based on the width of it's container ([#2412](https://github.com/Shopify/polaris-react/pull/2412))
 - Fixed a race condition in DatePicker ([#2373](https://github.com/Shopify/polaris-react/pull/2373))
-- Added the top bar height to the `Topbar` in `Frame` to ensure the `Sticky` components get the correct top position ([2415](https://github.com/Shopify/polaris-react/pull/2415))
+- Added the top bar height to the `Topbar` in `Frame` to ensure the `Sticky` components get the correct top position ([#2415](https://github.com/Shopify/polaris-react/pull/2415))
 - Fixed `merge` mutating its arguments ([#2317](https://github.com/Shopify/polaris-react/pull/2317))
+- Updated `Card` footer actions to be right aligned by default again ([#2407](https://github.com/Shopify/polaris-react/pull/2407))
 
 ### Documentation
 

--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -93,11 +93,15 @@
 
 .Footer {
   display: flex;
-  justify-content: flex-start;
+  justify-content: flex-end;
   padding: 0 spacing() spacing();
 
   @include page-content-when-not-fully-condensed {
     padding: 0 spacing(loose) spacing(loose);
+  }
+
+  &.LeftJustified {
+    justify-content: flex-start;
   }
 
   .Section-subdued + & {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -29,6 +29,8 @@ export interface CardProps {
   secondaryFooterActions?: ComplexAction[];
   /** The content of the disclosure button rendered when there is more than one secondary footer action */
   secondaryFooterActionsDisclosureText?: string;
+  /** Alignment of the footer actions on the card, defaults to right */
+  footerActionAlignment?: 'right' | 'left';
 }
 
 // TypeScript can't generate types that correctly infer the typing of
@@ -49,6 +51,7 @@ export const Card: React.FunctionComponent<CardProps> & {
   primaryFooterAction,
   secondaryFooterActions,
   secondaryFooterActionsDisclosureText,
+  footerActionAlignment = 'right',
 }: CardProps) {
   const i18n = useI18n();
 
@@ -94,11 +97,23 @@ export const Card: React.FunctionComponent<CardProps> & {
 
   const footerMarkup =
     primaryFooterActionMarkup || secondaryFooterActionsMarkup ? (
-      <div className={styles.Footer}>
-        <ButtonGroup>
-          {secondaryFooterActionsMarkup}
-          {primaryFooterActionMarkup}
-        </ButtonGroup>
+      <div
+        className={classNames(
+          styles.Footer,
+          footerActionAlignment === 'left' && styles.LeftJustified,
+        )}
+      >
+        {footerActionAlignment === 'right' ? (
+          <ButtonGroup>
+            {secondaryFooterActionsMarkup}
+            {primaryFooterActionMarkup}
+          </ButtonGroup>
+        ) : (
+          <ButtonGroup>
+            {primaryFooterActionMarkup}
+            {secondaryFooterActionsMarkup}
+          </ButtonGroup>
+        )}
       </div>
     ) : null;
 

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -237,7 +237,7 @@ Use for less important card actions, or actions merchants may do before reviewin
 
 <!-- content-for: web -->
 
-Use footer actions for a card’s most important actions, or actions merchants should do after reviewing the contents of the card. For example, merchants should review the contents of a shipment before an important action like adding tracking information.
+Use footer actions for a card’s most important actions, or actions merchants should do after reviewing the contents of the card. For example, merchants should review the contents of a shipment before an important action like adding tracking information. Footer actions can be left or right aligned with the `footerActionAlignment` prop.
 
 <!-- /content-for -->
 

--- a/src/components/Card/tests/Card.test.tsx
+++ b/src/components/Card/tests/Card.test.tsx
@@ -4,6 +4,7 @@ import {
   trigger,
   findByTestID,
 } from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {Card, Badge, Button, Popover, ActionList} from 'components';
 import {WithinContentContext} from '../../../utilities/within-content-context';
 import {Section} from '../components';
@@ -72,6 +73,55 @@ describe('<Card />', () => {
 
     expect(card.find(Button)).toHaveLength(1);
     expect(card.find(Card.Header)).toHaveLength(1);
+  });
+
+  describe('footerActionAlignment prop', () => {
+    it('renders right-aligned if not supplied', () => {
+      const card = mountWithApp(
+        <Card
+          primaryFooterAction={{content: 'primary action'}}
+          secondaryFooterActions={[{content: 'secondary action'}]}
+        >
+          <p>Some card content.</p>
+        </Card>,
+      );
+
+      const buttons = card.findAll(Button);
+      expect(buttons[0].prop('children')).toBe('secondary action');
+      expect(buttons[1].prop('children')).toBe('primary action');
+    });
+
+    it('renders right-aligned if set to "right"', () => {
+      const card = mountWithApp(
+        <Card
+          primaryFooterAction={{content: 'primary action'}}
+          secondaryFooterActions={[{content: 'secondary action'}]}
+          footerActionAlignment="right"
+        >
+          <p>Some card content.</p>
+        </Card>,
+      );
+
+      const buttons = card.findAll(Button);
+      expect(buttons[0].prop('children')).toBe('secondary action');
+      expect(buttons[1].prop('children')).toBe('primary action');
+    });
+
+    it('renders left-aligned if set to "left"', () => {
+      const card = mountWithApp(
+        <Card
+          primaryFooterAction={{content: 'primary action'}}
+          secondaryFooterActions={[{content: 'secondary action'}]}
+          footerActionAlignment="left"
+        >
+          <p>Some card content.</p>
+        </Card>,
+      );
+
+      const buttons = card.findAll(Button);
+      expect(buttons[0].prop('children')).toBe('primary action');
+      expect(buttons[1].prop('children')).toBe('secondary action');
+    });
   });
 
   it('renders a primary footer action', () => {


### PR DESCRIPTION
Reverts https://github.com/Shopify/polaris-react/pull/2104
See https://github.com/Shopify/polaris-react/issues/2075 for more context on this change

### WHY are these changes introduced?

It seemed to be generally accepted that this change is rendering buttons strangely, as seen in https://github.com/Shopify/polaris-react/issues/2075#issuecomment-535561407.

<img width="905" alt="Screen Shot 2019-09-26 at 11 35 12 AM" src="https://user-images.githubusercontent.com/150352/65702891-c72b7e80-e051-11e9-920b-0a6f4b1824bf.png">

After the PR I am reverting, polaris-react renders secondary buttons on the left, then primary buttons, which is contrary to the expected `Primary > Secondary` reading order.  The blue button should be on the left.

So, I set out to revert this change (because every consumer of `Card` would be expecting right-aligned buttons prior to that change, IMO that was a breaking change), and give the ability to control alignment.

### WHAT is this pull request doing?

Final product:
<img width="964" alt="Screen Shot 2019-11-06 at 11 02 40 AM" src="https://user-images.githubusercontent.com/150352/68314904-f8519280-0084-11ea-8c00-beb966064191.png">

  - Adds new `footerActionAlignment` prop to `<Card>` to control the overall left/right alignment. Default to `right` for historical consumers

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Card} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Card
        title="Card with right-aligned footer actions"
        primaryFooterAction={{content: 'Do a thing'}}
        secondaryFooterActions={[
          {content: 'Do another thing'},
          {content: 'Do a third thing'},
        ]}
        sectioned
      >
        Some copy
      </Card>
      <Card
        title="Card with left-aligned footer actions"
        primaryFooterAction={{content: 'Do a thing'}}
        secondaryFooterActions={[
          {content: 'Do another thing'},
          {content: 'Do a third thing'},
        ]}
        footerActionAlignment="left"
        sectioned
      >
        Some copy
      </Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing) (via browser simulation)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
