### PR TITLE
[Popover] Add fluidContent prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@
 - `Page` no longer renders navigation or actions in print mode ([#2469](https://github.com/Shopify/polaris-react/pull/2469))
 - Added an `emptyState` prop to `ResourceList` ([#2160](https://github.com/Shopify/polaris-react/pull/2160))
 - Migrated `Dropzone` to a functional component and reduce complexity ([#2360](https://github.com/Shopify/polaris-react/pull/2360))
+- Added `fluidContent` prop to `Popover` ([#2494](https://github.com/Shopify/polaris-react/pull/2494))
 
 ### Bug fixes
 

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -86,6 +86,11 @@ $content-max-width: rem(400px);
   max-height: none;
 }
 
+.Content-fluidContent {
+  max-height: none;
+  max-width: none;
+}
+
 .Pane {
   flex: 1 1 0%;
   max-width: 100%;

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -41,6 +41,8 @@ export interface PopoverProps {
   fullWidth?: boolean;
   /** Allow popover to stretch to fit content vertically */
   fullHeight?: boolean;
+  /** Allow popover content to determine the overlay width/height */
+  fluidContent?: boolean;
   /** Remains in a fixed position */
   fixed?: boolean;
   /** Used to illustrate the type of popover element */

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -41,7 +41,7 @@ export interface PopoverProps {
   fullWidth?: boolean;
   /** Allow popover to stretch to fit content vertically */
   fullHeight?: boolean;
-  /** Allow popover content to determine the overlay width/height */
+  /** Allow popover content to determine the overlay width and height */
   fluidContent?: boolean;
   /** Remains in a fixed position */
   fixed?: boolean;

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -40,6 +40,7 @@ export interface PopoverOverlayProps {
   children?: React.ReactNode;
   fullWidth?: boolean;
   fullHeight?: boolean;
+  fluidContent?: boolean;
   preferredPosition?: PreferredPosition;
   preferredAlignment?: PreferredAlignment;
   active: boolean;
@@ -179,7 +180,14 @@ export class PopoverOverlay extends React.PureComponent<
   private renderPopover = (overlayDetails: OverlayDetails) => {
     const {measuring, desiredHeight, positioning} = overlayDetails;
 
-    const {id, children, sectioned, fullWidth, fullHeight} = this.props;
+    const {
+      id,
+      children,
+      sectioned,
+      fullWidth,
+      fullHeight,
+      fluidContent,
+    } = this.props;
 
     const className = classNames(
       styles.Popover,
@@ -193,6 +201,7 @@ export class PopoverOverlay extends React.PureComponent<
     const contentClassNames = classNames(
       styles.Content,
       fullHeight && styles['Content-fullHeight'],
+      fluidContent && styles['Content-fluidContent'],
     );
 
     const content = (

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -159,6 +159,19 @@ describe('<Popover />', () => {
     expect(popoverOverlay.prop('fullWidth')).toBe(true);
   });
 
+  it('passes fluidContent to PopoverOverlay', () => {
+    const popover = mountWithAppProvider(
+      <Popover
+        active
+        fluidContent
+        activator={<div>Activator</div>}
+        onClose={spy}
+      />,
+    );
+    const popoverOverlay = findByTestID(popover, 'popoverOverlay');
+    expect(popoverOverlay.prop('fluidContent')).toBe(true);
+  });
+
   it('calls onClose when you click outside the Popover', () => {
     mountWithAppProvider(
       <Popover


### PR DESCRIPTION
### WHY are these changes introduced?

Consumers may want their `<Popover />` to be wider or taller than its current max width and max height.

My use case is for fitting a multi-month `<DatePicker />` inside of a `<Popover />`, which currently doesn't fit.

### WHAT is this pull request doing?

Adds a `fluidContent` prop (taken from @joshuajay 's fork in Shopify admin :pray:) that lets the popover's content determine its width and height.

**Before**
![image](https://user-images.githubusercontent.com/2354121/70086081-9c285280-15df-11ea-9a83-d7fb2dce613f.png)

**After**
![image](https://user-images.githubusercontent.com/2354121/70086217-e8739280-15df-11ea-9af4-8d6ddc2d89dd.png)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';
import {Page, Popover, Button, ActionList, DatePicker, Banner} from '../src';

export function Playground() {
  const [active, setActive] = useState(false);
  const togglePopoverActive = () =>
    setActive((popoverActive) => !popoverActive);

  // normal content
  // const content = <p>Hello</p>;

  // wide content
  const content = <DatePicker month={0} year={2020} multiMonth />;

  // tall content
  // const content = [...Array(10).keys()].map((key) => <Banner key={key} />);

  return (
    <Page title="Playground">
      <Popover
        active={active}
        activator={
          <Button onClick={togglePopoverActive}>Toggle popover</Button>
        }
        onClose={togglePopoverActive}
        fluidContent
      >
        <Popover.Pane>
          <Popover.Section>{content}</Popover.Section>
        </Popover.Pane>
      </Popover>
    </Page>
  );
}


```

</details>

### 🎩 checklist

* [X] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [X] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [X] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes — did not update; README does not include info on other similar props
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [N/A] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
