### PR TITLE
Added eslint rule to restrict testing utility imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -62,7 +62,7 @@
         "paths": [
           {
             "name": "test-utilities/legacy",
-            "message": "Please import the modern testing library from test-utilities instead"
+            "message": "Please import the modern testing library from 'test-utilities' instead"
           }
         ]
       }

--- a/.eslintrc
+++ b/.eslintrc
@@ -56,6 +56,17 @@
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "jsx-a11y/no-noninteractive-element-to-interactive-role": "off",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "test-utilities/legacy",
+            "message": "Please import the modern testing library from test-utilities instead"
+          }
+        ]
+      }
+    ],
     "@typescript-eslint/camelcase": [
       "error",
       {

--- a/src/components/AccountConnection/tests/AccountConnection.test.tsx
+++ b/src/components/AccountConnection/tests/AccountConnection.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Avatar, buttonFrom} from 'components';
 import {AccountConnection} from '../AccountConnection';

--- a/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {UnstyledLink} from 'components';

--- a/src/components/ActionList/components/Section/tests/Section.test.tsx
+++ b/src/components/ActionList/components/Section/tests/Section.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Item} from '../../Item';
 import {Section} from '../Section';

--- a/src/components/ActionList/tests/ActionList.test.tsx
+++ b/src/components/ActionList/tests/ActionList.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {ImportMinor, ExportMinor} from '@shopify/polaris-icons';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {ActionList} from '../ActionList';

--- a/src/components/ActionMenu/components/MenuAction/tests/MenuAction.test.tsx
+++ b/src/components/ActionMenu/components/MenuAction/tests/MenuAction.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {CaretDownMinor, SaveMinor} from '@shopify/polaris-icons';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 
 import {Icon} from '../../../../Icon';

--- a/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
+++ b/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {SaveMinor} from '@shopify/polaris-icons';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 
 import {Popover, ActionList} from 'components';

--- a/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
+++ b/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 
 import {Button, Popover} from 'components';

--- a/src/components/ActionMenu/tests/ActionMenu.test.tsx
+++ b/src/components/ActionMenu/tests/ActionMenu.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 
 import {MenuGroupDescriptor, ActionListItemDescriptor} from '../../../types';

--- a/src/components/AppProvider/tests/AppProvider.test.tsx
+++ b/src/components/AppProvider/tests/AppProvider.test.tsx
@@ -1,5 +1,6 @@
 import React, {useContext} from 'react';
 import {matchMedia} from '@shopify/jest-dom-mocks';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities/react-testing';
 import {MediaQueryProvider} from 'components/MediaQueryProvider';

--- a/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
+++ b/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {OptionList, ActionList, Popover} from 'components';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {TextField} from '../../TextField';
 import {Key} from '../../../../../types';

--- a/src/components/Autocomplete/tests/Autocomplete.test.tsx
+++ b/src/components/Autocomplete/tests/Autocomplete.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {CirclePlusMinor} from '@shopify/polaris-icons';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {Spinner} from 'components';
 import {Key} from '../../../types';

--- a/src/components/Avatar/tests/Avatar-ssr.test.tsx
+++ b/src/components/Avatar/tests/Avatar-ssr.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Avatar, Image} from 'components';
 

--- a/src/components/Avatar/tests/Avatar.test.tsx
+++ b/src/components/Avatar/tests/Avatar.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {Avatar, Image} from 'components';

--- a/src/components/Backdrop/tests/Backdrop.test.tsx
+++ b/src/components/Backdrop/tests/Backdrop.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {Backdrop} from '..';
 

--- a/src/components/Badge/tests/Badge.test.tsx
+++ b/src/components/Badge/tests/Badge.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {VisuallyHidden} from 'components';
 import {Badge, Status, Progress, PROGRESS_LABELS, STATUS_LABELS} from '..';

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -8,6 +8,7 @@ import {
   FlagMajorTwotone,
 } from '@shopify/polaris-icons';
 import {ReactWrapper} from 'enzyme';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {BannerContext} from 'utilities/banner-context';
 import {Button, Icon, UnstyledLink, Heading} from 'components';

--- a/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {CallbackAction, LinkAction} from '../../../types';
 import {Breadcrumbs} from '../Breadcrumbs';

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {PlusMinor} from '@shopify/polaris-icons';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {UnstyledLink, Icon, Spinner} from 'components';

