### PR TITLE
[Tooltip] Add an example for a light tooltip

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -38,7 +38,7 @@
 - Updated the `PageActions` example ([#2471](https://github.com/Shopify/polaris-react/pull/2471))
 - Fixed spacing of the `Filters` data table example ([#2477](https://github.com/Shopify/polaris-react/pull/2477))
 - Fixed duplicate and unclear prop descriptions of `EmptyState` ([#2477](https://github.com/Shopify/polaris-react/pull/2477))
-- Added an example for a light Tooltip ((#2434)[https://github.com/Shopify/polaris-react/pull/2434])
+- Added an example for a light `Tooltip` ([#2434](https://github.com/Shopify/polaris-react/pull/2434))
 
 ### Development workflow
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -38,6 +38,7 @@
 - Updated the `PageActions` example ([#2471](https://github.com/Shopify/polaris-react/pull/2471))
 - Fixed spacing of the `Filters` data table example ([#2477](https://github.com/Shopify/polaris-react/pull/2477))
 - Fixed duplicate and unclear prop descriptions of `EmptyState` ([#2477](https://github.com/Shopify/polaris-react/pull/2477))
+- Added an example for a light Tooltip ((#2434)[https://github.com/Shopify/polaris-react/pull/2434])
 
 ### Development workflow
 

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -74,6 +74,18 @@ Use only when necessary to provide an explanation for an interface element.
 </div>
 ```
 
+### Light tooltip
+
+A light tooltip draws less attention than the default tooltip. Use only when necessary to provide an explanation for an interface element with less emphasis.
+
+```jsx
+<div style={{padding: '75px 0'}}>
+  <Tooltip light active content="This order has shipping labels.">
+    <Link>Order #1001</Link>
+  </Tooltip>
+</div>
+```
+
 ---
 
 ## Related components


### PR DESCRIPTION
## Issue summary

I was confusing instances of light colored tooltips with a Popover since it wasn't immediately obvious to me that this prop existed. This PR surfaces that prop via an example in the style guide.

I don't mind if we close this PR if we feel we don't need this addition.