### PR TITLE
add pre-commit hook to generate new color docs if the source changes

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -27,7 +27,7 @@ module PreCommit
   def generate_color_docs
     changed_files.each do |path|
       if COLOR_DOC_SOURCE_FILE_PATHS.include? path
-        puts "Color system changes detected. Generating new docs..."
+        puts "Color system changes detected. Generating new docs (may take a couple minutes)..."
         %x(yarn run colordocs)
         %x(git add "documentation/Color system.md")
       end

--- a/pre-commit
+++ b/pre-commit
@@ -1,12 +1,14 @@
 #!/usr/bin/ruby --disable-gems
 
 NON_COMMITTABLE_FILE_PATHS = ['playground/Playground.tsx']
+COLOR_DOC_SOURCE_FILE_PATHS = ['src/utilities/theme/role-variants.ts']
 
 module PreCommit
   extend self
 
   def main
     ignore_playground
+    generate_color_docs
   end
 
   private
@@ -18,6 +20,16 @@ module PreCommit
         puts "Please remove changes from #{path} before committing"
         puts "Or run `git update-index --assume-unchanged #{path}` to git ignore this file"
         abort "Use `git commit --no-verify` to force add this file"
+      end
+    end
+  end
+
+  def generate_color_docs
+    changed_files.each do |path|
+      if COLOR_DOC_SOURCE_FILE_PATHS.include? path
+        puts "Color system changes detected. Generating new docs..."
+        %x(yarn run colordocs)
+        %x(git add "documentation/Color system.md")
       end
     end
   end


### PR DESCRIPTION
This will run `yarn colordocs` and add the updated docs when committing a change to `role-variants.ts`