--- a/src/components/ButtonGroup/components/Item/tests/Item.test.tsx
+++ b/src/components/ButtonGroup/components/Item/tests/Item.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {Button} from 'components';

--- a/src/components/ButtonGroup/tests/ButtonGroup.test.tsx
+++ b/src/components/ButtonGroup/tests/ButtonGroup.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 

--- a/src/components/CalloutCard/tests/CalloutCard.test.tsx
+++ b/src/components/CalloutCard/tests/CalloutCard.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Button, ButtonGroup} from 'components';
 import {CalloutCard} from '../CalloutCard';

--- a/src/components/Caption/tests/Caption.test.tsx
+++ b/src/components/Caption/tests/Caption.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Caption} from '../Caption';
 

--- a/src/components/Card/components/Header/tests/Header.test.tsx
+++ b/src/components/Card/components/Header/tests/Header.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {ButtonGroup, Heading, buttonsFrom} from 'components';
 import {Header} from '../Header';

--- a/src/components/Card/components/Section/tests/Section.test.tsx
+++ b/src/components/Card/components/Section/tests/Section.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Badge, Subheading, ButtonGroup, Button} from 'components';
 import {Section} from '../Section';

--- a/src/components/Card/components/Subsection/tests/Subsection.test.tsx
+++ b/src/components/Card/components/Subsection/tests/Subsection.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Subsection} from '../Subsection';
 

--- a/src/components/Card/tests/Card.test.tsx
+++ b/src/components/Card/tests/Card.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {
   mountWithAppProvider,
   trigger,

--- a/src/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/Checkbox/tests/Checkbox.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Key} from '../../../types';
 import {Checkbox} from '../Checkbox';

--- a/src/components/Choice/tests/Choice.test.tsx
+++ b/src/components/Choice/tests/Choice.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {InlineError} from 'components';
 import {Choice} from '../Choice';

--- a/src/components/ChoiceList/tests/ChoiceList.test.tsx
+++ b/src/components/ChoiceList/tests/ChoiceList.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {mountWithApp} from 'test-utilities';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {RadioButton, Checkbox, InlineError, errorTextID} from 'components';
 import {ChoiceList, ChoiceDescriptor} from '../ChoiceList';

--- a/src/components/Collapsible/tests/Collapsible.test.tsx
+++ b/src/components/Collapsible/tests/Collapsible.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import Collapsible from '../Collapsible';
 

--- a/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
+++ b/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {calculateDraggerY, alphaForDraggerY} from '../utilities';
 import {Slidable} from '../../Slidable';

--- a/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
+++ b/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {calculateDraggerY, hueForDraggerY} from '../utilities';
 import {Slidable} from '../../Slidable';

--- a/src/components/ColorPicker/tests/ColorPicker-ssr.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker-ssr.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Slidable} from '../components';
 import {ColorPicker} from '../ColorPicker';

--- a/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {EventListener} from '../../EventListener';
 import {Slidable, AlphaPicker} from '../components';

--- a/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mount} from 'enzyme';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {ContextualSaveBar} from '../ContextualSaveBar';
 

--- a/src/components/DataTable/components/Cell/tests/Cell.test.tsx
+++ b/src/components/DataTable/components/Cell/tests/Cell.test.tsx
@@ -1,5 +1,6 @@
 import React, {ReactElement} from 'react';
 import {CaretUpMinor, CaretDownMinor} from '@shopify/polaris-icons';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 
 import {Icon} from '../../../..';

--- a/src/components/DataTable/components/Navigation/tests/Navigation.test.tsx
+++ b/src/components/DataTable/components/Navigation/tests/Navigation.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Button} from 'components';
 import {Navigation} from '../Navigation';

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {Cell} from '../components';
 import DataTable, {DataTableProps} from '../DataTable';

--- a/src/components/DatePicker/components/Day/tests/Day.test.tsx
+++ b/src/components/DatePicker/components/Day/tests/Day.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Day} from '../Day';
 

--- a/src/components/DatePicker/components/Month/tests/Month.test.tsx
+++ b/src/components/DatePicker/components/Month/tests/Month.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Weekdays} from '@shopify/javascript-utilities/dates';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Weekday} from '../../Weekday';
 import {Day} from '../../Day';

--- a/src/components/DatePicker/components/Weekday/tests/Weekday.test.tsx
+++ b/src/components/DatePicker/components/Weekday/tests/Weekday.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Weekdays} from '@shopify/javascript-utilities/dates';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Weekday} from '../Weekday';
 

