### PR TITLE
Remove prettier.stylelintIntegration config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,7 +29,6 @@
   },
   "javascript.validate.enable": false,
   "jest.autoEnable": false,
-  "prettier.stylelintIntegration": true,
   "scss.validate": false,
   "search.exclude": {
     "**/bower_components": true,


### PR DESCRIPTION
### WHY are these changes introduced?

v3 of the prettier vscode plugin has been released and it has changed how eslint/stylelint integration works. It now no-longer tries to call a built-in version of prettier-eslint / prettier-stylelint - those commands are only used if they're installed locally in your project (this is a good thing as it stops potential for weird version mismatches between local packages and the ones provided by the vscode plugin).

We don't use those packages in polaris because instead we run prettier as a rule within eslint and stylelint (using https://github.com/prettier/eslint-plugin-prettier and https://github.com/prettier/stylelint-prettier).

The `prettier.stylelintIntegration` and `prettier.eslintIntegration` vscode settings now do nothing at all except throw warning popup saying they're deprecated and no longer have any effect.

### WHAT is this pull request doing?

Removes the `prettier.stylelintIntegration` option as it does nothing, as per https://github.com/prettier/prettier-vscode/issues/1083

### Fallout

The prettier vscode update now means that the prettier extension will only autofix prettier violations, it won't correct any violations of any autofixable eslint and stylelint rules.

In https://github.com/Shopify/polaris-react/pull/2369 I removed `prettier.eslintIntegration` and configured the eslint plugin to autofix JS/TS, so that autofixable eslint rules are fixed on save in addition - retaining the same behaviour as before.

However I can't do the same for css/scss because the stylelint plugin we suggest does not support autofixing. And even more fun, it was recently yanked from the extensions library (https://github.com/stylelint/stylelint/pull/4438). Fortunately there are forks that do support autofixing so I'll suggest people use that in a follow up.
