### PR TITLE
[Filters] Ensure aria-expanded is not set to undefined on mount

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@
 
 - Fixed issue with `Filters` component displaying an undesired margin top and bottom on the button element on Safari ([#2292](https://github.com/Shopify/polaris-react/pull/2292))
 
+- Fixed an issue with the `Filters` component where the `aria-expanded` attribute was `undefined` on mount ([#2589]https://github.com/Shopify/polaris-react/pull/2589)
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -489,7 +489,7 @@ class Filters extends React.Component<ComposedProps, State> {
 
       transformedActions.push({
         popoverContent: this.generateFilterMarkup(filter),
-        popoverOpen: this.state[`${key}${Suffix.Shortcut}`],
+        popoverOpen: Boolean(this.state[`${key}${Suffix.Shortcut}`]),
         key,
         content: label,
         disabled,

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -217,6 +217,20 @@ describe('<Filters />', () => {
       ).toHaveLength(2);
     });
 
+    it('receives shortcut filters with popoverOpen set to false on mount', () => {
+      const resourceFilters = mountWithAppProvider(
+        <Filters {...mockPropsWithShortcuts} />,
+      );
+
+      const rightPopoverableActions = resourceFilters
+        .find(ConnectedFilterControl)
+        .props().rightPopoverableActions;
+
+      rightPopoverableActions!.forEach((action) => {
+        expect(action.popoverOpen).toBe(false);
+      });
+    });
+
     it('toggles a shortcut filter', () => {
       const resourceFilters = mountWithAppProvider(
         <Filters {...mockPropsWithShortcuts} />,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
When the Filters components mounts onto the DOM, the `aria-expanded` attribute on the Popover activator is set to `undefined`, which is an invalid value; the `aria-expanded` attribute should be set to either `true` or `false`.

<img width="893" alt="Screen Shot 2020-01-03 at 11 30 26 AM" src="https://user-images.githubusercontent.com/8534230/71739873-a761de80-2e28-11ea-9944-6e9ece9d4784.png">

This results in an error when running a Lighthouse accessibility audit on a page that uses the Filters component.

<img width="823" alt="Screen Shot 2020-01-03 at 11 26 15 AM" src="https://user-images.githubusercontent.com/8534230/71739960-ded08b00-2e28-11ea-89e4-8a987bdcd10c.png">

The `aria-expanded` attribute is set to `true` or `false` once a user starts interacting with the Popover activator.

![filter-aria-expanded-before](https://user-images.githubusercontent.com/8534230/71739862-9e710d00-2e28-11ea-9e4b-eb8197371faa.gif)

### WHAT is this pull request doing?
This PR ensures the `aria-expanded` attribute of the Popover activator in the Filters component is always set to either `true` or `false`.

The activator's `aria-expanded` attribute is determined by the `popoverOpen` key of a given action, which is set to the value of ```this.state[`${key}${Suffix.Shortcut}`]``` in the Filters component.

```js
// In Filters.tsx
      transformedActions.push({
        popoverOpen: this.state[`${key}${Suffix.Shortcut}`],
        // Other props...
      });

// In ConnectedFilterControl.tsx
private popoverFrom(actions: PopoverableAction[]): React.ReactElement[] {
    return actions.map((action) => {
      return (
        <Item key={action.key}>
          <Popover
            active={action.popoverOpen}
            // Other props...
          >
            {action.popoverContent}
          </Popover>
        </Item>
      );
    });
  }
```

On mount, however, ```this.state[`${key}${Suffix.Shortcut}`]```  is undefined.

![image](https://user-images.githubusercontent.com/8534230/71740161-85b52700-2e29-11ea-90cd-2846f41ed541.png)

The state key for a filter action gets defined when the popover is either opened or closed on click, but it is not initialized on mount.

```js
// In Filters.tsx
  state: State = {
    open: false,
    readyForFocus: false,
  };

  private openFilter(key: string) {
    this.setState({[`${key}${Suffix.Filter}`]: true});
  }

  private closeFilter(key: string) {
    this.setState({[`${key}${Suffix.Filter}`]: false});
  }
```

To ensure the `aria-expanded` attribute is set to either `true` or `false`, this PR transforms the value of ```this.state[`${key}${Suffix.Shortcut}`]``` into a Boolean when setting the `popoverOpen` key of a given action:

```js
// In Filters.tsx
      transformedActions.push({
        popoverOpen: Boolean(this.state[`${key}${Suffix.Shortcut}`]),
        // Other props...
      });
```

<img width="1101" alt="Screen Shot 2020-01-03 at 11 59 18 AM" src="https://user-images.githubusercontent.com/8534230/71740758-14767380-2e2b-11ea-8ffb-259b13c0503b.png">


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';
import {
  Avatar,
  Card,
  ChoiceList,
  ResourceList,
  Filters,
  TextStyle,
} from '../src';

export function Playground() {
  const [accountStatus, setAccountStatus] = useState(null);
  const [moneySpent, setMoneySpent] = useState(null);
  const [taggedWith, setTaggedWith] = useState(null);
  const [queryValue, setQueryValue] = useState(null);

  const handleAccountStatusChange = useCallback(
    (value) => setAccountStatus(value),
    [],
  );
  const handleMoneySpentChange = useCallback(
    (value) => setMoneySpent(value),
    [],
  );
  const handleTaggedWithChange = useCallback(
    (value) => setTaggedWith(value),
    [],
  );
  const handleFiltersQueryChange = useCallback(
    (value) => setQueryValue(value),
    [],
  );
  const handleAccountStatusRemove = useCallback(
    () => setAccountStatus(null),
    [],
  );
  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
  const handleFiltersClearAll = useCallback(() => {
    handleAccountStatusRemove();
    handleMoneySpentRemove();
    handleTaggedWithRemove();
    handleQueryValueRemove();
  }, [
    handleAccountStatusRemove,
    handleMoneySpentRemove,
    handleQueryValueRemove,
    handleTaggedWithRemove,
  ]);

  const filters = [
    {
      key: 'accountStatus',
      label: 'Account status',
      filter: (
        <ChoiceList
          title="Account status"
          titleHidden
          choices={[
            {label: 'Enabled', value: 'enabled'},
            {label: 'Not invited', value: 'not invited'},
            {label: 'Invited', value: 'invited'},
            {label: 'Declined', value: 'declined'},
          ]}
          selected={accountStatus || []}
          onChange={handleAccountStatusChange}
          allowMultiple
        />
      ),
      shortcut: true,
    },
  ];

  const appliedFilters = [];

  return (
    <div style={{height: '568px'}}>
      <Card>
        <ResourceList
          resourceName={{singular: 'customer', plural: 'customers'}}
          filterControl={
            <Filters
              queryValue={queryValue}
              filters={filters}
              appliedFilters={appliedFilters}
              onQueryChange={handleFiltersQueryChange}
              onQueryClear={handleQueryValueRemove}
              onClearAll={handleFiltersClearAll}
            />
          }
          items={[
            {
              id: 341,
              url: 'customers/341',
              name: 'Mae Jemison',
              location: 'Decatur, USA',
            },
            {
              id: 256,
              url: 'customers/256',
              name: 'Ellen Ochoa',
              location: 'Los Angeles, USA',
            },
          ]}
          renderItem={(item) => {
            const {id, url, name, location} = item;
            const media = <Avatar customer size="medium" name={name} />;

            return (
              <ResourceList.Item
                id={id}
                url={url}
                media={media}
                accessibilityLabel={`View details for ${name}`}
              >
                <h3>
                  <TextStyle variation="strong">{name}</TextStyle>
                </h3>
                <div>{location}</div>
              </ResourceList.Item>
            );
          }}
        />
      </Card>
    </div>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
