### PR TITLE
Use CSF format for rendering playground stories

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,19 +1,10 @@
-import 'storybook-chromatic';
 import React from 'react';
-import {
-  configure,
-  addParameters,
-  addDecorator,
-  storiesOf,
-} from '@storybook/react';
+import {configure, addParameters, addDecorator} from '@storybook/react';
 import {setConsoleOptions} from '@storybook/addon-console';
 import {withContexts} from '@storybook/addon-contexts/react';
 import {create} from '@storybook/theming';
 import tokens from '@shopify/polaris-tokens';
 import {AppProvider} from '../src';
-import {Playground} from '../playground/Playground';
-import {KitchenSink} from '../playground/KitchenSink';
-import {DetailsPage} from '../playground/DetailsPage';
 import enTranslations from '../locales/en.json';
 import {UNSTABLE_Color} from '../src/utilities/theme';
 
@@ -106,27 +97,12 @@ setConsoleOptions((opts) => {
   return opts;
 });
 
-function addPlaygroundStory(readmeModules) {
-  storiesOf('Playground|Playground', module)
-    .addParameters({
-      chromatic: {disable: true},
-    })
-    .add('Playground', () => <Playground />)
-    .add('Details page', () => <DetailsPage />)
-    .add('Kitchen sink', () => <KitchenSink readmeModules={readmeModules} />);
-}
-
-// import all README.md files within component folders
-const readmeReq = require.context(
-  '../src/components',
-  true,
-  /\/.+\/README.md$/,
+configure(
+  [
+    // Playground stories
+    require.context('../playground', true, /stories.tsx$/),
+    // Component readme stories
+    require.context('../src/components', true, /\/.+\/README.md$/),
+  ],
+  module,
 );
-function loadStories() {
-  const readmeModules = readmeReq.keys().map((filename) => readmeReq(filename));
-  addPlaygroundStory(readmeModules);
-
-  return readmeModules;
-}
-
-configure(loadStories, module);

--- a/playground/KitchenSink.tsx
+++ b/playground/KitchenSink.tsx
@@ -2,7 +2,16 @@ import React from 'react';
 
 type ReadmeModule = Record<string, any>;
 
-export function KitchenSink({readmeModules}: {readmeModules: ReadmeModule[]}) {
+const readmeReq = require.context(
+  '../src/components',
+  true,
+  /\/.+\/README.md$/,
+);
+const readmeModules = readmeReq
+  .keys()
+  .map((filename): ReadmeModule => readmeReq(filename));
+
+export function KitchenSink() {
   return readmeModules.reduce((memo, readmeModule) => {
     const stories = Object.entries(readmeModule)
       .filter(filterExports)

--- a/playground/stories.tsx
+++ b/playground/stories.tsx
@@ -1,0 +1,16 @@
+import {Playground} from './Playground';
+import {KitchenSink} from './KitchenSink';
+import {DetailsPage} from './DetailsPage';
+
+// eslint-disable-next-line import/no-default-export, import/no-anonymous-default-export
+export default {
+  title: 'Playground|Playground',
+  parameters: {
+    chromatic: {disable: true},
+  },
+};
+
+(KitchenSink as any).story = {name: 'Kitchen sink'};
+(DetailsPage as any).story = {name: 'Details page'};
+
+export {Playground, KitchenSink, DetailsPage};


### PR DESCRIPTION
### WHY are these changes introduced?

This means we're no longer using the old storiesOf API and pushes the story config for playgrounds in the playground folder instead of the storybook config

### WHAT is this pull request doing?

Defines playground stories in the playground stories.tsx.

### How to 🎩

Check  playground stories still render as before