### PR TITLE
Update stylelint-config-shopify to latest

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,6 +40,5 @@
     "styles/": true,
     "types/": true
   },
-  "stylelint.autoFixOnSave": true,
   "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@
 ### Dependency upgrades
 
 - Update to TypeScript 3.7 ([#2549](https://github.com/Shopify/polaris-react/pull/2549))
+- Update stylelint-config-shopify to 7.4.0 ([#2558](https://github.com/Shopify/polaris-react/pull/2558))
 
 ### Code quality
 

--- a/src/components/Page/Page.scss
+++ b/src/components/Page/Page.scss
@@ -19,6 +19,7 @@ body {
   // Ensure bottom margins of any children are contained
   &::after {
     content: '';
+    // stylelint-disable-next-line declaration-property-value-blacklist
     display: table;
   }
 }

--- a/src/styles/foundation/_colors.scss
+++ b/src/styles/foundation/_colors.scss
@@ -46,7 +46,7 @@ $color-palette-data: map-extend(
     );
   }
 
-  @if $for-background != null {
+  @if $for-background {
     $fetched-color: color-multiply($fetched-color, $for-background);
   }
 
@@ -75,7 +75,7 @@ Available options: #{available-names($color-palette-data)}
 /// @return {Color} The modified color.
 
 @function color-multiply($foreground, $background: null) {
-  @if $background == null {
+  @if $background {
     $background: rgb(255, 255, 255);
   }
 
@@ -122,7 +122,7 @@ $ms-high-contrast-color-data: (
 @function ms-high-contrast-color($color) {
   $fetched-color: map-get($ms-high-contrast-color-data, $color);
 
-  @if ($fetched-color) {
+  @if $fetched-color {
     @return $fetched-color;
   } @else {
     // stylelint-disable string-no-newline

--- a/src/styles/foundation/_layout.scss
+++ b/src/styles/foundation/_layout.scss
@@ -46,7 +46,7 @@ $layout-width-data: (
 @function layout-width($name, $value: base) {
   $fetched-value: map-get(map-get($layout-width-data, $name), $value);
 
-  @if type-of($fetched-value) != null {
+  @if type-of($fetched-value) {
     @return $fetched-value;
   } @else {
     @error 'Column `#{$name} - #{$value}` not found. Available columns: #{available-names($layout-width-data)}';

--- a/src/styles/foundation/_typography.scss
+++ b/src/styles/foundation/_typography.scss
@@ -110,7 +110,7 @@ $font-size-data: (
 @function font-family($family: base) {
   $fetched-value: map-get($font-family-data, $family);
 
-  @if $fetched-value != null {
+  @if $fetched-value {
     @return $fetched-value;
   } @else {
     @error 'Font family `#{$family}` not found. Available font families: #{available-names($font-family-data)}';
@@ -126,7 +126,7 @@ $font-size-data: (
 @function line-height($style, $variant: base) {
   $fetched-line-height: map-get(map-get($line-height-data, $style), $variant);
 
-  @if type-of($fetched-line-height) != null {
+  @if type-of($fetched-line-height) {
     @return $fetched-line-height;
   } @else {
     @error 'Line height `#{$style} - #{$variant}` not found. Available line heights: #{available-names($line-height-data)}';
@@ -142,7 +142,7 @@ $font-size-data: (
 @function font-size($style, $variant: base) {
   $fetched-font-size: map-get(map-get($font-size-data, $style), $variant);
 
-  @if type-of($fetched-font-size) != null {
+  @if type-of($fetched-font-size) {
     @return $fetched-font-size;
   } @else {
     @error 'Font size `#{$style} - #{$variant}` not found. Available font sizes: #{available-names($line-height-data)}';

--- a/src/styles/foundation/_utilities.scss
+++ b/src/styles/foundation/_utilities.scss
@@ -110,7 +110,7 @@ $base-font-size: 10px;
         )
       );
 
-      @if (type-of($value) == map) and (type-of(map-get($map, $key)) == map) {
+      @if type-of($value) == map and type-of(map-get($map, $key)) == map {
         $value: map-extend(map-get($map, $key), $value);
       }
     }

--- a/src/styles/shared/_breakpoints.scss
+++ b/src/styles/shared/_breakpoints.scss
@@ -27,9 +27,9 @@ $nav-min-window: em(layout-width(page-with-nav));
   // Reduces chances to have a style void
   // between two media queries
   // See https://github.com/sass-mq/sass-mq/issues/6
-  @if ($adjustment == -1px) {
+  @if $adjustment == -1px {
     $adjusted-value: -0.01em;
-  } @else if ($adjustment == 1px) {
+  } @else if $adjustment == 1px {
     $adjusted-value: 0.01em;
   }
 

--- a/src/styles/shared/_icons.scss
+++ b/src/styles/shared/_icons.scss
@@ -6,12 +6,12 @@
   svg {
     fill: $fill-color;
 
-    @if $secondary-color != null {
+    @if $secondary-color {
       color: $secondary-color;
     }
   }
 
-  @if $filter-color != null {
+  @if $filter-color {
     img {
       filter: $filter-color;
     }

--- a/src/styles/shared/_layout.scss
+++ b/src/styles/shared/_layout.scss
@@ -17,6 +17,7 @@
 /// If overriding an existing padding / margin that value should be used as
 /// $spacing.
 @mixin safe-area-for($property, $spacing, $area) {
+  // stylelint-disable-next-line scss/dimension-no-non-numeric-values
   $spacing: if($spacing == 0, #{$spacing}px, $spacing);
   #{$property}: #{$spacing};
   #{$property}: calc(#{$spacing} + constant(safe-area-inset-#{$area}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -5875,11 +5875,6 @@ cssesc@^0.1.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
   integrity sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=
 
-cssesc@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-1.0.1.tgz#ef7bd8d0229ed6a3a7051ff7771265fe7330e0a8"
-  integrity sha512-S2hzrpWvE6G/rW7i7IxJfWBYn27QWfOIncUW++8Rbo1VB5zsJDSVPcnI+Q8z7rhxT6/yZeLOCja4cZnghJrNGA==
-
 cssesc@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-2.0.0.tgz#3b13bd1bb1cb36e1bcb5a4dcd27f54c5dcb35703"
@@ -11242,6 +11237,11 @@ lodash.isarray@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
   integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
 
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
 lodash.isequal@^4.0.0, lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -11251,6 +11251,16 @@ lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isregexp@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isregexp/-/lodash.isregexp-4.0.1.tgz#e13e647b30cd559752a04cd912086faf7da1c30b"
+  integrity sha1-4T5kezDNVZdSoEzZEghvr32hwws=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -13776,15 +13786,6 @@ postcss-selector-parser@^3.0.0, postcss-selector-parser@^3.1.0:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-selector-parser@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-4.0.0.tgz#50c6570f40579036d8e63f23e6c0626fe5743527"
-  integrity sha512-5h+MvEjnzu1qy6MabjuoPatsGAjjDV9B24e7Cktjl+ClNtjVjmvAXjOFQr1u7RlWULKNGYaYVE4s+DIIQ4bOGA==
-  dependencies:
-    cssesc "^1.0.1"
-    indexes-of "^1.0.1"
-    uniq "^1.0.1"
-
 postcss-selector-parser@^5.0.0-rc.4:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz#249044356697b33b64f1a8f7c80922dddee7195c"
@@ -13817,10 +13818,10 @@ postcss-shopify@^2.2.1:
     postcss-selector-matches "4.0.0"
     postcss-will-change "3.0.0"
 
-postcss-sorting@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-sorting/-/postcss-sorting-4.0.0.tgz#abfdf41ff8f7710f66f5dc7e78a3a3cce3983c21"
-  integrity sha512-rN1USjy86i8rpr98PLVA0sYU4iZ+D1kU5vW/kKy6sZJTOm0O1HRD1JrX9KFyCtzU35XB9u3sMtLUoslKssIEoQ==
+postcss-sorting@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-sorting/-/postcss-sorting-4.1.0.tgz#a107f0bf3852977fa64e4442bc340c88d5aacdb3"
+  integrity sha512-r4T2oQd1giURJdHQ/RMb72dKZCuLOdWx2B/XhXN1Y1ZdnwXsKH896Qz6vD4tFy9xSjpKNYhlZoJmWyhH/7JUQw==
   dependencies:
     lodash "^4.17.4"
     postcss "^7.0.0"
@@ -13854,7 +13855,7 @@ postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
-postcss-value-parser@^4.0.0:
+postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz#482282c09a42706d1fc9a069b73f44ec08391dc9"
   integrity sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==
@@ -16662,42 +16663,44 @@ stylelint-config-prettier@^4.0.0:
   integrity sha512-cwh3QbBC2+3zBeMvuxFjT8XsbSdyoyELOY9BZqMuvphUKEQ+srkPWoN60FlvRwLB014TOke4Y12KvTtfKnaHhg==
 
 stylelint-config-shopify@^7.2.0:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/stylelint-config-shopify/-/stylelint-config-shopify-7.2.1.tgz#07567f0403e6c65525e666502163f6ef5bca76c5"
-  integrity sha512-HChP2m6nvc0QDAsirq9Tyi2PxMIn9iULuS7Ubnf0L1gJhEQS3EueoWpcJRIRm7qXjkQxutff1wwE/XHcen4QJg==
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-shopify/-/stylelint-config-shopify-7.4.0.tgz#c66f316d6fd1f0579b9d84b016e8cbf4d24b2b42"
+  integrity sha512-mLbUduYkMIrJNW9EUo0cDWIj/aYqF7Legy0w5KLBnzg2pBiUUrQfxGceyHUkDKh3EgO7APrDbwcvKmffrEocBQ==
   dependencies:
     merge "1.2.x"
     stylelint-config-prettier "^4.0.0"
-    stylelint-order "1.0.0"
-    stylelint-prettier "1.0.6"
-    stylelint-scss "3.3.0"
+    stylelint-order "2.2.1"
+    stylelint-prettier "1.1.2"
+    stylelint-scss "3.13.0"
 
-stylelint-order@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-order/-/stylelint-order-1.0.0.tgz#089fc3d5cdf7e7d4ac1882f65b60b25db750413c"
-  integrity sha512-2IVM8GzeKIDQDTETNdmgX99ywGrb7OqFWkniCw7QLqS/xONPGMLY/xAQnvGcUS3oBSo8znsoshsWVBqPz2Kv4Q==
+stylelint-order@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/stylelint-order/-/stylelint-order-2.2.1.tgz#cd2d4a0d81d91c705f1d275a58487e5ad5aa5828"
+  integrity sha512-019KBV9j8qp1MfBjJuotse6MgaZqGVtXMc91GU9MsS9Feb+jYUvUU3Z8XiClqPdqJZQ0ryXQJGg3U3PcEjXwfg==
   dependencies:
     lodash "^4.17.10"
     postcss "^7.0.2"
-    postcss-sorting "^4.0.0"
+    postcss-sorting "^4.1.0"
 
-stylelint-prettier@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-1.0.6.tgz#479b76336751cb617c5beb7545d05a791f945e1e"
-  integrity sha512-XKlTyJHJYiyXs9JXRMt2FQxMJoBSjz4I6+4+/R3o8/ePof19v9naC4d0zsMKUJ88by81+qHfqXBLfmAalu46cg==
+stylelint-prettier@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-1.1.2.tgz#2b19abe40789c380bffee3d4267c413d981a86ea"
+  integrity sha512-8QZ+EtBpMCXYB6cY0hNE3aCDKMySIx4Q8/malLaqgU/KXXa6Cj2KK8ulG1AJvUMD5XSSP8rOotqaCzR/BW6qAA==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-stylelint-scss@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-3.3.0.tgz#0de0ef241d347e32ed28a2cffb8397c37ae2738c"
-  integrity sha512-1E54Tsx/RPJDbGqLK8LcCUa62dB+KRg4zhqo/ub38PBpf16qz5mY/6VJCkQHSU3MygyyJDiFf/J5TLLznrRmGA==
+stylelint-scss@3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-3.13.0.tgz#875c76e61d95333c4f0ae737a310be6f1d27d780"
+  integrity sha512-SaLnvQyndaPcsgVJsMh6zJ1uKVzkRZJx+Wg/stzoB1mTBdEmGketbHrGbMQNymzH/0mJ06zDSpeCDvNxqIJE5A==
   dependencies:
-    lodash "^4.17.10"
+    lodash.isboolean "^3.0.3"
+    lodash.isregexp "^4.0.1"
+    lodash.isstring "^4.0.1"
     postcss-media-query-parser "^0.2.3"
     postcss-resolve-nested-selector "^0.1.1"
-    postcss-selector-parser "^4.0.0"
-    postcss-value-parser "^3.3.0"
+    postcss-selector-parser "^6.0.2"
+    postcss-value-parser "^4.0.2"
 
 stylelint@^9.9.0:
   version "9.10.1"


### PR DESCRIPTION
### WHY are these changes introduced?

Keeping up to date and fixing false positives in VScode.

This removes false positive warnings in TSX files when we define style
props like `<div style={{width: 100}}>Hi</div>` that vscode's stylelint
plugin reports. These never get surfaced when we run SK because that
doesn't run stylelint over tsx files but they're still annoying to see
in VSCode sidebars.

### WHAT is this pull request doing?

Update dependencies

Update code to follow new rules, mostly removing uneeded "!= null"
statements and parenthesis.

Disable autoFixing for the stylelint plugin - it turns out that it now
modifies app code on save even when nothing should change and that
causes conflicts with our ESLint rules. It can't be enabled on a
per-language basis so it needs to go entirely for now. (note that we still 
have prettier autoformatting on save so that still covers most autofixable stuff)
See https://github.com/stylelint/stylelint/issues/4485

### How to 🎩

Linting passes.

Editing SkeletonPage.tsx reports no style errors and doesn't change its content to something that triggers eslint warnings when you save it in VSCode.