### PR TITLE
Enzyme tidying

### DIFF
--- a/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
+++ b/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
-import {ReactWrapper} from 'enzyme';
 import {SaveMinor} from '@shopify/polaris-icons';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
+import {
+  mountWithAppProvider,
+  trigger,
+  ReactWrapper,
+} from 'test-utilities/legacy';
 
 import {Popover, ActionList} from 'components';
 import {MenuAction} from '../../MenuAction';

--- a/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
+++ b/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
-import {ReactWrapper} from 'enzyme';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
+import {
+  mountWithAppProvider,
+  trigger,
+  ReactWrapper,
+} from 'test-utilities/legacy';
 
 import {Button, Popover} from 'components';
 
@@ -13,8 +16,6 @@ import {
 } from '../../../../ActionList/components';
 
 import {RollupActions, RollupActionsProps} from '../RollupActions';
-
-type Wrapper = ReactWrapper<RollupActionsProps, any>;
 
 describe('<RollupActions />', () => {
   const mockProps = {
@@ -100,13 +101,13 @@ describe('<RollupActions />', () => {
   });
 });
 
-function findPopoverActivator(wrapper: Wrapper) {
+function findPopoverActivator(wrapper: ReactWrapper<RollupActionsProps>) {
   return wrapper
     .find(Button)
     .filterWhere((button) => button.prop('icon') === HorizontalDotsMinor);
 }
 
-function activatePopover(wrapper: Wrapper) {
+function activatePopover(wrapper: ReactWrapper<RollupActionsProps>) {
   const activator = findPopoverActivator(wrapper);
   trigger(activator, 'onClick');
 }

--- a/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
+++ b/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import {shallow} from 'enzyme';
 import {OptionList, ActionList, Popover} from 'components';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
+import {mountWithAppProvider, shallow, trigger} from 'test-utilities/legacy';
 import {TextField} from '../../TextField';
 import {Key} from '../../../../../types';
 import {ComboBox} from '..';

--- a/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
+++ b/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import {OptionList, ActionList, Popover} from 'components';
+import {mountWithApp} from 'test-utilities';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, shallow, trigger} from 'test-utilities/legacy';
+import {mountWithAppProvider} from 'test-utilities/legacy';
 import {TextField} from '../../TextField';
 import {Key} from '../../../../../types';
 import {ComboBox} from '..';
@@ -390,7 +391,7 @@ describe('<ComboBox/>', () => {
   describe('onEndReached', () => {
     it('gets called when the end of the option list is reached', () => {
       const spy = jest.fn();
-      const comboBox = shallow(
+      const comboBox = mountWithApp(
         <ComboBox
           options={options}
           selected={[]}
@@ -400,9 +401,10 @@ describe('<ComboBox/>', () => {
         />,
       );
 
-      const pane = comboBox.find(Popover.Pane);
-      trigger(pane, 'onScrolledToBottom');
+      // Focus the combobox so that the popover pane is rendered
+      comboBox.find('div', {role: 'combobox'})!.trigger('onFocus');
 
+      comboBox.find(Popover.Pane)!.trigger('onScrolledToBottom');
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -7,7 +7,6 @@ import {
   CircleInformationMajorTwotone,
   FlagMajorTwotone,
 } from '@shopify/polaris-icons';
-import {ReactWrapper} from 'enzyme';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {BannerContext} from 'utilities/banner-context';
@@ -54,16 +53,12 @@ describe('<Banner />', () => {
   it('disables aria-live when stopAnnouncements is enabled', () => {
     const politeBanner = mountWithAppProvider(<Banner />)
       .find('div')
-      .filterWhere(
-        (element: ReactWrapper) => element.prop('aria-live') === 'polite',
-      );
+      .filterWhere((element) => element.prop('aria-live') === 'polite');
     expect(politeBanner).toBeTruthy();
 
     const quietBanner = mountWithAppProvider(<Banner stopAnnouncements />)
       .find('div')
-      .filterWhere(
-        (element: ReactWrapper) => element.prop('aria-live') === 'off',
-      );
+      .filterWhere((element) => element.prop('aria-live') === 'off');
     expect(quietBanner).toBeTruthy();
   });
 
@@ -145,7 +140,7 @@ describe('<Banner />', () => {
 
       const div = mountWithAppProvider(<Test />)
         .find('div')
-        .filterWhere((element: ReactWrapper) => element.prop('tabIndex') === 0);
+        .filterWhere((element) => element.prop('tabIndex') === 0);
 
       expect(div.getDOMNode()).toBe(document.activeElement);
     });

--- a/src/components/ChoiceList/tests/ChoiceList.test.tsx
+++ b/src/components/ChoiceList/tests/ChoiceList.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import {ReactWrapper} from 'enzyme';
 import {mountWithApp} from 'test-utilities';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
 import {RadioButton, Checkbox, InlineError, errorTextID} from 'components';
 import {ChoiceList, ChoiceDescriptor} from '../ChoiceList';
 
@@ -329,7 +328,7 @@ describe('<ChoiceList />', () => {
       choiceList.setProps({selected});
     });
 
-    function changeCheckedForChoice(choice: ReactWrapper<any, any>) {
+    function changeCheckedForChoice(choice: ReactWrapper) {
       choice.simulate('click');
     }
   });

--- a/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import {mount} from 'test-utilities';
 // eslint-disable-next-line no-restricted-imports
-import {mount, mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithAppProvider} from 'test-utilities/legacy';
 import {ContextualSaveBar} from '../ContextualSaveBar';
 
 describe('<ContextualSaveBar />', () => {
@@ -90,11 +91,9 @@ describe('<ContextualSaveBar />', () => {
     });
 
     it('throws when no Frame or appBridge is provided', () => {
-      function fn() {
+      expect(() => {
         mount(<ContextualSaveBar {...props} />);
-      }
-
-      expect(fn).toThrow(
+      }).toThrow(
         'No Frame context was provided. Your component must be wrapped in a <Frame> component, or be used within an embedded application by setting the apiKey and shopOrigin properties on <AppProvider>. See https://polaris.shopify.com/components/structure/frame for implementation instructions.',
       );
     });

--- a/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {mount} from 'enzyme';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mount, mountWithAppProvider} from 'test-utilities/legacy';
 import {ContextualSaveBar} from '../ContextualSaveBar';
 
 describe('<ContextualSaveBar />', () => {

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import {act} from 'react-dom/test-utils';
-import {ReactWrapper} from 'enzyme';
 import {clock} from '@shopify/jest-dom-mocks';
 import {Label, Labelled, DisplayText, Caption} from 'components';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {DropZone} from '../DropZone';
 import {DropZoneContext} from '../context';
@@ -483,7 +482,7 @@ function fireEvent({
   testFiles = files,
   spy,
 }: {
-  element: ReactWrapper<any, any>;
+  element: ReactWrapper;
   eventType?: string;
   spy?: jest.Mock;
   testFiles?: object[];

--- a/src/components/Filters/components/ConnectedFilterControl/tests/ConnectedFilterControl.test.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/tests/ConnectedFilterControl.test.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import {ReactWrapper} from 'enzyme';
-
 import {Popover, Button} from 'components';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
 
 import {
   ConnectedFilterControl,

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {ReactWrapper} from 'enzyme';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {Button, Popover, Sheet, Tag, TextField, TextStyle} from 'components';
 // eslint-disable-next-line no-restricted-imports
@@ -7,6 +6,7 @@ import {
   mountWithAppProvider,
   trigger,
   findByTestID,
+  ReactWrapper,
 } from 'test-utilities/legacy';
 
 import Filters, {FiltersProps} from '../Filters';

--- a/src/components/Layout/tests/Layout.test.tsx
+++ b/src/components/Layout/tests/Layout.test.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import {
-  findByTestID,
-  matchByTestID,
-  mountWithAppProvider,
-} from 'test-utilities/legacy';
+import {findByTestID, mountWithAppProvider} from 'test-utilities/legacy';
 import {Section} from '../components';
 import {Layout} from '../Layout';
 
@@ -82,9 +78,9 @@ describe('<Layout />', () => {
           <MyComponent />
         </Layout.AnnotatedSection>,
       );
-      const description = matchByTestID(
+      const description = findByTestID(
         annotatedSection,
-        /AnnotationDescription/,
+        'AnnotationDescription',
       );
 
       expect(description.exists()).toBe(false);

--- a/src/components/Pagination/tests/Pagination.test.tsx
+++ b/src/components/Pagination/tests/Pagination.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import {ReactWrapper} from 'enzyme';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
+import {
+  mountWithAppProvider,
+  findByTestID,
+  ReactWrapper,
+} from 'test-utilities/legacy';
 import {Tooltip, TextField} from 'components';
 import {Key} from '../../../types';
 import {Pagination} from '../Pagination';
@@ -161,7 +164,7 @@ describe('<Pagination />', () => {
 
   describe('nextURL/previousURL', () => {
     let getElementById: jest.SpyInstance;
-    let pagination: ReactWrapper<any, any>;
+    let pagination: ReactWrapper;
 
     beforeEach(() => {
       getElementById = jest.spyOn(document, 'getElementById');
@@ -218,7 +221,7 @@ describe('<Pagination />', () => {
 function noop() {}
 
 function focusElement(
-  wrapper: ReactWrapper<any, any>,
+  wrapper: ReactWrapper,
   element: 'input' | 'textarea' | 'select',
 ) {
   const inputElement = wrapper

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {ReactWrapper} from 'enzyme';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
 import {TextContainer} from 'components';
 import {Key} from '../../../../../types';
 import {PositionedOverlay} from '../../../../PositionedOverlay';

--- a/src/components/Portal/tests/Portal.test.tsx
+++ b/src/components/Portal/tests/Portal.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {mount} from 'enzyme';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mount, mountWithAppProvider} from 'test-utilities/legacy';
 import {Portal} from '../Portal';
 import {portal} from '../../shared';
 

--- a/src/components/Portal/tests/Portal.test.tsx
+++ b/src/components/Portal/tests/Portal.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import {mount} from 'test-utilities';
 // eslint-disable-next-line no-restricted-imports
-import {mount, mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Portal} from '../Portal';
 import {portal} from '../../shared';
 

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import {ReactWrapper} from 'enzyme';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
+import {
+  mountWithAppProvider,
+  findByTestID,
+  ReactWrapper,
+} from 'test-utilities/legacy';
 import {Key} from 'types';
 import {DualThumb, DualThumbProps} from '../DualThumb';
 
@@ -1032,14 +1035,14 @@ describe('<DualThumb />', () => {
 
 function noop() {}
 
-function findThumbLower(containerComponent: ReactWrapper): ReactWrapper {
+function findThumbLower(containerComponent: ReactWrapper) {
   return containerComponent.find('button').first();
 }
 
-function findThumbUpper(containerComponent: ReactWrapper): ReactWrapper {
+function findThumbUpper(containerComponent: ReactWrapper) {
   return containerComponent.find('button').last();
 }
 
-function findTrack(containerComponent: ReactWrapper): ReactWrapper {
+function findTrack(containerComponent: ReactWrapper) {
   return findByTestID(containerComponent, 'trackWrapper');
 }

--- a/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import {ReactWrapper} from 'enzyme';
 // eslint-disable-next-line no-restricted-imports
 import {
   trigger,
   findByTestID,
   mountWithAppProvider,
+  ReactWrapper,
 } from 'test-utilities/legacy';
 import {Button, Select, Popover} from 'components';
 import {FilterCreator, FilterCreatorProps} from '../FilterCreator';
@@ -294,28 +294,28 @@ describe('<FilterCreator />', () => {
   });
 });
 
-function activatePopover(wrapper: ReactWrapper<FilterCreatorProps, any>) {
+function activatePopover(wrapper: ReactWrapper<FilterCreatorProps>) {
   trigger(findByTestID(wrapper, 'FilterCreator-FilterActivator'), 'onClick');
 }
 
-function findFilterKeySelect(popover: ReactWrapper<FilterCreatorProps, any>) {
+function findFilterKeySelect(popover: ReactWrapper<FilterCreatorProps>) {
   return popover.find(Select);
 }
 
 function selectFilterKey(
-  wrapper: ReactWrapper<FilterCreatorProps, any>,
+  wrapper: ReactWrapper<FilterCreatorProps>,
   filterKey: string,
 ) {
   trigger(wrapper.find(Select), 'onChange', filterKey);
 }
 
 function selectFilterValue(
-  wrapper: ReactWrapper<FilterCreatorProps, any>,
+  wrapper: ReactWrapper<FilterCreatorProps>,
   filterValue: string,
 ) {
   trigger(wrapper.find(FilterValueSelector), 'onChange', filterValue);
 }
 
-function clickAddFilter(wrapper: ReactWrapper<FilterCreatorProps, any>) {
+function clickAddFilter(wrapper: ReactWrapper<FilterCreatorProps>) {
   trigger(findByTestID(wrapper, 'FilterCreator-AddFilterButton'), 'onClick');
 }

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {ReactWrapper} from 'enzyme';
 import {
   ResourceList,
   Select,
@@ -14,6 +13,7 @@ import {
   findByTestID,
   mountWithAppProvider,
   trigger,
+  ReactWrapper,
 } from 'test-utilities/legacy';
 
 import {BulkActions, CheckableButton} from '../components';

--- a/src/components/Select/tests/Select.test.tsx
+++ b/src/components/Select/tests/Select.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import {ReactWrapper} from 'enzyme';
 import {InlineError} from 'components';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
 import {Select} from '../Select';
 
 describe('<Select />', () => {

--- a/src/components/TextField/components/Spinner/tests/Spinner.test.tsx
+++ b/src/components/TextField/components/Spinner/tests/Spinner.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+// eslint-disable-next-line no-restricted-imports
+import {shallow} from 'test-utilities/legacy';
 import {Spinner} from '../Spinner';
 
 describe('<Spinner />', () => {

--- a/src/components/TextField/components/Spinner/tests/Spinner.test.tsx
+++ b/src/components/TextField/components/Spinner/tests/Spinner.test.tsx
@@ -1,28 +1,24 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {shallow} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {Spinner} from '../Spinner';
 
 describe('<Spinner />', () => {
   describe('onChange', () => {
     it('adds a change callback', () => {
       const spy = jest.fn();
-      const spinner = shallow(
+      const spinner = mountWithApp(
         <Spinner onChange={spy} onMouseDown={noop} onMouseUp={noop} />,
       );
-      spinner
-        .find('[role="button"]')
-        .first()
-        .simulate('click');
+
+      spinner.find('div', {role: 'button'})!.trigger('onClick');
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith(1);
     });
   });
 
   describe('onClick', () => {
     it('adds a click callback', () => {
       const spy = jest.fn();
-      const spinner = shallow(
+      const spinner = mountWithApp(
         <Spinner
           onClick={spy}
           onChange={noop}
@@ -30,7 +26,7 @@ describe('<Spinner />', () => {
           onMouseUp={noop}
         />,
       );
-      spinner.simulate('click');
+      spinner.find('div', {className: 'Spinner'})!.trigger('onClick');
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });
@@ -41,17 +37,18 @@ describe('<Spinner />', () => {
         callback();
       });
       const changeSpy = jest.fn();
-      const spinner = shallow(
+      const spinner = mountWithApp(
         <Spinner
           onChange={changeSpy}
           onMouseDown={mouseDownSpy}
           onMouseUp={noop}
         />,
       );
+
       spinner
-        .find('[role="button"]')
-        .first()
-        .simulate('mousedown', {button: 0});
+        .find('div', {role: 'button'})!
+        .trigger('onMouseDown', {button: 0});
+
       expect(mouseDownSpy).toHaveBeenCalledTimes(1);
       expect(changeSpy).toHaveBeenCalledTimes(1);
     });
@@ -61,17 +58,18 @@ describe('<Spinner />', () => {
         callback();
       });
       const changeSpy = jest.fn();
-      const spinner = shallow(
+      const spinner = mountWithApp(
         <Spinner
           onChange={changeSpy}
           onMouseDown={mouseDownSpy}
           onMouseUp={noop}
         />,
       );
+
       spinner
-        .find('[role="button"]')
-        .first()
-        .simulate('mousedown', {button: 1});
+        .find('div', {role: 'button'})!
+        .trigger('onMouseDown', {button: 1});
+
       expect(mouseDownSpy).not.toHaveBeenCalled();
       expect(changeSpy).not.toHaveBeenCalled();
     });
@@ -80,13 +78,12 @@ describe('<Spinner />', () => {
   describe('onMouseUp', () => {
     it('adds a mouse up callback', () => {
       const spy = jest.fn();
-      const spinner = shallow(
+      const spinner = mountWithApp(
         <Spinner onChange={noop} onMouseDown={noop} onMouseUp={spy} />,
       );
-      spinner
-        .find('[role="button"]')
-        .first()
-        .simulate('mouseup');
+
+      spinner.find('div', {role: 'button'})!.trigger('onMouseUp');
+
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
+++ b/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import {CircleCancelMinor} from '@shopify/polaris-icons';
-import {ReactWrapper} from 'enzyme';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
 import {SearchField} from '../SearchField';
 
 describe('<TextField />', () => {

--- a/src/test-utilities/legacy.tsx
+++ b/src/test-utilities/legacy.tsx
@@ -1,4 +1,4 @@
-import {ReactWrapper, CommonWrapper, mount} from 'enzyme';
+import {mount, shallow, ReactWrapper, CommonWrapper} from 'enzyme';
 import React from 'react';
 import {act} from 'react-dom/test-utils';
 import {get} from '../utilities/get';
@@ -9,7 +9,9 @@ import {
   WithPolarisTestProviderOptions,
 } from '../components';
 
-export type AnyWrapper = ReactWrapper<any, any> | CommonWrapper<any, any>;
+export {mount, shallow, ReactWrapper};
+
+type AnyWrapper = ReactWrapper<any, any> | CommonWrapper<any, any>;
 
 export function findByTestID(root: ReactWrapper<any, any>, id: string) {
   function hasTestID(wrapper: ReactWrapper<any, any>) {

--- a/src/test-utilities/legacy.tsx
+++ b/src/test-utilities/legacy.tsx
@@ -9,7 +9,7 @@ import {
   WithPolarisTestProviderOptions,
 } from '../components';
 
-export {mount, ReactWrapper};
+export {ReactWrapper};
 
 type AnyWrapper = ReactWrapper<any, any> | CommonWrapper<any, any>;
 

--- a/src/test-utilities/legacy.tsx
+++ b/src/test-utilities/legacy.tsx
@@ -1,4 +1,4 @@
-import {mount, shallow, ReactWrapper, CommonWrapper} from 'enzyme';
+import {mount, ReactWrapper, CommonWrapper} from 'enzyme';
 import React from 'react';
 import {act} from 'react-dom/test-utils';
 import {get} from '../utilities/get';
@@ -9,7 +9,7 @@ import {
   WithPolarisTestProviderOptions,
 } from '../components';
 
-export {mount, shallow, ReactWrapper};
+export {mount, ReactWrapper};
 
 type AnyWrapper = ReactWrapper<any, any> | CommonWrapper<any, any>;
 
@@ -19,15 +19,6 @@ export function findByTestID(root: ReactWrapper<any, any>, id: string) {
   }
 
   return root.findWhere(hasTestID).first();
-}
-
-export function matchByTestID(root: ReactWrapper<any, any>, regexp: RegExp) {
-  function matchesTestID(wrapper: ReactWrapper<any, any>) {
-    const id = wrapper.prop('testID');
-    return typeof id === 'string' && regexp.test(id);
-  }
-
-  return root.findWhere(matchesTestID);
 }
 
 const reactAct = act as (func: () => void | Promise<void>) => Promise<void>;

--- a/src/utilities/tests/is-input-focused.test.tsx
+++ b/src/utilities/tests/is-input-focused.test.tsx
@@ -1,37 +1,36 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mount} from 'test-utilities/legacy';
+import {mount} from 'test-utilities';
 import {isInputFocused} from '../is-input-focused';
 
 describe('isInputFocused', () => {
   it('returns true when the the focused element is not input, textarea, select or has the attribute contenteditable', () => {
     const markup = mount(<button />);
-    (markup.getDOMNode() as HTMLElement).focus();
+    markup.domNode!.focus();
     expect(isInputFocused()).toBe(false);
   });
 
   it('returns true when an element with contenteditable is focused', () => {
     // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
     const markup = mount(<div contentEditable tabIndex={0} />);
-    (markup.getDOMNode() as HTMLElement).focus();
+    markup.domNode!.focus();
     expect(isInputFocused()).toBe(true);
   });
 
   it('returns true when a select element is focused', () => {
     const markup = mount(<select />);
-    (markup.getDOMNode() as HTMLElement).focus();
+    markup.domNode!.focus();
     expect(isInputFocused()).toBe(true);
   });
 
   it('returns true when a textarea element is focused', () => {
     const markup = mount(<textarea />);
-    (markup.getDOMNode() as HTMLElement).focus();
+    markup.domNode!.focus();
     expect(isInputFocused()).toBe(true);
   });
 
   it('returns true when a input element is focused', () => {
     const markup = mount(<input />);
-    (markup.getDOMNode() as HTMLElement).focus();
+    markup.domNode!.focus();
     expect(isInputFocused()).toBe(true);
   });
 });

--- a/src/utilities/tests/is-input-focused.test.tsx
+++ b/src/utilities/tests/is-input-focused.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {mount} from 'enzyme';
+// eslint-disable-next-line no-restricted-imports
+import {mount} from 'test-utilities/legacy';
 import {isInputFocused} from '../is-input-focused';
 
 describe('isInputFocused', () => {

--- a/src/utilities/tests/with-app-provider.test.tsx
+++ b/src/utilities/tests/with-app-provider.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {mount} from 'enzyme';
+// eslint-disable-next-line no-restricted-imports
+import {mount} from 'test-utilities/legacy';
 import {withAppProvider} from '../with-app-provider';
 
 describe('withAppProvider', () => {

--- a/src/utilities/tests/with-app-provider.test.tsx
+++ b/src/utilities/tests/with-app-provider.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mount} from 'test-utilities/legacy';
+import {mount} from 'test-utilities';
 import {withAppProvider} from '../with-app-provider';
 
 describe('withAppProvider', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

We want to use `@shopify/react-testing` in place of Enzyme. Let's avoid some usage of enzyme

### WHAT is this pull request doing?

- Rewrite tests using enzyme's `mount` and `shallow` to use react-testing
- Remove direct imports of enzyme, instead reexport `ReactWrapper` from enzyme.
- Simplify a few type generics to use default values as we can do `ReactWrapper` instead of `ReactWrapper<any, any>
- Remove matchByTestID helper that was only used once, rewrite the test using it to use findByTestID instead

### How to 🎩
 Confirm tests pass