### PR TITLE
[Tabs] Adds a means to hide tabs if there is only one

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@
 
 - Added `hideTags` prop to `Filters` ([#2573](https://github.com/Shopify/polaris-react/pull/2573))
 
+- Added `optionalSingleTab` prop to `Tabs` ([#2592](https://github.com/Shopify/polaris-react/pull/2592))
+
 ### Bug fixes
 
 - Fixed issue with `Filters` component displaying an undesired margin top and bottom on the button element on Safari ([#2292](https://github.com/Shopify/polaris-react/pull/2292))

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -27,6 +27,8 @@ export interface TabsProps {
   fitted?: boolean;
   /** Callback when tab is selected */
   onSelect?(selectedTabIndex: number): void;
+  /** Suppress tab header if there is only one tab */
+  optionalSingleTab?: boolean;
 }
 
 type CombinedProps = TabsProps & WithAppProviderProps;
@@ -74,11 +76,14 @@ class Tabs extends React.PureComponent<CombinedProps, State> {
       tabs,
       selected,
       fitted,
+      optionalSingleTab,
       children,
       polaris: {intl},
     } = this.props;
     const {tabToFocus, visibleTabs, hiddenTabs, showDisclosure} = this.state;
     const disclosureTabs = hiddenTabs.map((tabIndex) => tabs[tabIndex]);
+
+    const skipTabs = optionalSingleTab && visibleTabs.length <= 1;
 
     const panelMarkup = children
       ? tabs.map((_tab, index) => {
@@ -131,7 +136,9 @@ class Tabs extends React.PureComponent<CombinedProps, State> {
       </button>
     );
 
-    return (
+    return skipTabs ? (
+      <div>{children}</div>
+    ) : (
       <div>
         <ul
           role="tablist"


### PR DESCRIPTION
Devs had a need to create a HOC `Tabs` component for cases when the number of tabs was dynamic and the desire was to hide the tab UI if there is only one tab.

For example: https://github.com/Shopify/web/pull/22045/files#diff-c2ee73134750ecc64faa9c16571e09cf

### WHAT is this pull request doing?

This PR adds a new optional prop to `Tabs`.  If undefined or `false`, current behavior is retained.  If `true` and if there is not more than one visible tab, `children` is rendered directly, without being wrapped with the tabs markup.


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Card, Tabs} from '../src';

export function Playground() {
  const [selected, setSelected] = React.useState(0);

  const handleTabChange = React.useCallback(
    (selectedTabIndex) => setSelected(selectedTabIndex),
    [],
  );

  const tabs = [
    {
      id: 'prospects',
      content: 'Prospects',
      panelID: 'prospects-content',
    },
    // {
    //   id: 'second',
    //   content: 'Second',
    //   panelID: 'second-content',
    // },
  ];

  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}

      <Card>
        <Tabs
          tabs={tabs}
          selected={selected}
          onSelect={handleTabChange}
          optionalSingleTab
        >
          <Card.Section title={tabs[selected].content}>
            <p>Tab {selected} selected</p>
          </Card.Section>
        </Tabs>
      </Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
