### PR TITLE
[Filters] Fix example spacing; [EmptyState] Fix prop descriptions and cascade order

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -27,12 +27,15 @@
 - Added the top bar height to the `Topbar` in `Frame` to ensure the `Sticky` components get the correct top position ([#2415](https://github.com/Shopify/polaris-react/pull/2415))
 - Fixed `merge` mutating its arguments ([#2317](https://github.com/Shopify/polaris-react/pull/2317))
 - Updated `Card` footer actions to be right aligned by default again ([#2407](https://github.com/Shopify/polaris-react/pull/2407))
+- Fixed the `EmptyState` styles conditional on the `imageContained` prop not being applied ([#2477](https://github.com/Shopify/polaris-react/pull/2477))
 
 ### Documentation
 
 - Added a details page and kitchen sink example to Storybook ([#2402](https://github.com/Shopify/polaris-react/pull/2402))
 - Combined the interface used by `Page` so the types can be parsed ([#2358](https://github.com/Shopify/polaris-react/pull/2358))
 - Updated the `PageActions` example ([#2471](https://github.com/Shopify/polaris-react/pull/2471))
+- Fixed spacing of the `Filters` data table example ([#2477](https://github.com/Shopify/polaris-react/pull/2477))
+- Fixed duplicate and unclear prop descriptions of `EmptyState` ([#2477](https://github.com/Shopify/polaris-react/pull/2477))
 
 ### Development workflow
 

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -31,15 +31,6 @@ $illustration-width-cropped: calc(
   max-width: $page-max-width;
 }
 
-.imageContained {
-  .Image {
-    @include page-content-when-not-partially-condensed {
-      position: initial;
-      width: 100%;
-    }
-  }
-}
-
 .Section {
   position: relative;
   display: flex;
@@ -132,6 +123,15 @@ $illustration-width-cropped: calc(
       margin-top: 0;
       margin-left: $illustration-left-margin;
       width: $illustration-width;
+    }
+  }
+}
+
+.imageContained {
+  .Image {
+    @include page-content-when-not-partially-condensed {
+      position: initial;
+      width: 100%;
     }
   }
 }

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -14,11 +14,13 @@ import styles from './EmptyState.scss';
 export interface EmptyStateProps {
   /** The empty state heading */
   heading?: string;
-  /** The image to use for small screens */
+  /** The path to the image to display */
   image: string;
-  /** The image to use for large screens */
+  /** The path to the image to display on large screens */
   largeImage?: string;
-  /** The image to use for large screens */
+  /**
+   * Whether or not to limit the image to the size of its container on large screens.
+   */
   imageContained?: boolean;
   /** Elements to display inside empty state */
   children?: React.ReactNode;

--- a/src/components/Filters/README.md
+++ b/src/components/Filters/README.md
@@ -457,8 +457,8 @@ function DataTableFiltersExample() {
 
   return (
     <div style={{height: '568px'}}>
-      <Card sectioned>
-        <Card.Subsection>
+      <Card>
+        <Card.Section>
           <Filters
             queryValue={queryValue}
             filters={filters}
@@ -467,37 +467,35 @@ function DataTableFiltersExample() {
             onQueryClear={handleQueryValueRemove}
             onClearAll={handleFiltersClearAll}
           />
-        </Card.Subsection>
-        <Card.Subsection>
-          <DataTable
-            columnContentTypes={[
-              'text',
-              'numeric',
-              'numeric',
-              'numeric',
-              'numeric',
-            ]}
-            headings={[
-              'Product',
-              'Price',
-              'SKU Number',
-              'Net quantity',
-              'Net sales',
-            ]}
-            rows={[
-              ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
-              ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
-              [
-                'Navy Merino Wool Blazer with khaki chinos and yellow belt',
-                '$445.00',
-                124518,
-                32,
-                '$14,240.00',
-              ],
-            ]}
-            totals={['', '', '', 255, '$155,830.00']}
-          />
-        </Card.Subsection>
+        </Card.Section>
+        <DataTable
+          columnContentTypes={[
+            'text',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+          ]}
+          headings={[
+            'Product',
+            'Price',
+            'SKU Number',
+            'Net quantity',
+            'Net sales',
+          ]}
+          rows={[
+            ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+            ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+            [
+              'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+              '$445.00',
+              124518,
+              32,
+              '$14,240.00',
+            ],
+          ]}
+          totals={['', '', '', 255, '$155,830.00']}
+        />
       </Card>
     </div>
   );


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

#2475 Brought up that the `imageContained` prop description was a duplicate of the `largeImage` prop description, and that the `largeImage` and `image` prop descriptions are unclear. I also noticed that the spacing is off in the data table `Filters` thanks to a Slack thread earlier today.

### WHAT is this pull request doing?

- Fixes the spacing in the data table `Filters` example

|  Before | After  |
|---|---|
|<img width="786" alt="Screen Shot 2019-11-27 at 12 55 28 PM" src="https://user-images.githubusercontent.com/18447883/69747954-4a7e5480-1115-11ea-8655-76f9f0fec339.png">|<img width="780" alt="Screen Shot 2019-11-27 at 12 55 02 PM" src="https://user-images.githubusercontent.com/18447883/69747974-51a56280-1115-11ea-899d-1149925d5db3.png">|

- Fixes the `image`, `largeImage`, and `imageContained` prop descriptions of `EmptyState`
- Fixes the cascade order of the `.imageContained` class of `EmptyState`, which wasn't being applied due to the rearrangement of the styles that just shipped in #1570. 

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

- `git checkout doc-fixes && yarn dev`, Storybook will open automatically.
- Check the spacing of the "Filtering with a data table" example (screenshot above)
- Navigate the Playground in Storybook
    - Copy and paste the playground code collapsed below into `/playground/Playground.tsx`
    - Click the "Toggle image contained" secondary action to see the `imageContained` prop working as expected

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';
import {Page, EmptyState} from '../src';

export function Playground() {
  const [imageContained, setImageContained] = useState(false);
  const toggleImageContained = useCallback(
    () => setImageContained((imageContained) => !imageContained),
    [],
  );

  return (
    <Page
      title="Playground"
      secondaryActions={[
        {content: 'Toggle image contained', onAction: toggleImageContained},
      ]}
    >
      <EmptyState
        imageContained={imageContained}
        heading="Manage your inventory transfers"
        action={{content: 'Add transfer'}}
        secondaryAction={{
          content: 'Learn more',
          url: 'https://help.shopify.com',
        }}
        image="https://cdn.shopify.com/s/files/1/0757/9955/files/empty-state.svg"
      >
        <p>Track and receive your incoming inventory from suppliers.</p>
      </EmptyState>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
