### PR TITLE
[DropZone] Fixed cross browser security issue

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@
 - Fixed `TextField` to no longer render `aria-invalid="false"` ([#2282](https://github.com/Shopify/polaris-react/pull/2282))
 - Fixed `TextField` to only render `min` ,`max` and `step` attributes when explicitly passed ([#2282](https://github.com/Shopify/polaris-react/pull/2282))
 - Removed reference to `document` in `DropZone` ([#2560](https://github.com/Shopify/polaris-react/pull/2560))
+- Fixed Firefox issue in in `DropZone` ([#2568](https://github.com/Shopify/polaris-react/pull/2568))
 
 ### Documentation
 

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -468,7 +468,7 @@ interface DropZoneInputProps {
   type: Type;
   multiple: boolean;
   openFileDialog?: boolean;
-  onChange(event: DragEvent): void;
+  onChange(event: DragEvent | React.ChangeEvent<HTMLInputElement>): void;
   onFocus(): void;
   onBlur(): void;
   onFileDialogClose?(): void;

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -474,6 +474,8 @@ interface DropZoneInputProps {
   onFileDialogClose?(): void;
 }
 
+// Due to security reasons, browsers do not allow file inputs to be opened artificially.
+// For example `useEffect(() => { ref.click() })`. Oddly enough react class-based components bi-pass this.
 class DropZoneInput extends Component<DropZoneInputProps, never> {
   private fileInputNode = React.createRef<HTMLInputElement>();
 

--- a/src/components/DropZone/components/FileUpload/FileUpload.scss
+++ b/src/components/DropZone/components/FileUpload/FileUpload.scss
@@ -7,9 +7,6 @@ $slim-vertical-padding: ($slim-min-height - line-height(body) - rem(2px)) / 2;
 .FileUpload {
   padding: $fileupload-padding;
   text-align: center;
-  &.measuring {
-    display: none;
-  }
 }
 
 .Button {


### PR DESCRIPTION
### WHY are these changes introduced?

`DropZone` currently opens the file dialog via prop. However this is a security issue, and browsers *no not* allow file dialogs to be opened from artificial events. However using class-based components seen to be a workaround, probably related to how react handles synthetic events in class components. This is something we'll want to address in the future, and possible change our API.

### WHAT is this pull request doing?

* Wrapping the input element in a class component and managing dialog triggers within
* Adding tests

### How to 🎩

* test cross-browser
* specifically test the `drop-zone-with-custom-file-dialog-trigger` example

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