--- a/src/components/DatePicker/tests/DatePicker.test.tsx
+++ b/src/components/DatePicker/tests/DatePicker.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Weekdays} from '@shopify/javascript-utilities/dates';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Day, Month, Weekday} from '../components';
 import {DatePicker} from '../DatePicker';

--- a/src/components/DescriptionList/tests/DescriptionList.test.tsx
+++ b/src/components/DescriptionList/tests/DescriptionList.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 
 import {DescriptionList} from '../DescriptionList';

--- a/src/components/DisplayText/tests/DisplayText.test.tsx
+++ b/src/components/DisplayText/tests/DisplayText.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 
 import {DisplayText} from '../DisplayText';

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Icon, Caption, TextStyle} from 'components';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {DropZoneContext} from '../../../context';
 import {FileUpload} from '../FileUpload';

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {clock} from '@shopify/jest-dom-mocks';
 import {Label, Labelled, DisplayText, Caption} from 'components';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import DropZone from '../DropZone';

--- a/src/components/EmptySearchResult/tests/EmptySearchResult.test.tsx
+++ b/src/components/EmptySearchResult/tests/EmptySearchResult.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {DisplayText, TextStyle} from 'components';
 import {EmptySearchResult} from '../EmptySearchResult';

--- a/src/components/EmptyState/tests/EmptyState.test.tsx
+++ b/src/components/EmptyState/tests/EmptyState.test.tsx
@@ -6,7 +6,7 @@ import {
   UnstyledLink,
   Button,
 } from 'components';
-
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {WithinContentContext} from '../../../utilities/within-content-context';
 import {EmptyState} from '../EmptyState';

--- a/src/components/EventListener/tests/EventListener.test.tsx
+++ b/src/components/EventListener/tests/EventListener.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {EventListener} from '../EventListener';
 

--- a/src/components/ExceptionList/tests/ExceptionList.test.tsx
+++ b/src/components/ExceptionList/tests/ExceptionList.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {CirclePlusMinor, NoteMinor} from '@shopify/polaris-icons';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Icon} from 'components';
 import {ExceptionList} from '../ExceptionList';

--- a/src/components/Filters/components/ConnectedFilterControl/components/Item/tests/Item.test.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/components/Item/tests/Item.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {Item} from '../Item';
 

--- a/src/components/Filters/components/ConnectedFilterControl/tests/ConnectedFilterControl.test.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/tests/ConnectedFilterControl.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {ReactWrapper} from 'enzyme';
 
 import {Popover, Button} from 'components';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 
 import {

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {Button, Popover, Sheet, Tag, TextField, TextStyle} from 'components';
-
+// eslint-disable-next-line no-restricted-imports
 import {
   mountWithAppProvider,
   trigger,

--- a/src/components/Focus/tests/Focus.test.tsx
+++ b/src/components/Focus/tests/Focus.test.tsx
@@ -1,4 +1,5 @@
 import React, {useRef, useState, useEffect} from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Focus, FocusProps} from '../Focus';
 import {Discard} from '../../../types';

--- a/src/components/FooterHelp/tests/FooterHelp.test.tsx
+++ b/src/components/FooterHelp/tests/FooterHelp.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {QuestionMarkMajorTwotone} from '@shopify/polaris-icons';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Icon} from 'components';
 import {FooterHelp} from '../FooterHelp';

--- a/src/components/Form/tests/Form.test.tsx
+++ b/src/components/Form/tests/Form.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Form} from '../Form';
 

--- a/src/components/FormLayout/components/Group/tests/Group.test.tsx
+++ b/src/components/FormLayout/components/Group/tests/Group.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {TextField} from 'components';
 import {Group} from '../Group';

--- a/src/components/FormLayout/components/Item/tests/Item.test.tsx
+++ b/src/components/FormLayout/components/Item/tests/Item.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {TextField} from 'components';
 import {Item} from '../Item';

--- a/src/components/FormLayout/tests/FormLayout.test.tsx
+++ b/src/components/FormLayout/tests/FormLayout.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {TextField} from 'components';
 import {FormLayout} from '../FormLayout';

--- a/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/tests/DiscardConfirmationModal.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/components/DiscardConfirmationModal/tests/DiscardConfirmationModal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 
 import {Modal} from 'components';

--- a/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {Button, Image} from 'components';
 import {ContextualSaveBar} from '../ContextualSaveBar';

