### PR TITLE
Update vscode eslint plugin settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,11 @@
 // Place your settings in this file to overwrite default and user settings.
 {
   "css.validate": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
-  "eslint.autoFixOnSave": true,
-  "eslint.validate": [
-    {"language": "javascript", "autoFix": true},
-    {"language": "javascriptreact", "autoFix": true},
-    {"language": "typescript", "autoFix": true},
-    {"language": "typescriptreact", "autoFix": true}
-  ],
   "files.exclude": {
     "**/.DS_Store": true,
     "**/.git": true,


### PR DESCRIPTION
### WHY are these changes introduced?

v2 of vscode's eslint plugin got released and it changed some settings around. Notably it now autodetects typescript, and autofixing is exposed through the standard "editor.codeActionsOnSave" setting.

### WHAT is this pull request doing?

Updates vscode settings

### To Tophat

Check you're using v2. of eslint plugin
Confirm autofixing on save still works