### PR TITLE
[Page] print mode adjustments

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@
 - Removed the need for z-indexes in `Icon` ([#2207](https://github.com/Shopify/polaris-react/pull/2207))
 - Added `features` prop to `AppProvider` ([#2204](https://github.com/Shopify/polaris-react/pull/2204))
 - Added support for using `EmptyState` in a content context ([#1570](https://github.com/Shopify/polaris-react/pull/1570))
+- `Page` no longer renders navigation or actions in print mode ([#2469](https://github.com/Shopify/polaris-react/pull/2469))
 
 ### Bug fixes
 

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -30,6 +30,8 @@ $action-menu-rollup-computed-width: icon-size() + (spacing(tight) * 2);
   .hasActionMenu.mobileView & {
     padding-right: $action-menu-rollup-computed-width;
   }
+
+  @include print-hidden;
 }
 
 .BreadcrumbWrapper {
@@ -71,6 +73,8 @@ $action-menu-rollup-computed-width: icon-size() + (spacing(tight) * 2);
   .mobileView & {
     margin-top: spacing();
   }
+
+  @include print-hidden;
 }
 
 .ActionMenuWrapper {
@@ -92,4 +96,6 @@ $action-menu-rollup-computed-width: icon-size() + (spacing(tight) * 2);
   .mobileView.hasNavigation & {
     top: control-height() / 2;
   }
+
+  @include print-hidden;
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

When printing a page, we don't want the breadcrumbs or actions to be visible.

![image](https://user-images.githubusercontent.com/5505280/69656787-0a907200-102e-11ea-9c01-ae0f0af0256a.png)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

removing actions and breadcrumbs from Page header in print mode using the `print` media query mixin.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

Run the playground below and click the `Print` action to view the print mode page without any nav or actions.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';
import {PrintMinor} from '@shopify/polaris-icons';

export function Playground() {
  return (
    <Page
      breadcrumbs={[{content: 'Breadcrumbs', url: '#'}]}
      title="Print demo"
      primaryAction={{content: 'Primary Action', url: '#'}}
      secondaryActions={[
        {content: 'Print', icon: PrintMinor, onAction: window.print},
        {content: 'Secondary Action', url: '#'},
      ]}
      actionGroups={[
        {title: 'Action groups', actions: [{content: 'Action', url: '#'}]},
      ]}
      pagination={{hasNext: true}}
    >
      <p>Page content</p>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