--- a/src/components/Frame/components/Loading/tests/Loading.test.tsx
+++ b/src/components/Frame/components/Loading/tests/Loading.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Loading} from '../Loading';
 

--- a/src/components/Frame/components/Toast/tests/Toast.test.tsx
+++ b/src/components/Frame/components/Toast/tests/Toast.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {timer} from '@shopify/jest-dom-mocks';
+// eslint-disable-next-line no-restricted-imports
 import {
   mountWithAppProvider,
   trigger,

--- a/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
+++ b/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {timer} from '@shopify/jest-dom-mocks';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Toast} from '../../Toast';
 import Frame from '../../../Frame';

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {CSSTransition} from '@material-ui/react-transition-group';
 import {animationFrame} from '@shopify/jest-dom-mocks';
 import {documentHasStyle} from 'test-utilities';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {
   TrapFocus,

--- a/src/components/Icon/tests/Icon.test.tsx
+++ b/src/components/Icon/tests/Icon.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {PlusMinor} from '@shopify/polaris-icons';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Icon} from '../Icon';
 

--- a/src/components/Image/tests/Image.test.tsx
+++ b/src/components/Image/tests/Image.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {Image, SourceSet} from '../Image';
 

--- a/src/components/Indicator/tests/Indicator.test.tsx
+++ b/src/components/Indicator/tests/Indicator.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Indicator} from '../Indicator';
 

--- a/src/components/InlineError/tests/InlineError.test.tsx
+++ b/src/components/InlineError/tests/InlineError.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {InlineError, errorTextID} from '../InlineError';
 

--- a/src/components/KeyboardKey/tests/KeyboardKey.test.tsx
+++ b/src/components/KeyboardKey/tests/KeyboardKey.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {KeyboardKey} from '../KeyboardKey';
 

--- a/src/components/KeypressListener/tests/KeypressListener.test.tsx
+++ b/src/components/KeypressListener/tests/KeypressListener.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Key} from '../../../types';
 import {KeypressListener} from '../KeypressListener';

--- a/src/components/Label/tests/Label.test.tsx
+++ b/src/components/Label/tests/Label.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Label, labelID} from '../Label';
 

--- a/src/components/Labelled/tests/Labelled.test.tsx
+++ b/src/components/Labelled/tests/Labelled.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {InlineError, Label, buttonFrom, Labelled} from 'components';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 
 describe('<Labelled />', () => {

--- a/src/components/Layout/tests/Layout.test.tsx
+++ b/src/components/Layout/tests/Layout.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {
   findByTestID,
   matchByTestID,

--- a/src/components/Link/tests/Link.test.tsx
+++ b/src/components/Link/tests/Link.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Banner, UnstyledLink, Icon} from 'components';
 import en from '../../../../locales/en.json';

--- a/src/components/List/components/Item/tests/Item.test.tsx
+++ b/src/components/List/components/Item/tests/Item.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Item} from '../Item';
 

--- a/src/components/List/tests/List.test.tsx
+++ b/src/components/List/tests/List.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {List} from '../List';
 

--- a/src/components/Loading/tests/Loading.test.tsx
+++ b/src/components/Loading/tests/Loading.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Loading as AppBridgeLoading} from '@shopify/app-bridge/actions';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 
 import {Loading} from '../Loading';

--- a/src/components/MessageIndicator/tests/MessageIndicator.test.tsx
+++ b/src/components/MessageIndicator/tests/MessageIndicator.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {MessageIndicator} from '../MessageIndicator';
 

--- a/src/components/Modal/components/Dialog/tests/Dialog.test.tsx
+++ b/src/components/Modal/components/Dialog/tests/Dialog.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {animationFrame} from '@shopify/jest-dom-mocks';
+// eslint-disable-next-line no-restricted-imports
 import {trigger, mountWithAppProvider} from 'test-utilities/legacy';
 import {KeypressListener} from 'components';
 import {Dialog} from '../Dialog';

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Modal as AppBridgeModal} from '@shopify/app-bridge/actions';
 import {animationFrame} from '@shopify/jest-dom-mocks';
