### PR TITLE
Don't use Omit type in shipped code

### DIFF
--- a/src/components/Focus/tests/Focus.test.tsx
+++ b/src/components/Focus/tests/Focus.test.tsx
@@ -2,7 +2,6 @@ import React, {useRef, useState, useEffect} from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Focus, FocusProps} from '../Focus';
-import {Discard} from '../../../types';
 
 describe('<Focus />', () => {
   it('mounts', () => {
@@ -44,7 +43,7 @@ describe('<Focus />', () => {
   });
 });
 
-function FocusTestWrapper({children, ...props}: Discard<FocusProps, 'root'>) {
+function FocusTestWrapper({children, ...props}: Omit<FocusProps, 'root'>) {
   const root = useRef<HTMLDivElement>(null);
   const [, setMount] = useState(false);
 

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -13,7 +13,12 @@ import {useFeatures} from '../../utilities/features';
 
 type Inverse = 'inverse';
 
-interface ThemeProviderThemeConfig extends Omit<ThemeConfig, 'colorScheme'> {
+// TS 3.5+ includes the built-in Omit type which does the same thing. But if we
+// use that then we break consumers on older versions of TS. Consider removing
+// this when we drop support for consumers using TS <3.5 (in v5?)
+type Discard<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+interface ThemeProviderThemeConfig extends Discard<ThemeConfig, 'colorScheme'> {
   colorScheme?: ColorScheme | Inverse;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -326,8 +326,6 @@ export type DeepPartial<T> = {
     : DeepPartial<T[P]>;
 };
 
-export type Discard<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
 export type EffectCallback = () => void | (() => void | undefined);
 
 export type DependencyList = ReadonlyArray<unknown>;


### PR DESCRIPTION
### WHY are these changes introduced?

Lets not break consumers using TS <3.5 by using the built-in Omit type that was added in 3.5

### WHAT is this pull request doing?

Stop using omit in shippable code.
It's fine to use in tests though.

### How to 🎩

`yarn run build-consumer polaris-styleguide`  then run a build in the styleguide and confirm that it works.