### PR TITLE
[Button] Improve the disclosure API for button, allowing user to spec﻿﻿﻿ify the direction the disclosure icon faces

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,7 +12,8 @@
 - Prevented scrolling to `Popover` content in development ([#2403](https://github.com/Shopify/polaris-react/pull/2403))
 - Fixed an issue which caused HSL colors to not display in Edge ([#2418](https://github.com/Shopify/polaris-react/pull/2418))
 - Fixed an issue where the dropzone component jumped from an extra-large layout to a layout based on the width of its container ([#2412](https://github.com/Shopify/polaris-react/pull/2412))
-- Fixed an issue which caused HSL colors to not display in Edge ((#2418)[https://github.com/Shopify/polaris-react/pull/2418])
+- Fixed an issue which caused HSL colors to not display in Edge ([#2418](https://github.com/Shopify/polaris-react/pull/2418))
+- Changed Button's `disclosure` prop to be `boolean | "up" | "down"`, allowing greater control over the direction the disclosure caret faces ([#2431](https://github.com/Shopify/polaris-react/pull/2431))
 - Fixed an issue where the dropzone component jumped from an extra-large layout to a layout based on the width of it's container ([#2412](https://github.com/Shopify/polaris-react/pull/2412))
 - Fixed a race condition in DatePicker ([#2373](https://github.com/Shopify/polaris-react/pull/2373))
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -592,3 +592,13 @@ $partial-button-filled-pressed-box-shadow: inset 0 0 0 0 transparent,
   }
 }
 // stylelint-enable selector-max-specificity
+
+.DisclosureIcon {
+  transition-property: transform;
+  transition-duration: duration(slow);
+  transition-timing-function: easing(out);
+}
+
+.DisclosureIconFacingUp {
+  transform: rotate(-180deg);
+}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -44,8 +44,8 @@ export interface ButtonProps {
   pressed?: boolean;
   /** Allows the button to grow to the width of its container */
   fullWidth?: boolean;
-  /** Displays the button with a disclosure icon */
-  disclosure?: boolean;
+  /** Displays the button with a disclosure icon. Defaults to `down` when set to true */
+  disclosure?: 'down' | 'up' | boolean;
   /** Allows the button to submit a form */
   submit?: boolean;
   /** Renders a button that looks like a link */
@@ -154,9 +154,20 @@ export function Button({
     icon && children == null && styles.iconOnly,
   );
 
+  const disclosureIcon = (
+    <Icon source={loading ? 'placeholder' : CaretDownMinor} />
+  );
+
   const disclosureIconMarkup = disclosure ? (
     <IconWrapper>
-      <Icon source={loading ? 'placeholder' : CaretDownMinor} />
+      <div
+        className={classNames(
+          styles.DisclosureIcon,
+          disclosure === 'up' && styles.DisclosureIconFacingUp,
+        )}
+      >
+        {disclosureIcon}
+      </div>
     </IconWrapper>
   ) : null;
 

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -290,6 +290,30 @@ function PressedButton() {
 }
 ```
 
+### Button with disclosure
+
+<!-- example-for: web -->
+
+Use to denote something that can be progressively disclosed to the user on click.
+
+```jsx
+function DisclosureButtion() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <Button
+      plain
+      disclosure={expanded ? 'up' : 'down'}
+      onClick={() => {
+        setExpanded(!expanded);
+      }}
+    >
+      {expanded ? 'Show less' : 'Show more'}
+    </Button>
+  );
+}
+```
+
 ### Disabled state
 
 Use for actions that aren’t currently available. The surrounding interface should make it clear why the button is disabled and what needs to be done to enable it.

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -370,6 +370,26 @@ describe('<Button />', () => {
     });
   });
 
+  describe('disclosure', () => {
+    it('assumes "down" if set to true', () => {
+      const button = mountWithAppProvider(<Button disclosure />);
+      const disclosureIcon = button.find('.DisclosureIcon');
+      expect(disclosureIcon!.hasClass('DisclosureIconFacingUp')).toBe(false);
+    });
+
+    it('is facing down if set to "down"', () => {
+      const button = mountWithAppProvider(<Button disclosure="down" />);
+      const disclosureIcon = button.find('.DisclosureIcon');
+      expect(disclosureIcon!.hasClass('DisclosureIconFacingUp')).toBe(false);
+    });
+
+    it('is facing up if set to "up"', () => {
+      const button = mountWithAppProvider(<Button disclosure="up" />);
+      const disclosureIcon = button.find('.DisclosureIcon');
+      expect(disclosureIcon!.hasClass('DisclosureIconFacingUp')).toBe(true);
+    });
+  });
+
   describe('deprecations', () => {
     it('warns the ariaPressed prop has been replaced', () => {
       const warningSpy = jest


### PR DESCRIPTION
### WHY are these changes introduced?

We have a need to use a `Button` to control the collapsed/expanded state of a `Collapsible`.  When the collapsible is collapsed, we want to say `Show more` with downwards caret.  When expanded, we want to say `Show less` with upwards caret.

<img width="375" alt="Screen Shot 2019-11-14 at 10 34 23 AM" src="https://user-images.githubusercontent.com/150352/68871395-5821ec00-06ca-11ea-981d-55f3e83427e3.png">

The previous API is respected, so this is purely an opt-in enhancement

The icon will animate via CSS transition

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Card, Button} from '../src';

export function Playground() {
  const [expanded, setExpanded] = React.useState(false);

  return (
    <Page title="Playground">
      <Card sectioned>
        <Button plain>Button without `disclosure` prop</Button>
        <br />
        <Button>Button without `disclosure` prop</Button>
        <br />
        <Button plain disclosure>
          Button with `disclosure` prop
        </Button>
        <br />
        <Button plain disclosure="down">
          Button with `disclosure="down"` prop
        </Button>
        <br />
        <Button plain disclosure="up">
          Button with `disclosure="up"` prop
        </Button>
        <br />
        <Button
          plain
          disclosure={expanded ? 'up' : 'down'}
          onClick={() => setExpanded(!expanded)}
        >
          Button you can toggle down/up on click
        </Button>
        <br />
        <Button
          disclosure={expanded ? 'up' : 'down'}
          onClick={() => setExpanded(!expanded)}
        >
          Button you can toggle down/up on click
        </Button>
      </Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
