### PR TITLE
[Dropzone] Removed reference to window

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+- Removed reference to `window` in `DropZone` ([#2532](https://github.com/Shopify/polaris-react/pull/2532))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -300,7 +300,7 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
   useEventListener(dropNode, 'dragover', handleDragOver);
   useEventListener(dropNode, 'dragenter', handleDragEnter);
   useEventListener(dropNode, 'dragleave', handleDragLeave);
-  useEventListener(window, 'resize', adjustSize);
+  useEventListener(null, 'resize', adjustSize, {}, {defaultToWindow: true});
 
   useComponentDidMount(() => {
     adjustSize();

--- a/src/utilities/tests/use-event-listener.test.tsx
+++ b/src/utilities/tests/use-event-listener.test.tsx
@@ -72,4 +72,22 @@ describe('useEventListener', () => {
     component.unmount();
     expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('defaults to window when the option is set', () => {
+    const spy = jest.fn();
+    function Component() {
+      const div = useRef<HTMLDivElement>(null);
+
+      useEventListener(div, 'blur', spy, {}, {defaultToWindow: true});
+
+      useEffect(() => {
+        window.dispatchEvent(new Event('blur'));
+      });
+
+      return <div />;
+    }
+
+    mount(<Component />);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Removing all reference to `window` on code that can execute on the client