### PR TITLE
[Tooltip] Implement color system

### DIFF
--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -7,8 +7,8 @@ $content-max-width: rem(200px);
 .Tooltip {
   margin: $offset-from-activator spacing() spacing();
   opacity: 1;
-  box-shadow: shadow(deep);
-  border-radius: border-radius();
+  box-shadow: var(--p-popover-shadow, shadow(deep));
+  border-radius: var(--p-border-radius-base, border-radius());
   pointer-events: none;
   will-change: opacity, left, top;
   transition: opacity duration() easing(in) duration(fast);
@@ -28,17 +28,17 @@ $content-max-width: rem(200px);
 
 .light {
   .Wrapper {
-    background: color('white');
-    color: color('ink');
+    background: var(--p-surface, color('white'));
+    color: var(--p-text, color('ink'));
   }
 }
 
 .Wrapper {
   position: relative;
   display: flex;
-  background-color: color('ink');
-  border-radius: border-radius();
-  color: color('white');
+  background-color: var(--p-surface, color('ink'));
+  border-radius: var(--p-border-radius-base, border-radius());
+  color: var(--p-text, color('white'));
   max-height: $content-max-height;
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-ux/issues/368

Mockups [here](https://www.figma.com/file/4dAAt5iFPSaxUKiYVKrkYj/DL%E2%80%93Polaris-(Web)%3A-Components?node-id=2098%3A94).

This introduces the color system to the tooltip.

|-| No theme        | Light mode         | Dark mode  |
|:-:| ------------- |:-------------:| -----|
|Regular tooltip|      ![image](https://user-images.githubusercontent.com/22782157/71740631-bea1cb80-2e2a-11ea-87a2-63d20993be2b.png)  |      ![image](https://user-images.githubusercontent.com/22782157/71740637-c2cde900-2e2a-11ea-904e-e081915c6d60.png)  |   ![image](https://user-images.githubusercontent.com/22782157/71740648-c7929d00-2e2a-11ea-833c-7c24c10ea170.png)  |
|High contrast:|![image](https://user-images.githubusercontent.com/22782157/71740961-99618d00-2e2b-11ea-91fe-ee6493d76303.png)|![image](https://user-images.githubusercontent.com/22782157/71740966-9d8daa80-2e2b-11ea-9224-0af1b767b027.png)|![image](https://user-images.githubusercontent.com/22782157/71740967-a1b9c800-2e2b-11ea-8a16-08f2f2e5bd88.png)|

### How is this accomplished?

Since we will want to deprecate the `light` prop with the rollout of the design language, we don't need to colorize it here. We will also be "inversing" the colors so that the tooltip appears dark on a dark background, and likewise.