### PR TITLE
[TrapFocus] Fix tab focusing

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@
 - Ensure the normalizedValue within `TextField` is a string (this was already ensured through type-checking at the TypeScript level, but people could force through with casting to `any`, which caused problems) ([#2598](https://github.com/Shopify/polaris-react/pull/2598))
 
 - Fixed an issue with the `Filters` component where the `aria-expanded` attribute was `undefined` on mount ([#2589]https://github.com/Shopify/polaris-react/pull/2589)
+- Fixed `TrapFocus` from tabbing out of the container ([#2555](https://github.com/Shopify/polaris-react/pull/2555))
 
 ### Documentation
 

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "@babel/runtime": "^7.1.6",
     "@material-ui/react-transition-group": "^4.2.0",
     "@shopify/app-bridge": "^1.3.0",
-    "@shopify/javascript-utilities": "^2.2.1",
+    "@shopify/javascript-utilities": "^2.4.1",
     "@shopify/polaris-icons": "^3.3.0",
     "@shopify/polaris-tokens": "^2.6.0",
     "@shopify/useful-types": "^1.2.4",

--- a/src/components/KeypressListener/KeypressListener.tsx
+++ b/src/components/KeypressListener/KeypressListener.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {useEffect} from 'react';
 import {
   addEventListener,
   removeEventListener,
@@ -8,29 +8,31 @@ import {Key} from '../../types';
 export interface KeypressListenerProps {
   keyCode: Key;
   handler(event: KeyboardEvent): void;
+  keyEvent?: KeyEvent;
 }
 
-export class KeypressListener extends React.Component<
-  KeypressListenerProps,
-  never
-> {
-  componentDidMount() {
-    addEventListener(document, 'keyup', this.handleKeyEvent);
-  }
+export enum KeyEvent {
+  KeyDown = 'keydown',
+  KeyUp = 'keyup',
+}
 
-  componentWillUnmount() {
-    removeEventListener(document, 'keyup', this.handleKeyEvent);
-  }
-
-  render() {
-    return null;
-  }
-
-  private handleKeyEvent = (event: KeyboardEvent) => {
-    const {keyCode, handler} = this.props;
-
+export function KeypressListener({
+  keyCode,
+  handler,
+  keyEvent = KeyEvent.KeyUp,
+}: KeypressListenerProps) {
+  const handleKeyEvent = (event: KeyboardEvent) => {
     if (event.keyCode === keyCode) {
       handler(event);
     }
   };
+
+  useEffect(() => {
+    addEventListener(document, keyEvent, handleKeyEvent);
+    return () => {
+      removeEventListener(document, keyEvent, handleKeyEvent);
+    };
+  });
+
+  return null;
 }

--- a/src/components/KeypressListener/index.ts
+++ b/src/components/KeypressListener/index.ts
@@ -1,1 +1,5 @@
-export {KeypressListener, KeypressListenerProps} from './KeypressListener';
+export {
+  KeypressListener,
+  KeypressListenerProps,
+  KeyEvent,
+} from './KeypressListener';

--- a/src/components/Modal/components/Dialog/Dialog.scss
+++ b/src/components/Modal/components/Dialog/Dialog.scss
@@ -22,6 +22,9 @@ $large-width: rem(980px);
     justify-content: center;
   }
 }
+.Dialog:focus {
+  outline: 0;
+}
 
 .Modal {
   position: fixed;
@@ -42,10 +45,6 @@ $large-width: rem(980px);
   @include frame-when-nav-hidden {
     bottom: 0;
     max-height: 100%;
-  }
-
-  &:focus {
-    outline: 0;
   }
 
   @include breakpoint-after(layout-width(page-with-nav)) {

--- a/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/src/components/Modal/components/Dialog/Dialog.tsx
@@ -1,6 +1,7 @@
 import React, {useRef, useCallback} from 'react';
 import {durationBase} from '@shopify/polaris-tokens';
 import {Transition, CSSTransition} from '@material-ui/react-transition-group';
+import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
 import {classNames} from '../../../../utilities/css';
 
 import {AnimationProps, Key} from '../../../../types';
@@ -8,6 +9,7 @@ import {AnimationProps, Key} from '../../../../types';
 import {KeypressListener} from '../../../KeypressListener';
 import {TrapFocus} from '../../../TrapFocus';
 
+import {useComponentDidMount} from '../../../../utilities/use-component-did-mount';
 import styles from './Dialog.scss';
 
 export interface BaseDialogProps {
@@ -43,6 +45,10 @@ export function Dialog({
   );
   const TransitionChild = instant ? Transition : FadeUp;
 
+  useComponentDidMount(() => {
+    containerNode.current && focusFirstFocusableNode(containerNode.current);
+  });
+
   return (
     <TransitionChild
       {...props}
@@ -61,17 +67,19 @@ export function Dialog({
       >
         <TrapFocus>
           <div
-            className={classes}
             role="dialog"
             aria-labelledby={labelledBy}
             tabIndex={-1}
+            className={styles.Dialog}
           >
-            <KeypressListener
-              keyCode={Key.Escape}
-              handler={onClose}
-              testID="CloseKeypressListener"
-            />
-            {children}
+            <div className={classes}>
+              <KeypressListener
+                keyCode={Key.Escape}
+                handler={onClose}
+                testID="CloseKeypressListener"
+              />
+              {children}
+            </div>
           </div>
         </TrapFocus>
       </div>

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Modal as AppBridgeModal} from '@shopify/app-bridge/actions';
+import {findFirstFocusableNode} from '@shopify/javascript-utilities/focus';
 import {animationFrame} from '@shopify/jest-dom-mocks';
 // eslint-disable-next-line no-restricted-imports
 import {
@@ -51,6 +52,13 @@ describe('<Modal>', () => {
     expect(component.find(TestComponent).prop('withinContentContainer')).toBe(
       true,
     );
+  });
+
+  it('focuses the next focusable node on mount', () => {
+    const modal = mountWithAppProvider(<Modal onClose={jest.fn()} open />);
+    const focusedNode = findFirstFocusableNode(modal.find(Dialog).getDOMNode());
+
+    expect(focusedNode).toBe(document.activeElement);
   });
 
   describe('src', () => {

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -1,99 +1,109 @@
-import React from 'react';
-import {closest} from '@shopify/javascript-utilities/dom';
-import {
-  focusFirstFocusableNode,
-  findFirstFocusableNode,
-  focusLastFocusableNode,
-} from '@shopify/javascript-utilities/focus';
-import {write} from '@shopify/javascript-utilities/fastdom';
+import React, {useState, useRef} from 'react';
+import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
+import {Key} from '../../types';
 
+import {useComponentDidMount} from '../../utilities/use-component-did-mount';
 import {EventListener} from '../EventListener';
+import {KeypressListener, KeyEvent} from '../KeypressListener';
 import {Focus} from '../Focus';
+
+import {
+  findFirstKeyboardFocusableNode,
+  focusFirstKeyboardFocusableNode,
+  findLastKeyboardFocusableNode,
+  focusLastKeyboardFocusableNode,
+} from '../../utilities/focus';
 
 export interface TrapFocusProps {
   trapping?: boolean;
   children?: React.ReactNode;
 }
 
-interface State {
-  shouldFocusSelf: boolean | undefined;
-}
+export function TrapFocus({trapping = true, children}: TrapFocusProps) {
+  const [shouldFocusSelf, setFocusSelf] = useState<boolean | undefined>(
+    undefined,
+  );
 
-export class TrapFocus extends React.PureComponent<TrapFocusProps, State> {
-  state: State = {
-    shouldFocusSelf: undefined,
+  const focusTrapWrapper = useRef<HTMLDivElement>(null);
+
+  const handleTrappingChange = () => {
+    if (
+      focusTrapWrapper.current &&
+      focusTrapWrapper.current.contains(document.activeElement)
+    ) {
+      return false;
+    }
+    return trapping;
   };
 
-  private focusTrapWrapper: HTMLElement | null = null;
+  useComponentDidMount(() => setFocusSelf(handleTrappingChange()));
 
-  componentDidMount() {
-    this.setState(this.handleTrappingChange());
-  }
-
-  handleTrappingChange() {
-    const {trapping = true} = this.props;
-
-    if (
-      this.focusTrapWrapper &&
-      this.focusTrapWrapper.contains(document.activeElement)
-    ) {
-      return {shouldFocusSelf: false};
-    }
-
-    return {shouldFocusSelf: trapping};
-  }
-
-  render() {
-    const {children} = this.props;
-
-    return (
-      <Focus disabled={this.shouldDisable()} root={this.focusTrapWrapper}>
-        <div ref={this.setFocusTrapWrapper}>
-          <EventListener event="focusout" handler={this.handleBlur} />
-          {children}
-        </div>
-      </Focus>
-    );
-  }
-
-  private shouldDisable() {
-    const {trapping = true} = this.props;
-    const {shouldFocusSelf} = this.state;
-
+  const shouldDisableFirstElementFocus = () => {
     if (shouldFocusSelf === undefined) {
       return true;
     }
 
     return shouldFocusSelf ? !trapping : !shouldFocusSelf;
-  }
-
-  private setFocusTrapWrapper = (node: HTMLDivElement) => {
-    this.focusTrapWrapper = node;
   };
 
-  private handleBlur = (event: FocusEvent) => {
-    const {relatedTarget} = event;
-    const {focusTrapWrapper} = this;
-    const {trapping = true} = this.props;
+  const handleFocusIn = (event: FocusEvent) => {
+    const containerContentsHaveFocus =
+      focusTrapWrapper.current &&
+      focusTrapWrapper.current.contains(document.activeElement);
 
-    if (relatedTarget == null || trapping === false) {
+    if (
+      trapping === false ||
+      !focusTrapWrapper.current ||
+      containerContentsHaveFocus
+    ) {
       return;
     }
 
     if (
-      focusTrapWrapper &&
-      !focusTrapWrapper.contains(relatedTarget as HTMLElement) &&
-      (!relatedTarget ||
-        !closest(relatedTarget as HTMLElement, '[data-polaris-overlay]'))
+      focusTrapWrapper.current !== event.target &&
+      !focusTrapWrapper.current.contains(event.target as Node)
     ) {
-      event.preventDefault();
-
-      if (event.srcElement === findFirstFocusableNode(focusTrapWrapper)) {
-        return write(() => focusLastFocusableNode(focusTrapWrapper));
-      }
-      const firstNode =
-        findFirstFocusableNode(focusTrapWrapper) || focusTrapWrapper;
-      write(() => focusFirstFocusableNode(firstNode));
+      focusFirstFocusableNode(focusTrapWrapper.current);
     }
   };
+
+  const handleTab = (event: KeyboardEvent) => {
+    if (trapping === false || !focusTrapWrapper.current) {
+      return;
+    }
+
+    const firstFocusableNode = findFirstKeyboardFocusableNode(
+      focusTrapWrapper.current,
+    );
+    const lastFocusableNode = findLastKeyboardFocusableNode(
+      focusTrapWrapper.current,
+    );
+
+    if (event.target === lastFocusableNode && !event.shiftKey) {
+      event.preventDefault();
+      focusFirstKeyboardFocusableNode(focusTrapWrapper.current);
+    }
+
+    if (event.target === firstFocusableNode && event.shiftKey) {
+      event.preventDefault();
+      focusLastKeyboardFocusableNode(focusTrapWrapper.current);
+    }
+  };
+
+  return (
+    <Focus
+      disabled={shouldDisableFirstElementFocus()}
+      root={focusTrapWrapper.current}
+    >
+      <div ref={focusTrapWrapper}>
+        <EventListener event="focusin" handler={handleFocusIn} />
+        <KeypressListener
+          keyCode={Key.Tab}
+          keyEvent={KeyEvent.KeyDown}
+          handler={handleTab}
+        />
+        {children}
+      </div>
+    </Focus>
+  );
 }

--- a/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -308,9 +308,17 @@ describe('<TrapFocus />', () => {
 function noop() {}
 
 function firstNode(element: ReactWrapper) {
-  return focusUtils.findFirstKeyboardFocusableNode(element.getDOMNode());
+  const elementNode = element.getDOMNode();
+
+  if (Array.isArray(elementNode))
+    return focusUtils.findFirstKeyboardFocusableNode(elementNode[0]);
+  return focusUtils.findFirstKeyboardFocusableNode(elementNode as HTMLElement);
 }
 
 function lastNode(element: ReactWrapper) {
-  return focusUtils.findLastKeyboardFocusableNode(element.getDOMNode());
+  const elementNode = element.getDOMNode();
+
+  if (Array.isArray(elementNode))
+    return focusUtils.findLastKeyboardFocusableNode(elementNode[0]);
+  return focusUtils.findLastKeyboardFocusableNode(elementNode as HTMLElement);
 }

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -3,6 +3,9 @@ import {isElementInViewport} from './is-element-in-viewport';
 
 type Filter = (element: Element) => void;
 
+const KEYBOARD_FOCUSABLE_SELECTORS =
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]:not([tabindex="-1"])';
+
 export function handleMouseUpByBlurring({
   currentTarget,
 }: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) {
@@ -39,4 +42,65 @@ export function focusNextFocusableNode(node: HTMLElement, filter?: Filter) {
   }
 
   return false;
+}
+
+// https://github.com/Shopify/javascript-utilities/blob/1e705564643d6fe7ffea5ebfbbf3e6b759a66c9b/src/focus.ts
+export function findFirstKeyboardFocusableNode(
+  element: HTMLElement,
+  onlyDescendants = true,
+): HTMLElement | null {
+  if (!onlyDescendants && matches(element, KEYBOARD_FOCUSABLE_SELECTORS)) {
+    return element;
+  }
+  return element.querySelector(KEYBOARD_FOCUSABLE_SELECTORS);
+}
+
+export function focusFirstKeyboardFocusableNode(
+  element: HTMLElement,
+  onlyDescendants = true,
+) {
+  const firstFocusable = findFirstKeyboardFocusableNode(
+    element,
+    onlyDescendants,
+  );
+  if (firstFocusable) {
+    firstFocusable.focus();
+    return true;
+  }
+
+  return false;
+}
+
+export function findLastKeyboardFocusableNode(
+  element: HTMLElement,
+  onlyDescendants = true,
+) {
+  if (!onlyDescendants && matches(element, KEYBOARD_FOCUSABLE_SELECTORS)) {
+    return element;
+  }
+  const allFocusable = element.querySelectorAll(KEYBOARD_FOCUSABLE_SELECTORS);
+  return allFocusable[allFocusable.length - 1] as HTMLElement | null;
+}
+
+export function focusLastKeyboardFocusableNode(
+  element: HTMLElement,
+  onlyDescendants = true,
+) {
+  const lastFocusable = findLastKeyboardFocusableNode(element, onlyDescendants);
+  if (lastFocusable) {
+    lastFocusable.focus();
+    return true;
+  }
+
+  return false;
+}
+
+function matches(node: HTMLElement, selector: string) {
+  if (node.matches) {
+    return node.matches(selector);
+  }
+
+  const matches = (node.ownerDocument || document).querySelectorAll(selector);
+  let i = matches.length;
+  while (--i >= 0 && matches.item(i) !== node) return i > -1;
 }

--- a/src/utilities/tests/focus.test.ts
+++ b/src/utilities/tests/focus.test.ts
@@ -3,6 +3,9 @@ import {
   handleMouseUpByBlurring,
   focusNextFocusableNode,
   nextFocusableNode,
+  findFirstKeyboardFocusableNode,
+  focusFirstKeyboardFocusableNode,
+  findLastKeyboardFocusableNode,
 } from '../focus';
 
 describe('handleMouseUpByBlurring()', () => {
@@ -80,6 +83,94 @@ describe('focusNextFocusableNode', () => {
     focusNextFocusableNode(activator);
 
     expect(document.activeElement).toBe(otherNode);
+  });
+});
+
+describe('findFirstKeyboardFocusableNode', () => {
+  it('returns the element if the element is focusable and onlyDescendants is false', () => {
+    const {activator} = domSetup();
+
+    expect(findFirstKeyboardFocusableNode(activator, false)).toBe(activator);
+  });
+
+  it('returns the first keyboard focusable child if the parent element cannot be focused', () => {
+    const {activator, otherNodeNested} = domSetup({activatorTag: 'div'});
+
+    expect(findFirstKeyboardFocusableNode(activator, false)).toBe(
+      otherNodeNested,
+    );
+  });
+
+  it('returns the first keyboard focusable child if onlyDescendants is true', () => {
+    const {activator, otherNodeNested} = domSetup();
+
+    expect(findFirstKeyboardFocusableNode(activator, true)).toBe(
+      otherNodeNested,
+    );
+  });
+});
+
+describe('focusFirstKeyboardFocusableNode', () => {
+  it('returns true when the node is focused', () => {
+    const {activator} = domSetup();
+
+    expect(focusFirstKeyboardFocusableNode(activator, false)).toBe(true);
+  });
+
+  it('returns false when the node is not focused', () => {
+    const {activator} = domSetup({otherNodeTag: 'div'});
+
+    expect(focusFirstKeyboardFocusableNode(activator)).toBe(false);
+  });
+
+  it('focuses the node', () => {
+    const {activator, otherNode} = domSetup();
+
+    focusFirstKeyboardFocusableNode(activator);
+
+    expect(document.activeElement).toStrictEqual(otherNode);
+  });
+});
+
+describe('findLastKeyboardFocusableNode', () => {
+  it('returns the element if the element is focusable and onlyDescendants is false', () => {
+    const {activator} = domSetup();
+
+    expect(findLastKeyboardFocusableNode(activator, false)).toBe(activator);
+  });
+
+  it('returns the last keyboard focusable child if the parent element cannot be focused', () => {
+    const {wrapper, otherNode} = domSetup();
+
+    expect(findLastKeyboardFocusableNode(wrapper, false)).toBe(otherNode);
+  });
+
+  it('returns the last focusable child if onlyDescendants is true', () => {
+    const {wrapper, otherNode} = domSetup();
+
+    expect(findLastKeyboardFocusableNode(wrapper, true)).toBe(otherNode);
+  });
+});
+
+describe('focusLastKeyboardFocusableNode', () => {
+  it('returns true when the node is focused', () => {
+    const {activator} = domSetup();
+
+    expect(focusFirstKeyboardFocusableNode(activator, false)).toBe(true);
+  });
+
+  it('returns false when the node is not focused', () => {
+    const {activator} = domSetup({otherNodeTag: 'div'});
+
+    expect(focusFirstKeyboardFocusableNode(activator)).toBe(false);
+  });
+
+  it('focuses the node', () => {
+    const {activator, otherNode} = domSetup();
+
+    focusFirstKeyboardFocusableNode(activator);
+
+    expect(document.activeElement).toStrictEqual(otherNode);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1648,10 +1648,20 @@
   resolved "https://registry.yarnpkg.com/@shopify/integrity-sha-utils/-/integrity-sha-utils-1.0.3.tgz#0d767d419fc1709ce7f8601fd8f61a0caa89a946"
   integrity sha512-VMr+48xgk3RxRRNkXcU5tN5t+Zfr4vvJJo9Y2+WLEWdvGgwF1ZXtrxDGmxBGoDa31AsJQZ+Gsda9Sl9F9iDg+A==
 
-"@shopify/javascript-utilities@^2.1.0", "@shopify/javascript-utilities@^2.2.1":
+"@shopify/javascript-utilities@^2.1.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@shopify/javascript-utilities/-/javascript-utilities-2.4.0.tgz#2ffd528b0632af0392b860f33b4c5ed5c72cdafa"
   integrity sha512-ZfQo1i87iKsSR7mkJOk3/7aPgfuXPrTTbM0dUJTlzdyf13ftJ2Val/WdMicaCVFu2r60uSsqoq/QpF0fLFVlcQ==
+  dependencies:
+    "@types/lodash" "^4.14.65"
+    "@types/react" "^16.0.2"
+    lodash "^4.17.4"
+    lodash-decorators "^4.3.5"
+
+"@shopify/javascript-utilities@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@shopify/javascript-utilities/-/javascript-utilities-2.4.1.tgz#99e1994381fc33a2609f7792b6812feee32362fa"
+  integrity sha512-CDp4nWHjVXTr+rYV5RMBs8aJ5PbXUdbz47jnKisBWa9GFwJktZFj2PxefXqfLd51KpIuQpFnA/NMvq4M5tdTlw==
   dependencies:
     "@types/lodash" "^4.14.65"
     "@types/react" "^16.0.2"


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, `TrapFocus` does not listen for keyboard events such as tabbing. Instead, it handles what happens _after_ we lose focus of the container (`handleBlur`). The problem with this approach is two things:
- If we focus an element outside of the page (such as the browser's search bar), we can't get focus back to the page contents, even if the `activeElement` is what it should be.
- If we prevent focus from ever leaving the page contents (by removing the check `relatedTarget == null`, then we introduce a bug where we rip focus away from the rest of the page if the container was rendered separately such as in an iFrame (see this PR explaining why this change broke the style guide https://github.com/Shopify/polaris-react/pull/2530)

### WHAT is this pull request doing?

- Functionalize `TrapFocus` and `KeypressListener`
- Remove all of the logic that handles focus on the `blur` event
- Add a key press listener for `tab`
- Add an event listener for `focusin` to handle focusing the container

### How to 🎩

- Follow [these](https://github.com/Shopify/polaris-react/blob/6579045fbbf668b8f1624631cd5c7f609f4bff57/documentation/Tophatting%20documentation.md#how-to--documentation) instructions to tophat with the style guide
- Check that `Popover` is acting as expected (since it also makes use of `TrapFocus`)

#### Modal:
- Click on open button, modal opens
	- Expected result = `Dialog` should be focused
- Pressing tab should,
	- focus the first element after the last element (and the reverse when tabbing backwards)
- Modal is opened, click outside of page, keep tabbing until we,
	- focus the `Dialog` (not the first focusable element)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
