### PR TITLE
Be explict about some i18n oddness around undefined keys, and TextField's value

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@
 - Fixed a regression with the positioning of the `Popover` component ([#2305](https://github.com/Shopify/polaris-react/pull/2305))
 - Fixed Stack Item proportion when shrinking ([#2319](https://github.com/Shopify/polaris-react/pull/2319))
 - Fixed `RangeSlider` focus state style issues ([#1926](https://github.com/Shopify/polaris-react/pull/1926))
+- Ensure passing `{key: undefined}` into i18n will throw a runtime error in the same way as not passing in the key at all (this was ensured through type-checking at the TypeScript level but people could force through with casting to `any`) ([#2598](https://github.com/Shopify/polaris-react/pull/2598))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -31,5 +31,6 @@
 - Converted `Focus` into a functional component ([#2540](https://github.com/Shopify/polaris-react/pull/2540))
 - Converted `Tooltip` into a functional component ([#2543](https://github.com/Shopify/polaris-react/pull/2543))
 - Converted `Option` into a functional component ([#2541](https://github.com/Shopify/polaris-react/pull/2541))
+- Avoided unneeded work in `TextField` if character count is not rendered ([#2598](https://github.com/Shopify/polaris-react/pull/2598))
 
 ### Deprecations

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@
 - Fixed Stack Item proportion when shrinking ([#2319](https://github.com/Shopify/polaris-react/pull/2319))
 - Fixed `RangeSlider` focus state style issues ([#1926](https://github.com/Shopify/polaris-react/pull/1926))
 - Ensure passing `{key: undefined}` into i18n will throw a runtime error in the same way as not passing in the key at all (this was ensured through type-checking at the TypeScript level but people could force through with casting to `any`) ([#2598](https://github.com/Shopify/polaris-react/pull/2598))
+- Ensure the normalizedValue within `TextField` is a string (this was already ensured through type-checking at the TypeScript level, but people could force through with casting to `any`, which caused problems) ([#2598](https://github.com/Shopify/polaris-react/pull/2598))
 
 ### Documentation
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -217,36 +217,39 @@ export function TextField({
     </div>
   ) : null;
 
-  const characterCount = normalizedValue.length;
-  const characterCountLabel = maxLength
-    ? i18n.translate('Polaris.TextField.characterCountWithMaxLength', {
-        count: characterCount,
-        limit: maxLength,
-      })
-    : i18n.translate('Polaris.TextField.characterCount', {
-        count: characterCount,
-      });
+  let characterCountMarkup = null;
+  if (showCharacterCount) {
+    const characterCount = normalizedValue.length;
+    const characterCountLabel = maxLength
+      ? i18n.translate('Polaris.TextField.characterCountWithMaxLength', {
+          count: characterCount,
+          limit: maxLength,
+        })
+      : i18n.translate('Polaris.TextField.characterCount', {
+          count: characterCount,
+        });
 
-  const characterCountClassName = classNames(
-    styles.CharacterCount,
-    multiline && styles.AlignFieldBottom,
-  );
+    const characterCountClassName = classNames(
+      styles.CharacterCount,
+      multiline && styles.AlignFieldBottom,
+    );
 
-  const characterCountText = !maxLength
-    ? characterCount
-    : `${characterCount}/${maxLength}`;
+    const characterCountText = !maxLength
+      ? characterCount
+      : `${characterCount}/${maxLength}`;
 
-  const characterCountMarkup = showCharacterCount ? (
-    <div
-      id={`${id}CharacterCounter`}
-      className={characterCountClassName}
-      aria-label={characterCountLabel}
-      aria-live={focus ? 'polite' : 'off'}
-      aria-atomic="true"
-    >
-      {characterCountText}
-    </div>
-  ) : null;
+    characterCountMarkup = (
+      <div
+        id={`${id}CharacterCounter`}
+        className={characterCountClassName}
+        aria-label={characterCountLabel}
+        aria-live={focus ? 'polite' : 'off'}
+        aria-atomic="true"
+      >
+        {characterCountText}
+      </div>
+    );
+  }
 
   const clearButtonMarkup =
     clearButton && normalizedValue !== '' ? (

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -181,8 +181,12 @@ export function TextField({
     focused ? input.focus() : input.blur();
   }, [focused]);
 
-  const normalizedValue = value != null ? value : '';
   const {unstableGlobalTheming = false} = useFeatures();
+
+  // Use a typeof check here as Typescript mostly protects us from non-stringy
+  // values but overzealous usage of `any` in consuming apps means people have
+  // been known to pass a number in, so make it clear that doesn't work.
+  const normalizedValue = typeof value === 'string' ? value : '';
 
   const normalizedStep = step != null ? step : 1;
   const normalizedMax = max != null ? max : Infinity;

--- a/src/utilities/i18n/I18n.ts
+++ b/src/utilities/i18n/I18n.ts
@@ -33,21 +33,17 @@ export class I18n {
       return text.replace(REPLACE_REGEX, (match: string) => {
         const replacement: string = match.substring(1, match.length - 1)!;
 
-        if (!Object.prototype.hasOwnProperty.call(replacements, replacement)) {
-          const replacementKeys = Object.keys(replacements)
-            .map((key) => `'${key}'`)
-            .join(', ');
+        if (replacements[replacement] === undefined) {
+          const replacementData = JSON.stringify(replacements);
 
           throw new Error(
-            `No replacement found for key '${replacement}'. The following replacements were passed: ${replacementKeys}`,
+            `Error in translation for key '${id}'. No replacement found for key '${replacement}'. The following replacements were passed: '${replacementData}'`,
           );
         }
 
-        // Bringing back an old bit of oddness to expedite a release.
-        // {foo: undefined} is allowed in calling apps but won't trigger type
-        // warnings and won't get caught in the above check so let it through
-        // for now as JS can handle it ok. We should work out how to be
-        // stricter, or deliberatly allow undefined as a value
+        // This could be a string or a number, but JS doesn't mind which it gets
+        // and can handle that cast internally. So let it, to save us calling
+        // toString() on what's already a string in 90% of cases.
         return replacements[replacement] as string;
       });
     }

--- a/src/utilities/i18n/tests/I18n.test.ts
+++ b/src/utilities/i18n/tests/I18n.test.ts
@@ -35,7 +35,16 @@ describe('I18n.translate', () => {
     expect(() => {
       i18n.translate('key', {notString: 'bar'});
     }).toThrow(
-      `No replacement found for key 'string'. The following replacements were passed: 'notString'`,
+      `Error in translation for key 'key'. No replacement found for key 'string'. The following replacements were passed: '{"notString":"bar"}'`,
+    );
+
+    expect(() => {
+      // Cast because while typescript should guard against this, people have
+      // been known to misuse `any` and undefined can get passed into the
+      //  replacements
+      i18n.translate('key', {string: undefined as any});
+    }).toThrow(
+      `Error in translation for key 'key'. No replacement found for key 'string'. The following replacements were passed: '{}'`,
     );
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Following up https://github.com/Shopify/polaris-react/pull/2579.

### WHAT is this pull request doing?

Make passing `{foo: undefined}` into translations replacements a runtime error, in addition to a TS type error for those fun cases where people power through mistyping things using `any` (looking at you enzyme's trigger function that isn't type-safe).

Make TextField's `normalizedValue` be an empty string if you pass anything other than a string into it. Once again this is limited to be a string only by typescript but people using those not-type-safe functions can pass in a number and not be warned. Having normalizedValue be a number mucks up a bunch of things so catch that at runtime too.

Make TextField a little lazier by only working out character count stuff if we're actually about to display it. 

### How to 🎩

tests pass