### PR TITLE
Update Prettier to 1.19.1

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -25,6 +25,7 @@
 ### Dependency upgrades
 
 - Upgraded to TypeScript `v3.7.2` ([#2237](https://github.com/Shopify/polaris-react/pull/2237))
+- Upgraded to Prettier to `v1.19.1` ([#2443](https://github.com/Shopify/polaris-react/pull/2443))
 
 ### Code quality
 

--- a/scripts/build-shrink-ray.js
+++ b/scripts/build-shrink-ray.js
@@ -71,7 +71,6 @@ function setupShrinkRay() {
 }
 
 function sendCommitStatus(state) {
-  // prettier-ignore
   const statusUrl = `https://shrink-ray.shopifycloud.com/repos/${repo}/commits/${sha}/status/${state}`;
   console.log(`[shrink-ray] POST ${statusUrl}`);
   return fetch(statusUrl, {method: 'POST'});

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -71,7 +71,8 @@ export class ComboBox extends React.PureComponent<ComboBoxProps, State> {
 
     let newNavigableOptions: (
       | OptionDescriptor
-      | ActionListItemDescriptor)[] = [];
+      | ActionListItemDescriptor
+    )[] = [];
     if (nextActionsBefore) {
       newNavigableOptions = newNavigableOptions.concat(nextActionsBefore);
     }

--- a/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -26,9 +26,10 @@ $stacking-order: (
   // on the right side. We have to do negative margin on top and bottom
   // to compensate for the focus backdrop being smaller than the actual
   // hit area.
-  // prettier-ignore
-  margin:
-    (-0.5 * $difference-between-touch-area-and-backdrop) (-1 * $horizontal-padding) (-0.5 * $difference-between-touch-area-and-backdrop) (-0.5 * $horizontal-padding);
+  margin: (-0.5 * $difference-between-touch-area-and-backdrop)
+    (-1 * $horizontal-padding)
+    (-0.5 * $difference-between-touch-area-and-backdrop)
+    (-0.5 * $horizontal-padding);
   padding: $vertical-padding $horizontal-padding;
   color: color('ink', 'lighter');
   text-decoration: none;

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -52,7 +52,7 @@ interface State {
   skipFocused?: boolean;
   globalRibbonHeight: number;
   loadingStack: number;
-  toastMessages: (ToastPropsWithID)[];
+  toastMessages: ToastPropsWithID[];
   showContextualSaveBar: boolean;
 }
 

--- a/src/components/Frame/components/ToastManager/ToastManager.tsx
+++ b/src/components/Frame/components/ToastManager/ToastManager.tsx
@@ -14,7 +14,7 @@ import {useDeepCallback} from '../../../../utilities/use-deep-callback';
 import styles from './ToastManager.scss';
 
 export interface ToastManagerProps {
-  toastMessages: (ToastPropsWithID)[];
+  toastMessages: ToastPropsWithID[];
 }
 
 export const ToastManager = memo(function ToastManager({

--- a/src/components/Sticky/Sticky.tsx
+++ b/src/components/Sticky/Sticky.tsx
@@ -19,7 +19,8 @@ export type StickyProps = {
   disableWhenStacked?: boolean;
 } & (
   | {children: React.ReactNode}
-  | {children(isSticky: boolean): React.ReactNode});
+  | {children(isSticky: boolean): React.ReactNode}
+);
 
 type CombinedProps = StickyProps & WithAppProviderProps;
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -118,7 +118,8 @@ export type TextFieldProps = NonMutuallyExclusiveProps &
   (
     | {readOnly: true}
     | {disabled: true}
-    | {onChange(value: string, id: string): void});
+    | {onChange(value: string, id: string): void}
+  );
 
 export function TextField({
   prefix,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,8 @@ export * from './types';
 
 export * from './components';
 
-export {
-  ScrollLockManagerContext as _SECRET_INTERNAL_SCROLL_LOCK_MANAGER_CONTEXT,
-} from './utilities/scroll-lock-manager';
-export {
-  WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT,
-} from './utilities/within-content-context';
+export {ScrollLockManagerContext as _SECRET_INTERNAL_SCROLL_LOCK_MANAGER_CONTEXT} from './utilities/scroll-lock-manager';
+export {WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT} from './utilities/within-content-context';
 
 // eslint-disable-next-line @typescript-eslint/camelcase
 export {UNSTABLE_buildColors} from './utilities/theme';

--- a/src/styles/foundation/_colors.scss
+++ b/src/styles/foundation/_colors.scss
@@ -54,7 +54,6 @@ $color-palette-data: map-extend(
     @return $fetched-color;
   } @else {
     // stylelint-disable string-no-newline
-    // prettier-ignore
     $error: "
 Color `#{$hue}, #{$value}` not found. Make sure arguments are strings.
 GOOD: color('yellow')
@@ -127,7 +126,6 @@ $ms-high-contrast-color-data: (
     @return $fetched-color;
   } @else {
     // stylelint-disable string-no-newline
-    // prettier-ignore
     $error: "
 Color `#{$color}` not found. Make sure argument is a string.
 GOOD: ms-high-contrast-color('selected-text')

--- a/src/styles/foundation/_filters.scss
+++ b/src/styles/foundation/_filters.scss
@@ -30,7 +30,6 @@ $color-filter-palette-data: $polaris-color-filters;
     @return $fetched-color;
   } @else {
     // stylelint-disable string-no-newline
-    // prettier-ignore
     $error: "
 Filter `#{$hue}, #{$value}` not found. Make sure arguments are strings.
 GOOD: filter('yellow')

--- a/src/utilities/color-transformers.ts
+++ b/src/utilities/color-transformers.ts
@@ -270,10 +270,7 @@ function rgbToObject(color: string): RGBAColor {
   return objColor;
 }
 
-const hexToHsla: (color: string) => HSLAColor = compose(
-  rgbToHsl,
-  hexToRgb,
-);
+const hexToHsla: (color: string) => HSLAColor = compose(rgbToHsl, hexToRgb);
 
 const rbgStringToHsla: (color: string) => HSLAColor = compose(
   rgbToHsl,

--- a/src/utilities/tests/compose.test.ts
+++ b/src/utilities/tests/compose.test.ts
@@ -32,11 +32,7 @@ describe('compose', () => {
     const sanitizeSpy = jest.fn();
     const toSnakeCaseFromUpperSpy = jest.fn();
     const toUpperCaseSpy = jest.fn();
-    compose(
-      toUpperCaseSpy,
-      toSnakeCaseFromUpperSpy,
-      sanitizeSpy,
-    )();
+    compose(toUpperCaseSpy, toSnakeCaseFromUpperSpy, sanitizeSpy)();
 
     expect(sanitizeSpy).toHaveBeenCalledTimes(1);
     expect(toSnakeCaseFromUpperSpy).toHaveBeenCalledTimes(1);

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -190,10 +190,7 @@ const lightenToString: (
   color: HSLColor | string,
   lightness: number,
   saturation: number,
-) => string = compose(
-  hslToString,
-  createLightColor,
-);
+) => string = compose(hslToString, createLightColor);
 
 export function setTextColor(
   name: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13535,9 +13535,9 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-error@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
### WHY are these changes introduced?

Keeping up to date.

https://prettier.io/blog/2019/11/09/1.19.0.html has the lowdown, but stuff of interest is:

- Support for new syntax added in TS 3.7
- Fixing comment moving weirdness in useEffect style functions (see https://prettier.io/blog/2019/11/09/1.19.0.html#fix-moving-comments-in-function-calls-like-useeffect-6270-by-sosukesuzuki)
- Nicer formatting of union types

### WHAT is this pull request doing?

Updating the package in yarn then running a `yarn run format` to fixup expected changes

Removing a few unneeded prettier-ignores as Prettier no longer does ugly looking things in those cases.

### How to 🎩

Linting passes with no additional changes required