### PR TITLE
[TrapFocus] Convert TrapFocus to a functional component and fix tab focusing

### DIFF
--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -55,7 +55,7 @@ export function TrapFocus({trapping = true, children}: TrapFocusProps) {
 
   const handleKeyDownFirstElement = (event: any) => {
     if (event.keyCode === Key.Tab && focusTrapWrapper.current) {
-      event.shiftKey && focusLastFocusableNode(focusTrapWrapper.current);
+      event.shiftKey && focusFirstFocusableNode(focusTrapWrapper.current);
 
       document.removeEventListener('keydown', handleKeyDownFirstElement);
     }
@@ -68,25 +68,21 @@ export function TrapFocus({trapping = true, children}: TrapFocusProps) {
       return;
     }
 
-    const firstElement = findFirstFocusableNode(
-      findFirstFocusableNode(
-        focusTrapWrapper.current as HTMLElement,
-      ) as HTMLElement,
-    );
+    if (focusTrapWrapper.current) {
+      const firstElement = findFirstFocusableNode(
+        findFirstFocusableNode(
+          focusTrapWrapper.current as HTMLElement,
+        ) as HTMLElement,
+      );
 
-    if (
-      focusTrapWrapper.current &&
-      relatedTarget === findLastFocusableNode(focusTrapWrapper.current)
-    ) {
-      document.addEventListener('keydown', handleKeyDownLastElement);
-    }
+      relatedTarget === findLastFocusableNode(focusTrapWrapper.current) &&
+        document.addEventListener('keydown', handleKeyDownLastElement);
 
-    if (focusTrapWrapper.current && relatedTarget === firstElement) {
-      document.addEventListener('keydown', handleKeyDownFirstElement);
+      relatedTarget === firstElement &&
+        document.addEventListener('keydown', handleKeyDownFirstElement);
     }
 
     if (
-      focusTrapWrapper &&
       focusTrapWrapper.current &&
       !focusTrapWrapper.current.contains(relatedTarget as HTMLElement) &&
       (!relatedTarget ||


### PR DESCRIPTION
### What problem is this solving?

- Converts `TrapFocus` to a functional component
- Fixes the issue where tabbing past the last element should focus the first element (and likewise)

### How is this accomplished?

Add event listeners for `keydown` and focus an element depending if shift is pressed or not. There are two separate functions `handleKeyDownLastElement` and `handleKeyDownFirstElement` because there is a distinction between the first and last element and which should react to the shift key.

### Notes

- Noticing some weird tabbing in Storybook on Safari, though the issue seems to exist on master as well. Pressing tab interacts with the search bar making it difficult to tab through the page content. This also doesn't seem to be an issue with specifically `TrapFocus` because it also opens the search bar with components such as `ButtonGroup`.
- `focusTrapWrapper` is the div around the modal

- The following functions find different scopes:

```js
const component = <div><modal>*</modal></div>;
findFirstFocusableNode(component) = will find the modal
findLastFocusableNode(component) = will find the content (*)
```

### To-do:

- [ ] Add more tests to address codecov
- [ ] 🎩on Safari outside of Storybook
- [ ] Add a test for finding the `firstElement` (if component to be trapped has vs does not have a container)