### PR TITLE
Use export * in utility indexes too

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,5 +16,6 @@
 
 - Converted `/tests/build.test.js` to TypeScript ([#2617](https://github.com/Shopify/polaris-react/pull/2617))
 - Use `export *` to rexport component content in component indexs and subcomponent listings ([#2625](https://github.com/Shopify/polaris-react/pull/2625))
+- Use `export *` to rexport utility content ([#2636](https://github.com/Shopify/polaris-react/pull/2636))
 
 ### Deprecations

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -7,11 +7,12 @@ import {
   DefaultThemeColors,
   DefaultColorScheme,
   Tokens,
-  ColorScheme,
 } from '../../utilities/theme';
 import {useFeatures} from '../../utilities/features';
 
+type OriginalColorScheme = Required<ThemeConfig['colorScheme']>;
 type Inverse = 'inverse';
+type InversableColorScheme = OriginalColorScheme | Inverse;
 
 // TS 3.5+ includes the built-in Omit type which does the same thing. But if we
 // use that then we break consumers on older versions of TS. Consider removing
@@ -19,7 +20,7 @@ type Inverse = 'inverse';
 type Discard<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 interface ThemeProviderThemeConfig extends Discard<ThemeConfig, 'colorScheme'> {
-  colorScheme?: ColorScheme | Inverse;
+  colorScheme?: InversableColorScheme;
 }
 
 interface ThemeProviderProps {
@@ -101,14 +102,14 @@ export function ThemeProvider({
 }
 
 function isInverseColorScheme(
-  colorScheme?: ColorScheme | Inverse,
+  colorScheme?: InversableColorScheme,
 ): colorScheme is Inverse {
   return colorScheme === 'inverse';
 }
 
 function getColorScheme(
-  colorScheme: ColorScheme | Inverse | undefined,
-  parentColorScheme: ColorScheme | undefined,
+  colorScheme: InversableColorScheme | undefined,
+  parentColorScheme: OriginalColorScheme | undefined,
 ) {
   if (colorScheme == null) {
     return parentColorScheme || DefaultColorScheme;
@@ -123,8 +124,8 @@ function getColorScheme(
 
 function shouldInheritParentColors(
   isParentThemeProvider: boolean,
-  colorScheme: ColorScheme | Inverse | undefined,
-  parentColorScheme: ColorScheme | undefined,
+  colorScheme: InversableColorScheme | undefined,
+  parentColorScheme: OriginalColorScheme | undefined,
 ) {
   if (isParentThemeProvider) {
     return false;

--- a/src/utilities/app-bridge/index.ts
+++ b/src/utilities/app-bridge/index.ts
@@ -1,5 +1,5 @@
-export {AppBridgeContext} from './context';
+export * from './context';
 
-export {useAppBridge} from './hooks';
+export * from './hooks';
 
 export {createAppBridge, AppBridgeOptions} from './app-bridge';

--- a/src/utilities/features/index.ts
+++ b/src/utilities/features/index.ts
@@ -1,5 +1,5 @@
-export {FeaturesContext} from './context';
+export * from './context';
 
-export {Features} from './types';
+export * from './types';
 
-export {useFeatures} from './hooks';
+export * from './hooks';

--- a/src/utilities/frame/context.ts
+++ b/src/utilities/frame/context.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import {ToastPropsWithID, ToastID, ContextualSaveBarProps} from './types';
 
+// This is internal, but TS throws a build-time error if we don't export it
 export interface FrameContextType {
   showToast(toast: ToastPropsWithID): void;
   hideToast(toast: ToastID): void;

--- a/src/utilities/frame/index.ts
+++ b/src/utilities/frame/index.ts
@@ -1,10 +1,5 @@
-export {useFrame} from './hooks';
+export * from './hooks';
 
-export {FrameContext} from './context';
+export * from './context';
 
-export {
-  ContextualSaveBarProps,
-  ToastProps,
-  ToastID,
-  ToastPropsWithID,
-} from './types';
+export * from './types';

--- a/src/utilities/i18n/index.ts
+++ b/src/utilities/i18n/index.ts
@@ -1,5 +1,5 @@
-export {I18nContext} from './context';
+export * from './context';
 
-export {useI18n} from './hooks';
+export * from './hooks';
 
-export {I18n} from './I18n';
+export * from './I18n';

--- a/src/utilities/link/index.ts
+++ b/src/utilities/link/index.ts
@@ -1,5 +1,5 @@
-export {LinkLikeComponentProps, LinkLikeComponent} from './types';
+export * from './types';
 
-export {useLink} from './hooks';
+export * from './hooks';
 
-export {LinkContext} from './context';
+export * from './context';

--- a/src/utilities/media-query/context.tsx
+++ b/src/utilities/media-query/context.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// This is internal, but TS throws a build-time error if we don't export it
 export interface MediaQueryContextType {
   isNavigationCollapsed: boolean;
 }

--- a/src/utilities/media-query/index.ts
+++ b/src/utilities/media-query/index.ts
@@ -1,2 +1,2 @@
-export {MediaQueryContext} from './context';
-export {useMediaQuery} from './hooks';
+export * from './context';
+export * from './hooks';

--- a/src/utilities/resource-list/context.ts
+++ b/src/utilities/resource-list/context.ts
@@ -3,6 +3,7 @@ import React from 'react';
 import {CheckboxHandles} from '../../types';
 import {ResourceListSelectedItems, CheckableButtonKey} from './types';
 
+// This is internal, but TS throws a build-time error if we don't export it
 export interface ResourceListContextType {
   registerCheckableButtons?(
     key: CheckableButtonKey,

--- a/src/utilities/resource-list/index.ts
+++ b/src/utilities/resource-list/index.ts
@@ -1,8 +1,3 @@
-export {ResourceListContext} from './context';
+export * from './context';
 
-export {
-  ResourceListSelectedItems,
-  SELECT_ALL_ITEMS,
-  CheckableButtons,
-  CheckableButtonKey,
-} from './types';
+export * from './types';

--- a/src/utilities/scroll-lock-manager/index.ts
+++ b/src/utilities/scroll-lock-manager/index.ts
@@ -1,8 +1,5 @@
-export {ScrollLockManagerContext} from './context';
+export * from './context';
 
-export {useScrollLockManager} from './hooks';
+export * from './hooks';
 
-export {
-  ScrollLockManager,
-  SCROLL_LOCKING_ATTRIBUTE,
-} from './scroll-lock-manager';
+export * from './scroll-lock-manager';

--- a/src/utilities/scroll-lock-manager/scroll-lock-manager.ts
+++ b/src/utilities/scroll-lock-manager/scroll-lock-manager.ts
@@ -2,9 +2,7 @@ import {isServer} from '../target';
 
 export const SCROLL_LOCKING_ATTRIBUTE = 'data-lock-scrolling';
 
-export const SCROLL_LOCKING_WRAPPER_ATTRIBUTE = 'data-lock-scrolling-wrapper';
-
-export const SCROLL_LOCKING_CUSTOM_PROPERTY = '--scroll-lock-body-padding';
+const SCROLL_LOCKING_WRAPPER_ATTRIBUTE = 'data-lock-scrolling-wrapper';
 
 let scrollPosition = 0;
 

--- a/src/utilities/sticky-manager/index.ts
+++ b/src/utilities/sticky-manager/index.ts
@@ -1,5 +1,5 @@
-export {StickyManagerContext} from './context';
+export * from './context';
 
-export {useStickyManager} from './hooks';
+export * from './hooks';
 
-export {StickyManager} from './sticky-manager';
+export * from './sticky-manager';

--- a/src/utilities/sticky-manager/sticky-manager.ts
+++ b/src/utilities/sticky-manager/sticky-manager.ts
@@ -8,7 +8,7 @@ import tokens from '@shopify/polaris-tokens';
 import {dataPolarisTopBar, scrollable} from '../../components/shared';
 import {stackedContent} from '../breakpoints';
 
-export interface StickyItem {
+interface StickyItem {
   /** Node of the sticky element */
   stickyNode: HTMLElement;
   /** Placeholder element */

--- a/src/utilities/theme/index.ts
+++ b/src/utilities/theme/index.ts
@@ -1,14 +1,10 @@
-export {ThemeContext} from './context';
+export * from './context';
 
-export {useTheme} from './hooks';
+export * from './hooks';
 
-export {Theme, ThemeConfig, CustomPropertiesLike, ColorScheme} from './types';
+export {ThemeConfig} from './types';
 
-export {
-  DefaultThemeColors,
-  DefaultColorScheme,
-  roleVariants,
-} from './role-variants';
+export * from './role-variants';
 
 export {
   buildCustomProperties,
@@ -17,4 +13,4 @@ export {
   toCssCustomPropertySyntax,
 } from './utils';
 
-export {Tokens} from './tokens';
+export * from './tokens';

--- a/src/utilities/unique-id/index.ts
+++ b/src/utilities/unique-id/index.ts
@@ -1,5 +1,5 @@
-export {UniqueIdFactoryContext} from './context';
+export * from './context';
 
-export {useUniqueId} from './hooks';
+export * from './hooks';
 
-export {UniqueIdFactory, globalIdGeneratorFactory} from './unique-id-factory';
+export * from './unique-id-factory';


### PR DESCRIPTION
### WHY are these changes introduced?

Following on from #2619 and #2625 I looked at the utility index files and spotted that in almost all cases our index files rexport everything in the files they reference, or what they references is never used externally, so they can also use `export *` too.

### WHAT is this pull request doing?

* Updates utility indexes to use `export *` because doing things one way everywhere is easier than doing things one way in `components` and another way in `utilities`

[I did run into some issues](https://github.com/Shopify/polaris-react/pull/2636/files#diff-4eb03b66a1f37179b50db6bcb635f31cR4) with some interfaces that get used as the type that gets pushed into a React context.

I could either have those as a type or export the interface. I figured exporting the interface was an acceptable compromise as "a slightly leaky internal export that doesn't bleed into our public exports" was better than "disabling our linting rule that prefers the usage of interfaces over types".


### How to 🎩

Type check and tests pass
