### PR TITLE
[Color System] Style the RangeSlider's track

### DIFF
--- a/src/components/RangeSlider/RangeSlider.scss
+++ b/src/components/RangeSlider/RangeSlider.scss
@@ -1,0 +1,21 @@
+$range-track-height: rem(4px);
+$range-thumb-size: rem(24px);
+
+@mixin track-dashed {
+  $borderRadius: var(--p-border-radius-base, border-radius());
+  $dashedTrackColor: var(--p-border-secondary);
+  content: '';
+  position: absolute;
+  height: $range-track-height;
+  width: 100%;
+  background-image: linear-gradient(
+    to right,
+    $dashedTrackColor,
+    $dashedTrackColor 50%,
+    transparent 50%,
+    transparent 100%
+  );
+  background-size: $range-track-height $range-track-height;
+  border-radius: $borderRadius;
+  border-right: $borderRadius $dashedTrackColor solid;
+}

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -1,4 +1,5 @@
 @import '../../../../styles/common';
+@import '../../RangeSlider';
 
 $stacking-order: (
   output: 10,
@@ -6,8 +7,6 @@ $stacking-order: (
 );
 
 $range-wrapper: rem(28px);
-$range-track-height: rem(4px);
-$range-thumb-size: rem(24px);
 
 $range-thumb-border-error: rem(2px) solid color('red');
 
@@ -39,12 +38,13 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
 
 .Track {
   position: absolute;
+  z-index: 1;
   width: 100%;
   height: $range-track-height;
   border-radius: $range-thumb-size;
 
-  --unselected-range: #{color('sky', 'dark')};
-  --selected-range: #{color('indigo')};
+  --unselected-range: #{var(--p-override-transparent, color('sky', 'dark'))};
+  --selected-range: #{var(--p-action-interactive, color('indigo'))};
   --gradient-colors: var(--unselected-range, transparent) 0%,
     var(--unselected-range, transparent)
       var(--Polaris-RangeSlider-progress-lower),
@@ -56,7 +56,7 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
   background-image: linear-gradient(to right, var(--gradient-colors));
 
   .error & {
-    --selected-range: #{color('red')};
+    --selected-range: #{var(--p-action-critical, color('red'))};
     --gradient-colors: var(--unselected-range, transparent) 0%,
       var(--unselected-range, transparent)
         var(--Polaris-RangeSlider-progress-lower),
@@ -72,8 +72,12 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
 
   .disabled & {
     background-image: none;
-    background: color('sky', 'dark');
+    background: var(--p-border-secondary-disabled, color('sky', 'dark'));
   }
+}
+
+.Track--dashed {
+  @include track-dashed;
 }
 
 .Thumbs {

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -240,6 +240,7 @@ export class DualThumb extends React.Component<DualThumbProps, State> {
                 ref={this.track}
                 testID="track"
               />
+              <div className={styles['Track--dashed']} />
               <button
                 id={idLower}
                 className={thumbLowerClassName}

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -1,12 +1,11 @@
 @import '../../../../styles/common';
+@import '../../RangeSlider';
 
 $stacking-order: (
   output: 10,
   input: 20,
 );
 
-$range-track-height: rem(4px);
-$range-thumb-size: rem(24px);
 $range-thumb-shadow: (0 0 0 rem(1px) rgba(black, 0.2), shadow(faint));
 $range-thumb-shadow-hover: (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint));
 $range-thumb-shadow-error: 0 0 0 rem(1px) color('red');
@@ -33,6 +32,10 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
     background-color: transparent;
     cursor: pointer;
   }
+
+  &::after {
+    @include track-dashed;
+  }
 }
 
 .disabled {
@@ -52,8 +55,8 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
 }
 
 .Input {
-  --progress-lower: #{color('indigo')};
-  --progress-upper: #{color('sky', 'dark')};
+  --progress-lower: #{var(--p-action-interactive, color('indigo'))};
+  --progress-upper: #{var(--p-override-transparent, color('sky', 'dark'))};
   // create-react-app v2 leverages postcss-preset-env to transpile modern CSS
   // into something kinda supported by older browsers. Unfortunatly its
   // custom properties transpiler has a bug that means it doesn't like multiple
@@ -80,7 +83,6 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
     cursor: pointer;
     width: 100%;
     height: $range-track-height;
-    background-color: var(--progress-upper, color('sky', 'dark'));
     background-image: linear-gradient(to right, var(--gradient-colors));
     border: none;
     border-radius: $range-track-height;
@@ -119,10 +121,10 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
   }
 
   .error & {
-    --progress-lower: #{color('red')};
+    --progress-lower: #{var(--p-action-critical, color('red'))};
 
     @include range-track-selectors {
-      background-color: color('red', 'light');
+      background-color: var(--p-override-none, color('red', 'light'));
     }
 
     @include range-thumb-selectors {
@@ -135,6 +137,10 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
     @include range-track-selectors {
       cursor: auto;
       background-image: none;
+      background-color: var(
+        --p-border-secondary-disabled,
+        color('sky', 'dark')
+      );
     }
 
     @include range-thumb-selectors {
@@ -144,10 +150,6 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
   }
 
   &:focus {
-    @include range-track-selectors {
-      background-color: color('sky', 'dark');
-    }
-
     @include range-thumb-selectors {
       background: linear-gradient(
         color('sky', 'lighter'),


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-ux/issues/358

This PR implements the color system into the `RangeSlider's` track. The reason for this separation is so that we can break the `RangeSlider` into multiple PRs since there are a lot of new changes being applied. The thumb will be modified in a follow up PR.

### Single thumb:

|     -   |   Light         | Dark |
| ------------- |:-------------:| -----|
|     Regular     |       ![image](https://user-images.githubusercontent.com/22782157/72177381-8b24eb00-33ae-11ea-9340-9236bc96d41a.png) |   ![image](https://user-images.githubusercontent.com/22782157/72177396-90823580-33ae-11ea-86dd-dd77a6bacaf0.png)   |
|        Error      |       ![image](https://user-images.githubusercontent.com/22782157/72177443-ad1e6d80-33ae-11ea-811e-bffe08d64c7e.png)    |   ![image](https://user-images.githubusercontent.com/22782157/72177506-cfb08680-33ae-11ea-8ab9-cd92f60a7015.png)|
|        Disabled      |    ![image](https://user-images.githubusercontent.com/22782157/72177554-e951ce00-33ae-11ea-935e-1f64c97a72d2.png)    |   ![image](https://user-images.githubusercontent.com/22782157/72177548-e656dd80-33ae-11ea-9f8d-98a827dc08b5.png)   |

### Dual thumb:

|     -   |   Light         | Dark |
| ------------- |:-------------:| -----|
|     Regular     |      ![image](https://user-images.githubusercontent.com/22782157/72177792-76952280-33af-11ea-8ff6-02ceaf2c20b1.png)     |   ![image](https://user-images.githubusercontent.com/22782157/72177788-73019b80-33af-11ea-895b-c58cf231535e.png)   |
|        Error      |      ![image](https://user-images.githubusercontent.com/22782157/72177778-6ed57e00-33af-11ea-8d12-876f08d2856a.png)    |   ![image](https://user-images.githubusercontent.com/22782157/72177771-6aa96080-33af-11ea-80a2-eaa5d8f0a330.png) |
|        Disabled      |      ![image](https://user-images.githubusercontent.com/22782157/72177758-654c1600-33af-11ea-8aae-42923e660aca.png)      |   ![image](https://user-images.githubusercontent.com/22782157/72177742-5c5b4480-33af-11ea-935e-2f6b148f126d.png)  |
### WHAT is this pull request doing?

- Implements the design found in [Figma.](https://www.figma.com/file/4dAAt5iFPSaxUKiYVKrkYj/DL%E2%80%93Polaris-(Web)%3A-Components?node-id=2182%3A216)
- Renders a dashed track which is visible by making the original, unselected track transparent.
- <del>Adds some new neutral action border variables.</del> Makes use of existing `secondary border` variants.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)
