### PR TITLE
[TopBar.Search] Fix search dismissal overlay

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Added `hideTags` prop to `Filters` ([#2573](https://github.com/Shopify/polaris-react/pull/2573))
+- Added `searchResultsOverlayVisible` prop to `TopBar` which adds a translucent background to the search dismissal overlay when results are displayed ([#2440](https://github.com/Shopify/polaris-react/pull/2440))
 
 ### Bug fixes
 
@@ -22,6 +23,9 @@
 - Fixed an issue with the `Filters` component where the `aria-expanded` attribute was `undefined` on mount ([#2589]https://github.com/Shopify/polaris-react/pull/2589)
 - Fixed `TrapFocus` from tabbing out of the container ([#2555](https://github.com/Shopify/polaris-react/pull/2555))
 - Fixed `PositionedOverlay` not correctly getting its position when aligned to the right of the activator ([#2587](https://github.com/Shopify/polaris-react/pull/2587))
+- Search dismissal overlay now covers the entire screen ([#2440](https://github.com/Shopify/polaris-react/pull/2440))
+- Search results component will no longer unmount when hidden ([#2440](https://github.com/Shopify/polaris-react/pull/2440))
+- Search results will now match the width of the search field ([#2440](https://github.com/Shopify/polaris-react/pull/2440))
 
 ### Documentation
 

--- a/src/components/TopBar/TopBar.scss
+++ b/src/components/TopBar/TopBar.scss
@@ -95,6 +95,7 @@ $context-control-expand-after: 1400px;
 
 .SearchField {
   @include page-layout;
+  position: relative;
   width: 100%;
   margin: 0;
   max-width: none;
@@ -108,10 +109,6 @@ $context-control-expand-after: 1400px;
 
   @media (max-width: $page-left-alignment-breakpoint-max) {
     margin-left: 0;
-  }
-
-  @include breakpoint-after($not-condensed-content) {
-    position: relative;
   }
 }
 

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -27,6 +27,8 @@ export interface TopBarProps {
   searchResults?: React.ReactNode;
   /** A boolean property indicating whether search results are currently visible. */
   searchResultsVisible?: boolean;
+  /** Determines whether the search dismiss overlay should be visible */
+  searchResultsOverlayVisible?: boolean;
   /** A callback function that handles the dismissal of search results */
   onSearchResultsDismiss?: SearchProps['onDismiss'];
   /** A callback function that handles hiding and showing mobile navigation */
@@ -49,6 +51,7 @@ export const TopBar: React.FunctionComponent<TopBarProps> & {
   searchField,
   secondaryMenu,
   searchResultsVisible,
+  searchResultsOverlayVisible = false,
   onNavigationToggle,
   onSearchResultsDismiss,
   contextControl,
@@ -108,17 +111,16 @@ export const TopBar: React.FunctionComponent<TopBarProps> & {
     );
   }
 
-  const searchResultsMarkup =
-    searchResults && searchResultsVisible ? (
-      <Search visible={searchResultsVisible} onDismiss={onSearchResultsDismiss}>
-        {searchResults}
-      </Search>
-    ) : null;
-
   const searchMarkup = searchField ? (
     <React.Fragment>
       {searchField}
-      {searchResultsMarkup}
+      <Search
+        visible={searchResultsVisible}
+        onDismiss={onSearchResultsDismiss}
+        overlayVisible={searchResultsOverlayVisible}
+      >
+        {searchResults}
+      </Search>
     </React.Fragment>
   ) : null;
 

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -27,7 +27,7 @@ export interface TopBarProps {
   searchResults?: React.ReactNode;
   /** A boolean property indicating whether search results are currently visible. */
   searchResultsVisible?: boolean;
-  /** Determines whether the search dismiss overlay should be visible */
+  /** Whether or not the search results overlay has a visible backdrop */
   searchResultsOverlayVisible?: boolean;
   /** A callback function that handles the dismissal of search results */
   onSearchResultsDismiss?: SearchProps['onDismiss'];

--- a/src/components/TopBar/components/Search/Search.scss
+++ b/src/components/TopBar/components/Search/Search.scss
@@ -1,25 +1,23 @@
 @import '../../../../styles/common';
 @import '../../variables';
 
-$page-layout-when-not-partially-condensed-absolute: rem(743px);
-$search-results-min-width: 45rem;
-
 .Search {
-  position: absolute;
-  z-index: z-index(search, $stacking-order);
-  left: 0;
-  right: 0;
-  top: top-bar-height();
-  height: calc(100vh - #{top-bar-height()});
+  position: fixed;
   visibility: hidden;
   pointer-events: none;
-  padding: 0;
-  width: 100%;
+  top: top-bar-height();
+  left: 0;
+  right: 0;
 
-  @include breakpoint-after($not-condensed-content) {
-    top: top-bar-height() - spacing();
-    left: auto;
-    right: auto;
+  @include page-content-when-not-fully-condensed {
+    position: absolute;
+    top: 100%;
+    max-width: $search-max-width;
+    margin: spacing(extra-tight) spacing(loose) 0;
+  }
+
+  @include page-content-when-not-partially-condensed {
+    margin: spacing(extra-tight) spacing(extra-loose) 0;
   }
 }
 
@@ -28,32 +26,15 @@ $search-results-min-width: 45rem;
   pointer-events: all;
 }
 
-.Overlay {
-  position: absolute;
-  left: 0;
-  right: 0;
+.Results {
+  position: relative;
+  z-index: z-index(search, $stacking-order);
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  width: 100%;
-  max-width: $search-max-width;
-  min-width: $search-results-min-width;
-  max-height: 100%;
-
-  > * {
-    flex: 1 1 auto;
-    width: 100%;
-  }
-
-  @include breakpoint-after($not-condensed-content) {
-    position: relative;
-  }
+  max-height: calc(100vh - #{top-bar-height()});
+  margin: 0;
 
   @include page-content-when-not-fully-condensed {
     max-height: 60vh;
-  }
-
-  @include page-content-when-fully-condensed {
-    min-width: 100%;
   }
 }

--- a/src/components/TopBar/components/Search/Search.scss
+++ b/src/components/TopBar/components/Search/Search.scss
@@ -28,7 +28,7 @@
 
 .Results {
   position: relative;
-  z-index: z-index(search, $stacking-order);
+  z-index: z-index(nav, $fixed-element-stacking-order);
   display: flex;
   flex-direction: column;
   max-height: calc(100vh - #{top-bar-height()});

--- a/src/components/TopBar/components/Search/Search.tsx
+++ b/src/components/TopBar/components/Search/Search.tsx
@@ -8,7 +8,7 @@ export interface SearchProps {
   visible?: boolean;
   /** The content to display inside the search */
   children?: React.ReactNode;
-  /** Determines whether the dismiss overlay should be visible */
+  /** Whether or not the search results overlay has a visible backdrop */
   overlayVisible?: boolean;
   /** Callback when the search is dismissed */
   onDismiss?(): void;

--- a/src/components/TopBar/components/Search/Search.tsx
+++ b/src/components/TopBar/components/Search/Search.tsx
@@ -24,9 +24,13 @@ export function Search({
     return null;
   }
 
+  const overlayMarkup = visible ? (
+    <SearchDismissOverlay onDismiss={onDismiss} visible={overlayVisible} />
+  ) : null;
+
   return (
     <div className={classNames(styles.Search, visible && styles.visible)}>
-      <SearchDismissOverlay onDismiss={onDismiss} visible={overlayVisible} />
+      {overlayMarkup}
       <div className={styles.Results}>{children}</div>
     </div>
   );

--- a/src/components/TopBar/components/Search/Search.tsx
+++ b/src/components/TopBar/components/Search/Search.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {classNames} from '../../../../utilities/css';
+import {SearchDismissOverlay} from '../SearchDismissOverlay';
 import styles from './Search.scss';
 
 export interface SearchProps {
@@ -7,37 +8,26 @@ export interface SearchProps {
   visible?: boolean;
   /** The content to display inside the search */
   children?: React.ReactNode;
+  /** Determines whether the dismiss overlay should be visible */
+  overlayVisible?: boolean;
   /** Callback when the search is dismissed */
   onDismiss?(): void;
 }
 
-export class Search extends React.PureComponent<SearchProps, never> {
-  private node = React.createRef<HTMLDivElement>();
-
-  render() {
-    const {visible, children} = this.props;
-
-    const searchClassName = classNames(
-      styles.Search,
-      visible && styles.visible,
-    );
-
-    return (
-      <div
-        ref={this.node}
-        className={searchClassName}
-        onClick={this.handleDismiss}
-      >
-        <div className={styles.Overlay}>{children}</div>
-      </div>
-    );
+export function Search({
+  visible,
+  children,
+  onDismiss,
+  overlayVisible = false,
+}: SearchProps) {
+  if (children == null) {
+    return null;
   }
 
-  private handleDismiss = ({target}: React.MouseEvent<HTMLElement>) => {
-    const {onDismiss} = this.props;
-
-    if (onDismiss != null && target === this.node.current) {
-      onDismiss();
-    }
-  };
+  return (
+    <div className={classNames(styles.Search, visible && styles.visible)}>
+      <SearchDismissOverlay onDismiss={onDismiss} visible={overlayVisible} />
+      <div className={styles.Results}>{children}</div>
+    </div>
+  );
 }

--- a/src/components/TopBar/components/Search/tests/Search.test.tsx
+++ b/src/components/TopBar/components/Search/tests/Search.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Search} from '../Search';
+import {SearchDismissOverlay} from '../../SearchDismissOverlay';
 
 describe('<Search />', () => {
   it('mounts', () => {
@@ -14,10 +15,16 @@ describe('<Search />', () => {
     expect(search.text()).toContain('Hello Polaris');
   });
 
-  it('calls onDismiss when search is clicked', () => {
-    const spy = jest.fn();
-    const search = mountWithAppProvider(<Search onDismiss={spy} />);
-    search.simulate('click');
-    expect(spy).toHaveBeenCalled();
+  it('renders a SearchDismissOverlay', () => {
+    const search = mountWithAppProvider(<Search>Hello Polaris</Search>);
+    expect(search.find(SearchDismissOverlay)).toHaveLength(1);
+  });
+
+  it('passes the overlayVisible prop to SearchDismissOverlay', () => {
+    const search = mountWithAppProvider(
+      <Search overlayVisible>Hello Polaris</Search>,
+    );
+
+    expect(search.find(SearchDismissOverlay).prop('visible')).toBe(true);
   });
 });

--- a/src/components/TopBar/components/Search/tests/Search.test.tsx
+++ b/src/components/TopBar/components/Search/tests/Search.test.tsx
@@ -16,13 +16,15 @@ describe('<Search />', () => {
   });
 
   it('renders a SearchDismissOverlay', () => {
-    const search = mountWithAppProvider(<Search>Hello Polaris</Search>);
+    const search = mountWithAppProvider(<Search visible>Hello Polaris</Search>);
     expect(search.find(SearchDismissOverlay)).toHaveLength(1);
   });
 
   it('passes the overlayVisible prop to SearchDismissOverlay', () => {
     const search = mountWithAppProvider(
-      <Search overlayVisible>Hello Polaris</Search>,
+      <Search visible overlayVisible>
+        Hello Polaris
+      </Search>,
     );
 
     expect(search.find(SearchDismissOverlay).prop('visible')).toBe(true);

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
@@ -1,0 +1,14 @@
+@import '../../../../styles/common';
+@import '../../variables';
+
+.SearchDismissOverlay {
+  position: fixed;
+  top: top-bar-height();
+  left: 0;
+  right: 0;
+  height: calc(100vh - #{top-bar-height()});
+}
+
+.visible {
+  background: rgba(color('sky'), 0.8);
+}

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
@@ -27,4 +27,3 @@ $backdrop-color: rgba(33, 43, 54, 0.4);
     opacity: 1;
   }
 }
-}

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
@@ -1,14 +1,30 @@
 @import '../../../../styles/common';
 @import '../../variables';
 
+$entry-iterations: 1;
+$backdrop-color: rgba(33, 43, 54, 0.4);
+
 .SearchDismissOverlay {
   position: fixed;
   top: top-bar-height();
   left: 0;
   right: 0;
+  z-index: z-index(nav-backdrop, $fixed-element-stacking-order);
   height: calc(100vh - #{top-bar-height()});
 }
 
 .visible {
-  background: rgba(color('sky'), 0.8);
+  background-color: var(--p-backdrop, $backdrop-color);
+  animation: fade-in duration() $entry-iterations forwards;
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
 }

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.tsx
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.tsx
@@ -1,0 +1,39 @@
+import React, {useCallback, useRef} from 'react';
+import {classNames} from '../../../../utilities/css';
+import * as styles from './SearchDismissOverlay.scss';
+
+interface Props {
+  /** Callback when the search is dismissed */
+  onDismiss?(): void;
+  /** Determines whether the overlay should be visible */
+  visible?: boolean;
+}
+
+export function SearchDismissOverlay({
+  onDismiss = noop,
+  visible = false,
+}: Props) {
+  const node = useRef(null);
+
+  const handleDismiss = useCallback(
+    ({target}: React.MouseEvent<HTMLElement>) => {
+      if (target === node.current) {
+        onDismiss();
+      }
+    },
+    [onDismiss],
+  );
+
+  return (
+    <div
+      ref={node}
+      className={classNames(
+        styles.SearchDismissOverlay,
+        visible && styles.visible,
+      )}
+      onClick={handleDismiss}
+    />
+  );
+}
+
+function noop() {}

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.tsx
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useRef} from 'react';
+import {ScrollLock} from '../../../ScrollLock';
 import {classNames} from '../../../../utilities/css';
 import * as styles from './SearchDismissOverlay.scss';
 
@@ -25,14 +26,17 @@ export function SearchDismissOverlay({
   );
 
   return (
-    <div
-      ref={node}
-      className={classNames(
-        styles.SearchDismissOverlay,
-        visible && styles.visible,
-      )}
-      onClick={handleDismiss}
-    />
+    <React.Fragment>
+      {visible ? <ScrollLock /> : null}
+      <div
+        ref={node}
+        className={classNames(
+          styles.SearchDismissOverlay,
+          visible && styles.visible,
+        )}
+        onClick={handleDismiss}
+      />
+    </React.Fragment>
   );
 }
 

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.tsx
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.tsx
@@ -7,18 +7,15 @@ interface Props {
   /** Callback when the search is dismissed */
   onDismiss?(): void;
   /** Determines whether the overlay should be visible */
-  visible?: boolean;
+  visible: boolean;
 }
 
-export function SearchDismissOverlay({
-  onDismiss = noop,
-  visible = false,
-}: Props) {
-  const node = useRef(null);
+export function SearchDismissOverlay({onDismiss, visible}: Props) {
+  const node = useRef<HTMLDivElement>(null);
 
   const handleDismiss = useCallback(
-    ({target}: React.MouseEvent<HTMLElement>) => {
-      if (target === node.current) {
+    ({target}: React.MouseEvent<HTMLDivElement>) => {
+      if (target === node.current && onDismiss != null) {
         onDismiss();
       }
     },
@@ -39,5 +36,3 @@ export function SearchDismissOverlay({
     </React.Fragment>
   );
 }
-
-function noop() {}

--- a/src/components/TopBar/components/SearchDismissOverlay/index.ts
+++ b/src/components/TopBar/components/SearchDismissOverlay/index.ts
@@ -1,0 +1,1 @@
+export {SearchDismissOverlay} from './SearchDismissOverlay';

--- a/src/components/TopBar/components/SearchDismissOverlay/tests/SearchDismissOverlay.test.tsx
+++ b/src/components/TopBar/components/SearchDismissOverlay/tests/SearchDismissOverlay.test.tsx
@@ -5,14 +5,16 @@ import {SearchDismissOverlay} from '../SearchDismissOverlay';
 
 describe('<SearchDismissOverlay />', () => {
   it('mounts', () => {
-    const search = mountWithAppProvider(<SearchDismissOverlay />);
+    const search = mountWithAppProvider(
+      <SearchDismissOverlay visible={false} />,
+    );
     expect(search.exists()).toBe(true);
   });
 
   it('calls onDismiss when clicked', () => {
     const spy = jest.fn();
     const search = mountWithAppProvider(
-      <SearchDismissOverlay onDismiss={spy} />,
+      <SearchDismissOverlay visible={false} onDismiss={spy} />,
     );
     search.simulate('click');
     expect(spy).toHaveBeenCalled();

--- a/src/components/TopBar/components/SearchDismissOverlay/tests/SearchDismissOverlay.test.tsx
+++ b/src/components/TopBar/components/SearchDismissOverlay/tests/SearchDismissOverlay.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+// eslint-disable-next-line no-restricted-imports
+import {mountWithAppProvider} from 'test-utilities/legacy';
+import {SearchDismissOverlay} from '../SearchDismissOverlay';
+
+describe('<SearchDismissOverlay />', () => {
+  it('mounts', () => {
+    const search = mountWithAppProvider(<SearchDismissOverlay />);
+    expect(search.exists()).toBe(true);
+  });
+
+  it('calls onDismiss when clicked', () => {
+    const spy = jest.fn();
+    const search = mountWithAppProvider(
+      <SearchDismissOverlay onDismiss={spy} />,
+    );
+    search.simulate('click');
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/components/TopBar/components/index.ts
+++ b/src/components/TopBar/components/index.ts
@@ -2,6 +2,8 @@ export {Search, SearchProps} from './Search';
 
 export {SearchField, SearchFieldProps} from './SearchField';
 
+export {SearchDismissOverlay} from './SearchDismissOverlay';
+
 export {UserMenu, UserMenuProps} from './UserMenu';
 
 export {Menu, MenuProps} from './Menu';

--- a/src/components/TopBar/tests/TopBar.test.tsx
+++ b/src/components/TopBar/tests/TopBar.test.tsx
@@ -102,6 +102,18 @@ describe('<TopBar />', () => {
       expect(topBar.find(Search)).toHaveLength(1);
     });
 
+    it('renders the search results when `searchResultsVisible` is false', () => {
+      const topBar = mountWithAppProvider(
+        <TopBar
+          searchResults={searchResults}
+          searchResultsVisible={false}
+          searchField={searchField}
+        />,
+      );
+
+      expect(topBar.find(Search)).toHaveLength(1);
+    });
+
     it('renders the search prop', () => {
       const topBar = mountWithAppProvider(
         <TopBar
@@ -124,6 +136,18 @@ describe('<TopBar />', () => {
       );
 
       expect(topBar.find(Search).prop('visible')).toBe(true);
+    });
+
+    it('passes the searchResultsOverlayVisible prop to search', () => {
+      const topBar = mountWithAppProvider(
+        <TopBar
+          searchResults={searchResults}
+          searchField={searchField}
+          searchResultsOverlayVisible
+        />,
+      );
+
+      expect(topBar.find(Search).prop('overlayVisible')).toBe(true);
     });
 
     it('passes the onSearchDismiss prop to search', () => {


### PR DESCRIPTION
_Updated 10th of December_
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes [#10308](https://github.com/Shopify/store/issues/10308) (store)
Fixes [#5219](https://github.com/Shopify/store/issues/5219) (store)

In the `TopBar` component, there is a `Search` component that handles the display of the `searchResults` prop. The `Search` component includes a dismissal overlay, that calls the `onDismiss` prop when you click anywhere on the screen that isn't a part of the search field or search results. Currently this only works in certain areas as the overlay doesn't cover the entire screen space, specifically, there is a dead zone on the left side of the screen.

This PR also introduces a new design featuring a translucent background to the search dismissal overlay whenever the search results container is visible. This feature is behind an optional `searchResultsOverlayVisible` boolean prop, so it should be considered a non-breaking enhancement.

Additionally, there has been a long standing bug where the width of the search results could extend past the width of the search field at certain screen sizes, where the desired behaviour is that the two are the same width in order to reinforce the expectation that these two elements are linked. While I was updating the overlay and search components it made sense to resolve this bug at the same time.

Another thing that could potentially be discussed further or pulled into a separate PR is a quick change I made to how the search results render. See [this comment](https://github.com/Shopify/polaris-react/pull/2440#discussion_r355640641) for further explanation.

Lastly, I've also taken the liberty to convert the Search component to a functional component, and split the concerns of the dismiss overlay into its own component complete with tests.

### WHAT is this pull request doing?

I kind of explained that above.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsximport React, {useCallback, useState} from 'react';
import {ActionList, Card, Frame, TopBar} from '../src';

export function Playground() {
  const [searchActive, setSearchActive] = useState(false);
  const [searchValue, setSearchValue] = useState('');
  const handleSearchResultsDismiss = useCallback(() => {
    setSearchActive(false);
    setSearchValue('');
  }, []);
  const handleSearchFieldChange = useCallback((value) => {
    setSearchValue(value);
    setSearchActive(value.length > 0);
  }, []);

  const searchResultsMarkup = (
    <Card>
      <ActionList
        items={[
          {content: 'Shopify help center'},
          {content: 'Community forums'},
        ]}
      />
    </Card>
  );

  const searchFieldMarkup = (
    <TopBar.SearchField
      onChange={handleSearchFieldChange}
      value={searchValue}
      placeholder="Search"
    />
  );

  const topBarMarkup = (
    <TopBar
      searchResultsVisible={searchActive}
      searchField={searchFieldMarkup}
      searchResults={searchResultsMarkup}
      onSearchResultsDismiss={handleSearchResultsDismiss}
      searchResultsOverlayVisible
    />
  );

  return <Frame topBar={topBarMarkup} />;
}


```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
