### PR TITLE
[ColorPicker] Add keyboard controls to Slidable

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Added `hideTags` prop to `Filters` ([#2573](https://github.com/Shopify/polaris-react/pull/2573))
+- Added keyboard control to ColorPicker Slidable, HuePicker & AlphaPicker subcomponents ([#2413](https://github.com/Shopify/polaris-react/pull/2413))
 
 ### Bug fixes
 

--- a/src/components/ColorPicker/ColorPicker.tsx
+++ b/src/components/ColorPicker/ColorPicker.tsx
@@ -75,7 +75,11 @@ export class ColorPicker extends React.PureComponent<ColorPickerProps, State> {
         id={id}
         onMouseDown={this.handlePickerDrag}
       >
-        <div ref={this.setColorNode} className={styles.MainColor}>
+        <div
+          ref={this.setColorNode}
+          className={styles.MainColor}
+          onFocus={this.handleFocus}
+        >
           <div
             className={styles.ColorLayer}
             style={{backgroundColor: colorString}}
@@ -130,5 +134,10 @@ export class ColorPicker extends React.PureComponent<ColorPickerProps, State> {
   ) => {
     // prevents external elements from being selected
     event.preventDefault();
+  };
+
+  private handleFocus = (event: React.FocusEvent<HTMLElement>) => {
+    // Prevents MainColor from scrolling on focus
+    event.currentTarget.scrollTo(0, 0);
   };
 }

--- a/src/components/ColorPicker/components/AlphaPicker/AlphaPicker.tsx
+++ b/src/components/ColorPicker/components/AlphaPicker/AlphaPicker.tsx
@@ -34,7 +34,6 @@ export class AlphaPicker extends React.PureComponent<AlphaPickerProps, State> {
         <div className={styles.ColorLayer} style={{background}} />
         <Slidable
           draggerY={draggerY}
-          draggerX={0}
           onChange={this.handleChange}
           onDraggerHeight={this.setDraggerHeight}
         />

--- a/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
+++ b/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
@@ -67,11 +67,6 @@ describe('<AlphaPicker />', () => {
       trigger(alphaPicker.find(Slidable), 'onDraggerHeight', newDraggerHeight);
       expect(alphaPicker.find(Slidable).prop('draggerY')).toBe(expectedNewHue);
     });
-
-    it('passes draggerX to Slidable with value 0', () => {
-      const alphaPicker = mountWithAppProvider(<AlphaPicker {...mockProps} />);
-      expect(alphaPicker.find(Slidable).prop('draggerX')).toBe(0);
-    });
   });
 });
 

--- a/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
+++ b/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
@@ -54,6 +54,50 @@ describe('<AlphaPicker />', () => {
       });
       expect(onChangeSpy).toHaveBeenCalledWith(expectedHue);
     });
