### PR TITLE
[CheckableButton] add border-right when there are no actions

### DIFF
--- a/src/components/ResourceList/components/CheckableButton/CheckableButton.scss
+++ b/src/components/ResourceList/components/CheckableButton/CheckableButton.scss
@@ -22,11 +22,15 @@ $chekbox-label-margin: rem(20px);
   text-align: left;
   background: transparent;
   border: var(--p-override-none, border(dark));
-  border-radius: var(--p-border-radius-base, border-radius()) 0 0
-    var(--p-border-radius-base, border-radius());
-  border-right: none;
+  border-radius: var(--p-border-radius-base, border-radius());
   width: 100%;
   box-shadow: var(--p-override-none, shadow(faint));
+
+  [data-buttongroup-segmented] & {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right: none;
+  }
 
   &.globalTheming {
     @include recolor-icon(var(--p-icon-on-surface));


### PR DESCRIPTION
As part of https://github.com/Shopify/polaris-react/pull/2467 I missed the use case where we can have a selectable list without actions. In which case the border right was missing. 

### WHY are these changes introduced?

Using the button group selector we remove the border.

### WHAT is this pull request doing?

Using the button group selector we remove the border.

![checkable](https://user-images.githubusercontent.com/1229901/70239497-6d25f400-1739-11ea-9486-f0f914defb1b.gif)


### How to 🎩

In Storybook ensure these 2 examples render as expected (while selected):

- Resource list with selection and no bulk actions
- Resource list with bulk actions


🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
