### PR TITLE
[Popover] Prevent setting a11y attributes when activator disabled 

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,7 @@
 - Fixed `DropZone` not supporting new file selection when `allowMultiple` is `false` ([#2737](https://github.com/Shopify/polaris-react/pull/2737)) ([#2737](https://github.com/Shopify/polaris-react/pull/2737))
 - Fixed `DropZone` not supporting new file selection when `allowMultiple` is `false` ([#2737](https://github.com/Shopify/polaris-react/pull/2737))
 - Fixed `Pagination` sizing on small screens with tooltips ([2747](https://github.com/Shopify/polaris-react/pull/2747))
+- Fixed `Popover` setting a `tabindex` and other accessibility attributes on the activator wrapper when the `activator` is disabled ([#2473](https://github.com/Shopify/polaris-react/pull/2473))
 
 ### Documentation
 

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -5,8 +5,10 @@ import React, {
   useState,
   AriaAttributes,
 } from 'react';
-import {findFirstFocusableNode} from '@shopify/javascript-utilities/focus';
-import {focusNextFocusableNode} from '../../utilities/focus';
+import {
+  findFirstFocusableNode,
+  focusNextFocusableNode,
+} from '../../utilities/focus';
 import {Portal} from '../Portal';
 import {portal} from '../shared';
 import {useUniqueId} from '../../utilities/unique-id';
@@ -90,9 +92,20 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
     }
 
     const firstFocusable = findFirstFocusableNode(activatorContainer.current);
-    const focusableActivator = firstFocusable || activatorContainer.current;
-    setActivatorAttributes(focusableActivator, {id, active, ariaHaspopup});
-  }, [active, ariaHaspopup, id]);
+    const focusableActivator: HTMLElement & {
+      disabled?: boolean;
+    } = firstFocusable || activatorContainer.current;
+
+    const activatorDisabled =
+      'disabled' in focusableActivator && Boolean(focusableActivator.disabled);
+
+    setActivatorAttributes(focusableActivator, {
+      id,
+      active,
+      ariaHaspopup,
+      activatorDisabled,
+    });
+  }, [id, active, ariaHaspopup]);
 
   const handleClose = (source: PopoverCloseSource) => {
     onClose(source);

--- a/src/components/Popover/set-activator-attributes.ts
+++ b/src/components/Popover/set-activator-attributes.ts
@@ -4,15 +4,20 @@ export function setActivatorAttributes(
   activator: HTMLElement,
   {
     id,
-    active,
+    active = false,
     ariaHaspopup,
+    activatorDisabled = false,
   }: {
     id: string;
     active: boolean;
     ariaHaspopup: AriaAttributes['aria-haspopup'];
+    activatorDisabled: boolean;
   },
 ) {
-  activator.tabIndex = activator.tabIndex || 0;
+  if (!activatorDisabled) {
+    activator.tabIndex = activator.tabIndex || 0;
+  }
+
   activator.setAttribute('aria-controls', id);
   activator.setAttribute('aria-owns', id);
   activator.setAttribute('aria-expanded', String(active));

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -21,14 +21,39 @@ describe('<Popover />', () => {
     setActivatorAttributesSpy.mockRestore();
   });
 
-  it('invokes setActivatorAttributes with active, ariaHasPopup and id', () => {
+  it('invokes setActivatorAttributes with active, ariaHasPopup, activatorDisabled, and id', () => {
     mountWithApp(
       <Popover active={false} activator={<div>Activator</div>} onClose={spy} />,
     );
 
     expect(setActivatorAttributesSpy).toHaveBeenLastCalledWith(
       expect.any(Object),
-      {active: false, ariaHaspopup: undefined, id: 'Polarispopover1'},
+      {
+        active: false,
+        ariaHaspopup: undefined,
+        id: 'Polarispopover1',
+        activatorDisabled: false,
+      },
+    );
+  });
+
+  it('invokes setActivatorAttributes activatorDisabled true when the activator is disabled', () => {
+    mountWithApp(
+      <Popover
+        active={false}
+        activator={<button disabled>Activator</button>}
+        onClose={spy}
+      />,
+    );
+
+    expect(setActivatorAttributesSpy).toHaveBeenLastCalledWith(
+      expect.any(Object),
+      {
+        active: false,
+        ariaHaspopup: undefined,
+        id: 'Polarispopover1',
+        activatorDisabled: true,
+      },
     );
   });
 

--- a/src/components/Popover/tests/set-activator-attributes.test.ts
+++ b/src/components/Popover/tests/set-activator-attributes.test.ts
@@ -4,31 +4,85 @@ describe('setActivatorAttributes', () => {
   const id = 'id';
   it('applies aria-controls to the activator', () => {
     const div = document.createElement('div');
-    setActivatorAttributes(div, {active: true, id, ariaHaspopup: true});
+    setActivatorAttributes(div, {
+      active: true,
+      id,
+      ariaHaspopup: true,
+      activatorDisabled: false,
+    });
+
     expect(div.getAttribute('aria-controls')).toBe(id);
   });
 
   it('applies aria-owns to the activator', () => {
     const div = document.createElement('div');
-    setActivatorAttributes(div, {active: true, id, ariaHaspopup: true});
+    setActivatorAttributes(div, {
+      active: true,
+      id,
+      ariaHaspopup: true,
+      activatorDisabled: false,
+    });
+
     expect(div.getAttribute('aria-owns')).toBe(id);
   });
 
   it('applies aria-expanded to the activator', () => {
     const div = document.createElement('div');
-    setActivatorAttributes(div, {active: true, id, ariaHaspopup: true});
+    setActivatorAttributes(div, {
+      active: true,
+      id,
+      ariaHaspopup: true,
+      activatorDisabled: false,
+    });
+
     expect(div.getAttribute('aria-expanded')).toBe('true');
   });
 
   it('applies aria-haspopup to the activator', () => {
     const div = document.createElement('div');
-    setActivatorAttributes(div, {active: true, id, ariaHaspopup: true});
+    setActivatorAttributes(div, {
+      active: true,
+      id,
+      ariaHaspopup: true,
+      activatorDisabled: false,
+    });
+
     expect(div.getAttribute('aria-haspopup')).toBe('true');
   });
 
   it("does not apply aria-haspopover when it's undefined", () => {
     const div = document.createElement('div');
-    setActivatorAttributes(div, {active: true, id, ariaHaspopup: undefined});
+    setActivatorAttributes(div, {
+      active: true,
+      id,
+      ariaHaspopup: undefined,
+      activatorDisabled: false,
+    });
+
     expect(div.getAttribute('aria-haspopup')).toBeNull();
+  });
+
+  it('applies tabindex to the activator', () => {
+    const div = document.createElement('div');
+    setActivatorAttributes(div, {
+      active: true,
+      id,
+      ariaHaspopup: true,
+      activatorDisabled: false,
+    });
+
+    expect(div.getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('does not apply tabindex when activatorDisabled is true', () => {
+    const div = document.createElement('div');
+    setActivatorAttributes(div, {
+      active: true,
+      id,
+      ariaHaspopup: undefined,
+      activatorDisabled: true,
+    });
+
+    expect(div.getAttribute('tabindex')).toBeNull();
   });
 });

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -34,6 +34,20 @@ export function nextFocusableNode(
   return null;
 }
 
+// Popover needs to be able to find its activator even if it is disabled, which FOCUSABLE_SELECTOR doesn't support.
+
+export function findFirstFocusableNode(
+  element: HTMLElement,
+): HTMLElement | null {
+  const focusableSelector = `a,button,frame,iframe,input:not([type=hidden]),select,textarea,*[tabindex]`;
+
+  if (matches(element, focusableSelector)) {
+    return element;
+  }
+
+  return element.querySelector(focusableSelector);
+}
+
 export function focusNextFocusableNode(node: HTMLElement, filter?: Filter) {
   const nextFocusable = nextFocusableNode(node, filter);
   if (nextFocusable && nextFocusable instanceof HTMLElement) {


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, the `Popover` sets accessibility attributes on either the activator (if focusable) or the element it wraps the activator with. If the activator is not focusable because it is disabled, the activator's wrapper gets these attributes. This is a problem because the activator wrapper is a `div` (unless the `activatorWrapper` prop is set to something else) and the `div` having a `tabIndex="-1"` makes it focusable ironically! 

A good example of this can be seen in the "All filters disabled" `Filters` example. When viewing the playground code on `master`, you can view the unwanted attributes being set on and staying set on the wrapper `div` after toggling the disabled state of the filters.

<img width="822" alt="Screen Shot 2019-11-26 at 8 28 34 PM" src="https://user-images.githubusercontent.com/18447883/69685709-5a515680-108b-11ea-90be-74513ed1ed2e.png">

### WHAT is this pull request doing?

- Uses a version of the `findFirstFocusableNode` utility that doesn't eliminate disabled elements.
- Prevents `tabIndex` from being set on the activator when the activator is disabled

<img width="818" alt="Screen Shot 2019-11-26 at 8 23 01 PM" src="https://user-images.githubusercontent.com/18447883/69685514-a5b73500-108a-11ea-858b-8dcf33ecef9d.png">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

- Copy and paste the collapsed playground code below into `/playground/Playground.tsx`
- While still on `master`
    - `yarn dev`
    - View the playground and inspect the disabled "File type" filter popover activator. 
    - You'll see the focus ring is due to the `tabindex="-1"` on the wrapper `div` as well as the other accessibility attributes.
    - Click the "Toggle empty state" secondary action
    - Now that the activator `button` is no longer disabled it now has all of the expected accessibility attributes, but you'll see that the wrapper `div` still has all of the accessibility attributes on it as well.
- `git checkout popover-activatorDisabled`
    - Inspect the disabled "File type" filter popover activator again, you should see no attributes on the wrapper `div`
    - Click the "Toggle empty state" secondary action
    - You'll see that the accessibility attributes are all on the button 

<details>
<summary>Click to view collapsed example code</summary>

```jsx
import React, {useState, useCallback} from 'react';
import {
  Page,
  Layout,
  ResourceList,
  ResourceItem,
  EmptyState,
  Card,
  TextStyle,
  Select,
  Filters,
  Thumbnail,
  Tabs,
  SkeletonBodyText,
  Spinner,
} from '../src';

const allItems = [
  {
    id: 341,
    url: 'files/341',
    name: 'Point of sale staff',
    imgSource:
      'https://user-images.githubusercontent.com/29233959/61383074-fc5e6800-a87b-11e9-8e92-487153efd0dc.png',
    fileType: 'png',
  },
  {
    id: 256,
    url: 'files/256',
    name: 'File upload',
    imgSource:
      'https://user-images.githubusercontent.com/18447883/59945230-fa4be980-9434-11e9-9106-a373f0efbe08.png',
    fileType: 'png',
  },
];

const tabs = [
  {
    id: 'all-files',
    content: 'All',
    accessibilityLabel: 'All files',
    panelID: 'all-files-content',
  },
];

export function Playground() {
  const [viewLoadingState, setLoadingState] = useState(false);
  const [viewEmptyState, setEmptyState] = useState(true);
  const [filteredItems, setFilteredItems] = useState([]);
  const [fileType, setFileType] = useState('');
  const [queryValue, setQueryValue] = useState('');

  const toggleLoadingState = useCallback(
    () => setLoadingState((viewLoadingState) => !viewLoadingState),
    [],
  );

  const toggleEmptyState = useCallback(
    () => setEmptyState((viewEmptyState) => !viewEmptyState),
    [],
  );

  const updateFilteredItems = useCallback((items) => {
    setFilteredItems(items);
  }, []);

  const updateFileTypeFilter = useCallback(
    (value) => {
      setFileType(value);
      const itemsToFilter =
        queryValue && filteredItems.length > 0 ? filteredItems : allItems;
      updateFilteredItems(filterByFileType(value, itemsToFilter));
    },
    [filteredItems, queryValue, updateFilteredItems],
  );

  const updateQueryValue = useCallback(
    (value) => {
      setQueryValue(normalizeString(value));
      const itemsToFilter =
        fileType && filteredItems.length > 0 ? filteredItems : allItems;

      updateFilteredItems(
        filterByQueryValue(normalizeString(value), itemsToFilter),
      );
    },
    [fileType, filteredItems, updateFilteredItems],
  );

  const handleRemove = useCallback(() => {
    updateFileTypeFilter('');
  }, [updateFileTypeFilter]);

  const handleQueryClear = useCallback(() => {
    updateQueryValue('');
  }, [updateQueryValue]);

  const handleClearAll = useCallback(() => {
    updateFileTypeFilter('');
    updateQueryValue('');
  }, [updateFileTypeFilter, updateQueryValue]);

  let items = fileType || queryValue ? filteredItems : allItems;

  if (viewEmptyState) {
    items = [];
  }

  const filters = [
    {
      key: 'fileType',
      label: 'File type',
      filter: (
        <Select
          labelHidden
          label="File type"
          value={fileType}
          options={[
            {label: 'JPEG', value: 'jpeg'},
            {label: 'PNG', value: 'png'},
            {label: 'MP4', value: 'mp4'},
          ]}
          onChange={updateFileTypeFilter}
        />
      ),
      shortcut: true,
    },
  ];

  const appliedFilters = fileType
    ? [
        {
          key: 'fileType',
          label: `File type ${fileType.toUpperCase()}`,
          onRemove: handleRemove,
        },
      ]
    : [];

  const filterControl = (
    <Filters
      disabled={viewEmptyState}
      queryValue={queryValue}
      filters={filters}
      appliedFilters={appliedFilters}
      onQueryChange={updateQueryValue}
      onQueryClear={handleQueryClear}
      onClearAll={handleClearAll}
    />
  );

  const emptyStateMarkup = (
    <EmptyState
      heading="Upload a file to get started"
      action={{content: 'Upload files'}}
      image="https://cdn.shopify.com/s/files/1/2376/3301/products/file-upload-empty-state.png"
    >
      <p>
        You can use the Files section to upload images, videos, and other
        documents
      </p>
    </EmptyState>
  );

  const loadingStateMarkup = viewLoadingState ? (
    <Card>
      <SkeletonTabs />

      <div>
        <div style={{padding: '16px', marginTop: '1px'}}>
          <Filters
            disabled={viewEmptyState}
            queryValue={queryValue}
            filters={filters}
            appliedFilters={appliedFilters}
            onQueryChange={updateQueryValue}
            onQueryClear={handleQueryClear}
            onClearAll={handleClearAll}
          />
        </div>
        <div
          style={{
            display: 'flex',
            justifyContent: 'center',
            alignItems: 'center',
            minHeight: '160px',
          }}
        >
          <Spinner />
        </div>
      </div>
    </Card>
  ) : null;

  const withDataStateMarkup = !viewLoadingState ? (
    <Card>
      <Tabs selected={0} tabs={tabs}>
        <ResourceList
          showHeader
          hasMoreItems={!viewEmptyState && items.length < allItems.length}
          resourceName={{singular: 'file', plural: 'files'}}
          items={items}
          renderItem={renderItem}
          filterControl={filterControl}
        />
      </Tabs>
    </Card>
  ) : null;

  return (
    <Page
      title="Files"
      secondaryActions={[
        {
          content: 'Toggle empty state',
          onAction: toggleEmptyState,
          disabled: viewLoadingState,
        },
        {
          content: 'Toggle loading state',
          onAction: toggleLoadingState,
        },
      ]}
      breadcrumbs={[{content: 'Home', url: '/'}]}
    >
      <Layout>
        <Layout.Section>
          {loadingStateMarkup}
          {withDataStateMarkup}
        </Layout.Section>
      </Layout>
    </Page>
  );
}

function renderItem(item) {
  const {id, url, name, imgSource, altText = '', fileType} = item;
  const media = <Thumbnail alt={altText} source={imgSource} />;
  return (
    <ResourceItem id={id} url={url} media={media}>
      <h3>
        <TextStyle variation="strong">{name}</TextStyle>
      </h3>
      <div>{fileType}</div>
    </ResourceItem>
  );
}

function filterByFileType(fileType, items) {
  return items.filter((item) => item.fileType === fileType);
}

function filterByQueryValue(query, items) {
  return items.filter((item) => {
    return (
      normalizeString(item.name).includes(query) ||
      normalizeString(item.fileType).includes(query) ||
      normalizeString(item.imgSource).includes(query)
    );
  });
}

function normalizeString(string) {
  return string.toLowerCase();
}

function SkeletonTabs() {
  return (
    <div
      style={{
        width: '100%',
        display: 'flex',
        borderBottom: '1px solid #DFE3E8',
        height: '53px',
      }}
    >
      <div
        style={{
          width: '80px',
          padding: '21px 20px',
        }}
      >
        <SkeletonBodyText lines={1} />
      </div>
    </div>
  );
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
