### PR TITLE
[Color system] update modal to use border radius from new design language

### DIFF
--- a/src/components/Modal/components/Dialog/Dialog.scss
+++ b/src/components/Modal/components/Dialog/Dialog.scss
@@ -52,7 +52,7 @@ $large-width: rem(980px);
     position: relative;
     max-width: $small-width;
     margin: 0 auto;
-    border-radius: border-radius(large);
+    border-radius: var(--p-border-radius-wide, border-radius(large));
   }
 
   &.limitHeight {


### PR DESCRIPTION
Noticed we missed this while I was working on https://github.com/Shopify/polaris-react/pull/2459

|before|after|
|-|-|
|<img width="1552" alt="Screen Shot 2019-12-13 at 2 11 08 PM" src="https://user-images.githubusercontent.com/1403188/70825568-b79b1680-1db2-11ea-98ae-2590ee26f3cc.png">|<img width="1552" alt="Screen Shot 2019-12-13 at 2 11 00 PM" src="https://user-images.githubusercontent.com/1403188/70825574-c08be800-1db2-11ea-9b0a-44b7bfb3cb1f.png">|