### PR TITLE
[Popover] fix scrolling with scrollbar not working when content changes on scroll

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@
 
 ### Bug fixes
 
+- Fixed scrolling with scrollbar not working in Popover when content changes on scroll ([#2627](https://github.com/Shopify/polaris-react/pull/2627))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -45,12 +45,6 @@ $content-max-width: rem(400px);
   }
 }
 
-.measuring {
-  .Content {
-    display: block;
-  }
-}
-
 .positionedAbove {
   margin: spacing() spacing(tight) $visible-portion-of-arrow;
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/2605. (You can find all context in the issue)

`PopoverOverlay` changing the container's `display` from `block` to `flex` when it's measuring on subtree change (those changes happen to take place on scroll when a library like react-virtualized is used). This then seems to cause some browsers to stop the scrolling.
The Popover switches its container `display` from `block` to `flex` and vice versa when measuring. 

### WHAT is this pull request doing?
We wondered why we are switching `display` from `flex` to `block` when measuring and couldn't come up with a good explanation. So in this PR we are attempting to remove it. We did a pairing session with @chloerice where we also tried the custom build in web (looked at user menu and some autocomplete lists) and everything seemed fine. However, we are aware that we might be missing something crucial and were hoping that someone could chime in if they have any ideas. 

<details>
  <summary>Summary of your gif(s)</summary>
    <img src="https://user-images.githubusercontent.com/474248/72628161-c463da80-391b-11ea-9c21-b12bd52eca8b.gif" alt="scrolling behavior before change. Does not work when scrollbar is used" />
    <img src="https://user-images.githubusercontent.com/474248/72627831-21ab5c00-391b-11ea-8a17-78ecc76d0cd8.gif" alt="scrolling behavior after change. works when scrollbar is used" />
</details>


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Button, Page, Popover, Banner} from '../src';

export function Playground() {
  const [counter, setCounter] = React.useState(30);

  return (
    <Page title="Playground">
      <Banner>Scroll using the scrollbar</Banner>
      <br />
      <Popover
        active
        activator={
          <Button>
            I am <s>groot</s> button
          </Button>
        }
        onClose={() => {}}
      >
        <div
          style={{height: '200px', width: '100px', overflow: 'auto'}}
          onScroll={() => {
            setCounter((counter) => counter + 1);
          }}
        >
          <div style={{height: '1000px'}}>
            {Array.from({length: counter}).map((_, i) => (
              <div style={{height: '50px'}} key={i}>
                item {i}
              </div>
            ))}
          </div>
        </div>
      </Popover>
    </Page>
  );
}


```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
