### PR TITLE
[DropZone] Prevent dropzone border from showing on focus when disabled

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 
+- Fixed a bug where `DropZone` would show an outline on drag when `outline` is false ([#2527](https://github.com/Shopify/polaris-react/pull/2527))
 - Fixed a bug where `Navigation` calls `onNavigationDismiss` on large screens when focused and the escape key is pressed ([#2607](https://github.com/Shopify/polaris-react/pull/2607))
 - Fixed issue with `Filters` component displaying an undesired margin top and bottom on the button element on Safari ([#2292](https://github.com/Shopify/polaris-react/pull/2292))
 - Doesn't render `MenuActions` if no actions are passed to an `actionGroups` item inside `Page` ([#2266](https://github.com/Shopify/polaris-react/pull/2266))

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -67,7 +67,7 @@ $dropzone-stacking-order: (
   &:not(.isDisabled) {
     background-color: $dropzone-overlay-background;
 
-    &::after {
+    &.hasOutline::after {
       border: border-width(thick) $dropzone-border-style
         $dropzone-overlay-border-color;
 

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -83,6 +83,7 @@ $dropzone-stacking-order: (
   &:not(.isDisabled) {
     background-color: $dropzone-overlay-background;
 
+    // stylelint-disable-next-line selector-max-specificity
     &.hasOutline::after {
       border-color: $dropzone-overlay-border-color;
     }

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -67,7 +67,7 @@ $dropzone-stacking-order: (
   &:not(.isDisabled) {
     background-color: $dropzone-overlay-background;
 
-    &.hasOutline::after {
+    &::after {
       border: border-width(thick) $dropzone-border-style
         $dropzone-overlay-border-color;
 
@@ -83,7 +83,7 @@ $dropzone-stacking-order: (
   &:not(.isDisabled) {
     background-color: $dropzone-overlay-background;
 
-    &::after {
+    &.hasOutline::after {
       border-color: $dropzone-overlay-border-color;
     }
   }
@@ -92,7 +92,7 @@ $dropzone-stacking-order: (
 .isDisabled {
   cursor: not-allowed;
 
-  &::after {
+  &.hasOutline::after {
     border-color: $dropzone-border-color-disabled;
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes #2390

We need to prevent the Dropzone from showing a border when the `outline` prop is false. 

Currently, it is still shown within the `.isDragging` and `.isDisabled` classes despite `outline` being false.

### WHAT is this pull request doing?

Scoping CSS within `.isDragging` and `.isDisabled` to only show a border when `outline` is true.

### Reproduction steps 🎩
- Add a dropzone component to your playground
- Set the `outline` prop to `false`
- Set `active` to `true` (the `active` prop triggers the `. isDragging` class)

### How to 🎩
- Follow the reproduction steps above
- Ensure no outline is shown around the DropZone

### Screenshots 📸 
![gif](https://user-images.githubusercontent.com/12142249/72368115-6b9e0300-36cb-11ea-93b6-ed11eae2fccc.gif)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
