### PR TITLE
[DropZone] Add `size` prop to overwrite computed size based on node

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+- Added `size` prop to `DropZone` ([#2468](https://github.com/Shopify/polaris-react/pull/2468))
 - Added `external` prop to `ResourceList` ([#2408](https://github.com/Shopify/polaris-react/pull/2408))
 - Added `onMouseEnter` and `onTouchStart` props to `Button` ([#2409](https://github.com/Shopify/polaris-react/pull/2409))
 - Added `ariaHaspopup` prop to `Popover` ([#2248](https://github.com/Shopify/polaris-react/pull/2248))

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -28,6 +28,8 @@ import {DropZoneContext} from './context';
 
 import {fileAccepted, getDataTransferFiles} from './utils';
 
+import {Size} from './types';
+
 import styles from './DropZone.scss';
 
 export type Type = 'file' | 'image';
@@ -40,7 +42,7 @@ interface State {
   focused: boolean;
   numFiles: number;
   overlayText?: string;
-  size: string;
+  size: Size;
   measuring: boolean;
   type?: string;
 }
@@ -92,6 +94,8 @@ export interface DropZoneProps {
   dropOnPage?: boolean;
   /** Sets the default file dialog state */
   openFileDialog?: boolean;
+  /** Forces unique dropzone container size */
+  size?: Size;
   /** Adds custom validations */
   customValidator?(file: File): boolean;
   /** Callback triggered on click */
@@ -164,20 +168,25 @@ class DropZone extends React.Component<CombinedProps, State> {
 
   private adjustSize = debounce(
     () => {
-      if (!this.node.current) {
+      if (!this.node.current || this.props.size) {
         return;
       }
 
-      let size = 'extraLarge';
+      console.log('Will adjust size based on node', this.node.current);
+
+      let size = Size.ExtraLarge;
+
       const width = this.node.current.getBoundingClientRect().width;
 
       if (width < 100) {
-        size = 'small';
+        size = Size.Small;
       } else if (width < 160) {
-        size = 'medium';
+        size = Size.Medium;
       } else if (width < 300) {
-        size = 'large';
+        size = Size.Large;
       }
+
+      console.log('Adjusted size is', size);
 
       this.setState({
         size,
@@ -208,7 +217,7 @@ class DropZone extends React.Component<CombinedProps, State> {
       focused: false,
       numFiles: 0,
       overlayText: intl.translate(`Polaris.DropZone.overlayText${suffix}`),
-      size: 'extraLarge',
+      size: this.props.size || Size.ExtraLarge,
       measuring: true,
       type,
     };
@@ -264,10 +273,10 @@ class DropZone extends React.Component<CombinedProps, State> {
       (active || dragging) && styles.isDragging,
       disabled && styles.isDisabled,
       error && styles.hasError,
-      size && size === 'extraLarge' && styles.sizeExtraLarge,
-      size && size === 'large' && styles.sizeLarge,
-      size && size === 'medium' && styles.sizeMedium,
-      size && size === 'small' && styles.sizeSmall,
+      size && size === Size.ExtraLarge && styles.sizeExtraLarge,
+      size && size === Size.Large && styles.sizeLarge,
+      size && size === Size.Medium && styles.sizeMedium,
+      size && size === Size.Small && styles.sizeSmall,
       measuring && styles.measuring,
     );
 
@@ -276,12 +285,12 @@ class DropZone extends React.Component<CombinedProps, State> {
         <div className={styles.Overlay}>
           <Stack vertical spacing="tight">
             <Icon source={DragDropMajorMonotone} color="indigo" />
-            {size === 'extraLarge' && (
+            {size === Size.ExtraLarge && (
               <DisplayText size="small" element="p">
                 {overlayText}
               </DisplayText>
             )}
-            {(size === 'medium' || size === 'large') && (
+            {(size === Size.Medium || size === Size.Large) && (
               <Caption>{overlayText}</Caption>
             )}
           </Stack>
@@ -293,12 +302,12 @@ class DropZone extends React.Component<CombinedProps, State> {
         <div className={styles.Overlay}>
           <Stack vertical spacing="tight">
             <Icon source={CircleAlertMajorMonotone} color="red" />
-            {size === 'extraLarge' && (
+            {size === Size.ExtraLarge && (
               <DisplayText size="small" element="p">
                 {errorOverlayText}
               </DisplayText>
             )}
-            {(size === 'medium' || size === 'large') && (
+            {(size === Size.Medium || size === Size.Large) && (
               <Caption>{errorOverlayText}</Caption>
             )}
           </Stack>

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -214,7 +214,7 @@ class DropZone extends React.Component<CombinedProps, State> {
       numFiles: 0,
       overlayText: intl.translate(`Polaris.DropZone.overlayText${suffix}`),
       size: this.props.size || SizeValue.ExtraLarge,
-      measuring: this.props.size ? false : true,
+      measuring: !this.props.size,
       type,
     };
   }

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -94,7 +94,7 @@ export interface DropZoneProps {
   dropOnPage?: boolean;
   /** Sets the default file dialog state */
   openFileDialog?: boolean;
-  /** Uses fixed size instead of dynamic dropzone container size */
+  /** Uses fixed size instead of computed dropzone container size */
   size?: Size;
   /** Adds custom validations */
   customValidator?(file: File): boolean;

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -172,8 +172,6 @@ class DropZone extends React.Component<CombinedProps, State> {
         return;
       }
 
-      console.log('Will adjust size based on node', this.node.current);
-
       let size = Size.ExtraLarge;
 
       const width = this.node.current.getBoundingClientRect().width;
@@ -185,8 +183,6 @@ class DropZone extends React.Component<CombinedProps, State> {
       } else if (width < 300) {
         size = Size.Large;
       }
-
-      console.log('Adjusted size is', size);
 
       this.setState({
         size,

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -214,7 +214,7 @@ class DropZone extends React.Component<CombinedProps, State> {
       numFiles: 0,
       overlayText: intl.translate(`Polaris.DropZone.overlayText${suffix}`),
       size: this.props.size || SizeValue.ExtraLarge,
-      measuring: true,
+      measuring: this.props.size ? false : true,
       type,
     };
   }

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -94,7 +94,7 @@ export interface DropZoneProps {
   dropOnPage?: boolean;
   /** Sets the default file dialog state */
   openFileDialog?: boolean;
-  /** Uses fixed size instead of dropzone container size */
+  /** Uses fixed size instead of dynamic dropzone container size */
   size?: Size;
   /** Adds custom validations */
   customValidator?(file: File): boolean;

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -94,7 +94,7 @@ export interface DropZoneProps {
   dropOnPage?: boolean;
   /** Sets the default file dialog state */
   openFileDialog?: boolean;
-  /** Forces unique dropzone container size */
+  /** Uses fixed size instead of dropzone container size */
   size?: Size;
   /** Adds custom validations */
   customValidator?(file: File): boolean;

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -28,7 +28,7 @@ import {DropZoneContext} from './context';
 
 import {fileAccepted, getDataTransferFiles} from './utils';
 
-import {Size} from './types';
+import {Size, SizeValue} from './types';
 
 import styles from './DropZone.scss';
 
@@ -172,16 +172,16 @@ class DropZone extends React.Component<CombinedProps, State> {
         return;
       }
 
-      let size = Size.ExtraLarge;
+      let size = SizeValue.ExtraLarge;
 
       const width = this.node.current.getBoundingClientRect().width;
 
       if (width < 100) {
-        size = Size.Small;
+        size = SizeValue.Small;
       } else if (width < 160) {
-        size = Size.Medium;
+        size = SizeValue.Medium;
       } else if (width < 300) {
-        size = Size.Large;
+        size = SizeValue.Large;
       }
 
       this.setState({
@@ -213,7 +213,7 @@ class DropZone extends React.Component<CombinedProps, State> {
       focused: false,
       numFiles: 0,
       overlayText: intl.translate(`Polaris.DropZone.overlayText${suffix}`),
-      size: this.props.size || Size.ExtraLarge,
+      size: this.props.size || SizeValue.ExtraLarge,
       measuring: true,
       type,
     };
@@ -269,10 +269,10 @@ class DropZone extends React.Component<CombinedProps, State> {
       (active || dragging) && styles.isDragging,
       disabled && styles.isDisabled,
       error && styles.hasError,
-      size && size === Size.ExtraLarge && styles.sizeExtraLarge,
-      size && size === Size.Large && styles.sizeLarge,
-      size && size === Size.Medium && styles.sizeMedium,
-      size && size === Size.Small && styles.sizeSmall,
+      size && size === SizeValue.ExtraLarge && styles.sizeExtraLarge,
+      size && size === SizeValue.Large && styles.sizeLarge,
+      size && size === SizeValue.Medium && styles.sizeMedium,
+      size && size === SizeValue.Small && styles.sizeSmall,
       measuring && styles.measuring,
     );
 
@@ -281,12 +281,12 @@ class DropZone extends React.Component<CombinedProps, State> {
         <div className={styles.Overlay}>
           <Stack vertical spacing="tight">
             <Icon source={DragDropMajorMonotone} color="indigo" />
-            {size === Size.ExtraLarge && (
+            {size === SizeValue.ExtraLarge && (
               <DisplayText size="small" element="p">
                 {overlayText}
               </DisplayText>
             )}
-            {(size === Size.Medium || size === Size.Large) && (
+            {(size === SizeValue.Medium || size === SizeValue.Large) && (
               <Caption>{overlayText}</Caption>
             )}
           </Stack>
@@ -298,12 +298,12 @@ class DropZone extends React.Component<CombinedProps, State> {
         <div className={styles.Overlay}>
           <Stack vertical spacing="tight">
             <Icon source={CircleAlertMajorMonotone} color="red" />
-            {size === Size.ExtraLarge && (
+            {size === SizeValue.ExtraLarge && (
               <DisplayText size="small" element="p">
                 {errorOverlayText}
               </DisplayText>
             )}
-            {(size === Size.Medium || size === Size.Large) && (
+            {(size === SizeValue.Medium || size === SizeValue.Large) && (
               <Caption>{errorOverlayText}</Caption>
             )}
           </Stack>

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Icon, Caption, TextStyle} from 'components';
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {DropZoneContext} from '../../../context';
+import {Size} from '../../../types';
 import {FileUpload} from '../FileUpload';
 import {fileUpload as fileUploadImage, imageUpload} from '../../../images';
 
@@ -17,7 +18,7 @@ describe('<FileUpload />', () => {
       const fileUpload = mountWithAppProvider(
         <DropZoneContext.Provider
           value={{
-            size: 'extraLarge',
+            size: Size.ExtraLarge,
             type: 'file',
             ...defaultStates,
             measuring: true,
@@ -37,7 +38,7 @@ describe('<FileUpload />', () => {
       const fileUpload = mountWithAppProvider(
         <DropZoneContext.Provider
           value={{
-            size: 'extraLarge',
+            size: Size.ExtraLarge,
             type: 'file',
             ...defaultStates,
           }}
@@ -54,7 +55,7 @@ describe('<FileUpload />', () => {
     it('renders extra large view for type image', () => {
       const fileUpload = mountWithAppProvider(
         <DropZoneContext.Provider
-          value={{size: 'extraLarge', type: 'image', ...defaultStates}}
+          value={{size: Size.ExtraLarge, type: 'image', ...defaultStates}}
         >
           <FileUpload />
         </DropZoneContext.Provider>,
@@ -70,7 +71,7 @@ describe('<FileUpload />', () => {
     it('renders large view for type file', () => {
       const fileUpload = mountWithAppProvider(
         <DropZoneContext.Provider
-          value={{size: 'large', type: 'file', ...defaultStates}}
+          value={{size: Size.Large, type: 'file', ...defaultStates}}
         >
           <FileUpload />
         </DropZoneContext.Provider>,
@@ -85,7 +86,7 @@ describe('<FileUpload />', () => {
     it('renders large view for type image', () => {
       const fileUpload = mountWithAppProvider(
         <DropZoneContext.Provider
-          value={{size: 'large', type: 'image', ...defaultStates}}
+          value={{size: Size.Large, type: 'image', ...defaultStates}}
         >
           <FileUpload />
         </DropZoneContext.Provider>,
@@ -101,7 +102,7 @@ describe('<FileUpload />', () => {
   it('renders medium view', () => {
     const fileUpload = mountWithAppProvider(
       <DropZoneContext.Provider
-        value={{size: 'medium', type: 'file', ...defaultStates}}
+        value={{size: Size.Medium, type: 'file', ...defaultStates}}
       >
         <FileUpload />
       </DropZoneContext.Provider>,
@@ -114,7 +115,7 @@ describe('<FileUpload />', () => {
   it('renders small view', () => {
     const fileUpload = mountWithAppProvider(
       <DropZoneContext.Provider
-        value={{size: 'small', type: 'file', ...defaultStates}}
+        value={{size: Size.Small, type: 'file', ...defaultStates}}
       >
         <FileUpload />
       </DropZoneContext.Provider>,
@@ -126,7 +127,7 @@ describe('<FileUpload />', () => {
   it('sets a default actionTitle if the prop is provided then removed', () => {
     const fileUpload = mountWithAppProvider(
       <DropZoneContext.Provider
-        value={{size: 'large', type: 'file', ...defaultStates}}
+        value={{size: Size.Large, type: 'file', ...defaultStates}}
       >
         <FileUpload actionTitle="Title" />
       </DropZoneContext.Provider>,
@@ -139,7 +140,7 @@ describe('<FileUpload />', () => {
   it('sets a default actionHint if the prop is provided then removed', () => {
     const fileUpload = mountWithAppProvider(
       <DropZoneContext.Provider
-        value={{size: 'large', type: 'file', ...defaultStates}}
+        value={{size: Size.Large, type: 'file', ...defaultStates}}
       >
         <FileUpload actionHint="Hint" />
       </DropZoneContext.Provider>,

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Icon, Caption, TextStyle} from 'components';
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {DropZoneContext} from '../../../context';
-import {Size} from '../../../types';
+import {SizeValue} from '../../../types';
 import {FileUpload} from '../FileUpload';
 import {fileUpload as fileUploadImage, imageUpload} from '../../../images';
 
@@ -18,7 +18,7 @@ describe('<FileUpload />', () => {
       const fileUpload = mountWithAppProvider(
         <DropZoneContext.Provider
           value={{
-            size: Size.ExtraLarge,
+            size: SizeValue.ExtraLarge,
             type: 'file',
             ...defaultStates,
             measuring: true,
@@ -38,7 +38,7 @@ describe('<FileUpload />', () => {
       const fileUpload = mountWithAppProvider(
         <DropZoneContext.Provider
           value={{
-            size: Size.ExtraLarge,
+            size: SizeValue.ExtraLarge,
             type: 'file',
             ...defaultStates,
           }}
@@ -55,7 +55,7 @@ describe('<FileUpload />', () => {
     it('renders extra large view for type image', () => {
       const fileUpload = mountWithAppProvider(
         <DropZoneContext.Provider
-          value={{size: Size.ExtraLarge, type: 'image', ...defaultStates}}
+          value={{size: SizeValue.ExtraLarge, type: 'image', ...defaultStates}}
         >
           <FileUpload />
         </DropZoneContext.Provider>,
@@ -71,7 +71,7 @@ describe('<FileUpload />', () => {
     it('renders large view for type file', () => {
       const fileUpload = mountWithAppProvider(
         <DropZoneContext.Provider
-          value={{size: Size.Large, type: 'file', ...defaultStates}}
+          value={{size: SizeValue.Large, type: 'file', ...defaultStates}}
         >
           <FileUpload />
         </DropZoneContext.Provider>,
@@ -86,7 +86,7 @@ describe('<FileUpload />', () => {
     it('renders large view for type image', () => {
       const fileUpload = mountWithAppProvider(
         <DropZoneContext.Provider
-          value={{size: Size.Large, type: 'image', ...defaultStates}}
+          value={{size: SizeValue.Large, type: 'image', ...defaultStates}}
         >
           <FileUpload />
         </DropZoneContext.Provider>,
@@ -102,7 +102,7 @@ describe('<FileUpload />', () => {
   it('renders medium view', () => {
     const fileUpload = mountWithAppProvider(
       <DropZoneContext.Provider
-        value={{size: Size.Medium, type: 'file', ...defaultStates}}
+        value={{size: SizeValue.Medium, type: 'file', ...defaultStates}}
       >
         <FileUpload />
       </DropZoneContext.Provider>,
@@ -115,7 +115,7 @@ describe('<FileUpload />', () => {
   it('renders small view', () => {
     const fileUpload = mountWithAppProvider(
       <DropZoneContext.Provider
-        value={{size: Size.Small, type: 'file', ...defaultStates}}
+        value={{size: SizeValue.Small, type: 'file', ...defaultStates}}
       >
         <FileUpload />
       </DropZoneContext.Provider>,
@@ -127,7 +127,7 @@ describe('<FileUpload />', () => {
   it('sets a default actionTitle if the prop is provided then removed', () => {
     const fileUpload = mountWithAppProvider(
       <DropZoneContext.Provider
-        value={{size: Size.Large, type: 'file', ...defaultStates}}
+        value={{size: SizeValue.Large, type: 'file', ...defaultStates}}
       >
         <FileUpload actionTitle="Title" />
       </DropZoneContext.Provider>,
@@ -140,7 +140,7 @@ describe('<FileUpload />', () => {
   it('sets a default actionHint if the prop is provided then removed', () => {
     const fileUpload = mountWithAppProvider(
       <DropZoneContext.Provider
-        value={{size: Size.Large, type: 'file', ...defaultStates}}
+        value={{size: SizeValue.Large, type: 'file', ...defaultStates}}
       >
         <FileUpload actionHint="Hint" />
       </DropZoneContext.Provider>,

--- a/src/components/DropZone/context.tsx
+++ b/src/components/DropZone/context.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {Size} from './types';
+import {Size, SizeValue} from './types';
 
 interface DropZoneContextType {
   disabled: boolean;
@@ -13,7 +13,7 @@ interface DropZoneContextType {
 export const DropZoneContext = React.createContext<DropZoneContextType>({
   disabled: false,
   focused: false,
-  size: Size.ExtraLarge,
+  size: SizeValue.ExtraLarge,
   type: 'file',
   measuring: false,
 });

--- a/src/components/DropZone/context.tsx
+++ b/src/components/DropZone/context.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 
+import {Size} from './types';
+
 interface DropZoneContextType {
   disabled: boolean;
   focused: boolean;
   measuring: boolean;
-  size: string;
+  size: Size;
   type: string;
 }
 
 export const DropZoneContext = React.createContext<DropZoneContextType>({
   disabled: false,
   focused: false,
-  size: 'extraLarge',
+  size: Size.ExtraLarge,
   type: 'file',
   measuring: false,
 });

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -285,6 +285,15 @@ describe('<DropZone />', () => {
       expect(captionText.contains(overlayText)).toBe(true);
     });
 
+    it('renders a Caption containing the overlayText when size is medium', () => {
+      const dropZone = mountWithAppProvider(
+        <DropZone overlayText={overlayText} size="medium" />,
+      );
+      fireEvent({element: dropZone, eventType: 'dragenter'});
+      const captionText = dropZone.find(Caption);
+      expect(captionText.contains(overlayText)).toBe(true);
+    });
+
     it('renders a Caption containing the overlayText on large screens', () => {
       setBoundingClientRect('large');
       const dropZone = mountWithAppProvider(
@@ -295,10 +304,28 @@ describe('<DropZone />', () => {
       expect(captionText.contains(overlayText)).toBe(true);
     });
 
+    it('renders a Caption containing the overlayText on when size is large', () => {
+      const dropZone = mountWithAppProvider(
+        <DropZone overlayText={overlayText} size="large" />,
+      );
+      fireEvent({element: dropZone, eventType: 'dragenter'});
+      const captionText = dropZone.find(Caption);
+      expect(captionText.contains(overlayText)).toBe(true);
+    });
+
     it('renders a DisplayText containing the overlayText on extra-large screens', () => {
       setBoundingClientRect('extraLarge');
       const dropZone = mountWithAppProvider(
         <DropZone overlayText={overlayText} />,
+      );
+      fireEvent({element: dropZone, eventType: 'dragenter'});
+      const displayText = dropZone.find(DisplayText);
+      expect(displayText.contains(overlayText)).toBe(true);
+    });
+
+    it('renders a DisplayText containing the overlayText when size is extraLarge', () => {
+      const dropZone = mountWithAppProvider(
+        <DropZone overlayText={overlayText} size="extraLarge" />,
       );
       fireEvent({element: dropZone, eventType: 'dragenter'});
       const displayText = dropZone.find(DisplayText);
@@ -427,6 +454,25 @@ describe('<DropZone />', () => {
       );
 
       expect(dropZone.find('#file')).toHaveLength(1);
+    });
+
+    it('sets size from props on context when passed', () => {
+      const size = 'small';
+
+      function Component() {
+        return (
+          <DropZone size="small">
+            <DropZoneContext.Consumer>
+              {(ctx) => {
+                return size === ctx.size ? <div /> : null;
+              }}
+            </DropZoneContext.Consumer>
+          </DropZone>
+        );
+      }
+
+      const component = mountWithApp(<Component />);
+      expect(component).toContainReactComponent('div');
     });
   });
 

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -275,6 +275,17 @@ describe('<DropZone />', () => {
       expect(caption).toHaveLength(0);
     });
 
+    it('does not render the overlayText size is small', () => {
+      const dropZone = mountWithAppProvider(
+        <DropZone overlayText={overlayText} size="small" />,
+      );
+      fireEvent({element: dropZone, eventType: 'dragenter'});
+      const displayText = dropZone.find(DisplayText);
+      const caption = dropZone.find(Caption);
+      expect(displayText).toHaveLength(0);
+      expect(caption).toHaveLength(0);
+    });
+
     it('renders a Caption containing the overlayText on medium screens', () => {
       setBoundingClientRect('medium');
       const dropZone = mountWithAppProvider(

--- a/src/components/DropZone/types.ts
+++ b/src/components/DropZone/types.ts
@@ -1,1 +1,8 @@
 export type DropZoneEvent = DragEvent | React.ChangeEvent<HTMLInputElement>;
+
+export enum Size {
+  Small = 'small',
+  Medium = 'medium',
+  Large = 'large',
+  ExtraLarge = 'extraLarge',
+}

--- a/src/components/DropZone/types.ts
+++ b/src/components/DropZone/types.ts
@@ -1,6 +1,8 @@
 export type DropZoneEvent = DragEvent | React.ChangeEvent<HTMLInputElement>;
 
-export enum Size {
+export type Size = 'small' | 'medium' | 'large' | 'extraLarge';
+
+export enum SizeValue {
   Small = 'small',
   Medium = 'medium',
   Large = 'large',


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

We are running into issues with the initial `size` defined in `DropZone`. 

See [`web` issue for context](https://github.com/Shopify/web/issues/19946).

When the component initializes, `size` in `state` is set to `extraLarge`. 
When the component is successfully mounted, `size` will be updated based on the node's dimensions.

During this measuring process, we apply a height of `rem(205px)` (`extraLarge`)

<img width="1719" alt="67314907-86e5e180-f4d3-11e9-9c98-aefa9ec4dbe5" src="https://user-images.githubusercontent.com/3925905/69579061-c35ba000-0f9f-11ea-8933-57cb6a14d02d.png">

This causes the UI to 'jump' when the measuring step completes and the computed value is < `extraLarge`.

![Nov-25-2019 16-24-58](https://user-images.githubusercontent.com/3925905/69579265-2d744500-0fa0-11ea-91d5-9ea836c5d943.gif)


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR adds a new `size` prop to `DropZone`. It overrides the dynamic / computed size. When passing a `size`, we won't calculate dimensions based on current node. Helpful when the dropzone's dimension won't change, for example in the Product Details variants card. 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

🎩 in `web`.

- `yarn run build-consumer web`
- Checkout `variants-card-jump-issue` in `web`
- Make sure you have a single location on your shop
- Open the Product Details page in React for a product with variants
- Make sure the 'jumping' effect is gone when you load the page (see variants card)


<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, DropZone} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <DropZone type="image" size="small">
        <div>
          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus
          tempor interdum diam scelerisque tempus. Sed aliquet eros in elit
          scelerisque, luctus condimentum arcu iaculis. Maecenas malesuada
          mollis justo vel lacinia. Nullam eget velit vel tortor pharetra
          aliquam sit amet nec lorem
        </div>
      </DropZone>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