+// eslint-disable-next-line no-restricted-imports
 import {
   findByTestID,
   mountWithAppProvider,

--- a/src/components/Navigation/components/Item/components/Secondary/tests/Secondary.test.tsx
+++ b/src/components/Navigation/components/Item/components/Secondary/tests/Secondary.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 
 import {Secondary} from '../Secondary';

--- a/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {PlusMinor} from '@shopify/polaris-icons';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {Icon, UnstyledLink, Indicator, Badge} from 'components';
+// eslint-disable-next-line no-restricted-imports
 import {trigger, mountWithAppProvider} from 'test-utilities/legacy';
 import {NavigationContext} from '../../../context';
 

--- a/src/components/Navigation/components/Message/tests/Message.test.tsx
+++ b/src/components/Navigation/components/Message/tests/Message.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Message} from '../Message';
 import {Badge} from '../../../../Badge';

--- a/src/components/Navigation/components/Section/tests/Section.test.tsx
+++ b/src/components/Navigation/components/Section/tests/Section.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {matchMedia, animationFrame} from '@shopify/jest-dom-mocks';
+// eslint-disable-next-line no-restricted-imports
 import {
   findByTestID,
   trigger,

--- a/src/components/Navigation/tests/Navigation.test.tsx
+++ b/src/components/Navigation/tests/Navigation.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Navigation} from '../Navigation';
 import {NavigationContext} from '../context';

--- a/src/components/OptionList/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/OptionList/components/Checkbox/tests/Checkbox.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Checkbox, CheckboxProps} from '../Checkbox';
 

--- a/src/components/OptionList/components/Option/tests/Option.test.tsx
+++ b/src/components/OptionList/components/Option/tests/Option.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Checkbox} from '../../Checkbox';
 import {Option, OptionProps} from '../Option';

--- a/src/components/OptionList/tests/OptionList.test.tsx
+++ b/src/components/OptionList/tests/OptionList.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Option} from '../components';
 import {

--- a/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
+++ b/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Badge, DisplayText, Avatar} from 'components';
 import {Title} from '../Title';

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -7,6 +7,7 @@ import {
   Badge,
   Avatar,
 } from 'components';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {LinkAction} from '../../../../../types';
 import {HeaderPrimaryAction} from '../../../types';

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -4,6 +4,7 @@ import {
   TitleBar as AppBridgeTitleBar,
 } from '@shopify/app-bridge/actions';
 import {animationFrame} from '@shopify/jest-dom-mocks';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Page, PageProps, Card, Avatar, Badge} from 'components';
 import {Header} from '../components';

--- a/src/components/PageActions/tests/PageActions.test.tsx
+++ b/src/components/PageActions/tests/PageActions.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {ButtonGroup} from '../../ButtonGroup';
 import {Stack} from '../../Stack';

--- a/src/components/Pagination/tests/Pagination.test.tsx
+++ b/src/components/Pagination/tests/Pagination.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {ReactWrapper} from 'enzyme';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {Tooltip, TextField} from 'components';
 import {Key} from '../../../types';

--- a/src/components/Popover/components/Pane/tests/Pane.test.tsx
+++ b/src/components/Popover/components/Pane/tests/Pane.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {TextContainer, Scrollable} from 'components';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {Pane} from '../Pane';
 import {Section} from '../../Section';

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {ReactWrapper} from 'enzyme';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {TextContainer} from 'components';
 import {Key} from '../../../../../types';

--- a/src/components/Popover/components/Section/tests/Section.test.tsx
+++ b/src/components/Popover/components/Section/tests/Section.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {TextContainer} from 'components';
 import {Section} from '../Section';

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -1,4 +1,5 @@
 import React, {useState, useCallback} from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {Popover} from '../Popover';

--- a/src/components/Portal/tests/Portal.test.tsx
+++ b/src/components/Portal/tests/Portal.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {mount} from 'enzyme';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Portal} from '../Portal';
 import {portal} from '../../shared';

