### PR TITLE
[ActionMenu] Applied color system

### DIFF
--- a/src/components/ActionMenu/components/MenuAction/MenuAction.scss
+++ b/src/components/ActionMenu/components/MenuAction/MenuAction.scss
@@ -13,8 +13,9 @@ $difference-between-touch-area-and-backdrop: control-height() -
   padding: 0 $menu-action-padding-x;
   min-height: control-height();
   text-decoration: none;
-  color: color('ink', 'light');
+  color: var(--p-text, color('ink', 'light'));
 
+  // Start - Delete below me when rolling out global theming
   &:hover,
   &:active {
     color: color('ink');
@@ -56,6 +57,67 @@ $difference-between-touch-area-and-backdrop: control-height() -
       @include recolor-icon(color('ink', 'lightest'));
     }
   }
+  // End - Delete after me when rolling out global theming
+
+  &.globalTheming {
+    border-radius: var(--p-border-radius-base);
+
+    &:hover {
+      background: var(--p-action-secondary-hovered);
+    }
+
+    &:focus {
+      background-color: transparent;
+    }
+
+    // stylelint-disable-next-line selector-max-specificity
+    &:focus:not(:active) {
+      @include focus-ring;
+    }
+
+    &:active {
+      background: var(--p-action-secondary-pressed);
+    }
+
+    &.disabled {
+      color: var(--p-text-disabled);
+      cursor: default;
+      pointer-events: none;
+
+      // stylelint-disable-next-line selector-max-specificity
+      .IconWrapper {
+        @include recolor-icon(var(--p-icon-disabled));
+      }
+    }
+
+    .IconWrapper {
+      @include recolor-icon(--p-icon);
+    }
+
+    // Start - overrides than can be deleted during global theming rollout
+    &:hover,
+    &:active {
+      color: var(--p-text);
+
+      // stylelint-disable-next-line selector-max-specificity
+      .IconWrapper {
+        @include recolor-icon(var(--p-icon));
+      }
+    }
+
+    &:focus,
+    &:active {
+      // stylelint-disable-next-line selector-max-specificity
+      &::after {
+        background: transparent;
+      }
+    }
+
+    &::after {
+      height: auto;
+    }
+    // End - overrides than can be deleted during global theming rollout
+  }
 }
 
 .ContentWrapper {
@@ -64,7 +126,10 @@ $difference-between-touch-area-and-backdrop: control-height() -
 }
 
 .IconWrapper {
-  @include recolor-icon(color('ink', 'lighter'), color('white'));
+  @include recolor-icon(
+    var(--p-icon, color('ink', 'lighter')),
+    var(--p-override-transparent, color('white'))
+  );
   display: inline-block;
 
   &:first-child {
@@ -81,6 +146,6 @@ $difference-between-touch-area-and-backdrop: control-height() -
   }
 
   &.disabled {
-    @include recolor-icon(color('ink', 'lightest'));
+    @include recolor-icon(var(--p-icon-disabled, color('ink', 'lightest')));
   }
 }

--- a/src/components/ActionMenu/components/MenuAction/MenuAction.tsx
+++ b/src/components/ActionMenu/components/MenuAction/MenuAction.tsx
@@ -3,6 +3,7 @@ import {CaretDownMinor} from '@shopify/polaris-icons';
 
 import {classNames} from '../../../../utilities/css';
 import {handleMouseUpByBlurring} from '../../../../utilities/focus';
+import {useFeatures} from '../../../../utilities/features';
 import {ComplexAction} from '../../../../types';
 
 import {Icon} from '../../../Icon';
@@ -25,6 +26,8 @@ export function MenuAction({
   disabled,
   onAction,
 }: MenuActionProps) {
+  const {unstableGlobalTheming} = useFeatures();
+
   const iconMarkup = icon && (
     <span className={styles.IconWrapper}>
       <Icon source={icon} />
@@ -50,6 +53,7 @@ export function MenuAction({
 
   const menuActionClassNames = classNames(
     styles.MenuAction,
+    unstableGlobalTheming && styles.globalTheming,
     disabled && styles.disabled,
   );
 

--- a/src/components/ActionMenu/components/MenuAction/tests/MenuAction.test.tsx
+++ b/src/components/ActionMenu/components/MenuAction/tests/MenuAction.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {CaretDownMinor, SaveMinor} from '@shopify/polaris-icons';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {Icon} from '../../../../Icon';
 import {UnstyledLink} from '../../../../UnstyledLink';
@@ -117,6 +118,26 @@ describe('<MenuAction />', () => {
       trigger(wrapper.find('button'), 'onClick');
 
       expect(onActionSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('globalTheming', () => {
+    it('adds a global theming class when global theming is enabled', () => {
+      const menuAction = mountWithApp(<MenuAction />, {
+        features: {unstableGlobalTheming: true},
+      });
+      expect(menuAction).toContainReactComponent('button', {
+        className: 'MenuAction globalTheming',
+      });
+    });
+
+    it('does not add a global theming class when global theming is disabled', () => {
+      const menuAction = mountWithApp(<MenuAction />, {
+        features: {unstableGlobalTheming: true},
+      });
+      expect(menuAction).toContainReactComponent('button', {
+        className: 'MenuAction globalTheming',
+      });
     });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes *partly* https://github.com/Shopify/polaris-ux/issues/332

### Screenies
#### Regular 
<img width="634" alt="Screen Shot 2020-01-09 at 1 00 07 PM" src="https://user-images.githubusercontent.com/24610840/72110695-db487280-3306-11ea-9040-0236e2331eeb.png">
<img width="647" alt="Screen Shot 2020-01-09 at 1 00 17 PM" src="https://user-images.githubusercontent.com/24610840/72110698-dd123600-3306-11ea-88dd-76fe3c272aad.png">

#### Subdued
<img width="620" alt="Screen Shot 2020-01-09 at 1 00 32 PM" src="https://user-images.githubusercontent.com/24610840/72110706-e3081700-3306-11ea-9608-5dad361f0407.png">
<img width="531" alt="Screen Shot 2020-01-09 at 12 59 54 PM" src="https://user-images.githubusercontent.com/24610840/72110708-e4d1da80-3306-11ea-99fd-4a012e204c5a.png">

I wasn't sure if I should go with `-p-text/icon` or `-p-text/icon-subdued` and Figma hasn't been updated with `Page` yet. @allylane Johan mentioned you might have the context to answer this. What are your thoughts?
