### PR TITLE
hopefully fix combobox key issue

### DIFF
--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -459,7 +459,7 @@ function assignOptionIds(
     (
       option: OptionDescriptor | ActionListItemDescriptor,
       optionIndex: number,
-    ) => Object.assign({id: `${comboBoxId}-${optionIndex}`}, option),
+) => ({id: `${comboBoxId}-${optionIndex}`, ...option}),
   );
   return options;
 }

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -459,9 +459,7 @@ function assignOptionIds(
     (
       option: OptionDescriptor | ActionListItemDescriptor,
       optionIndex: number,
-    ) => {
-      option.id = `${comboBoxId}-${optionIndex}`;
-    },
+    ) => Object.assign({id: `${comboBoxId}-${optionIndex}`}, option),
   );
   return options;
 }


### PR DESCRIPTION
was using autocomplete in a project, and kept getting these errors:

```
index.js:1 Warning: Encountered two children with the same key, `ComboBox3-0`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
    in ul (created by OptionList)
    in li (created by OptionList)
    in ul (created by OptionList)
    in OptionList (created by ComboBox)
    in div (created by ComboBox)
    in div (created by Scrollable)
    in Scrollable (created by Pane)
    in Pane (created by ComboBox)
    in div (created by PositionedOverlay)
    in div (created by PositionedOverlay)
    in div (created by PositionedOverlay)
    in div (created by PositionedOverlay)
    in PositionedOverlay (created by PopoverOverlay)
    in PopoverOverlay (created by Popover)
    in Portal (created by Popover)
    in div (created by Popover)
    in Popover (created by ComboBox)
    in div (created by ComboBox)
    in ComboBox (created by Autocomplete)
    in Autocomplete (at timezone.tsx:126)
    in TimezonePicker (at add.tsx:154)
    in div (created by Item$5)
    in Item$5 (created by FormLayout)
    in div (created by FormLayout)
    in FormLayout (at add.tsx:114)
    in form (created by Form)
    in Form (at add.tsx:113)
    in div (created by Section$4)
    in Section$4 (at add.tsx:112)
    in div (created by Page)
    in div (created by Page)
    in Page (created by WithAppProvider(Page))
    in WithAppProvider(Page) (at page.tsx:25)
    in div (created by Frame)
    in main (created by Frame)
    in div (created by Frame)
    in Frame (created by WithAppProvider(Frame))
    in WithAppProvider(Frame) (at page.tsx:24)
    in MediaQueryProvider (created by AppProvider)
    in div (created by ThemeProvider)
    in ThemeProvider (created by AppProvider)
    in AppProvider (at page.tsx:23)
    in div (at page.tsx:9)
    in Page (at add.tsx:111)
    in AddEventPage (created by App)
    in App
    in Container (created by AppContainer)
    in AppContainer
```

Which caused unexpected results on the combobox when typing characters, but it would all work fine when backspacing.

Inspecting the autocomplete options that I'm giving the component returns:

```
(6) [{…}, {…}, {…}, {…}, {…}, {…}]
0: {value: "America/Yakutat", label: "AKST - America/Yakutat (GMT -09:00)", offset: 540, id: "ComboBox3-0"}
1: {value: "America/Resolute", label: "CST - America/Resolute (GMT -06:00)", offset: 360, id: "ComboBox3-1"}
2: {value: "Etc/UTC", label: "UTC - Etc/UTC (GMT +00:00)", offset: 0, id: "ComboBox3-0", active: false}
3: {value: "Africa/Ceuta", label: "CET - Africa/Ceuta (GMT +01:00)", offset: -60, id: "ComboBox3-3"}
4: {value: "Africa/Maputo", label: "CAT - Africa/Maputo (GMT +02:00)", offset: -120, id: "ComboBox3-4"}
5: {value: "Asia/Beirut", label: "EET - Asia/Beirut (GMT +02:00)", offset: -120, id: "ComboBox3-5"}
length: 6
__proto__: Array(0)
```

As you can see, `id` properties exist, and one of them is a duplicate. This is odd, as:

1. I do not set the `id` property at all on the options I provide
2. Even if I do set the `id` property on the options I provide, the same result occurs

Derefencing the options with the following before I hand them over to autocomplete solves the issue

``` typescript
function dereferenceObjects<T>(items: Array<T>) {
	return items.slice().map(v => Object.assign({}, v))
}
```

Which then made me suspect that the polaris codebase is just writing to the source option object, instead of creating a new one.

This is a rough fix, I have not tested it.

Thanks to @sumitrai for debugging this with me on our work on Fountain.

You can see the problem in action with:

- [commit](https://github.com/bevry/fountain/commit/4dda5b9fe9cada33c2b54066d05d37f10a62f48d)
- [demo](https://fountain-c564pwujj.now.sh/events/add)

And the fix:

- [commit](https://github.com/bevry/fountain/commit/79716b22725a73c730fac22d367bf833884aed67)
- [demo](https://fountain-escc7027t.now.sh/events/add)

Test by typing `utc` and backspacing it. Notice that backspacing from `utc` to `ut` shows the correct result, but going from `u` to `ut` does not.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
