### PR TITLE
[ResourceList] Add external prop to ResourceList

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+- Add `external` prop to `ResourceList` [#2408](https://github.com/Shopify/polaris-react/pull/2408)
+
 ### Bug fixes
 
 - Fixed an issue which caused HSL colors to not display in Edge ((#2418)[https://github.com/Shopify/polaris-react/pull/2418])

--- a/src/components/ResourceItem/ResourceItem.tsx
+++ b/src/components/ResourceItem/ResourceItem.tsx
@@ -48,6 +48,8 @@ export interface BaseProps {
   sortOrder?: number;
   /** URL for the resource’s details page (required unless onClick is provided) */
   url?: string;
+  /** Allows url to open in a new tab */
+  external?: boolean;
   /** Callback when clicked (required if url is omitted) */
   onClick?(id?: string): void;
   /** Content for the details area */
@@ -130,6 +132,7 @@ class BaseResourceItem extends React.Component<CombinedProps, State> {
     const {
       children,
       url,
+      external,
       media,
       shortcutActions,
       ariaControls,
@@ -280,6 +283,7 @@ class BaseResourceItem extends React.Component<CombinedProps, State> {
         aria-label={ariaLabel}
         className={styles.Link}
         url={url}
+        external={external}
         tabIndex={tabIndex}
         id={this.overlayId}
       />

--- a/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -69,6 +69,7 @@ describe('<ResourceItem />', () => {
   };
 
   const url = 'http://test-link.com';
+  const external = false;
   const ariaLabel = 'View Item';
 
   describe('accessibilityLabel', () => {
@@ -212,6 +213,48 @@ describe('<ResourceItem />', () => {
       );
 
       expect(findByTestID(element, 'Item-Wrapper').prop('data-href')).toBe(url);
+    });
+  });
+
+  describe('external', () => {
+    it('renders an <UnstyledLink /> with undefined external prop', () => {
+      const element = mountWithAppProvider(
+        <ResourceListContext.Provider value={mockDefaultContext}>
+          <ResourceItem id="itemId" url={url} />
+        </ResourceListContext.Provider>,
+      );
+
+      expect(element.find(UnstyledLink).prop('external')).toBeUndefined();
+    });
+
+    it('renders an <UnstyledLink /> with external set to true', () => {
+      const element = mountWithAppProvider(
+        <ResourceListContext.Provider value={mockDefaultContext}>
+          <ResourceItem
+            id="itemId"
+            url={url}
+            accessibilityLabel={ariaLabel}
+            external
+          />
+        </ResourceListContext.Provider>,
+      );
+
+      expect(element.find(UnstyledLink).prop('external')).toBe(true);
+    });
+
+    it('renders an <UnstyledLink /> with external set to false', () => {
+      const element = mountWithAppProvider(
+        <ResourceListContext.Provider value={mockDefaultContext}>
+          <ResourceItem
+            id="itemId"
+            url={url}
+            accessibilityLabel={ariaLabel}
+            external={external}
+          />
+        </ResourceListContext.Provider>,
+      );
+
+      expect(element.find(UnstyledLink).prop('external')).toBe(false);
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

This change was introduced since when it comes to launching an app in the app list, certain apps should be opened in the embedded setting (i.e. same tab) or externally (i.e. another tab). The external prop identifies which apps should be opened externally.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR doesn't make any design changes. 

<details>

When external is true:
![Kapture 2019-11-06 at 11 40 28](https://user-images.githubusercontent.com/42748054/68318199-63ea2e80-008a-11ea-8002-c218d6e7d863.gif)

When external is false/undefined:
![Kapture 2019-11-06 at 11 42 59](https://user-images.githubusercontent.com/42748054/68318372-aca1e780-008a-11ea-8067-c3f9c78b00d7.gif)

</details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

In playground copy and paste: 
<details>

```
import React from 'react';
import {Page, ResourceList, ResourceItem, Avatar, TextStyle} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <ResourceList
        resourceName={{singular: 'customer', plural: 'customers'}}
        items={[
          {
            id: 145,
            url: 'customers/145',
            avatarSource:
              'https://burst.shopifycdn.com/photos/freelance-designer-working-on-laptop.jpg?width=746',
            name: 'Yi So-Yeon',
            location: 'Gwangju, South Korea',
            latestOrderUrl: 'orders/1456',
          },
        ]}
        renderItem={(item) => {
          const {id, url, avatarSource, name, location, latestOrderUrl} = item;
          const shortcutActions = latestOrderUrl
        ? [{content: 'View latest order', url: latestOrderUrl}]
        : null;

          return (
            <ResourceItem
              id={id}
              url={url}
              media={
                <Avatar
                  customer
                  size="medium"
                  name={name}
                  source={avatarSource}
                />
              }
              shortcutActions={shortcutActions}
              accessibilityLabel={`View details for ${name}`}
              name={name}
              external
            >
              <h3>
                <TextStyle variation="strong">{name}</TextStyle>
              </h3>
              <div>{location}</div>
            </ResourceItem>
          );
        }}
      />
    </Page>
  );
}

```
</details>

- vist `Shopify/polaris-react/src/components/ResourceItem/README.md`
- on line 158 add `external` (in resourceList props)
- Run playground
- click on ResourceList example
- url should now open in a new tab

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
