### PR TITLE
Bump polaris-icons version to 3.9.0

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -31,6 +31,8 @@
 
 ### Dependency upgrades
 
+- Updated `@shopify/polaris-icons` to v3.9.0 ([#2610](https://github.com/Shopify/polaris-react/pull/2610))
+
 ### Code quality
 
 - Converted `MenuGroup` into a functional component ([#2536](https://github.com/Shopify/polaris-react/pull/2536))

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "@material-ui/react-transition-group": "^4.2.0",
     "@shopify/app-bridge": "^1.3.0",
     "@shopify/javascript-utilities": "^2.4.1",
-    "@shopify/polaris-icons": "^3.3.0",
+    "@shopify/polaris-icons": "^3.9.0",
     "@shopify/polaris-tokens": "^2.6.0",
     "@shopify/useful-types": "^1.2.4",
     "@types/hoist-non-react-statics": "^3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,10 +1686,10 @@
   dependencies:
     tslib "^1.9.3"
 
-"@shopify/polaris-icons@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-3.3.0.tgz#7031791d44bfe60e2f999c8fbf0ea67ab7a047c8"
-  integrity sha512-+nB2rthx6vS8vlJms5unGbThwrdGXAPMCD2PoQG/Eq5uQU1EmhkVOIFaEK7AS62J2m+HaqbLw/zrlbBkZHZUrQ==
+"@shopify/polaris-icons@^3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-3.9.0.tgz#7064b234824788972593efcda9ae7b87f2a2da43"
+  integrity sha512-isGvHpkH57IsQl6iAZA81LaIPdGi8gNSON5hLWXSERvP9SwgTenfDrkOD3UvzLY09Hh7m8lkFBMUVv/ta33xrg==
 
 "@shopify/polaris-tokens@^2.6.0":
   version "2.6.0"


### PR DESCRIPTION

### WHY are these changes introduced?

Keeping up to date

We don't need anything in this, but it helps kick consumers onto the build with better chunking support

### WHAT is this pull request doing?

Updates polaris-icons version.