### PR TITLE
[DataTable] Add prop to disable scroll indicator

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@
 - Added a split variant to `Button` ([#2329](https://github.com/Shopify/polaris-react/pull/2329))
 - Allow DataTable headers to be React Elements ([#2635](https://github.com/Shopify/polaris-react/pull/2635))
 - Added support for explicit order of items in `ActionMenu` ([2057](https://github.com/Shopify/polaris-react/pull/2057))
+- Made the `DataTable` horizontal `Navigation` optional ([#2647](https://github.com/Shopify/polaris-react/pull/2647))
 
 ### Bug fixes
 

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -36,8 +36,12 @@ export interface DataTableProps {
   showTotalsInFooter?: boolean;
   /** Lists of data points which map to table body rows. */
   rows: TableData[][];
-  /** Truncate content in first column instead of wrapping.
+  /** Hide column visibility and navigation buttons above the header when the table horizontally collapses to be scrollable.
    * @default false
+   */
+  hideScrollIndicator?: boolean;
+  /** Truncate content in first column instead of wrapping.
+   * @default true
    */
   truncate?: boolean;
   /** Vertical alignment of content in the cells.
@@ -131,6 +135,7 @@ class DataTableInner extends React.PureComponent<
       showTotalsInFooter,
       rows,
       footerContent,
+      hideScrollIndicator = false,
     } = this.props;
     const {
       condensed,
@@ -166,15 +171,19 @@ class DataTableInner extends React.PureComponent<
       <tfoot>{totalsMarkup}</tfoot>
     ) : null;
 
+    const navigationMarkup = hideScrollIndicator ? null : (
+      <Navigation
+        columnVisibilityData={columnVisibilityData}
+        isScrolledFarthestLeft={isScrolledFarthestLeft}
+        isScrolledFarthestRight={isScrolledFarthestRight}
+        navigateTableLeft={this.navigateTable('left')}
+        navigateTableRight={this.navigateTable('right')}
+      />
+    );
+
     return (
       <div className={wrapperClassName}>
-        <Navigation
-          columnVisibilityData={columnVisibilityData}
-          isScrolledFarthestLeft={isScrolledFarthestLeft}
-          isScrolledFarthestRight={isScrolledFarthestRight}
-          navigateTableLeft={this.navigateTable('left')}
-          navigateTableRight={this.navigateTable('right')}
-        />
+        {navigationMarkup}
         <div className={className} ref={this.dataTable}>
           <div className={styles.ScrollContainer} ref={this.scrollContainer}>
             <EventListener event="resize" handler={this.handleResize} />

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {Checkbox} from 'components';
-import {Cell} from '../components';
+import {Cell, Navigation} from '../components';
 import {DataTable, DataTableProps} from '../DataTable';
 
 describe('<DataTable />', () => {
@@ -220,6 +220,30 @@ describe('<DataTable />', () => {
       firstColumnCells.forEach((cell) =>
         expect(cell.prop('truncate')).toBe(true),
       );
+    });
+  });
+
+  describe('hideScrollIndicator', () => {
+    it('shows <Navigation /> by default', () => {
+      const dataTable = mountWithAppProvider(<DataTable {...defaultProps} />);
+
+      expect(dataTable.find(Navigation)).toHaveLength(1);
+    });
+
+    it('hide <Navigation /> when true', () => {
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} hideScrollIndicator />,
+      );
+
+      expect(dataTable.find(Navigation)).toHaveLength(0);
+    });
+
+    it('show <Navigation /> when false', () => {
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} hideScrollIndicator={false} />,
+      );
+
+      expect(dataTable.find(Navigation)).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Needed in Web because we are using the DataTable in a modal and the scroll indicator doesn't look very good. 

![image](https://user-images.githubusercontent.com/21130966/72922663-7257f600-3d1b-11ea-88ed-c4819abe524e.png)


### WHAT is this pull request doing?

Adding a prop `showNavigationOnCollapse` (default true), that when false, hides the scroll indicator.

<img width="986" alt="image" src="https://user-images.githubusercontent.com/21130966/72923465-20b06b00-3d1d-11ea-85f7-05305688350a.png">

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Card, DataTable, Page} from '@shopify/polaris';

export function Playground() {
  return (
    <Page title="Sales by product">
      <Card sectioned>
        <Card.Section>
          <DataTable
            columnContentTypes={[Array(30).fill('text')]}
            headings={Array(30).fill('Header')}
            rows={[Array(30).fill('Content')]}
            hideScrollIndicator
          />
        </Card.Section>

        <Card.Section>
          <DataTable
            columnContentTypes={[Array(30).fill('text')]}
            headings={Array(30).fill('Header')}
            rows={[Array(30).fill('Content')]}
          />
        </Card.Section>
      </Card>
    </Page>
  );
}


```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
