### PR TITLE
Use default import for styles

### DIFF
--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.tsx
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useRef} from 'react';
 import {ScrollLock} from '../../../ScrollLock';
 import {classNames} from '../../../../utilities/css';
-import * as styles from './SearchDismissOverlay.scss';
+import styles from './SearchDismissOverlay.scss';
 
 interface Props {
   /** Callback when the search is dismissed */


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes warning notice when building

### WHAT is this pull request doing?

Use a default import for styles instead of namespace import, like we do everywhere else

### How to 🎩
 Run `yarn run build` and see the following notice messages are no longer present:

```
'SearchDismissOverlay' is not exported by 'build-intermediate/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss'
'visible' is not exported by 'build-intermediate/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss'
```