### PR TITLE
[Toast] Use the color system variables

### DIFF
--- a/src/components/Frame/components/Toast/Toast.scss
+++ b/src/components/Frame/components/Toast/Toast.scss
@@ -13,7 +13,7 @@ $Backdrop-opacity: 0.88;
     --p-surface-inverse-foreground,
     rgba(color('black'), $Backdrop-opacity)
   );
-  box-shadow: shadow();
+  box-shadow: var(--p-override-none, shadow());
   color: var(--p-text-on-inverse, color('white'));
   margin-bottom: spacing(loose);
 

--- a/src/components/Frame/components/Toast/Toast.scss
+++ b/src/components/Frame/components/Toast/Toast.scss
@@ -8,10 +8,13 @@ $Backdrop-opacity: 0.88;
   display: inline-flex;
   max-width: rem(500px);
   padding: spacing(tight) spacing();
-  border-radius: border-radius();
-  background: rgba(color('black'), $Backdrop-opacity);
+  border-radius: var(--p-border-radius-wide, border-radius());
+  background: var(
+    --p-surface-inverse-foreground,
+    rgba(color('black'), $Backdrop-opacity)
+  );
   box-shadow: shadow();
-  color: color('white');
+  color: var(--p-text-on-inverse, color('white'));
   margin-bottom: spacing(loose);
 
   @include breakpoint-after($breakpoint) {
@@ -29,7 +32,16 @@ $Backdrop-opacity: 0.88;
 }
 
 .error {
-  background: rgba(color('red', 'dark'), $Backdrop-opacity);
+  $error-color: var(--p-text-on-dark, color('white'));
+  background: var(
+    --p-critical-action,
+    rgba(color('red', 'dark'), $Backdrop-opacity)
+  );
+  color: $error-color;
+
+  .CloseButton {
+    fill: $error-color;
+  }
 }
 
 .CloseButton {
@@ -42,10 +54,14 @@ $Backdrop-opacity: 0.88;
   border: none;
   appearance: none;
   background: transparent;
-  fill: color('white');
+  fill: var(--p-text-on-inverse, color('white'));
   cursor: pointer;
 
   &:focus {
     outline: none;
+  }
+
+  @media (-ms-high-contrast: active) {
+    fill: ms-high-contrast-color('text');
   }
 }


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-ux/issues/346

### WHY are these changes introduced?

Implementing the new color system in the `Toast` component.

| Light mode | Dark mode | MSEdge high contrast | 
| - | - | - |
| ![image](https://user-images.githubusercontent.com/22782157/68506809-6ee2c180-0238-11ea-8aea-7e46cb9c5350.png)| ![image](https://user-images.githubusercontent.com/22782157/68506825-7609cf80-0238-11ea-9575-584fd5c06d5b.png)| ![image](https://user-images.githubusercontent.com/22782157/68506635-072c7680-0238-11ea-9ebd-648e3e07fb30.png) |

### WHAT is this pull request doing?

Updates color variables and the `border-radius`.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
