### PR TITLE
[V5] invert translations order in AppProvider i18n

### DIFF
--- a/UNRELEASED-v5.md
+++ b/UNRELEASED-v5.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed `AppBridge`, `ResourcePicker` and `Loading`, `Modal`, `Page`, `Toast` App Bridge render delegation ([#2046](https://github.com/Shopify/polaris-react/pull/2046))
 - Drop support for iOS 9 ([#2195](https://github.com/Shopify/polaris-react/pull/2195))
 - The styles in global.scss have been moved into AppProvider. This only affects apps using the 'esnext' build; if you import `@shopify/polaris/styles.css` you are unaffected. Any applications using the 'esnext' build no longer needs to import the `@shopify/polaris/esnext/global.scss` file as it does nothing. An empty global.scss is provided in order to not break existing integration with sewing-kit versions < 0.113.0. ([#2392](https://github.com/Shopify/polaris-react/pull/2392))
+- Reversed the precedence of the language dictionaries passed into the `AppProvider`'s `i18n` prop. When passing an array of dictionaries the first dictionary should be your prefered language, followed by any fallback languages. ([]())
 
 ### Enhancements
 

--- a/UNRELEASED-v5.md
+++ b/UNRELEASED-v5.md
@@ -12,7 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed `AppBridge`, `ResourcePicker` and `Loading`, `Modal`, `Page`, `Toast` App Bridge render delegation ([#2046](https://github.com/Shopify/polaris-react/pull/2046))
 - Drop support for iOS 9 ([#2195](https://github.com/Shopify/polaris-react/pull/2195))
 - The styles in global.scss have been moved into AppProvider. This only affects apps using the 'esnext' build; if you import `@shopify/polaris/styles.css` you are unaffected. Any applications using the 'esnext' build no longer needs to import the `@shopify/polaris/esnext/global.scss` file as it does nothing. An empty global.scss is provided in order to not break existing integration with sewing-kit versions < 0.113.0. ([#2392](https://github.com/Shopify/polaris-react/pull/2392))
-- Reversed the precedence of the language dictionaries passed into the `AppProvider`'s `i18n` prop. When passing an array of dictionaries the first dictionary should be your prefered language, followed by any fallback languages. ([]())
+- Reversed the precedence of the language dictionaries passed into the `AppProvider`'s `i18n` prop. When passing an array of dictionaries the first dictionary should be your prefered language, followed by any fallback languages. ([#2572](https://github.com/Shopify/polaris-react/pull/2572))
 
 ### Enhancements
 

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -28,7 +28,7 @@ interface State {
 }
 
 export interface AppProviderProps {
-  /** A locale object or array of locale objects that overrides default translations. If specifying an array then your fallback language dictionaries should come first, followed by your primary language dictionary */
+  /** A locale object or array of locale objects that overrides default translations. If specifying an array then your primary language dictionary should come first, followed by your fallback language dictionaries */
   i18n: ConstructorParameters<typeof I18n>[0];
   /** A custom component to use for all links used by Polaris components */
   linkComponent?: LinkLikeComponent;

--- a/src/components/AppProvider/README.md
+++ b/src/components/AppProvider/README.md
@@ -459,13 +459,8 @@ function App() {
 
   // i18n.translations is an array of translation dictionaries, where the first
   // dictionary is the desired language, and the second is the fallback.
-  // AppProvider however expects that the first dictionary is the fallback
-  // and the second is the desired language. Thus we need to reverse the array
-  // to ensure the dictionaries are in the order desired by AppProvider
   return (
-    <AppProvider i18n={i18n.translations.reverse()}>
-      {/* App content */}
-    </AppProvider>
+    <AppProvider i18n={i18n.translations}>{/* App content */}</AppProvider>
   );
 }
 ```

--- a/src/utilities/i18n/I18n.ts
+++ b/src/utilities/i18n/I18n.ts
@@ -11,11 +11,13 @@ export class I18n {
   private translation: TranslationDictionary = {};
 
   /**
-   * @param translation A locale object or array of locale objects that overrides default translations. If specifying an array then your fallback language dictionaries should come first, followed by your primary language dictionary
+   * @param translation A locale object or array of locale objects that overrides default translations. If specifying an array then your desired language dictionary should come first, followed by your fallback language dictionaries
    */
   constructor(translation: TranslationDictionary | TranslationDictionary[]) {
+    // slice the array to make a shallow copy of it, so we don't accidentally
+    // modify the original translation array
     this.translation = Array.isArray(translation)
-      ? merge(...translation)
+      ? merge(...translation.slice().reverse())
       : translation;
   }
 

--- a/src/utilities/i18n/tests/I18n.test.ts
+++ b/src/utilities/i18n/tests/I18n.test.ts
@@ -18,12 +18,12 @@ describe('I18n.translate', () => {
 
   it('merges multiple dictionaries', () => {
     const translations: Record<string, string>[] = [
-      {one: 'uno', two: 'deux', three: 'trois'},
+      {one: 'un', two: 'deux', three: 'trois'},
       {one: 'one', two: 'two', three: 'three', fallback: 'fallback'},
     ];
 
     const i18n = new I18n(translations);
-    expect(i18n.translate('one')).toBe('uno');
+    expect(i18n.translate('one')).toBe('un');
     expect(i18n.translate('fallback')).toBe('fallback');
 
     // Assert the original translations array is not mutated

--- a/src/utilities/i18n/tests/I18n.test.ts
+++ b/src/utilities/i18n/tests/I18n.test.ts
@@ -17,12 +17,17 @@ describe('I18n.translate', () => {
   });
 
   it('merges multiple dictionaries', () => {
-    const i18n = new I18n([
-      {one: 'one', two: 'two', three: 'three', fallback: 'fallback'},
+    const translations: Record<string, string>[] = [
       {one: 'uno', two: 'deux', three: 'trois'},
-    ]);
+      {one: 'one', two: 'two', three: 'three', fallback: 'fallback'},
+    ];
+
+    const i18n = new I18n(translations);
     expect(i18n.translate('one')).toBe('uno');
     expect(i18n.translate('fallback')).toBe('fallback');
+
+    // Assert the original translations array is not mutated
+    expect(translations[0].two).toBe('deux');
   });
 
   it('uses replacements', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Previously you had to put the language you wanted at the end of the
array which was not obvious and didn't match the behaviour of
react-i18n.

### WHAT is this pull request doing?

Now if you pass an array into `<AppProvider i18n>` then the first object
in that array should be your preferred language.

This leads to simpler integration and simpler documentation on our side.

### How to 🎩

Check tests
