### PR TITLE
Fixup stylelint setup in VSCode after plugin changes

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,7 @@
     "dbaeumer.vscode-eslint",
     "EditorConfig.editorconfig",
     "esbenp.prettier-vscode",
-    "mrmlnc.vscode-scss",
-    "shinnn.stylelint"
+    "hex-ci.stylelint-plus",
+    "mrmlnc.vscode-scss"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,6 +44,6 @@
     "styles/": true,
     "types/": true
   },
-  "stylelint.enable": true,
+  "stylelint.autoFixOnSave": true,
   "typescript.tsdk": "./node_modules/typescript/lib"
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The shinn.stylelint extension has been removed from the marketplace,
suggest using hex-ci.stylelint-plus instead as it is a an up-to-date
fork that adds autofixing - this removes an error saying "you're trying to
recommend a non-existent extension".

Add style autofixing config to vscode. This ensures autofixable
stylelint rules are fixed on save. This stopped working recently when
the prettier extension changed how it handled stylelint integration (it
now suggests using the autofixing built into the stylelint-plus and
eslint extensions directly)

### WHAT is this pull request doing?

Updates VSCode workspace settings

### How to 🎩

Remove your locally installed version of `shinn.stylelint` in vscode and instead install [hex-ci.stylelint-plus](https://marketplace.visualstudio.com/items?itemName=hex-ci.stylelint-plus)

To test formatting on save works you'll need a stylelint rule that can be autofixable but prettier doesn't care about. I suggest [selector-pseudo-element-colon-notation](https://stylelint.io/user-guide/rules/selector-pseudo-element-colon-notation) where writing `.thing:before` should autofix to `.thing::before`