### PR TITLE
[Color system] Use CSS hsla() instead of hsl() to fix Edge bug

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+- Fixed an issue which caused HSL colors to not display in Edge ((#2418)[https://github.com/Shopify/polaris-react/pull/2418])
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -79,7 +79,7 @@ describe('<ThemeProvider />', () => {
     expect(wrapper.find('div').props().style).toStrictEqual(
       expect.objectContaining({
         '--top-bar-background': '#108043',
-        '--top-bar-background-lighter': 'hsl(147, 63%, 43%, 1)',
+        '--top-bar-background-lighter': 'hsla(147, 63%, 43%, 1)',
         '--top-bar-color': 'rgb(255, 255, 255)',
       }),
     );
@@ -114,7 +114,7 @@ describe('<ThemeProvider />', () => {
     expect(wrapper.find('div').props().style).toStrictEqual(
       expect.objectContaining({
         '--top-bar-background': '#021123',
-        '--top-bar-background-lighter': 'hsl(213, 74%, 22%, 1)',
+        '--top-bar-background-lighter': 'hsla(213, 74%, 22%, 1)',
         '--top-bar-color': 'rgb(255, 255, 255)',
       }),
     );
@@ -130,7 +130,7 @@ describe('<ThemeProvider />', () => {
 
     expect(themeProvider.find('div').props().style).toStrictEqual(
       expect.objectContaining({
-        '--p-surface-background': 'hsl(0, 0%, 98%, 1)',
+        '--p-surface-background': 'hsla(0, 0%, 98%, 1)',
       }),
     );
   });

--- a/src/utilities/color-transformers.ts
+++ b/src/utilities/color-transformers.ts
@@ -249,7 +249,7 @@ export function hslToString(hslColor: HSLAColor | string) {
   }
 
   const {alpha = 1, hue, lightness, saturation} = hslColor;
-  return `hsl(${hue}, ${saturation}%, ${lightness}%, ${alpha})`;
+  return `hsla(${hue}, ${saturation}%, ${lightness}%, ${alpha})`;
 }
 
 function rgbToObject(color: string): RGBAColor {

--- a/src/utilities/theme/tests/utils.test.ts
+++ b/src/utilities/theme/tests/utils.test.ts
@@ -32,7 +32,7 @@ describe('setTheme', () => {
 
     expect(theme).toStrictEqual([
       ['--top-bar-color', 'rgb(255, 255, 255)'],
-      ['--top-bar-background-lighter', 'hsl(184, 85%, 43%, 1)'],
+      ['--top-bar-background-lighter', 'hsla(184, 85%, 43%, 1)'],
     ]);
   });
 });
@@ -52,7 +52,7 @@ describe('needsVariant', () => {
 describe('buildCustomProperties', () => {
   const legacyCustomProperties = {
     '--top-bar-background': '#eeeeee',
-    '--top-bar-background-lighter': 'hsl(0, 10%, 100%, 1)',
+    '--top-bar-background-lighter': 'hsla(0, 10%, 100%, 1)',
     '--top-bar-color': 'rgb(33, 43, 54)',
   };
 


### PR DESCRIPTION
### WHY are these changes introduced?

Passing an optional alpha to CSS `hsl()` breaks in Edge. Per MDN docs:

> As of CSS Colors Level 4, `hsla()` is an alias for `hsl()`. In browsers that implement the Level 4 standard, they accept the same parameters and behave the same way.

But turns out Edge (EdgeHTML) did not implement the Level 4 standard: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14995939/

For those curious, here is a [reduced test case](https://codepen.io/timlayton/pen/qBBKYrq).

### WHAT is this pull request doing?

`hsl()` -> `hsla()`

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

* [ ] ~Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)~
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] ~Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)~
* [ ] ~Updated the component's `README.md` with documentation changes~
* [ ] ~[Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide~
* [ ] ~For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)~

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