--- a/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Rect} from '@shopify/javascript-utilities/geometry';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {EventListener} from '../../EventListener';
 import {

--- a/src/components/ProgressBar/tests/ProgressBar.test.tsx
+++ b/src/components/ProgressBar/tests/ProgressBar.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {ProgressBar} from '../ProgressBar';
 

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {ReactWrapper} from 'enzyme';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {Key} from 'types';
 import {DualThumb, DualThumbProps} from '../DualThumb';

--- a/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/tests/SingleThumb.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {SingleThumb} from '../SingleThumb';
 

--- a/src/components/RangeSlider/tests/RangeSlider.test.tsx
+++ b/src/components/RangeSlider/tests/RangeSlider.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {RangeSlider} from '../RangeSlider';
 import {DualThumb, SingleThumb} from '../components';

--- a/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {
   findByTestID,
   mountWithAppProvider,

--- a/src/components/ResourceList/components/BulkActions/tests/BulkActions.test.tsx
+++ b/src/components/ResourceList/components/BulkActions/tests/BulkActions.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Transition, CSSTransition} from '@material-ui/react-transition-group';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {Popover} from 'components';

--- a/src/components/ResourceList/components/CheckableButton/tests/CheckableButton.test.tsx
+++ b/src/components/ResourceList/components/CheckableButton/tests/CheckableButton.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {Checkbox} from 'components';

--- a/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/DateSelector/tests/DateSelector.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {DatePicker, Select, TextField} from 'components';
+// eslint-disable-next-line no-restricted-imports
 import {trigger, mountWithAppProvider} from 'test-utilities/legacy';
 import {
   DateSelector,

--- a/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {ReactWrapper} from 'enzyme';
+// eslint-disable-next-line no-restricted-imports
 import {
   trigger,
   findByTestID,

--- a/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/tests/FilterValueSelector.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterValueSelector/tests/FilterValueSelector.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {trigger, mountWithAppProvider} from 'test-utilities/legacy';
 import {Select, TextField} from 'components';
 import {FilterValueSelector} from '../FilterValueSelector';

--- a/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/tests/FilterControl.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {trigger, mountWithAppProvider} from 'test-utilities/legacy';
 import {TextField, Tag, Button} from 'components';
 import {ResourceListContext} from '../../../../../utilities/resource-list';

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   EmptyState,
 } from 'components';
+// eslint-disable-next-line no-restricted-imports
 import {
   findByTestID,
   mountWithAppProvider,

--- a/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
+++ b/src/components/ResourcePicker/tests/ResourcePicker.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {ResourcePicker as AppBridgeResourcePicker} from '@shopify/app-bridge/actions';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import ResourcePicker from '../ResourcePicker';
 

--- a/src/components/ScrollLock/tests/ScrollLock.test.tsx
+++ b/src/components/ScrollLock/tests/ScrollLock.test.tsx
@@ -1,4 +1,5 @@
 import React, {useState, useCallback} from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {SCROLL_LOCKING_ATTRIBUTE} from '../../../utilities/scroll-lock-manager';
 import {ScrollLock} from '../ScrollLock';

--- a/src/components/Scrollable/components/ScrollTo/tests/ScrollTo.test.tsx
+++ b/src/components/Scrollable/components/ScrollTo/tests/ScrollTo.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {ScrollTo} from '../ScrollTo';
 import {ScrollableContext} from '../../../context';

--- a/src/components/Scrollable/tests/Scrollable.test.tsx
+++ b/src/components/Scrollable/tests/Scrollable.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Scrollable} from '../Scrollable';
 import {ScrollableContext} from '../context';

--- a/src/components/Select/tests/Select.test.tsx
+++ b/src/components/Select/tests/Select.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {ReactWrapper} from 'enzyme';
 import {InlineError} from 'components';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Select} from '../Select';
 

--- a/src/components/SettingToggle/tests/SettingToggle.test.tsx
+++ b/src/components/SettingToggle/tests/SettingToggle.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {SettingAction} from 'components/SettingAction';
 import {SettingToggle} from '../SettingToggle';

--- a/src/components/Sheet/tests/Sheet.test.tsx
+++ b/src/components/Sheet/tests/Sheet.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {CSSTransition} from '@material-ui/react-transition-group';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 
 import {Backdrop} from 'components/Backdrop';

--- a/src/components/SkeletonBodyText/tests/SkeletonBodyText.test.tsx
+++ b/src/components/SkeletonBodyText/tests/SkeletonBodyText.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {SkeletonBodyText} from '../SkeletonBodyText';
 

--- a/src/components/SkeletonDisplayText/tests/SkeletonDisplayText.test.tsx
+++ b/src/components/SkeletonDisplayText/tests/SkeletonDisplayText.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {SkeletonDisplayText} from '../SkeletonDisplayText';
 

--- a/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
+++ b/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {
   Layout,

--- a/src/components/SkeletonThumbnail/tests/SkeletonThumbnail.test.tsx
+++ b/src/components/SkeletonThumbnail/tests/SkeletonThumbnail.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {SkeletonThumbnail} from '../SkeletonThumbnail';
 

--- a/src/components/Spinner/tests/Spinner.test.tsx
+++ b/src/components/Spinner/tests/Spinner.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {Spinner, Color} from '../Spinner';

--- a/src/components/Sticky/tests/Sticky.test.tsx
+++ b/src/components/Sticky/tests/Sticky.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import Sticky from '../Sticky';
 

--- a/src/components/Subheading/tests/Subheading.test.tsx
+++ b/src/components/Subheading/tests/Subheading.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Button} from 'components';
 import {Subheading} from '../Subheading';

--- a/src/components/Tabs/components/Item/tests/Item.test.tsx
+++ b/src/components/Tabs/components/Item/tests/Item.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {UnstyledLink} from 'components';
 import {Item} from '../Item';

--- a/src/components/Tabs/components/List/tests/List.test.tsx
+++ b/src/components/Tabs/components/List/tests/List.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {List} from '../List';
 import {Item} from '../../Item';

--- a/src/components/Tabs/components/Panel/tests/Panel.test.tsx
+++ b/src/components/Tabs/components/Panel/tests/Panel.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Panel} from '../Panel';
 

