### PR TITLE
Use react-testing to test ThemeProvider

### DIFF
--- a/src/test-utilities/react-testing.tsx
+++ b/src/test-utilities/react-testing.tsx
@@ -7,7 +7,7 @@ import {
   WithPolarisTestProviderOptions,
 } from '../components';
 
-export {mount};
+export {createMount, mount};
 
 export const mountWithApp = createMount<
   WithPolarisTestProviderOptions,


### PR DESCRIPTION
### WHY are these changes introduced?

The current way of testing using mountWithAppProvider causes problems when adding support for nested theme providers in #2459 - we need a way to test a ThemeProvider that has been wrapped only in a FeaturesContext so we don't get interference from the ThemeProvider provided by the PolarisTestProvider.

### WHAT is this pull request doing?

Migrates ThemeProvider to use react-testing instead of enzyme, and sets up a custom mounter to deal with the above along the way.

We also leverage some of the new matchers provided by react-testing

### How to 🎩

tests pass