+
+    it('is called on ArrowUp keyup event', () => {
+      const onChangeSpy = jest.fn();
+      const alphaPicker = mountWithAppProvider(
+        <AlphaPicker {...mockProps} onChange={onChangeSpy} />,
+      );
+      alphaPicker.find('[role="application"]').simulate('keyup', {
+        key: 'ArrowUp',
+      });
+      expect(onChangeSpy).toHaveBeenCalled();
+    });
+
+    it('is called on ArrowDown keyup event', () => {
+      const onChangeSpy = jest.fn();
+      const alphaPicker = mountWithAppProvider(
+        <AlphaPicker {...mockProps} onChange={onChangeSpy} />,
+      );
+      alphaPicker.find('[role="application"]').simulate('keyup', {
+        key: 'ArrowDown',
+      });
+      expect(onChangeSpy).toHaveBeenCalled();
+    });
+
+    it('is not called on ArrowLeft keyup event', () => {
+      const onChangeSpy = jest.fn();
+      const alphaPicker = mountWithAppProvider(
+        <AlphaPicker {...mockProps} onChange={onChangeSpy} />,
+      );
+      alphaPicker.find('[role="application"]').simulate('keyup', {
+        key: 'ArrowLeft',
+      });
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('is not called on ArrowRight keyup event', () => {
+      const onChangeSpy = jest.fn();
+      const alphaPicker = mountWithAppProvider(
+        <AlphaPicker {...mockProps} onChange={onChangeSpy} />,
+      );
+      alphaPicker.find('[role="application"]').simulate('keyup', {
+        key: 'ArrowRight',
+      });
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('<Slidable />', () => {

--- a/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
+++ b/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
@@ -54,6 +54,19 @@ describe('<AlphaPicker />', () => {
       });
       expect(onChangeSpy).toHaveBeenCalledWith(expectedHue);
     });
+  });
+
+  describe('<Slidable />', () => {
+    it('receives dragger height changes and uses them to calculate draggerY', () => {
+      const alpha = 0.7;
+      const alphaPicker = mountWithAppProvider(
+        <AlphaPicker {...mockProps} alpha={alpha} />,
+      );
+      const newDraggerHeight = 7;
+      const expectedNewHue = calculateDraggerY(alpha, 0, newDraggerHeight);
+      trigger(alphaPicker.find(Slidable), 'onDraggerHeight', newDraggerHeight);
+      expect(alphaPicker.find(Slidable).prop('draggerY')).toBe(expectedNewHue);
+    });
 
     it('is called on ArrowUp keyup event', () => {
       const onChangeSpy = jest.fn();
@@ -63,7 +76,7 @@ describe('<AlphaPicker />', () => {
       alphaPicker.find('[role="application"]').simulate('keyup', {
         key: 'ArrowUp',
       });
-      expect(onChangeSpy).toHaveBeenCalled();
+      expect(onChangeSpy).toHaveBeenCalledTimes(1);
     });
 
     it('is called on ArrowDown keyup event', () => {
@@ -74,7 +87,7 @@ describe('<AlphaPicker />', () => {
       alphaPicker.find('[role="application"]').simulate('keyup', {
         key: 'ArrowDown',
       });
-      expect(onChangeSpy).toHaveBeenCalled();
+      expect(onChangeSpy).toHaveBeenCalledTimes(1);
     });
 
     it('is not called on ArrowLeft keyup event', () => {
@@ -97,19 +110,6 @@ describe('<AlphaPicker />', () => {
         key: 'ArrowRight',
       });
       expect(onChangeSpy).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('<Slidable />', () => {
-    it('receives dragger height changes and uses them to calculate draggerY', () => {
-      const alpha = 0.7;
-      const alphaPicker = mountWithAppProvider(
-        <AlphaPicker {...mockProps} alpha={alpha} />,
-      );
-      const newDraggerHeight = 7;
-      const expectedNewHue = calculateDraggerY(alpha, 0, newDraggerHeight);
-      trigger(alphaPicker.find(Slidable), 'onDraggerHeight', newDraggerHeight);
-      expect(alphaPicker.find(Slidable).prop('draggerY')).toBe(expectedNewHue);
     });
   });
 });

--- a/src/components/ColorPicker/components/HuePicker/HuePicker.tsx
+++ b/src/components/ColorPicker/components/HuePicker/HuePicker.tsx
@@ -28,7 +28,6 @@ export class HuePicker extends React.PureComponent<HuePickerProps, State> {
       <div className={styles.HuePicker} ref={this.setSliderHeight}>
         <Slidable
           draggerY={draggerY}
-          draggerX={0}
           onChange={this.handleChange}
           onDraggerHeight={this.setDraggerHeight}
         />

--- a/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
+++ b/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
@@ -59,6 +59,50 @@ describe('<HuePicker />', () => {
       trigger(huePicker.find(Slidable), 'onDraggerHeight', newDraggerHeight);
       expect(huePicker.find(Slidable).prop('draggerY')).toBe(expectedNewHue);
     });
+
+    it('is called on ArrowUp keyup event', () => {
+      const onChangeSpy = jest.fn();
+      const alphaPicker = mountWithAppProvider(
+        <HuePicker {...mockProps} onChange={onChangeSpy} />,
+      );
+      alphaPicker.find('[role="application"]').simulate('keyup', {
+        key: 'ArrowUp',
+      });
+      expect(onChangeSpy).toHaveBeenCalled();
+    });
+
+    it('is called on ArrowDown keyup event', () => {
+      const onChangeSpy = jest.fn();
+      const alphaPicker = mountWithAppProvider(
+        <HuePicker {...mockProps} onChange={onChangeSpy} />,
+      );
+      alphaPicker.find('[role="application"]').simulate('keyup', {
+        key: 'ArrowDown',
+      });
+      expect(onChangeSpy).toHaveBeenCalled();
+    });
+
+    it('is not called on ArrowLeft keyup event', () => {
+      const onChangeSpy = jest.fn();
+      const alphaPicker = mountWithAppProvider(
+        <HuePicker {...mockProps} onChange={onChangeSpy} />,
+      );
+      alphaPicker.find('[role="application"]').simulate('keyup', {
+        key: 'ArrowLeft',
+      });
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('is not called on ArrowRight keyup event', () => {
+      const onChangeSpy = jest.fn();
+      const alphaPicker = mountWithAppProvider(
+        <HuePicker {...mockProps} onChange={onChangeSpy} />,
+      );
+      alphaPicker.find('[role="application"]').simulate('keyup', {
+        key: 'ArrowRight',
+      });
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
+++ b/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
@@ -62,10 +62,10 @@ describe('<HuePicker />', () => {
 
     it('is called on ArrowUp keyup event', () => {
       const onChangeSpy = jest.fn();
-      const alphaPicker = mountWithAppProvider(
+      const huePicker = mountWithAppProvider(
         <HuePicker {...mockProps} onChange={onChangeSpy} />,
       );
-      alphaPicker.find('[role="application"]').simulate('keyup', {
+      huePicker.find('[role="application"]').simulate('keyup', {
         key: 'ArrowUp',
       });
       expect(onChangeSpy).toHaveBeenCalled();
@@ -73,10 +73,10 @@ describe('<HuePicker />', () => {
 
     it('is called on ArrowDown keyup event', () => {
       const onChangeSpy = jest.fn();
-      const alphaPicker = mountWithAppProvider(
+      const huePicker = mountWithAppProvider(
         <HuePicker {...mockProps} onChange={onChangeSpy} />,
       );
-      alphaPicker.find('[role="application"]').simulate('keyup', {
+      huePicker.find('[role="application"]').simulate('keyup', {
         key: 'ArrowDown',
       });
       expect(onChangeSpy).toHaveBeenCalled();
@@ -84,10 +84,10 @@ describe('<HuePicker />', () => {
 
     it('is not called on ArrowLeft keyup event', () => {
       const onChangeSpy = jest.fn();
-      const alphaPicker = mountWithAppProvider(
+      const huePicker = mountWithAppProvider(
         <HuePicker {...mockProps} onChange={onChangeSpy} />,
       );
-      alphaPicker.find('[role="application"]').simulate('keyup', {
+      huePicker.find('[role="application"]').simulate('keyup', {
         key: 'ArrowLeft',
       });
       expect(onChangeSpy).not.toHaveBeenCalled();
@@ -95,10 +95,10 @@ describe('<HuePicker />', () => {
 
     it('is not called on ArrowRight keyup event', () => {
       const onChangeSpy = jest.fn();
-      const alphaPicker = mountWithAppProvider(
+      const huePicker = mountWithAppProvider(
         <HuePicker {...mockProps} onChange={onChangeSpy} />,
       );
-      alphaPicker.find('[role="application"]').simulate('keyup', {
+      huePicker.find('[role="application"]').simulate('keyup', {
         key: 'ArrowRight',
       });
       expect(onChangeSpy).not.toHaveBeenCalled();

--- a/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
+++ b/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
@@ -59,11 +59,6 @@ describe('<HuePicker />', () => {
       trigger(huePicker.find(Slidable), 'onDraggerHeight', newDraggerHeight);
       expect(huePicker.find(Slidable).prop('draggerY')).toBe(expectedNewHue);
     });
-
-    it('passes draggerX to Slidable with value 0', () => {
-      const huePicker = mountWithAppProvider(<HuePicker {...mockProps} />);
-      expect(huePicker.find(Slidable).prop('draggerX')).toBe(0);
-    });
   });
 });
 

--- a/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
+++ b/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
@@ -68,7 +68,7 @@ describe('<HuePicker />', () => {
       huePicker.find('[role="application"]').simulate('keyup', {
         key: 'ArrowUp',
       });
-      expect(onChangeSpy).toHaveBeenCalled();
+      expect(onChangeSpy).toHaveBeenCalledTimes(1);
     });
 
     it('is called on ArrowDown keyup event', () => {
@@ -79,7 +79,7 @@ describe('<HuePicker />', () => {
       huePicker.find('[role="application"]').simulate('keyup', {
         key: 'ArrowDown',
       });
-      expect(onChangeSpy).toHaveBeenCalled();
+      expect(onChangeSpy).toHaveBeenCalledTimes(1);
     });
 
     it('is not called on ArrowLeft keyup event', () => {

--- a/src/components/ColorPicker/components/Slidable/Slidable.tsx
+++ b/src/components/ColorPicker/components/Slidable/Slidable.tsx
@@ -118,9 +118,15 @@ export class Slidable extends React.PureComponent<SlidableProps, State> {
         {touchEndListener}
         {touchCancelListener}
         <div
+          role="slider"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={0}
+          onKeyUp={this.handleKeyUp}
           style={draggerPositioning}
           className={styles.Dragger}
           ref={this.setDraggerNode}
+          tabIndex={0}
         />
       </div>
     );
@@ -183,5 +189,31 @@ export class Slidable extends React.PureComponent<SlidableProps, State> {
     const offsetX = x - rect.left;
     const offsetY = y - rect.top;
     onChange({x: offsetX, y: offsetY});
+  };
+
+  private handleKeyUp = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (this.node == null) {
+      return;
+    }
+    const {key, shiftKey} = event;
+    const {draggerX = 0, draggerY = 0, onChange} = this.props;
+    const rect = this.node.getBoundingClientRect();
+    const stepX = shiftKey ? rect.width / 20 : rect.width / 100;
+    const stepY = shiftKey ? rect.height / 20 : rect.height / 100;
+
+    switch (key) {
+      case 'ArrowUp':
+        onChange({x: draggerX, y: draggerY - stepY});
+        break;
+      case 'ArrowDown':
+        onChange({x: draggerX, y: draggerY + stepY});
+        break;
+      case 'ArrowRight':
+        onChange({x: draggerX + stepX, y: draggerY});
+        break;
+      case 'ArrowLeft':
+        onChange({x: draggerX - stepX, y: draggerY});
+        break;
+    }
   };
 }

--- a/src/components/ColorPicker/components/Slidable/Slidable.tsx
+++ b/src/components/ColorPicker/components/Slidable/Slidable.tsx
@@ -118,7 +118,7 @@ export class Slidable extends React.PureComponent<SlidableProps, State> {
         {touchEndListener}
         {touchCancelListener}
         <div
-          role="slider"
+          role="application"
           aria-valuemin={0}
           aria-valuemax={100}
           aria-valuenow={0}
@@ -126,6 +126,7 @@ export class Slidable extends React.PureComponent<SlidableProps, State> {
           style={draggerPositioning}
           className={styles.Dragger}
           ref={this.setDraggerNode}
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
           tabIndex={0}
         />
       </div>
@@ -196,6 +197,7 @@ export class Slidable extends React.PureComponent<SlidableProps, State> {
       return;
     }
     const {key, shiftKey} = event;
+    const twoDimensional = this.props.draggerX !== undefined;
     const {draggerX = 0, draggerY = 0, onChange} = this.props;
     const rect = this.node.getBoundingClientRect();
     const stepX = shiftKey ? rect.width / 20 : rect.width / 100;
@@ -209,10 +211,14 @@ export class Slidable extends React.PureComponent<SlidableProps, State> {
         onChange({x: draggerX, y: draggerY + stepY});
         break;
       case 'ArrowRight':
-        onChange({x: draggerX + stepX, y: draggerY});
+        if (twoDimensional) {
+          onChange({x: draggerX + stepX, y: draggerY});
+        }
         break;
       case 'ArrowLeft':
-        onChange({x: draggerX - stepX, y: draggerY});
+        if (twoDimensional) {
+          onChange({x: draggerX - stepX, y: draggerY});
+        }
         break;
     }
   };

--- a/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -37,6 +37,21 @@ describe('<ColorPicker />', () => {
         expect(spy).not.toHaveBeenCalled();
       });
     });
+
+    describe('onFocus', () => {
+      it('prevents scrolling of MainColor when onFocus called', () => {
+        const colorPicker = mountWithAppProvider(
+          <ColorPicker color={red} onChange={noop} />,
+        );
+        const mainColor = colorPicker.childAt(0);
+        const mainColorNode = mainColor.getDOMNode();
+
+        mainColor.simulate('focus');
+
+        expect(mainColorNode.scrollTop).toBe(0);
+        expect(mainColorNode.scrollLeft).toBe(0);
+      });
+    });
   });
 
   describe('Hue slider', () => {
@@ -70,7 +85,7 @@ describe('<ColorPicker />', () => {
           .simulate('keyup', {
             key: 'ArrowUp',
           });
-        expect(onChangeSpy).toHaveBeenCalled();
+        expect(onChangeSpy).toHaveBeenCalledTimes(1);
       });
 
       it('is called on ArrowDown keyup event', () => {
@@ -84,7 +99,7 @@ describe('<ColorPicker />', () => {
           .simulate('keyup', {
             key: 'ArrowDown',
           });
-        expect(onChangeSpy).toHaveBeenCalled();
+        expect(onChangeSpy).toHaveBeenCalledTimes(1);
       });
 
       it('is called on ArrowLeft keyup event', () => {
@@ -98,7 +113,7 @@ describe('<ColorPicker />', () => {
           .simulate('keyup', {
             key: 'ArrowLeft',
           });
-        expect(onChangeSpy).toHaveBeenCalled();
+        expect(onChangeSpy).toHaveBeenCalledTimes(1);
       });
 
       it('is called on ArrowRight keyup event', () => {
@@ -112,7 +127,7 @@ describe('<ColorPicker />', () => {
           .simulate('keyup', {
             key: 'ArrowRight',
           });
-        expect(onChangeSpy).toHaveBeenCalled();
+        expect(onChangeSpy).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -58,6 +58,62 @@ describe('<ColorPicker />', () => {
         window.dispatchEvent(new Event('mousemove'));
         expect(spy).not.toHaveBeenCalled();
       });
+
+      it('is called on ArrowUp keyup event', () => {
+        const onChangeSpy = jest.fn();
+        const colorPicker = mountWithAppProvider(
+          <ColorPicker color={red} onChange={onChangeSpy} />,
+        );
+        colorPicker
+          .find('[role="application"]')
+          .first()
+          .simulate('keyup', {
+            key: 'ArrowUp',
+          });
+        expect(onChangeSpy).toHaveBeenCalled();
+      });
+
+      it('is called on ArrowDown keyup event', () => {
+        const onChangeSpy = jest.fn();
+        const colorPicker = mountWithAppProvider(
+          <ColorPicker color={red} onChange={onChangeSpy} />,
+        );
+        colorPicker
+          .find('[role="application"]')
+          .first()
+          .simulate('keyup', {
+            key: 'ArrowDown',
+          });
+        expect(onChangeSpy).toHaveBeenCalled();
+      });
+
+      it('is called on ArrowLeft keyup event', () => {
+        const onChangeSpy = jest.fn();
+        const colorPicker = mountWithAppProvider(
+          <ColorPicker color={red} onChange={onChangeSpy} />,
+        );
+        colorPicker
+          .find('[role="application"]')
+          .first()
+          .simulate('keyup', {
+            key: 'ArrowLeft',
+          });
+        expect(onChangeSpy).toHaveBeenCalled();
+      });
+
+      it('is called on ArrowRight keyup event', () => {
+        const onChangeSpy = jest.fn();
+        const colorPicker = mountWithAppProvider(
+          <ColorPicker color={red} onChange={onChangeSpy} />,
+        );
+        colorPicker
+          .find('[role="application"]')
+          .first()
+          .simulate('keyup', {
+            key: 'ArrowRight',
+          });
+        expect(onChangeSpy).toHaveBeenCalled();
+      });
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/277

There is currently no way to set a colour value in the `ColorPicker` without the use of mouse/touch controls.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR makes the slider on each of the `ColorPicker` `Slidable` elements focusable and allows interaction using the arrow and shift keys.

**Interaction after changes:**

![https://screenshot.click/08-17-jf24w-yomho.gif](https://screenshot.click/08-17-jf24w-yomho.gif)

### Still to do

- [ ] Need to decide on what [ARIA role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques) to use for the 2 dimensional main colour picker panel. The `slider` role doesn't work as it is intended for a slider that works on a single axis.
- [ ] If sticking with `slider` role for 1 axis sliders (`HuePicker` & `AlphaPicker`) I need to fix the value for `aria-valuenow`, currently just has a placeholder value of `0`.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
