### PR TITLE
 [Dropzone] hide dropzone until its had a chance to measure its width and set i…

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+- Fixed an issue where the dropzone component jumped from an extra-large layout to a layout based on the width of it's container [#2412](https://github.com/Shopify/polaris-react/pull/2412)
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -116,6 +116,11 @@ $dropzone-stacking-order: (
   min-height: $dropzone-min-height-small;
 }
 
+.measuring {
+  visibility: hidden;
+  min-height: 0;
+}
+
 .Container {
   flex: 1;
 }

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -41,6 +41,7 @@ interface State {
   numFiles: number;
   overlayText?: string;
   size: string;
+  measuring: boolean;
   type?: string;
 }
 
@@ -178,7 +179,10 @@ class DropZone extends React.Component<CombinedProps, State> {
         size = 'large';
       }
 
-      this.setState({size});
+      this.setState({
+        size,
+        measuring: false,
+      });
     },
     50,
     {trailing: true},
@@ -205,6 +209,7 @@ class DropZone extends React.Component<CombinedProps, State> {
       numFiles: 0,
       overlayText: intl.translate(`Polaris.DropZone.overlayText${suffix}`),
       size: 'extraLarge',
+      measuring: true,
       type,
     };
   }
@@ -223,6 +228,7 @@ class DropZone extends React.Component<CombinedProps, State> {
       type,
       overlayText,
       errorOverlayText,
+      measuring,
     } = this.state;
     const {
       label,
@@ -262,6 +268,7 @@ class DropZone extends React.Component<CombinedProps, State> {
       size && size === 'large' && styles.sizeLarge,
       size && size === 'medium' && styles.sizeMedium,
       size && size === 'small' && styles.sizeSmall,
+      measuring && styles.measuring,
     );
 
     const dragOverlay =
@@ -308,6 +315,7 @@ class DropZone extends React.Component<CombinedProps, State> {
       focused,
       size,
       type: type || 'file',
+      measuring,
     };
 
     return (

--- a/src/components/DropZone/components/FileUpload/FileUpload.scss
+++ b/src/components/DropZone/components/FileUpload/FileUpload.scss
@@ -7,6 +7,9 @@ $slim-vertical-padding: ($slim-min-height - line-height(body) - rem(2px)) / 2;
 .FileUpload {
   padding: $fileupload-padding;
   text-align: center;
+  &.measuring {
+    display: none;
+  }
 }
 
 .Button {

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -22,7 +22,9 @@ export interface FileUploadProps {
 
 export function FileUpload(props: FileUploadProps) {
   const i18n = useI18n();
-  const {size, type, focused, disabled} = useContext(DropZoneContext);
+  const {size, measuring, type, focused, disabled} = useContext(
+    DropZoneContext,
+  );
   const suffix = capitalize(type);
   const {
     actionTitle = i18n.translate(
@@ -115,8 +117,13 @@ export function FileUpload(props: FileUploadProps) {
       </Stack>
     ) : null;
 
+  const fileUploadClassName = classNames(
+    styles.FileUpload,
+    measuring && styles.measuring,
+  );
+
   return (
-    <div className={styles.FileUpload}>
+    <div className={fileUploadClassName}>
       {smallView}
       {mediumView}
       {largeView}

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -10,7 +10,28 @@ describe('<FileUpload />', () => {
     hover: false,
     focused: false,
     disabled: false,
+    measuring: false,
   };
+  describe('measuring', () => {
+    it('hides the FileUpload while measuring is true', () => {
+      const fileUpload = mountWithAppProvider(
+        <DropZoneContext.Provider
+          value={{
+            size: 'extraLarge',
+            type: 'file',
+            ...defaultStates,
+            measuring: true,
+          }}
+        >
+          <FileUpload />
+        </DropZoneContext.Provider>,
+      );
+
+      const wrapper = fileUpload.find('div').first();
+      expect(wrapper.hasClass('measuring')).toBe(true);
+    });
+  });
+
   describe('extraLarge', () => {
     it('renders extra large view for type file', () => {
       const fileUpload = mountWithAppProvider(

--- a/src/components/DropZone/context.tsx
+++ b/src/components/DropZone/context.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 interface DropZoneContextType {
   disabled: boolean;
   focused: boolean;
+  measuring: boolean;
   size: string;
   type: string;
 }
@@ -12,4 +13,5 @@ export const DropZoneContext = React.createContext<DropZoneContextType>({
   focused: false,
   size: 'extraLarge',
   type: 'file',
+  measuring: false,
 });


### PR DESCRIPTION
Hide Dropzone and children until the component has had a chance to measure its width and set its size. 

further context:
https://shopify.slack.com/archives/C8H54T86Q/p1570650697013000
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/2270

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
