### PR TITLE
TypeScript 3.7 (take 2)

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@
 
 ### Dependency upgrades
 
+- Update to TypeScript 3.7 ([#2549](https://github.com/Shopify/polaris-react/pull/2549))
+
 ### Code quality
 
 ### Deprecations

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "shx": "^0.3.2",
     "storybook-chromatic": "^3.1.0",
     "svgo": "^1.3.0",
-    "typescript": "~3.5.1"
+    "typescript": "~3.7.2"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -214,7 +214,7 @@ export class ComboBox extends React.PureComponent<ComboBoxProps, State> {
 
     const context = {
       comboBoxId,
-      selectedOptionId: this.selectedOptionId,
+      selectedOptionId: this.selectedOptionId(),
     };
 
     return (
@@ -445,7 +445,7 @@ export class ComboBox extends React.PureComponent<ComboBoxProps, State> {
     }
   };
 
-  private get selectedOptionId(): string | undefined {
+  private selectedOptionId(): string | undefined {
     const {selectedOption, selectedIndex, comboBoxId} = this.state;
     return selectedOption ? `${comboBoxId}-${selectedIndex}` : undefined;
   }

--- a/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import {
-  ContextualSaveBarProps as BaseContextualSaveBarProps,
+  ContextualSaveBarProps as ContextualSaveBarProps1,
   useFrame,
 } from '../../utilities/frame';
 
 // The script in the styleguide that generates the Props Explorer data expects
-// a component's props to be found in the Props interface. This silly workaround
-// ensures that the Props Explorer table is generated correctly, instead of
-// crashing if we write `ContextualSaveBar extends React.Component<ContextualSaveBarProps>`
-export interface ContextualSaveBarProps extends BaseContextualSaveBarProps {}
+// that the interface defining the props is defined in this file, not imported
+// from elsewhere. This silly workaround ensures that the Props Explorer table
+// is generated correctly.
+export interface ContextualSaveBarProps extends ContextualSaveBarProps1 {}
 
 export const ContextualSaveBar = React.memo(function ContextualSaveBar({
   message,

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -473,6 +473,9 @@ function setBoundingClientRect(size: keyof typeof widths) {
         left: 0,
         bottom: 0,
         right: 0,
+        x: 0,
+        y: 0,
+        toJSON() {},
       };
     });
 }

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -107,14 +107,6 @@ class Filters extends React.Component<ComposedProps, State> {
   private moreFiltersButtonContainer = createRef<HTMLDivElement>();
   private focusNode = createRef<HTMLDivElement>();
 
-  private get hasAppliedFilters(): boolean {
-    const {appliedFilters, queryValue} = this.props;
-    const filtersApplied = Boolean(appliedFilters && appliedFilters.length > 0);
-    const queryApplied = Boolean(queryValue && queryValue !== '');
-
-    return filtersApplied || queryApplied;
-  }
-
   render() {
     const {
       filters,
@@ -300,7 +292,7 @@ class Filters extends React.Component<ComposedProps, State> {
 
     const filtersDesktopFooterMarkup = (
       <div className={styles.FiltersContainerFooter}>
-        <Button onClick={onClearAll} disabled={!this.hasAppliedFilters}>
+        <Button onClick={onClearAll} disabled={!this.hasAppliedFilters()}>
           {intl.translate('Polaris.Filters.clearAllFilters')}
         </Button>
         <Button onClick={this.closeFilters} primary>
@@ -311,7 +303,7 @@ class Filters extends React.Component<ComposedProps, State> {
 
     const filtersMobileFooterMarkup = (
       <div className={styles.FiltersMobileContainerFooter}>
-        {this.hasAppliedFilters ? (
+        {this.hasAppliedFilters() ? (
           <Button onClick={onClearAll} fullWidth>
             {intl.translate('Polaris.Filters.clearAllFilters')}
           </Button>
@@ -390,6 +382,14 @@ class Filters extends React.Component<ComposedProps, State> {
         <KeypressListener keyCode={Key.Escape} handler={this.closeFilters} />
       </div>
     );
+  }
+
+  private hasAppliedFilters(): boolean {
+    const {appliedFilters, queryValue} = this.props;
+    const filtersApplied = Boolean(appliedFilters && appliedFilters.length > 0);
+    const queryApplied = Boolean(queryValue && queryValue !== '');
+
+    return filtersApplied || queryApplied;
   }
 
   private getAppliedFilterContent(key: string): string | undefined {

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -53,7 +53,7 @@ class Page extends React.PureComponent<ComposedProps, never> {
   private titlebar: AppBridgeTitleBar.TitleBar | undefined;
 
   componentDidMount() {
-    if (this.delegateToAppbridge === false || !this.props.polaris.appBridge) {
+    if (this.delegateToAppbridge() === false || !this.props.polaris.appBridge) {
       return;
     }
 
@@ -72,7 +72,7 @@ class Page extends React.PureComponent<ComposedProps, never> {
   }
 
   componentDidUpdate(prevProps: ComposedProps) {
-    if (this.titlebar == null || this.delegateToAppbridge === false) {
+    if (this.titlebar == null || this.delegateToAppbridge() === false) {
       return;
     }
 
@@ -89,7 +89,7 @@ class Page extends React.PureComponent<ComposedProps, never> {
   }
 
   componentWillUnmount() {
-    if (this.titlebar == null || this.delegateToAppbridge === false) {
+    if (this.titlebar == null || this.delegateToAppbridge() === false) {
       return;
     }
 
@@ -119,7 +119,7 @@ class Page extends React.PureComponent<ComposedProps, never> {
     );
 
     const headerMarkup =
-      this.delegateToAppbridge || this.hasHeaderContent() === false ? null : (
+      this.delegateToAppbridge() || this.hasHeaderContent() === false ? null : (
         <Header {...rest} />
       );
 
@@ -131,7 +131,7 @@ class Page extends React.PureComponent<ComposedProps, never> {
     );
   }
 
-  private get delegateToAppbridge(): boolean {
+  private delegateToAppbridge(): boolean {
     const {
       polaris: {appBridge},
       forceRender = false,

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -6,9 +6,9 @@ import {RangeSliderDefault} from './utilities';
 import {SingleThumb, DualThumb} from './components';
 
 // The script in the styleguide that generates the Props Explorer data expects
-// a component's props to be found in the Props interface. This silly workaround
-// ensures that the Props Explorer table is generated correctly, instead of
-// crashing if we write `RangeSlider extends React.Component<RangeSliderProps>`
+// that the interface defining the props is defined in this file, not imported
+// from elsewhere. This silly workaround ensures that the Props Explorer table
+// is generated correctly.
 interface Props extends RangeSliderProps {}
 
 export function RangeSlider({

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -490,16 +490,7 @@ describe('<DualThumb />', () => {
         });
       getBoundingClientRectSpy = jest
         .spyOn(Element.prototype, 'getBoundingClientRect')
-        .mockImplementation(() => {
-          return {
-            width: 124,
-            height: 0,
-            top: 0,
-            left: -12,
-            bottom: 0,
-            right: 0,
-          };
-        });
+        .mockImplementation(mockGetBoundingClientRect);
     });
 
     afterAll(() => {
@@ -703,16 +694,7 @@ describe('<DualThumb />', () => {
         });
       getBoundingClientRectSpy = jest
         .spyOn(Element.prototype, 'getBoundingClientRect')
-        .mockImplementation(() => {
-          return {
-            width: 124,
-            height: 0,
-            top: 0,
-            left: -12,
-            bottom: 0,
-            right: 0,
-          };
-        });
+        .mockImplementation(mockGetBoundingClientRect);
     });
 
     afterAll(() => {
@@ -1042,4 +1024,20 @@ function findThumbUpper(containerComponent: ReactWrapper): ReactWrapper {
 
 function findTrack(containerComponent: ReactWrapper): ReactWrapper {
   return findByTestID(containerComponent, 'trackWrapper');
+}
+
+function mockGetBoundingClientRect(): ReturnType<
+  Element['getBoundingClientRect']
+> {
+  return {
+    width: 124,
+    height: 0,
+    top: 0,
+    left: -12,
+    bottom: 0,
+    right: 0,
+    x: 0,
+    y: 0,
+    toJSON() {},
+  };
 }

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -146,7 +146,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
     };
   }
 
-  private get selectable() {
+  private selectable() {
     const {promotedBulkActions, bulkActions, selectable} = this.props;
 
     return Boolean(
@@ -156,7 +156,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
     );
   }
 
-  private get bulkSelectState(): boolean | 'indeterminate' {
+  private bulkSelectState(): boolean | 'indeterminate' {
     const {selectedItems, items} = this.props;
     let selectState: boolean | 'indeterminate' = 'indeterminate';
     if (
@@ -173,7 +173,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
     return selectState;
   }
 
-  private get headerTitle() {
+  private headerTitle() {
     const {
       resourceName = this.defaultResourceName,
       items,
@@ -205,7 +205,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
     }
   }
 
-  private get bulkActionsLabel() {
+  private bulkActionsLabel() {
     const {
       selectedItems = [],
       items,
@@ -222,7 +222,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
     });
   }
 
-  private get bulkActionsAccessibilityLabel() {
+  private bulkActionsAccessibilityLabel() {
     const {
       resourceName = this.defaultResourceName,
       selectedItems = [],
@@ -265,7 +265,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
     }
   }
 
-  private get paginatedSelectAllText() {
+  private paginatedSelectAllText() {
     const {
       hasMoreItems,
       selectedItems,
@@ -274,7 +274,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
       polaris: {intl},
     } = this.props;
 
-    if (!this.selectable || !hasMoreItems) {
+    if (!this.selectable() || !hasMoreItems) {
       return;
     }
 
@@ -286,7 +286,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
     }
   }
 
-  private get paginatedSelectAllAction() {
+  private paginatedSelectAllAction() {
     const {
       hasMoreItems,
       selectedItems,
@@ -295,7 +295,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
       polaris: {intl},
     } = this.props;
 
-    if (!this.selectable || !hasMoreItems) {
+    if (!this.selectable() || !hasMoreItems) {
       return;
     }
 
@@ -313,7 +313,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
     };
   }
 
-  private get emptySearchResultText() {
+  private emptySearchResultText() {
     const {
       polaris: {intl},
       resourceName = this.defaultResourceName,
@@ -329,6 +329,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/member-ordering
   componentDidMount() {
     this.forceUpdate();
     if (this.props.loading) {
@@ -336,6 +337,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/member-ordering
   componentDidUpdate({
     loading: prevLoading,
     items: prevItems,
@@ -372,6 +374,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/member-ordering
   render() {
     const {
       items,
@@ -393,18 +396,18 @@ class ResourceList extends React.Component<CombinedProps, State> {
       <div className={styles.FiltersWrapper}>{filterControl}</div>
     ) : null;
 
-    const bulkActionsMarkup = this.selectable ? (
+    const bulkActionsMarkup = this.selectable() ? (
       <div className={styles.BulkActionsWrapper}>
         <BulkActions
-          label={this.bulkActionsLabel}
-          accessibilityLabel={this.bulkActionsAccessibilityLabel}
-          selected={this.bulkSelectState}
+          label={this.bulkActionsLabel()}
+          accessibilityLabel={this.bulkActionsAccessibilityLabel()}
+          selected={this.bulkSelectState()}
           onToggleAll={this.handleToggleAll}
           selectMode={selectMode}
           onSelectModeToggle={this.handleSelectMode}
           promotedActions={promotedBulkActions}
-          paginatedSelectAllAction={this.paginatedSelectAllAction}
-          paginatedSelectAllText={this.paginatedSelectAllText}
+          paginatedSelectAllAction={this.paginatedSelectAllAction()}
+          paginatedSelectAllText={this.paginatedSelectAllText()}
           actions={bulkActions}
           disabled={loading}
           smallScreen={smallScreen}
@@ -434,11 +437,11 @@ class ResourceList extends React.Component<CombinedProps, State> {
 
     const headerTitleMarkup = (
       <div className={styles.HeaderTitleWrapper} testID="headerTitleWrapper">
-        {this.headerTitle}
+        {this.headerTitle()}
       </div>
     );
 
-    const selectButtonMarkup = this.selectable ? (
+    const selectButtonMarkup = this.selectable() ? (
       <div className={styles.SelectButtonWrapper}>
         <Button
           disabled={selectMode}
@@ -450,11 +453,11 @@ class ResourceList extends React.Component<CombinedProps, State> {
       </div>
     ) : null;
 
-    const checkableButtonMarkup = this.selectable ? (
+    const checkableButtonMarkup = this.selectable() ? (
       <div className={styles.CheckableButtonWrapper}>
         <CheckableButton
-          accessibilityLabel={this.bulkActionsAccessibilityLabel}
-          label={this.headerTitle}
+          accessibilityLabel={this.bulkActionsAccessibilityLabel()}
+          label={this.headerTitle()}
           onToggleAll={this.handleToggleAll}
           plain
           disabled={loading}
@@ -463,7 +466,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
     ) : null;
 
     const needsHeader =
-      this.selectable ||
+      this.selectable() ||
       (sortOptions && sortOptions.length > 0) ||
       alternateTool;
 
@@ -486,9 +489,9 @@ class ResourceList extends React.Component<CombinedProps, State> {
                   !alternateTool &&
                   styles['HeaderWrapper-hasSort'],
                 alternateTool && styles['HeaderWrapper-hasAlternateTool'],
-                this.selectable && styles['HeaderWrapper-hasSelect'],
+                this.selectable() && styles['HeaderWrapper-hasSelect'],
                 loading && styles['HeaderWrapper-disabled'],
-                this.selectable &&
+                this.selectable() &&
                   selectMode &&
                   styles['HeaderWrapper-inSelectMode'],
                 isSticky && styles['HeaderWrapper-isSticky'],
@@ -514,7 +517,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
 
     const emptyStateMarkup = showEmptyState ? (
       <div className={styles.EmptySearchResultWrapper}>
-        <EmptySearchResult {...this.emptySearchResultText} withIllustration />
+        <EmptySearchResult {...this.emptySearchResultText()} withIllustration />
       </div>
     ) : null;
 
@@ -566,7 +569,7 @@ class ResourceList extends React.Component<CombinedProps, State> {
     );
 
     const context = {
-      selectable: this.selectable,
+      selectable: this.selectable(),
       selectedItems,
       selectMode,
       resourceName,

--- a/src/components/ResourceList/components/BulkActions/BulkActions.tsx
+++ b/src/components/ResourceList/components/BulkActions/BulkActions.tsx
@@ -109,7 +109,7 @@ class BulkActions extends React.PureComponent<CombinedProps, State> {
     {trailing: true},
   );
 
-  private get numberOfPromotedActionsToRender(): number {
+  private numberOfPromotedActionsToRender(): number {
     const {promotedActions} = this.props;
     const {containerWidth, measuring} = this.state;
 
@@ -141,7 +141,7 @@ class BulkActions extends React.PureComponent<CombinedProps, State> {
     return counter;
   }
 
-  private get hasActions() {
+  private hasActions() {
     const {promotedActions, actions} = this.props;
     return Boolean(
       (promotedActions && promotedActions.length > 0) ||
@@ -149,7 +149,7 @@ class BulkActions extends React.PureComponent<CombinedProps, State> {
     );
   }
 
-  private get actionSections(): BulkActionListSection[] | undefined {
+  private actionSections(): BulkActionListSection[] | undefined {
     const {actions} = this.props;
 
     if (!actions || actions.length === 0) {
@@ -169,6 +169,7 @@ class BulkActions extends React.PureComponent<CombinedProps, State> {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/member-ordering
   componentDidMount() {
     const {actions, promotedActions} = this.props;
 
@@ -189,6 +190,7 @@ class BulkActions extends React.PureComponent<CombinedProps, State> {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/member-ordering
   render() {
     const {
       selectMode,
@@ -203,6 +205,8 @@ class BulkActions extends React.PureComponent<CombinedProps, State> {
       paginatedSelectAllAction,
       polaris: {intl},
     } = this.props;
+
+    const actionSections = this.actionSections();
 
     if (promotedActions && promotedActions.length > MAX_PROMOTED_ACTIONS) {
       // eslint-disable-next-line no-console
@@ -257,10 +261,9 @@ class BulkActions extends React.PureComponent<CombinedProps, State> {
       </Button>
     );
 
-    const numberOfPromotedActionsToRender = this
-      .numberOfPromotedActionsToRender;
+    const numberOfPromotedActionsToRender = this.numberOfPromotedActionsToRender();
 
-    const allActionsPopover = this.hasActions ? (
+    const allActionsPopover = this.hasActions() ? (
       <div className={styles.Popover} ref={this.setMoreActionsNode}>
         <Popover
           active={smallScreenPopoverVisible}
@@ -278,7 +281,7 @@ class BulkActions extends React.PureComponent<CombinedProps, State> {
         >
           <ActionList
             items={promotedActions}
-            sections={this.actionSections}
+            sections={actionSections}
             onActionAnyItem={this.toggleSmallScreenPopover}
           />
         </Popover>
@@ -317,19 +320,16 @@ class BulkActions extends React.PureComponent<CombinedProps, State> {
 
     let combinedActions: ActionListSection[] = [];
 
-    if (this.actionSections && rolledInPromotedActions.length > 0) {
-      combinedActions = [
-        {items: rolledInPromotedActions},
-        ...this.actionSections,
-      ];
-    } else if (this.actionSections) {
-      combinedActions = this.actionSections;
+    if (actionSections && rolledInPromotedActions.length > 0) {
+      combinedActions = [{items: rolledInPromotedActions}, ...actionSections];
+    } else if (actionSections) {
+      combinedActions = actionSections;
     } else if (rolledInPromotedActions.length > 0) {
       combinedActions = [{items: rolledInPromotedActions}];
     }
 
     const actionsPopover =
-      this.actionSections || rolledInPromotedActions.length > 0 || measuring ? (
+      actionSections || rolledInPromotedActions.length > 0 || measuring ? (
         <div className={styles.Popover} ref={this.setMoreActionsNode}>
           <Popover
             active={largeScreenPopoverVisible}

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -32,10 +32,10 @@ export function ThemeProvider({
     [customProperties, themeConfig, unstableGlobalTheming],
   );
 
-  // We want these values to be `null` instead of `undefined` when not set.
+  // We want these values to be empty string instead of `undefined` when not set.
   // Otherwise, setting a style property to `undefined` does not remove it from the DOM.
-  const backgroundColor = customProperties['--p-surface-background'] || null;
-  const color = customProperties['--p-text-on-surface'] || null;
+  const backgroundColor = customProperties['--p-surface-background'] || '';
+  const color = customProperties['--p-text-on-surface'] || '';
 
   useEffect(() => {
     document.body.style.backgroundColor = backgroundColor;

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -2,16 +2,16 @@ import React, {useRef} from 'react';
 import {Toast as AppBridgeToast} from '@shopify/app-bridge/actions';
 
 import {DEFAULT_TOAST_DURATION} from '../Frame';
-import {ToastProps as BaseToastProps, useFrame} from '../../utilities/frame';
+import {ToastProps as ToastProps1, useFrame} from '../../utilities/frame';
 import {useUniqueId} from '../../utilities/unique-id';
 import {useDeepEffect} from '../../utilities/use-deep-effect';
 import {useAppBridge} from '../../utilities/app-bridge';
 
 // The script in the styleguide that generates the Props Explorer data expects
-// a component's props to be found in the Props interface. This silly workaround
-// ensures that the Props Explorer table is generated correctly, instead of
-// crashing if we write `ComposedProps = ToastProps & WithAppProviderProps`
-export interface ToastProps extends BaseToastProps {}
+// that the interface defining the props is defined in this file, not imported
+// from elsewhere. This silly workaround ensures that the Props Explorer table
+// is generated correctly.
+export interface ToastProps extends ToastProps1 {}
 
 export const Toast = React.memo(function Toast(props: ToastProps) {
   const id = useUniqueId('Toast');

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -44,7 +44,7 @@ export class TrapFocus extends React.PureComponent<TrapFocusProps, State> {
     const {children} = this.props;
 
     return (
-      <Focus disabled={this.shouldDisable} root={this.focusTrapWrapper}>
+      <Focus disabled={this.shouldDisable()} root={this.focusTrapWrapper}>
         <div ref={this.setFocusTrapWrapper}>
           <EventListener event="focusout" handler={this.handleBlur} />
           {children}
@@ -53,7 +53,7 @@ export class TrapFocus extends React.PureComponent<TrapFocusProps, State> {
     );
   }
 
-  private get shouldDisable() {
+  private shouldDisable() {
     const {trapping = true} = this.props;
     const {shouldFocusSelf} = this.state;
 

--- a/src/utilities/tests/is-element-in-viewport.test.ts
+++ b/src/utilities/tests/is-element-in-viewport.test.ts
@@ -69,5 +69,8 @@ function mockGetBoundingClientRect({
     right,
     height,
     width,
+    x: 0,
+    y: 0,
+    toJSON() {},
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17361,15 +17361,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
-  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
-
-typescript@~3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
-  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
+typescript@^3.7.2, typescript@~3.7.2:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
### WHY are these changes introduced?

#2237 bumped us up to typescript 3.7, but it got reverted in #2501 because it didn't play nice in consuming projects.

This reverts the revert and fixes the issues that caused the problems in consuming projects.

### WHAT is this pull request doing?

Updates to TS 3.7, fixing any type checking issues.

If you have an uninitialized property that then gets referenced (like by
having a getter for it) then TS emits declarations that break in
consuming projects. Convert a bunch of cases where we created getters for non-existant
properties to use boring old method functions, thus allowing consumer builds to work again..

### How to 🎩

Tests / linting pass

Test this in a consuming project:

- Checkout the latest version of polaris-styleguide
- In polaris-react: `yarn run build-consumer polaris-styleguide`
- Then in the styleguide `yarn run build` and see that the build passes