--- a/src/components/Tabs/components/Tab/tests/Tab.test.tsx
+++ b/src/components/Tabs/components/Tab/tests/Tab.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Tab} from '../Tab';
 

--- a/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
+++ b/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {TabMeasurer} from '../TabMeasurer';
 import {Tab} from '../../Tab';

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {Tab, Panel, TabMeasurer} from '../components';
 import Tabs, {TabsProps} from '../Tabs';

--- a/src/components/Tag/tests/Tag.test.tsx
+++ b/src/components/Tag/tests/Tag.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Tag} from '../Tag';
 

--- a/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
+++ b/src/components/TextField/components/Resizer/tests/Resizer.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {
   mountWithAppProvider,
   findByTestID,

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1,4 +1,5 @@
 import React, {ReactElement} from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {InlineError, Labelled, Connected, Select} from 'components';
 import {mountWithApp} from 'test-utilities';

--- a/src/components/TextStyle/tests/TextStyle.test.tsx
+++ b/src/components/TextStyle/tests/TextStyle.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {TextStyle} from '../TextStyle';
 

--- a/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {ThemeProvider} from '../ThemeProvider';
 import {ThemeContext, useTheme} from '../../../utilities/theme';

--- a/src/components/Toast/tests/Toast.test.tsx
+++ b/src/components/Toast/tests/Toast.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Toast as AppBridgeToast} from '@shopify/app-bridge/actions';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Toast} from '../Toast';
 

--- a/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {findByTestID, mountWithAppProvider} from 'test-utilities/legacy';
 import {Link} from 'components';
 import {Tooltip} from '../Tooltip';

--- a/src/components/TopBar/components/Menu/components/Message/tests/Message.test.tsx
+++ b/src/components/TopBar/components/Menu/components/Message/tests/Message.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Message} from '../Message';
 import {Badge} from '../../../../../../Badge';

--- a/src/components/TopBar/components/Menu/tests/Menu.test.tsx
+++ b/src/components/TopBar/components/Menu/tests/Menu.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 
 import {ActionList, Popover} from 'components';

--- a/src/components/TopBar/components/Search/tests/Search.test.tsx
+++ b/src/components/TopBar/components/Search/tests/Search.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Search} from '../Search';
 

--- a/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
+++ b/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {CircleCancelMinor} from '@shopify/polaris-icons';
 import {ReactWrapper} from 'enzyme';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {SearchField} from '../SearchField';
 

--- a/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
+++ b/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {ViewMinor} from '@shopify/polaris-icons';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {UserMenu} from '../UserMenu';
 

--- a/src/components/TopBar/tests/TopBar.test.tsx
+++ b/src/components/TopBar/tests/TopBar.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {Image, UnstyledLink} from 'components';
 import {TopBar} from '../TopBar';

--- a/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {
   EventListener,

--- a/src/components/Truncate/tests/Truncate.test.tsx
+++ b/src/components/Truncate/tests/Truncate.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Truncate} from '../Truncate';
 

--- a/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
+++ b/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {UnstyledLink} from 'components/UnstyledLink';
 


### PR DESCRIPTION
### WHY are these changes introduced?

In `v4` we added `@shopify/react-testing` as our main testing library and started to refer to our enzyme code as legacy.

### WHAT is this pull request doing?

* Add linting rule
* Add ignores
