### PR TITLE
[TrapFocus] Remove cast

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+- Fixed type-error in `TrapFocus` that causing `querySelector` being ran on null ([#2574](https://github.com/Shopify/polaris-react/pull/2574))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -88,7 +88,8 @@ export class TrapFocus extends React.PureComponent<TrapFocusProps, State> {
       if (event.srcElement === findFirstFocusableNode(focusTrapWrapper)) {
         return write(() => focusLastFocusableNode(focusTrapWrapper));
       }
-      const firstNode = findFirstFocusableNode(focusTrapWrapper) as HTMLElement;
+      const firstNode =
+        findFirstFocusableNode(focusTrapWrapper) || focusTrapWrapper;
       write(() => focusFirstFocusableNode(firstNode));
     }
   };


### PR DESCRIPTION
Causing production errors

`return element.querySelector(exports.FOCUSABLE_SELECTOR)`
`write(() => focusFirstFocusableNode(firstNode));`