### PR TITLE
Export color factory function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,5 @@ export {
   WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT,
 } from './utilities/within-content-context';
 
-export {buildColors as UNSTABLE_BuildColors} from './utilities/theme/utils';
+export {buildColors as UNSTABLE_BuildColors} from './utilities/theme';
 export {AppBridgeContext} from './utilities/app-bridge';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,12 @@ export * from './types';
 
 export * from './components';
 
-export {ScrollLockManagerContext as _SECRET_INTERNAL_SCROLL_LOCK_MANAGER_CONTEXT} from './utilities/scroll-lock-manager';
-export {WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT} from './utilities/within-content-context';
+export {
+  ScrollLockManagerContext as _SECRET_INTERNAL_SCROLL_LOCK_MANAGER_CONTEXT,
+} from './utilities/scroll-lock-manager';
+export {
+  WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT,
+} from './utilities/within-content-context';
 
 export {buildColors} from './utilities/theme/utils';
 export {AppBridgeContext} from './utilities/app-bridge';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,6 @@ export {
   WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT,
 } from './utilities/within-content-context';
 
-export {buildColors as UNSTABLE_BuildColors} from './utilities/theme';
+// eslint-disable-next-line @typescript-eslint/camelcase
+export {UNSTABLE_buildColors} from './utilities/theme';
 export {AppBridgeContext} from './utilities/app-bridge';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,5 @@ export {
   WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT,
 } from './utilities/within-content-context';
 
-export {buildColors} from './utilities/theme/utils';
+export {buildColors as unstableBuildColors} from './utilities/theme/utils';
 export {AppBridgeContext} from './utilities/app-bridge';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,8 @@ export * from './types';
 
 export * from './components';
 
-export {
-  ScrollLockManagerContext as _SECRET_INTERNAL_SCROLL_LOCK_MANAGER_CONTEXT,
-} from './utilities/scroll-lock-manager';
-export {
-  WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT,
-} from './utilities/within-content-context';
+export {ScrollLockManagerContext as _SECRET_INTERNAL_SCROLL_LOCK_MANAGER_CONTEXT} from './utilities/scroll-lock-manager';
+export {WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT} from './utilities/within-content-context';
+
+export {buildColors} from './utilities/theme/utils';
 export {AppBridgeContext} from './utilities/app-bridge';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,5 @@ export {
   WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT,
 } from './utilities/within-content-context';
 
-export {buildColors as unstableBuildColors} from './utilities/theme/utils';
+export {buildColors as UNSTABLE_BuildColors} from './utilities/theme/utils';
 export {AppBridgeContext} from './utilities/app-bridge';

--- a/src/utilities/theme/index.ts
+++ b/src/utilities/theme/index.ts
@@ -6,4 +6,8 @@ export {Theme, ThemeConfig, CustomPropertiesLike} from './types';
 
 export {UNSTABLE_Color} from './color-adjustments';
 
-export {buildCustomProperties, buildThemeContext, buildColors} from './utils';
+export {
+  buildCustomProperties,
+  buildThemeContext,
+  buildColors as UNSTABLE_buildColors,
+} from './utils';

--- a/src/utilities/theme/index.ts
+++ b/src/utilities/theme/index.ts
@@ -9,5 +9,6 @@ export {UNSTABLE_Color} from './color-adjustments';
 export {
   buildCustomProperties,
   buildThemeContext,
+  // eslint-disable-next-line @typescript-eslint/camelcase
   buildColors as UNSTABLE_buildColors,
 } from './utils';

--- a/src/utilities/theme/index.ts
+++ b/src/utilities/theme/index.ts
@@ -6,4 +6,4 @@ export {Theme, ThemeConfig, CustomPropertiesLike} from './types';
 
 export {UNSTABLE_Color} from './color-adjustments';
 
-export {buildCustomProperties, buildThemeContext} from './utils';
+export {buildCustomProperties, buildThemeContext, buildColors} from './utils';


### PR DESCRIPTION
### WHY are these changes introduced?
Other programs should be able to use the color factory.

### WHAT is this pull request doing?
It adds the `buildColors` to the list of exports.