### PR TITLE
[Filters] Enable autoComplete behaviour

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@
 
 - Added `hideTags` prop to `Filters` ([#2573](https://github.com/Shopify/polaris-react/pull/2573))
 - Added `searchResultsOverlayVisible` prop to `TopBar` which adds a translucent background to the search dismissal overlay when results are displayed ([#2440](https://github.com/Shopify/polaris-react/pull/2440))
+- Added `autoComplete` prop to `Filters` ([#2624](https://github.com/Shopify/polaris-react/pull/2624))
 
 ### Bug fixes
 

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -83,6 +83,8 @@ export interface FiltersProps {
   helpText?: string | React.ReactNode;
   /** Hide tags for applied filters */
   hideTags?: boolean;
+  /** Enable browser autofill in the query field */
+  autoComplete?: boolean;
 }
 
 type ComposedProps = FiltersProps & WithAppProviderProps;
@@ -129,6 +131,7 @@ class Filters extends React.Component<ComposedProps, State> {
       disabled = false,
       helpText,
       hideTags,
+      autoComplete = false,
     } = this.props;
     const {resourceName} = this.context;
     const {open, readyForFocus} = this.state;
@@ -266,6 +269,7 @@ class Filters extends React.Component<ComposedProps, State> {
           clearButton
           onClearButtonClick={onQueryClear}
           disabled={disabled}
+          autoComplete={autoComplete}
         />
       </ConnectedFilterControl>
     );

--- a/src/components/Filters/README.md
+++ b/src/components/Filters/README.md
@@ -274,6 +274,7 @@ function ResourceListFiltersExample() {
               onQueryChange={handleFiltersQueryChange}
               onQueryClear={handleQueryValueRemove}
               onClearAll={handleFiltersClearAll}
+              autoComplete
             />
           }
           items={[

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -468,6 +468,28 @@ describe('<Filters />', () => {
       expect(helpTextMarkup).toHaveLength(0);
     });
   });
+
+  describe('autoComplete', () => {
+    it('enables autoComplete in the search field when true', () => {
+      const resourceFilters = mountWithAppProvider(
+        <Filters {...mockProps} autoComplete />,
+      );
+
+      expect(resourceFilters.find(TextField).prop('autoComplete')).toBe(true);
+    });
+
+    it("doesn't enable autoComplete in the search field when false", () => {
+      const autoCompleteFalse = false;
+
+      const resourceFilters = mountWithAppProvider(
+        <Filters {...mockProps} autoComplete={autoCompleteFalse} />,
+      );
+
+      expect(resourceFilters.find(TextField).prop('autoComplete')).toBe(
+        autoCompleteFalse,
+      );
+    });
+  });
 });
 
 function noop() {}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/2623. 

- As part of the Reactification of our admin ProductIndex, we need a way to enable autoComplete within the Filters component, in order to mirror Rails behaviour. (Fixes https://github.com/Shopify/store/issues/12362)
- AutoComplete suggestions under a Filter TextField can facilitate convenience for merchants, as they are likely to type the same few filters often. 💫
- Being able to mirror the Rails behaviour would make the Reactification of the admin interface seamless for merchants! ✨

### WHAT is this pull request doing?
-  The `Filters` component now takes a boolean prop, `autoComplete`, and simply passes it on to the TextField it renders.
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
