### PR TITLE
[Card] Custom footer actions example should be right aligned

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,7 +5,6 @@
 ### Enhancements
 
 - Added `hideTags` prop to `Filters` ([#2573](https://github.com/Shopify/polaris-react/pull/2573))
-- Updated `Card` with custom footer actions example to be right aligned [#2603](https://github.com/Shopify/polaris-react/pull/2603))
 
 ### Bug fixes
 
@@ -18,6 +17,8 @@
 - Fixed `RangeSlider` focus state style issues ([#1926](https://github.com/Shopify/polaris-react/pull/1926))
 
 ### Documentation
+
+- Updated `Card` with custom footer actions example to be right-aligned ([#2603](https://github.com/Shopify/polaris-react/pull/2603))
 
 ### Development workflow
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Added `hideTags` prop to `Filters` ([#2573](https://github.com/Shopify/polaris-react/pull/2573))
+- Updated `Card` with custom footer actions example to be right aligned [#2603](https://github.com/Shopify/polaris-react/pull/2603))
 
 ### Bug fixes
 

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -316,10 +316,12 @@ Use to present actionable content that is optional or not the primary purpose of
         to your account. A special code will be required each time you log in,
         ensuring only you can access your account.
       </p>
-      <ButtonGroup>
-        <Button>Enable two-step authentication</Button>
-        <Button plain>Learn more</Button>
-      </ButtonGroup>
+      <Stack distribution='trailing'>
+        <ButtonGroup>
+          <Button>Enable two-step authentication</Button>
+          <Button plain>Learn more</Button>
+        </ButtonGroup>
+      </Stack>
     </Stack>
   </Card.Section>
 </Card>

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -316,7 +316,7 @@ Use to present actionable content that is optional or not the primary purpose of
         to your account. A special code will be required each time you log in,
         ensuring only you can access your account.
       </p>
-      <Stack distribution='trailing'>
+      <Stack distribution="trailing">
         <ButtonGroup>
           <Button>Enable two-step authentication</Button>
           <Button plain>Learn more</Button>


### PR DESCRIPTION
### WHY are these changes introduced?

`Card` footer actions are now right aligned by default, but the custom footer example was left aligned.

### WHAT is this pull request doing?

Wrap the `ButtonGroup` in a `Stack`.