### PR TITLE
[TrapFocus] Don't trap the focus if the relatedTarget is null

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+- Fixed a regression in `TrapFocus` that prevented focus outside of an `iframe` ([#2530](https://github.com/Shopify/polaris-react/pull/2530))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -73,7 +73,7 @@ export class TrapFocus extends React.PureComponent<TrapFocusProps, State> {
     const {focusTrapWrapper} = this;
     const {trapping = true} = this.props;
 
-    if (trapping === false) {
+    if (relatedTarget == null || trapping === false) {
       return;
     }
 

--- a/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -8,10 +8,6 @@ import {
   TextField,
   Button,
 } from 'components';
-import {
-  findFirstFocusableNode,
-  findLastFocusableNode,
-} from '@shopify/javascript-utilities/focus';
 import {TrapFocus} from '../TrapFocus';
 
 describe('<TrapFocus />', () => {
@@ -96,48 +92,10 @@ describe('<TrapFocus />', () => {
       .find('button')
       .getDOMNode();
 
-    const trapFocus = mountWithAppProvider(
-      <TrapFocus>
-        <TextField label="" value="" onChange={noop} autoFocus />
-        <TextField label="" value="" onChange={noop} autoFocus />
-      </TrapFocus>,
-    );
-
     const event: FocusEvent = new FocusEvent('focusout', {
       relatedTarget: externalDomNode,
     });
     Object.assign(event, {preventDefault: jest.fn()});
-
-    describe('prevents default when focus moves to an external node', () => {
-      let rafSpy: jest.SpyInstance;
-
-      beforeEach(() => {
-        rafSpy = jest.spyOn(window, 'requestAnimationFrame');
-        rafSpy.mockImplementation((callback) => callback());
-      });
-
-      afterEach(() => {
-        rafSpy.mockRestore();
-      });
-
-      it('has one focusable node', () => {
-        trigger(trapFocus.find(EventListener), 'handler', {
-          ...event,
-          srcElement: findFirstFocusableNode(trapFocus.getDOMNode()),
-        });
-
-        expect(event.preventDefault).toHaveBeenCalled();
-      });
-
-      it('it has multiple focusable nodes', () => {
-        trigger(trapFocus.find(EventListener), 'handler', {
-          ...event,
-          srcElement: findLastFocusableNode(trapFocus.getDOMNode()),
-        });
-
-        expect(event.preventDefault).toHaveBeenCalled();
-      });
-    });
 
     it('allows default when trapping is false', () => {
       const trapFocus = mountWithAppProvider(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/polaris-react/issues/2531

We initially removed this line so that we could trap focus within a container, even if focus leaves the page content (or an iframe).

Although this is not a breaking change on its own, it causes a bug with the style guide which disallows the user to interact with the rest of the page such as the examples drop down and the search bar.

We'll be fixing `TrapFocus` in another PR which handles keyboard inputs instead of handling when focus leaves the container.

<!--
  Context about the problem that’s being addressed.
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Follow [these](https://github.com/Shopify/polaris-react/blob/6579045fbbf668b8f1624631cd5c7f609f4bff57/documentation/Tophatting%20documentation.md#how-to--documentation) instructions to test the style guide.

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the [Polaris UI kit](https://polaris.shopify.com/resources/polaris-ui-kit)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
