### PR TITLE
Update sass to work around CRA build crashes

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 - Fixed scrolling with scrollbar not working in Popover when content changes on scroll ([#2627](https://github.com/Shopify/polaris-react/pull/2627))
+- Work around a build crash when using create-react-app due to a bug in css parsing in `postcss-custom-properties` ([#2643](https://github.com/Shopify/polaris-react/pull/2643))
 
 ### Documentation
 

--- a/src/styles/shared/_controls.scss
+++ b/src/styles/shared/_controls.scss
@@ -110,10 +110,10 @@
       &::before {
         content: '';
         position: absolute;
-        top: calc(var(--control-border-width) * -1);
-        right: calc(var(--control-border-width) * -1);
-        bottom: calc(var(--control-border-width) * -1);
-        left: calc(var(--control-border-width) * -1);
+        top: calc(-1 * var(--control-border-width));
+        right: calc(-1 * var(--control-border-width));
+        bottom: calc(-1 * var(--control-border-width));
+        left: calc(-1 * var(--control-border-width));
         border-radius: var(--p-border-radius-base);
         background-color: var(--p-action-interactive);
         opacity: 0;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/2629

The current version of CRA' s build uses a version of https://github.com/postcss/postcss-custom-properties that crashes when it comes across ~var()s inside calc()s~ a very specific order of calls: `  top:calc(var(--control-border-width)*-1)`. See https://github.com/Shopify/polaris-react/issues/2629#issuecomment-577319704 for more info.  This has been fixed in the newest version of postcss-custom-properties but that's not made its way into CRA (via postcss-preset-env) and probably won't be for some time.

### WHAT is this pull request doing?

Flip the order of values (yes I know this sounds silly)

### How to 🎩

Ask @dleroux nicely to see that there are no visual regressions.

- Do a build `yarn run build`
- Create a new CRA project with `yarn create react-app testing`
- Copy the build styles.css into the CRA app and import the styles from CRA's src/ index.js file and see if a build compiles using `yarn run build`