### PR TITLE
[Popover] Set right position when preferred alignment is right.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,7 @@
 
 - Fixed an issue with the `Filters` component where the `aria-expanded` attribute was `undefined` on mount ([#2589]https://github.com/Shopify/polaris-react/pull/2589)
 - Fixed `TrapFocus` from tabbing out of the container ([#2555](https://github.com/Shopify/polaris-react/pull/2555))
+- Fixed `PositionedOverlay` not correctly getting its position when aligned to the right of activator ([#2587](https://github.com/Shopify/polaris-react/pull/2587))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,7 @@
 - Fixed an issue with the `Filters` component where the `aria-expanded` attribute was `undefined` on mount ([#2589]https://github.com/Shopify/polaris-react/pull/2589)
 - Fixed `TrapFocus` from tabbing out of the container ([#2555](https://github.com/Shopify/polaris-react/pull/2555))
 - Fixed `PositionedOverlay` not correctly getting its position when aligned to the right of activator ([#2587](https://github.com/Shopify/polaris-react/pull/2587))
+- Fixed `PositionedOverlay` not correctly getting its position when aligned to the right of the activator ([#2587](https://github.com/Shopify/polaris-react/pull/2587))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,7 +21,6 @@
 
 - Fixed an issue with the `Filters` component where the `aria-expanded` attribute was `undefined` on mount ([#2589]https://github.com/Shopify/polaris-react/pull/2589)
 - Fixed `TrapFocus` from tabbing out of the container ([#2555](https://github.com/Shopify/polaris-react/pull/2555))
-- Fixed `PositionedOverlay` not correctly getting its position when aligned to the right of activator ([#2587](https://github.com/Shopify/polaris-react/pull/2587))
 - Fixed `PositionedOverlay` not correctly getting its position when aligned to the right of the activator ([#2587](https://github.com/Shopify/polaris-react/pull/2587))
 
 ### Documentation

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -52,7 +52,7 @@ $content-max-width: rem(400px);
 }
 
 .positionedAbove {
-  margin: spacing() 0 $visible-portion-of-arrow spacing(tight);
+  margin: spacing() spacing(tight) $visible-portion-of-arrow;
 
   &.fullWidth {
     margin: 0 0 $visible-portion-of-arrow;

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -125,14 +125,11 @@ export class PositionedOverlay extends React.PureComponent<
     const {render, fixed, classNames: propClassNames} = this.props;
 
     const style = {
-      // stylelint-disable function-name-case
       top: top == null || isNaN(top) ? undefined : top,
       left: left == null || isNaN(left) ? undefined : left,
       right: right == null || isNaN(right) ? undefined : right,
       width: width == null || isNaN(width) ? undefined : width,
-      // stylelint-disable-next-line value-keyword-case
       zIndex: zIndex == null || isNaN(zIndex) ? undefined : zIndex,
-      // stylelint-enable function-name-case
     };
 
     const className = classNames(

--- a/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -70,6 +70,20 @@ describe('<PositionedOverlay />', () => {
         <PositionedOverlay {...mockProps} preferredAlignment="left" />,
       );
 
+      expect((positionedOverlay.find('div').prop('style') as any).left).toBe(0);
+      expect(
+        (positionedOverlay.find('div').prop('style') as any).right,
+      ).toBeUndefined();
+    });
+
+    it('aligns right if preferredAlignment is given', () => {
+      const positionedOverlay = mountWithAppProvider(
+        <PositionedOverlay {...mockProps} preferredAlignment="right" />,
+      );
+
+      expect((positionedOverlay.find('div').prop('style') as any).right).toBe(
+        0,
+      );
       expect(
         (positionedOverlay.find('div').prop('style') as any).left,
       ).toBeUndefined();

--- a/src/components/PositionedOverlay/utilities/math.ts
+++ b/src/components/PositionedOverlay/utilities/math.ts
@@ -98,13 +98,12 @@ export function calculateHorizontalPosition(
       Math.max(0, activatorRect.left - overlayMargins.horizontal),
     );
   } else if (preferredAlignment === 'right') {
-    const activatorRight = activatorRect.left + activatorRect.width;
+    const activatorRight =
+      containerRect.width - (activatorRect.left + activatorRect.width);
+
     return Math.min(
       maximum,
-      Math.max(
-        0,
-        activatorRight - overlayRect.width + overlayMargins.horizontal,
-      ),
+      Math.max(0, activatorRight - overlayMargins.horizontal),
     );
   }
 

--- a/src/components/Scrollable/Scrollable.scss
+++ b/src/components/Scrollable/Scrollable.scss
@@ -20,6 +20,10 @@ $shadow-top: inset 0 $shadow-size $shadow-size (-1 * $shadow-size)
   overflow-y: auto;
 }
 
+.verticalHasScrolling {
+  overflow-y: scroll;
+}
+
 .hasTopShadow {
   box-shadow: $shadow-top;
 }

--- a/src/components/Scrollable/Scrollable.tsx
+++ b/src/components/Scrollable/Scrollable.tsx
@@ -125,9 +125,8 @@ export class Scrollable extends React.Component<ScrollableProps, State> {
       horizontal && styles.horizontal,
       topShadow && styles.hasTopShadow,
       bottomShadow && styles.hasBottomShadow,
+      vertical && canScroll && styles.verticalHasScrolling,
     );
-
-    const overflowY = vertical && canScroll ? 'scroll' : undefined;
 
     return (
       <ScrollableContext.Provider value={this.scrollToPosition}>
@@ -137,7 +136,6 @@ export class Scrollable extends React.Component<ScrollableProps, State> {
             {...scrollable.props}
             {...rest}
             ref={this.setScrollArea}
-            style={{overflowY}}
           >
             {children}
           </div>

--- a/src/components/Scrollable/Scrollable.tsx
+++ b/src/components/Scrollable/Scrollable.tsx
@@ -163,7 +163,6 @@ export class Scrollable extends React.Component<ScrollableProps, State> {
     const shouldTopShadow = Boolean(shadow && scrollTop > 0);
 
     const canScroll = scrollHeight > clientHeight;
-
     const hasScrolledToBottom = scrollHeight - scrollTop === clientHeight;
 
     if (canScroll && hasScrolledToBottom && onScrolledToBottom) {

--- a/src/components/Scrollable/Scrollable.tsx
+++ b/src/components/Scrollable/Scrollable.tsx
@@ -42,6 +42,7 @@ interface State {
   topShadow: boolean;
   bottomShadow: boolean;
   scrollPosition: number;
+  canScroll: boolean;
 }
 
 export class Scrollable extends React.Component<ScrollableProps, State> {
@@ -56,6 +57,7 @@ export class Scrollable extends React.Component<ScrollableProps, State> {
     topShadow: false,
     bottomShadow: false,
     scrollPosition: 0,
+    canScroll: false,
   };
 
   private stickyManager = new StickyManager();
@@ -104,7 +106,7 @@ export class Scrollable extends React.Component<ScrollableProps, State> {
   }
 
   render() {
-    const {topShadow, bottomShadow} = this.state;
+    const {topShadow, bottomShadow, canScroll} = this.state;
     const {
       children,
       className,
@@ -125,6 +127,8 @@ export class Scrollable extends React.Component<ScrollableProps, State> {
       bottomShadow && styles.hasBottomShadow,
     );
 
+    const overflowY = vertical && canScroll ? 'scroll' : undefined;
+
     return (
       <ScrollableContext.Provider value={this.scrollToPosition}>
         <StickyManagerContext.Provider value={this.stickyManager}>
@@ -133,6 +137,7 @@ export class Scrollable extends React.Component<ScrollableProps, State> {
             {...scrollable.props}
             {...rest}
             ref={this.setScrollArea}
+            style={{overflowY}}
           >
             {children}
           </div>
@@ -158,6 +163,7 @@ export class Scrollable extends React.Component<ScrollableProps, State> {
     const shouldTopShadow = Boolean(shadow && scrollTop > 0);
 
     const canScroll = scrollHeight > clientHeight;
+
     const hasScrolledToBottom = scrollHeight - scrollTop === clientHeight;
 
     if (canScroll && hasScrolledToBottom && onScrolledToBottom) {
@@ -168,6 +174,7 @@ export class Scrollable extends React.Component<ScrollableProps, State> {
       topShadow: shouldTopShadow,
       bottomShadow: shouldBottomShadow,
       scrollPosition: scrollTop,
+      canScroll,
     });
   };
 

--- a/src/components/TopBar/components/Menu/Menu.tsx
+++ b/src/components/TopBar/components/Menu/Menu.tsx
@@ -57,6 +57,7 @@ export function Menu(props: MenuProps) {
       onClose={onClose}
       fixed
       fullHeight={isFullHeight}
+      preferredAlignment="right"
     >
       <ActionList onActionAnyItem={onClose} sections={actions} />
       {messageMarkup}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1673

### WHAT is this pull request doing?

From what I can tell the issue is that the Scrollable scrollbars appear inside the Popover after the PositionOverlay has done its calculations and since the content is responsive, once the scrollbars are added the content wraps. 

For example. If the window is 1000px wide, the overlay 100px wide, the left position will be calculated at 900px. Once the scrollbars appear, the left position does not get recalculated because the content is responsive. The left position pushed the overlay against the right side of the browser and when too close to the chrome causes the content to wrap. This occurs only when the popover is too close to the right of the window. 

This is one of a few attempts at fixing this issue. When a popover has a preferred right, we go from the right instead of the left. That way, even if scrollbars appear, the right position stays the same, and the left does not counter it. 

It also contains a change that when content can be scrolled in a Scrollable container, it sets `overflow-y: scroll` then reverts to `auto` when the content cannot be scrolled. This forces the layout engines to set the element width properly.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';
import {ArrowLeftMinor} from '@shopify/polaris-icons';
import {
  AppProvider,
  Frame,
  Page,
  Card,
  ActionList,
  TopBar,
  Button,
  Popover,
} from '../src';

export function Playground() {
  const [userMenuOpen, setUserMenuOpen] = useState(false);
  const [searchActive, setSearchActive] = useState(false);
  const [searchText, setSearchText] = useState('');
  const [popover1Active, setPopover1Active] = useState(false);
  const [popover2Active, setPopover2Active] = useState(false);
  const [popover3Active, setPopover3Active] = useState(false);
  const [popover1PositionBelow, setPopover1PositionBelow] = useState(true);
  const [popover2PositionBelow, setPopover2PositionBelow] = useState(true);
  const [popover3PositionBelow, setPopover3PositionBelow] = useState(true);
  const [showScrollingUserMenu, setShowScrollingUserMenu] = useState(true);

  const toggleUserMenu = () => {
    setUserMenuOpen(!userMenuOpen);
  };

  const toggleScrollingUserMenu = () => {
    setShowScrollingUserMenu(!showScrollingUserMenu);
  };

  const togglePopover = (popoverID: string) => () => {
    setPopover1Active(popoverID === 'popover1' ? !popover1Active : false);
    setPopover2Active(popoverID === 'popover2' ? !popover2Active : false);
    setPopover3Active(popoverID === 'popover3' ? !popover3Active : false);
  };

  const handleSearchResultsDismiss = () => {
    setSearchActive(false);
    setSearchText('');
  };

  const handleSearchChange = (value) => {
    setSearchText(value);
    if (value.length > 0) {
      setSearchActive(true);
    } else {
      setSearchActive(false);
    }
  };

  const theme = {
    colors: {
      topBar: {
        background: '#357997',
        backgroundLighter: '#6192a9',
        color: '#FFFFFF',
      },
    },
    logo: {
      width: 124,
      topBarSource:
        'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-color.svg?6215648040070010999',
      url: 'http://jadedpixel.com',
      accessibilityLabel: 'Jaded Pixel',
    },
  };

  const actionsWithScroll = [
    {
      items: [{content: 'Back to Shopify', icon: ArrowLeftMinor}],
    },
    {
      items: [{content: 'Community forums'}],
    },
    {
      items: [{content: 'Community forums'}],
    },
    {
      items: [{content: 'Community forums'}],
    },
    {
      items: [{content: 'Community forums'}],
    },
    {
      items: [{content: 'Community forums'}],
    },
    {
      items: [{content: 'Community forums'}],
    },
  ];

  const actions = [
    {
      items: [{content: 'Back to Shopify', icon: ArrowLeftMinor}],
    },
    {
      items: [{content: 'Community forums'}],
    },
    {
      items: [{content: 'Community forums'}],
    },
    {
      items: [{content: 'Community forums'}],
    },
  ];

  const userMenuMarkup = (
    <TopBar.UserMenu
      actions={showScrollingUserMenu ? actionsWithScroll : actions}
      name="Dharma"
      detail="Jaded Pixel"
      initials="D"
      open={userMenuOpen}
      onToggle={toggleUserMenu}
    />
  );

  const searchResultsMarkup = (
    <Card>
      <ActionList
        items={[
          {content: 'Shopify help center'},
          {content: 'Community forums'},
        ]}
      />
    </Card>
  );

  const searchFieldMarkup = (
    <TopBar.SearchField
      onChange={handleSearchChange}
      value={searchText}
      placeholder="Search"
    />
  );

  const topBarMarkup = (
    <TopBar
      showNavigationToggle
      userMenu={userMenuMarkup}
      searchResultsVisible={searchActive}
      searchField={searchFieldMarkup}
      searchResults={searchResultsMarkup}
      onSearchResultsDismiss={handleSearchResultsDismiss}
    />
  );

  const activator1 = (
    <Button onClick={togglePopover('popover1')}>Popover Left</Button>
  );

  const activator2 = (
    <Button onClick={togglePopover('popover2')}>Popover Center</Button>
  );

  const activator3 = (
    <Button onClick={togglePopover('popover3')}>Popover Right</Button>
  );

  return (
    <AppProvider i18n={{}} theme={theme}>
      <Frame topBar={topBarMarkup}>
        <Page
          title="Popover alignment/width bug"
          primaryAction={{
            content: `Render ${
              showScrollingUserMenu ? 'non-scrolling' : 'scrolling'
            } user menu`,
            onAction: toggleScrollingUserMenu,
          }}
        >
          <Card>
            <Card.Section
              actions={[
                {
                  content: 'Toggle position',
                  onAction: () =>
                    setPopover1PositionBelow(!popover1PositionBelow),
                },
              ]}
            >
              <Popover
                active={popover1Active}
                activator={activator1}
                onClose={togglePopover('popover1')}
                preferredAlignment="left"
                preferredPosition={popover1PositionBelow ? 'below' : 'above'}
              >
                <ActionList
                  items={[{content: 'Import'}, {content: 'Export'}]}
                />
              </Popover>
            </Card.Section>
            <Card.Section
              actions={[
                {
                  content: 'Toggle position',
                  onAction: () =>
                    setPopover2PositionBelow(!popover2PositionBelow),
                },
              ]}
            >
              <Popover
                active={popover2Active}
                activator={activator2}
                onClose={togglePopover('popover2')}
                preferredAlignment="center"
                preferredPosition={popover2PositionBelow ? 'below' : 'above'}
              >
                <ActionList
                  items={[{content: 'Import'}, {content: 'Export'}]}
                />
              </Popover>
            </Card.Section>
            <Card.Section
              actions={[
                {
                  content: 'Toggle position',
                  onAction: () =>
                    setPopover3PositionBelow(!popover3PositionBelow),
                },
              ]}
            >
              <Popover
                active={popover3Active}
                activator={activator3}
                onClose={togglePopover('popover3')}
                preferredAlignment="right"
                preferredPosition={popover3PositionBelow ? 'below' : 'above'}
              >
                <ActionList
                  items={[{content: 'Import'}, {content: 'Export'}]}
                />
              </Popover>
            </Card.Section>
          </Card>
        </Page>
      </Frame>
    </AppProvider>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
