### PR TITLE
Rework useToggle and remove useForcibleToggle

### DIFF
--- a/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
+++ b/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
@@ -21,7 +21,7 @@ export interface RollupActionsProps {
 export function RollupActions({items = [], sections = []}: RollupActionsProps) {
   const i18n = useI18n();
 
-  const [rollupOpen, toggleRollupOpen] = useToggle(false);
+  const {value: rollupOpen, toggle: toggleRollupOpen} = useToggle(false);
 
   if (items.length === 0 && sections.length === 0) {
     return null;

--- a/src/components/ButtonGroup/components/Item/Item.tsx
+++ b/src/components/ButtonGroup/components/Item/Item.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {useForcibleToggle} from '../../../../utilities/use-toggle';
+import {useToggle} from '../../../../utilities/use-toggle';
 import {classNames} from '../../../../utilities/css';
 
 import styles from '../../ButtonGroup.scss';
@@ -9,10 +9,11 @@ export interface ItemProps {
 }
 
 export function Item({button}: ItemProps) {
-  const [
-    focused,
-    {forceTrue: forceTrueFocused, forceFalse: forceFalseFocused},
-  ] = useForcibleToggle(false);
+  const {
+    value: focused,
+    setTrue: forceTrueFocused,
+    setFalse: forceFalseFocused,
+  } = useToggle(false);
 
   const className = classNames(
     styles.Item,

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -55,10 +55,10 @@ export const Card: React.FunctionComponent<CardProps> & {
 }: CardProps) {
   const i18n = useI18n();
 
-  const [
-    secondaryActionsPopoverOpen,
-    toggleSecondaryActionsPopoverOpen,
-  ] = useToggle(false);
+  const {
+    value: secondaryActionsPopoverOpen,
+    toggle: toggleSecondaryActionsPopoverOpen,
+  } = useToggle(false);
 
   const className = classNames(styles.Card, subdued && styles.subdued);
 

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -24,7 +24,7 @@ import {useI18n} from '../../utilities/i18n';
 import {useEventListener} from '../../utilities/use-event-listener';
 import {useUniqueId} from '../../utilities/unique-id';
 import {useComponentDidMount} from '../../utilities/use-component-did-mount';
-import {useForcibleToggle} from '../../utilities/use-toggle';
+import {useToggle} from '../../utilities/use-toggle';
 
 import {FileUpload} from './components';
 import {DropZoneContext} from './context';
@@ -170,10 +170,11 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
 
   const [dragging, setDragging] = useState(false);
   const [internalError, setInternalError] = useState(false);
-  const [
-    focused,
-    {forceTrue: handleFocus, forceFalse: handleBlur},
-  ] = useForcibleToggle(false);
+  const {
+    value: focused,
+    setTrue: handleFocus,
+    setFalse: handleBlur,
+  } = useToggle(false);
   const [numFiles, setNumFiles] = useState(0);
   const [size, setSize] = useState('extraLarge');
   const [measuring, setMeasuring] = useState(true);

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -6,7 +6,7 @@ import {ContextualSaveBarProps} from '../../../../utilities/frame';
 import {Button} from '../../../Button';
 import {useI18n} from '../../../../utilities/i18n';
 import {useTheme} from '../../../../utilities/theme';
-import {useForcibleToggle} from '../../../../utilities/use-toggle';
+import {useToggle} from '../../../../utilities/use-toggle';
 import {Image} from '../../../Image';
 import {Stack} from '../../../Stack';
 
@@ -23,13 +23,11 @@ export function ContextualSaveBar({
   const i18n = useI18n();
   const {logo} = useTheme();
 
-  const [
-    discardConfirmationModalVisible,
-    {
-      toggle: toggleDiscardConfirmationModal,
-      forceFalse: closeDiscardConfirmationModal,
-    },
-  ] = useForcibleToggle(false);
+  const {
+    value: discardConfirmationModalVisible,
+    toggle: toggleDiscardConfirmationModal,
+    setFalse: closeDiscardConfirmationModal,
+  } = useToggle(false);
 
   const handleDiscardAction = useCallback(() => {
     if (discardAction && discardAction.onAction) {

--- a/src/components/ResourceList/components/FilterControl/components/FilterCreator/FilterCreator.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterCreator/FilterCreator.tsx
@@ -4,7 +4,7 @@ import {Popover} from '../../../../../Popover';
 import {Select} from '../../../../../Select';
 import {FormLayout} from '../../../../../FormLayout';
 import {Form} from '../../../../../Form';
-import {useForcibleToggle} from '../../../../../../utilities/use-toggle';
+import {useToggle} from '../../../../../../utilities/use-toggle';
 import {useI18n} from '../../../../../../utilities/i18n';
 
 import {FilterValueSelector} from '../FilterValueSelector';
@@ -26,10 +26,11 @@ export function FilterCreator({
   disabled,
   onAddFilter,
 }: FilterCreatorProps) {
-  const [
-    popoverActive,
-    {toggle: togglePopoverActive, forceFalse: setPopoverActiveFalse},
-  ] = useForcibleToggle(false);
+  const {
+    value: popoverActive,
+    toggle: togglePopoverActive,
+    setFalse: setPopoverActiveFalse,
+  } = useToggle(false);
   const [selectedFilter, setSelectedFilter] = useState<Filter>();
   const [selectedFilterKey, setSelectedFilterKey] = useState<
     AppliedFilter['key']

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -4,7 +4,7 @@ import {classNames} from '../../utilities/css';
 import {getWidth} from '../../utilities/get-width';
 import {useI18n} from '../../utilities/i18n';
 import {useTheme} from '../../utilities/theme';
-import {useForcibleToggle} from '../../utilities/use-toggle';
+import {useToggle} from '../../utilities/use-toggle';
 import {Icon} from '../Icon';
 import {Image} from '../Image';
 import {UnstyledLink} from '../UnstyledLink';
@@ -56,10 +56,11 @@ export const TopBar: React.FunctionComponent<TopBarProps> & {
   const i18n = useI18n();
   const {logo} = useTheme();
 
-  const [
-    focused,
-    {forceTrue: forceTrueFocused, forceFalse: forceFalseFocused},
-  ] = useForcibleToggle(false);
+  const {
+    value: focused,
+    setTrue: forceTrueFocused,
+    setFalse: forceFalseFocused,
+  } = useToggle(false);
 
   const className = classNames(
     styles.NavigationIcon,

--- a/src/utilities/use-toggle.ts
+++ b/src/utilities/use-toggle.ts
@@ -1,24 +1,16 @@
 import {useState, useCallback} from 'react';
 
+/**
+ * Returns a stateful value, and a set of memoized functions to toggle it,
+ * set it to true and set it to false
+ */
 export function useToggle(initialState: boolean) {
-  const [state, setState] = useState(initialState);
-  const toggle = useCallback(() => setState((state) => !state), []);
+  const [value, setState] = useState(initialState);
 
-  // cast needed to say this returns a two item array with the items in
-  // their specific positions instead of `(typeof state | typeof toggle)[]`
-  return [state, toggle] as [typeof state, typeof toggle];
-}
-
-export function useForcibleToggle(initialState: boolean) {
-  const [state, setState] = useState(initialState);
-
-  const toggles = {
+  return {
+    value,
     toggle: useCallback(() => setState((state) => !state), []),
-    forceTrue: useCallback(() => setState(true), []),
-    forceFalse: useCallback(() => setState(false), []),
+    setTrue: useCallback(() => setState(true), []),
+    setFalse: useCallback(() => setState(false), []),
   };
-
-  // cast needed to say this returns a two item array with the items in
-  // their specific positions instead of `(typeof state | typeof toggles)[]`
-  return [state, toggles] as [typeof state, typeof toggles];
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Having useToggle and useForcibleToggle is a little confusing. lets have one way of doing things.
This new API mimics the useToggle() hook implemented in the
@shopify/react-hooks package so we can easily move to that if we wish to
do so in the future


### WHAT is this pull request doing?
Replaces useToggle with a new implementation, remove useForcibleToggle. update usage

### How to 🎩

typecheck / tests pass