### PR TITLE
Enable strictPropertyInitialization TS config

### DIFF
--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -77,7 +77,7 @@ class Frame extends React.PureComponent<CombinedProps, State> {
     showContextualSaveBar: false,
   };
 
-  private contextualSaveBar: ContextualSaveBarProps | null;
+  private contextualSaveBar: ContextualSaveBarProps | null = null;
   private globalRibbonContainer: HTMLDivElement | null = null;
   private navigationNode = createRef<HTMLDivElement>();
   private skipToMainContentTargetNode =

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -97,7 +97,7 @@ const APP_BRIDGE_PROPS: (keyof ModalProps)[] = [
 
 class Modal extends React.Component<CombinedProps, State> {
   static Section = Section;
-  focusReturnPointNode: HTMLElement;
+  focusReturnPointNode: HTMLElement | null = null;
 
   state: State = {
     iframeHeight: IFRAME_LOADING_HEIGHT,
@@ -331,7 +331,11 @@ class Modal extends React.Component<CombinedProps, State> {
     });
 
     if (this.focusReturnPointNode) {
-      write(() => focusFirstFocusableNode(this.focusReturnPointNode, false));
+      write(
+        () =>
+          this.focusReturnPointNode &&
+          focusFirstFocusableNode(this.focusReturnPointNode, false),
+      );
     }
   };
 

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -23,7 +23,7 @@ export class Portal extends React.PureComponent<PortalProps, State> {
 
   state: State = {isMounted: false};
 
-  private portalNode: HTMLElement;
+  private portalNode: HTMLElement | null = null;
 
   private portalId =
     this.props.idPrefix !== ''
@@ -49,7 +49,7 @@ export class Portal extends React.PureComponent<PortalProps, State> {
   componentDidUpdate(_: PortalProps, prevState: State) {
     const {onPortalCreated = noop} = this.props;
 
-    if (this.context != null) {
+    if (this.portalNode && this.context != null) {
       const {UNSTABLE_cssCustomProperties, textColor} = this.context;
       if (UNSTABLE_cssCustomProperties != null) {
         const style = `${UNSTABLE_cssCustomProperties};color:${textColor};`;
@@ -64,11 +64,13 @@ export class Portal extends React.PureComponent<PortalProps, State> {
   }
 
   componentWillUnmount() {
-    document.body.removeChild(this.portalNode);
+    if (this.portalNode) {
+      document.body.removeChild(this.portalNode);
+    }
   }
 
   render() {
-    return this.state.isMounted
+    return this.portalNode && this.state.isMounted
       ? createPortal(this.props.children, this.portalNode)
       : null;
   }

--- a/src/components/ResourceList/components/BulkActions/BulkActions.tsx
+++ b/src/components/ResourceList/components/BulkActions/BulkActions.tsx
@@ -77,9 +77,9 @@ class BulkActions extends React.PureComponent<CombinedProps, State> {
     measuring: true,
   };
 
-  private containerNode: HTMLElement | null;
-  private largeScreenButtonsNode: HTMLElement | null;
-  private moreActionsNode: HTMLElement | null;
+  private containerNode: HTMLElement | null = null;
+  private largeScreenButtonsNode: HTMLElement | null = null;
+  private moreActionsNode: HTMLElement | null = null;
   private checkableWrapperNode = createRef<HTMLDivElement>();
   private largeScreenGroupNode = createRef<HTMLDivElement>();
   private smallScreenGroupNode = createRef<HTMLDivElement>();

--- a/src/components/Scrollable/Scrollable.tsx
+++ b/src/components/Scrollable/Scrollable.tsx
@@ -60,7 +60,7 @@ export class Scrollable extends React.Component<ScrollableProps, State> {
 
   private stickyManager = new StickyManager();
 
-  private scrollArea: HTMLElement | null;
+  private scrollArea: HTMLElement | null = null;
 
   private handleResize = debounce(
     () => {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -42,7 +42,7 @@ export class Tooltip extends React.PureComponent<TooltipProps, State> {
   };
 
   private id = getUniqueID();
-  private activatorContainer: HTMLElement | null;
+  private activatorContainer: HTMLElement | null = null;
   private mouseEntered = false;
 
   componentDidMount() {

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -24,7 +24,7 @@ export class TrapFocus extends React.PureComponent<TrapFocusProps, State> {
     shouldFocusSelf: undefined,
   };
 
-  private focusTrapWrapper: HTMLElement;
+  private focusTrapWrapper: HTMLElement | null = null;
 
   componentDidMount() {
     this.setState(this.handleTrappingChange());
@@ -33,7 +33,10 @@ export class TrapFocus extends React.PureComponent<TrapFocusProps, State> {
   handleTrappingChange() {
     const {trapping = true} = this.props;
 
-    if (this.focusTrapWrapper.contains(document.activeElement)) {
+    if (
+      this.focusTrapWrapper &&
+      this.focusTrapWrapper.contains(document.activeElement)
+    ) {
       return {shouldFocusSelf: false};
     }
 

--- a/src/utilities/sticky-manager/sticky-manager.ts
+++ b/src/utilities/sticky-manager/sticky-manager.ts
@@ -31,7 +31,7 @@ export interface StickyItem {
 export class StickyManager {
   private stickyItems: StickyItem[] = [];
   private stuckItems: StickyItem[] = [];
-  private container: Document | HTMLElement;
+  private container: Document | HTMLElement | null = null;
   private topBarOffset = 0;
 
   private handleResize = debounce(
@@ -70,7 +70,7 @@ export class StickyManager {
   setContainer(el: Document | HTMLElement) {
     this.container = el;
     if (isDocument(el)) {
-      this.setTopBarOffset();
+      this.setTopBarOffset(el);
     }
     addEventListener(this.container, 'scroll', this.handleScroll);
     addEventListener(window, 'resize', this.handleResize);
@@ -89,7 +89,7 @@ export class StickyManager {
       return;
     }
 
-    const scrollTop = scrollTopFor(this.container);
+    const scrollTop = this.container ? scrollTopFor(this.container) : 0;
     const containerTop = getRectForNode(this.container).top + this.topBarOffset;
 
     this.stickyItems.forEach((stickyItem) => {
@@ -225,8 +225,8 @@ export class StickyManager {
     return nodeFound >= 0;
   }
 
-  private setTopBarOffset() {
-    const topbarElement = this.container.querySelector(
+  private setTopBarOffset(container: Document) {
+    const topbarElement = container.querySelector(
       `:not(${scrollable.selector}) ${dataPolarisTopBar.selector}`,
     );
     this.topBarOffset = topbarElement ? topbarElement.clientHeight : 0;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,9 @@
     "declarationDir": "types",
     "declarationMap": false,
     "jsx": "react-native",
-    // strictFunctionTypes & strictPropertyInitialization are implictly
-    // enabled by strict mode but we're not yet compliant, so disable for now
+    // strictPropertyInitialization is implictly enabled by strict mode but
+    // we're not yet compliant, so disable for now
     "strictFunctionTypes": false,
-    "strictPropertyInitialization": false,
     "importHelpers": true,
     "skipLibCheck": false
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "declarationDir": "types",
     "declarationMap": false,
     "jsx": "react-native",
-    // strictPropertyInitialization is implictly enabled by strict mode but
+    // strictFunctionTypes is implictly enabled by strict mode but
     // we're not yet compliant, so disable for now
     "strictFunctionTypes": false,
     "importHelpers": true,


### PR DESCRIPTION
### WHY are these changes introduced?

We try to be strict mode compliant but this was disabled. This fixes the
components that fell afoul of that lint. Mostly this is accounting for
refs that may be null


### WHAT is this pull request doing?

Enable strictPropertyInitialization in our tsconfig

Add correct initializations to properties that were flagged. In most cases this was we were saying a value may be null but actually we never initialized it so it was `undefined`. Initilaizing to null is the fix.

### How to 🎩

- Ensure Modal still renders as you'd expect
- Ensure a component that uses a portal (like Toast or Popover) still renders its portaled content correctly.
- Ensure sticky managed items still work