### PR TITLE
[Navigation] Fix navigation hide on key press

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@
 
 ### Bug fixes
 
+- Fixed a bug where `Navigation` calls `onNavigationDismiss` on large screens when focused and the escape key is pressed ([#2607](https://github.com/Shopify/polaris-react/pull/2607))
 - Fixed issue with `Filters` component displaying an undesired margin top and bottom on the button element on Safari ([#2292](https://github.com/Shopify/polaris-react/pull/2292))
 - Doesn't render `MenuActions` if no actions are passed to an `actionGroups` item inside `Page` ([#2266](https://github.com/Shopify/polaris-react/pull/2266))
 - Fixed `PositionedOverlay` incorrectly calculating `Topbar.UserMenu` `Popover` width ([#1692](https://github.com/Shopify/polaris-react/pull/1692))

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -391,8 +391,15 @@ class Frame extends React.PureComponent<CombinedProps, State> {
 
   private handleNavKeydown = (event: React.KeyboardEvent<HTMLElement>) => {
     const {key} = event;
+    const {
+      polaris: {
+        mediaQuery: {isNavigationCollapsed},
+      },
+      showMobileNavigation,
+    } = this.props;
 
-    if (key === 'Escape') {
+    const mobileNavShowing = isNavigationCollapsed && showMobileNavigation;
+    if (mobileNavShowing && key === 'Escape') {
       this.handleNavigationDismiss();
     }
   };

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {CSSTransition} from '@material-ui/react-transition-group';
 import {animationFrame} from '@shopify/jest-dom-mocks';
-import {documentHasStyle} from 'test-utilities';
+import {documentHasStyle, mountWithApp} from 'test-utilities';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {
@@ -9,7 +9,7 @@ import {
   ContextualSaveBar as PolarisContextualSavebar,
   Loading as PolarisLoading,
 } from 'components';
-import Frame from '../Frame';
+import Frame, {FrameProps} from '../Frame';
 import {
   ContextualSaveBar as FrameContextualSavebar,
   Loading as FrameLoading,
@@ -41,196 +41,241 @@ describe('<Frame />', () => {
     });
   });
 
-  it('renders a TrapFocus with a `trapping` prop set to true around the navigation on small screens and showMobileNavigation is true', () => {
-    const navigation = <div />;
-    const frame = mountWithAppProvider(
-      <Frame showMobileNavigation navigation={navigation} />,
-      {mediaQuery: {isNavigationCollapsed: true}},
-    ).find(Frame);
+  describe('skipToContentTarget', () => {
+    it('renders a skip to content link with the proper text', () => {
+      const skipToContentLinkText = mountWithAppProvider(<Frame />)
+        .find('a')
+        .at(0)
+        .text();
 
-    const trapFocus = frame.find(TrapFocus);
+      expect(skipToContentLinkText).toStrictEqual('Skip to content');
+    });
 
-    expect(trapFocus.exists()).toBe(true);
-    expect(trapFocus.prop('trapping')).toBe(true);
+    it('sets focus to the main content target anchor element when the skip to content link is clicked', () => {
+      const frame = mountWithAppProvider(<Frame />);
+      const mainAnchor = frame.find('main').find('a');
+      trigger(frame.find('a').at(0), 'onClick');
+      expect(mainAnchor.getDOMNode()).toBe(document.activeElement);
+    });
+
+    it('sets focus to target element when the skip to content link is clicked', () => {
+      const targetId = 'SkipToContentTarget';
+      const targetRef = React.createRef<HTMLAnchorElement>();
+
+      const skipToContentTarget = (
+        // eslint-disable-next-line jsx-a11y/anchor-is-valid
+        <a id={targetId} ref={targetRef} tabIndex={-1} href="" />
+      );
+
+      const frame = mountWithAppProvider(
+        <Frame skipToContentTarget={targetRef}>{skipToContentTarget}</Frame>,
+      );
+
+      const triggerAnchor = frame.find('a').at(0);
+      const targetAnchor = frame.find(`#${targetId}`);
+      trigger(triggerAnchor, 'onFocus');
+      trigger(triggerAnchor, 'onClick');
+
+      expect(triggerAnchor.getDOMNode().getAttribute('href')).toBe(
+        `#${targetId}`,
+      );
+      expect(targetAnchor.getDOMNode()).toBe(document.activeElement);
+    });
   });
 
-  it('renders a TrapFocus with a `trapping` prop set to false prop around the navigation on small screens and showMobileNavigation is false', () => {
-    const navigation = <div />;
-    const frame = mountWithAppProvider(<Frame navigation={navigation} />, {
-      mediaQuery: {isNavigationCollapsed: true},
-    }).find(Frame);
+  describe('topBar', () => {
+    it('renders with a top bar data attribute if a topBar is passed', () => {
+      const topbar = <div />;
+      const topBar = mountWithAppProvider(<Frame topBar={topbar} />);
 
-    const trapFocus = frame.find(TrapFocus);
-    expect(trapFocus.exists()).toBe(true);
-    expect(trapFocus.prop('trapping')).toBe(false);
+      expect(topBar.find('[data-polaris-top-bar]')).toHaveLength(1);
+    });
+
+    it('does not render with a top bar data attribute if none is passed', () => {
+      const topBar = mountWithAppProvider(<Frame />);
+
+      expect(topBar.find('[data-polaris-top-bar]')).toHaveLength(0);
+    });
   });
 
-  it('renders a TrapFocus with a `trapping` prop set to false prop around the navigation on large screens even if showMobileNavigation is true', () => {
-    const navigation = <div />;
-    const trapFocus = mountWithAppProvider(
-      <Frame showMobileNavigation navigation={navigation} />,
-    ).find(TrapFocus);
+  describe('navigation', () => {
+    it('renders a TrapFocus with a `trapping` prop set to true around the navigation on small screens and showMobileNavigation is true', () => {
+      const navigation = <div />;
+      const frame = mountWithAppProvider(
+        <Frame showMobileNavigation navigation={navigation} />,
+        {mediaQuery: {isNavigationCollapsed: true}},
+      ).find(Frame);
 
-    expect(trapFocus.exists()).toBe(true);
-    expect(trapFocus.prop('trapping')).toBe(false);
+      const trapFocus = frame.find(TrapFocus);
+
+      expect(trapFocus.exists()).toBe(true);
+      expect(trapFocus.prop('trapping')).toBe(true);
+    });
+
+    it('renders a TrapFocus with a `trapping` prop set to false prop around the navigation on small screens and showMobileNavigation is false', () => {
+      const navigation = <div />;
+      const frame = mountWithAppProvider(<Frame navigation={navigation} />, {
+        mediaQuery: {isNavigationCollapsed: true},
+      }).find(Frame);
+
+      const trapFocus = frame.find(TrapFocus);
+      expect(trapFocus.exists()).toBe(true);
+      expect(trapFocus.prop('trapping')).toBe(false);
+    });
+
+    it('renders a TrapFocus with a `trapping` prop set to false prop around the navigation on large screens even if showMobileNavigation is true', () => {
+      const navigation = <div />;
+      const trapFocus = mountWithAppProvider(
+        <Frame showMobileNavigation navigation={navigation} />,
+      ).find(TrapFocus);
+
+      expect(trapFocus.exists()).toBe(true);
+      expect(trapFocus.prop('trapping')).toBe(false);
+    });
+
+    it('renders a CSSTransition around the navigation with `appear` and `exit` set to true on small screen', () => {
+      const navigation = <div />;
+      const cssTransition = mountWithAppProvider(
+        <Frame showMobileNavigation navigation={navigation} />,
+        {mediaQuery: {isNavigationCollapsed: true}},
+      )
+        .find(TrapFocus)
+        .find(CSSTransition);
+
+      expect(cssTransition.prop('appear')).toBe(true);
+      expect(cssTransition.prop('exit')).toBe(true);
+    });
+
+    it('renders a CSSTransition around the navigation with `appear` and `exit` set to false on large screen', () => {
+      const navigation = <div />;
+      const cssTransition = mountWithAppProvider(
+        <Frame navigation={navigation} />,
+      )
+        .find(TrapFocus)
+        .find(CSSTransition);
+
+      expect(cssTransition.prop('appear')).toBe(false);
+      expect(cssTransition.prop('exit')).toBe(false);
+    });
+
+    it('renders a CSSTransition around the navigation with an `in` prop set to false if showMobileNavigation is true', () => {
+      const navigation = <div />;
+      const cssTransition = mountWithAppProvider(
+        <Frame showMobileNavigation={false} navigation={navigation} />,
+      )
+        .find(Frame)
+        .find(TrapFocus)
+        .find(CSSTransition);
+
+      expect(cssTransition.prop('in')).toBe(false);
+    });
+
+    it('renders a CSSTransition around the navigation with an `in` prop set to true if showMobileNavigation is true', () => {
+      const navigation = <div />;
+      const cssTransition = mountWithAppProvider(
+        <Frame showMobileNavigation navigation={navigation} />,
+      )
+        .find(Frame)
+        .find(TrapFocus)
+        .find(CSSTransition);
+
+      expect(cssTransition.prop('in')).toBe(true);
+    });
+
+    it('renders with a has nav data attribute when nav is passed', () => {
+      const navigation = <div />;
+      const frame = mountWithAppProvider(<Frame navigation={navigation} />);
+      expect(frame.find('[data-has-navigation]')).toHaveLength(1);
+    });
+
+    it('does not render with a has nav data attribute when nav is not passed', () => {
+      const frame = mountWithAppProvider(<Frame />);
+      expect(frame.find('[data-has-navigation]')).toHaveLength(0);
+    });
+
+    it('does not call onNavigationDismiss when escape is pressed and screen size is large', () => {
+      const spy = jest.fn();
+      const frame = mountWithApp(
+        <Frame navigation={<div />} onNavigationDismiss={spy} />,
+      );
+      frame
+        .find('div', {id: 'AppFrameNav'})!
+        .trigger('onKeyDown', {key: 'Escape'});
+
+      const {onNavigationDismiss} = frame.props as FrameProps;
+
+      expect(onNavigationDismiss).not.toHaveBeenCalled();
+    });
+
+    it('calls onNavigationDismiss when escape is pressed and screen size is small', () => {
+      const spy = jest.fn();
+      const frame = mountWithApp(
+        <Frame
+          navigation={<div />}
+          showMobileNavigation
+          onNavigationDismiss={spy}
+        />,
+        {mediaQuery: {isNavigationCollapsed: true}},
+      );
+      frame
+        .find('div', {id: 'AppFrameNav'})!
+        .trigger('onKeyDown', {key: 'Escape'});
+
+      const {onNavigationDismiss} = frame.props as FrameProps;
+
+      expect(onNavigationDismiss).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('renders a CSSTransition around the navigation with `appear` and `exit` set to true on small screen', () => {
-    const navigation = <div />;
-    const cssTransition = mountWithAppProvider(
-      <Frame showMobileNavigation navigation={navigation} />,
-      {mediaQuery: {isNavigationCollapsed: true}},
-    )
-      .find(TrapFocus)
-      .find(CSSTransition);
+  describe('globalRibbon', () => {
+    // JSDOM 11.12.0 does not support setting/reading custom properties so we are
+    // unable to assert that we set a custom property
+    // See https://github.com/jsdom/jsdom/issues/1895
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('sets a root property with global ribbon height if passed', () => {
+      mountWithAppProvider(<Frame globalRibbon={<div />} />);
+      expect(documentHasStyle('--global-ribbon-height', '0px')).toBe(true);
+    });
 
-    expect(cssTransition.prop('appear')).toBe(true);
-    expect(cssTransition.prop('exit')).toBe(true);
+    // JSDOM 11.12.0 does not support setting/reading custom properties so we are
+    // unable to assert that we set a custom property
+    // See https://github.com/jsdom/jsdom/issues/1895
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('sets a root property with global ribbon height if new props are passed', () => {
+      const frame = mountWithAppProvider(<Frame />);
+      frame.setProps({globalRibbon: <div />});
+      expect(documentHasStyle('--global-ribbon-height', '0px')).toBe(true);
+    });
+
+    // JSDOM 11.12.0 does not support setting/reading custom properties so we are
+    // unable to assert that we set a custom property
+    // See https://github.com/jsdom/jsdom/issues/1895
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('sets a root property with global ribbon height of 0 if there is no globalRibbon prop', () => {
+      mountWithAppProvider(<Frame />);
+      expect(documentHasStyle('--global-ribbon-height', '0px')).toBe(true);
+    });
   });
 
-  it('renders a CSSTransition around the navigation with `appear` and `exit` set to false on large screen', () => {
-    const navigation = <div />;
-    const cssTransition = mountWithAppProvider(
-      <Frame navigation={navigation} />,
-    )
-      .find(TrapFocus)
-      .find(CSSTransition);
-
-    expect(cssTransition.prop('appear')).toBe(false);
-    expect(cssTransition.prop('exit')).toBe(false);
+  describe('ContextualSavebar', () => {
+    it('renders a Frame ContextualSavebar if Polaris ContextualSavebar is rendered', () => {
+      const frame = mountWithAppProvider(
+        <Frame>
+          <PolarisContextualSavebar />
+        </Frame>,
+      );
+      expect(frame.find(FrameContextualSavebar).exists()).toBe(true);
+    });
   });
 
-  it('renders a CSSTransition around the navigation with an `in` prop set to false if showMobileNavigation is true', () => {
-    const navigation = <div />;
-    const cssTransition = mountWithAppProvider(
-      <Frame showMobileNavigation={false} navigation={navigation} />,
-    )
-      .find(Frame)
-      .find(TrapFocus)
-      .find(CSSTransition);
-
-    expect(cssTransition.prop('in')).toBe(false);
-  });
-
-  it('renders a CSSTransition around the navigation with an `in` prop set to true if showMobileNavigation is true', () => {
-    const navigation = <div />;
-    const cssTransition = mountWithAppProvider(
-      <Frame showMobileNavigation navigation={navigation} />,
-    )
-      .find(Frame)
-      .find(TrapFocus)
-      .find(CSSTransition);
-
-    expect(cssTransition.prop('in')).toBe(true);
-  });
-
-  it('renders a skip to content link with the proper text', () => {
-    const skipToContentLinkText = mountWithAppProvider(<Frame />)
-      .find('a')
-      .at(0)
-      .text();
-
-    expect(skipToContentLinkText).toStrictEqual('Skip to content');
-  });
-
-  it('sets focus to the main content target anchor element when the skip to content link is clicked', () => {
-    const frame = mountWithAppProvider(<Frame />);
-    const mainAnchor = frame.find('main').find('a');
-    trigger(frame.find('a').at(0), 'onClick');
-    expect(mainAnchor.getDOMNode()).toBe(document.activeElement);
-  });
-
-  it('sets focus to target element when the skip to content link is clicked', () => {
-    const targetId = 'SkipToContentTarget';
-    const targetRef = React.createRef<HTMLAnchorElement>();
-
-    const skipToContentTarget = (
-      // eslint-disable-next-line jsx-a11y/anchor-is-valid
-      <a id={targetId} ref={targetRef} tabIndex={-1} href="" />
-    );
-
-    const frame = mountWithAppProvider(
-      <Frame skipToContentTarget={targetRef}>{skipToContentTarget}</Frame>,
-    );
-
-    const triggerAnchor = frame.find('a').at(0);
-    const targetAnchor = frame.find(`#${targetId}`);
-    trigger(triggerAnchor, 'onFocus');
-    trigger(triggerAnchor, 'onClick');
-
-    expect(triggerAnchor.getDOMNode().getAttribute('href')).toBe(
-      `#${targetId}`,
-    );
-    expect(targetAnchor.getDOMNode()).toBe(document.activeElement);
-  });
-
-  it('renders with a has nav data attribute when nav is passed', () => {
-    const navigation = <div />;
-    const frame = mountWithAppProvider(<Frame navigation={navigation} />);
-    expect(frame.find('[data-has-navigation]')).toHaveLength(1);
-  });
-
-  it('does not render with a has nav data attribute when nav is not passed', () => {
-    const frame = mountWithAppProvider(<Frame />);
-    expect(frame.find('[data-has-navigation]')).toHaveLength(0);
-  });
-
-  it('renders with a top bar data attribute if a topBar is passed', () => {
-    const topbar = <div />;
-    const topBar = mountWithAppProvider(<Frame topBar={topbar} />);
-
-    expect(topBar.find('[data-polaris-top-bar]')).toHaveLength(1);
-  });
-
-  it('does not render with a top bar data attribute if none is passed', () => {
-    const topBar = mountWithAppProvider(<Frame />);
-
-    expect(topBar.find('[data-polaris-top-bar]')).toHaveLength(0);
-  });
-
-  // JSDOM 11.12.0 does not support setting/reading custom properties so we are
-  // unable to assert that we set a custom property
-  // See https://github.com/jsdom/jsdom/issues/1895
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('sets a root property with global ribbon height if passed', () => {
-    mountWithAppProvider(<Frame globalRibbon={<div />} />);
-    expect(documentHasStyle('--global-ribbon-height', '0px')).toBe(true);
-  });
-
-  // JSDOM 11.12.0 does not support setting/reading custom properties so we are
-  // unable to assert that we set a custom property
-  // See https://github.com/jsdom/jsdom/issues/1895
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('sets a root property with global ribbon height if new props are passed', () => {
-    const frame = mountWithAppProvider(<Frame />);
-    frame.setProps({globalRibbon: <div />});
-    expect(documentHasStyle('--global-ribbon-height', '0px')).toBe(true);
-  });
-
-  // JSDOM 11.12.0 does not support setting/reading custom properties so we are
-  // unable to assert that we set a custom property
-  // See https://github.com/jsdom/jsdom/issues/1895
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('sets a root property with global ribbon height of 0 if there is no globalRibbon prop', () => {
-    mountWithAppProvider(<Frame />);
-    expect(documentHasStyle('--global-ribbon-height', '0px')).toBe(true);
-  });
-
-  it('renders a Frame ContextualSavebar if Polaris ContextualSavebar is rendered', () => {
-    const frame = mountWithAppProvider(
-      <Frame>
-        <PolarisContextualSavebar />
-      </Frame>,
-    );
-    expect(frame.find(FrameContextualSavebar).exists()).toBe(true);
-  });
-
-  it('renders a Frame Loading if Polaris Loading is rendered', () => {
-    const frame = mountWithAppProvider(
-      <Frame>
-        <PolarisLoading />
-      </Frame>,
-    );
-    expect(frame.find(FrameLoading).exists()).toBe(true);
+  describe('loading', () => {
+    it('renders a Frame Loading if Polaris Loading is rendered', () => {
+      const frame = mountWithAppProvider(
+        <Frame>
+          <PolarisLoading />
+        </Frame>,
+      );
+      expect(frame.find(FrameLoading).exists()).toBe(true);
+    });
   });
 });

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -9,7 +9,7 @@ import {
   ContextualSaveBar as PolarisContextualSavebar,
   Loading as PolarisLoading,
 } from 'components';
-import Frame, {FrameProps} from '../Frame';
+import Frame from '../Frame';
 import {
   ContextualSaveBar as FrameContextualSavebar,
   Loading as FrameLoading,
@@ -202,8 +202,6 @@ describe('<Frame />', () => {
         .find('div', {id: 'AppFrameNav'})!
         .trigger('onKeyDown', {key: 'Escape'});
 
-      const {onNavigationDismiss} = frame.props as FrameProps;
-
       expect(spy).not.toHaveBeenCalled();
     });
 
@@ -221,9 +219,7 @@ describe('<Frame />', () => {
         .find('div', {id: 'AppFrameNav'})!
         .trigger('onKeyDown', {key: 'Escape'});
 
-      const {onNavigationDismiss} = frame.props as FrameProps;
-
-      expect(onNavigationDismiss).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -204,7 +204,7 @@ describe('<Frame />', () => {
 
       const {onNavigationDismiss} = frame.props as FrameProps;
 
-      expect(onNavigationDismiss).not.toHaveBeenCalled();
+      expect(spy).not.toHaveBeenCalled();
     });
 
     it('calls onNavigationDismiss when escape is pressed and screen size is small', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

There's an issue in production where if any item within the Navigation component has focus and you hit the escape key, the nav will try to hide itself off to the left.
[Screencast](https://screenshot.click/screencast_2020-01-08_15-48-59.mp4)

There's no github issue for this. I randomly stumbled upon it while working on something else.

### WHAT is this pull request doing?

This pr adds a check to make sure the nav is both active and on a small screen before calling dismiss.

🎩
1. Visit the details page in storybook
1. Click on a nav item
1. While that item is still active, hit escape. Nothing should happen

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
