### PR TITLE
Recommend official stylelint extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,7 @@
     "dbaeumer.vscode-eslint",
     "EditorConfig.editorconfig",
     "esbenp.prettier-vscode",
-    "hex-ci.stylelint-plus",
+    "stylelint.vscode-stylelint",
     "mrmlnc.vscode-scss"
   ]
 }


### PR DESCRIPTION
The story of stylelint in vscode has had a rough month or so.

The original extension we used `shinn.stylelint` was removed as the author no longer supported it, so we switched over to a recent fork `hex-ci.stylelint-plus` as a stopgap. This also triggered the stylelint org to sort out creating an official extension, which was recently published as `stylelint.vscode-stylelint` and is now being actively maintained.

Now there is an official extension, we should use it. It offers a few improvements over the hex-ci fork, most notably it uses the version of stylelint in our project instead of the version bundled with the extension. The new official extension also supports autofixing issues, but we can't use that just yet as it [incorrectly modifies some files](https://github.com/stylelint/stylelint/issues/4449) (A fix has been merged upstream but not yet released so hopefully that's close). This isn't the end of the world as the most common issues - prettier violations will get autofixed thanks for the formatter anyway.