### PR TITLE
Moar export rejigging

### DIFF
--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import {useI18n} from '../../utilities/i18n';
 import {ActionListItemDescriptor} from '../../types';
-import {OptionDescriptor} from '../OptionList';
 import {Spinner} from '../Spinner';
 
 import {TextField, ComboBox, ComboBoxProps} from './components';
@@ -12,7 +11,7 @@ export interface AutocompleteProps {
   /** A unique identifier for the Autocomplete */
   id?: string;
   /** Collection of options to be listed */
-  options: OptionDescriptor[];
+  options: ComboBoxProps['options'];
   /** The selected options */
   selected: string[];
   /** The text field component attached to the list of options */

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -14,9 +14,9 @@ import {ActionList} from '../ActionList';
 
 import styles from './Button.scss';
 
-export type Size = 'slim' | 'medium' | 'large';
-export type TextAlign = 'left' | 'right' | 'center';
-export type IconSource = IconProps['source'];
+type Size = 'slim' | 'medium' | 'large';
+type TextAlign = 'left' | 'right' | 'center';
+type IconSource = IconProps['source'];
 
 export interface ButtonProps {
   /** The content to display inside the button */

--- a/src/components/ColorPicker/index.ts
+++ b/src/components/ColorPicker/index.ts
@@ -1,3 +1,1 @@
 export * from './ColorPicker';
-export * from '../../utilities/color-types';
-export * from '../../utilities/color-transformers';

--- a/src/components/Connected/Connected.tsx
+++ b/src/components/Connected/Connected.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {Item, ItemPosition} from './components';
+import {Item} from './components';
 import styles from './Connected.scss';
 
 export interface ConnectedProps {
@@ -14,17 +14,17 @@ export interface ConnectedProps {
 
 export function Connected({children, left, right}: ConnectedProps) {
   const leftConnectionMarkup = left ? (
-    <Item position={ItemPosition.Left}>{left}</Item>
+    <Item position="left">{left}</Item>
   ) : null;
 
   const rightConnectionMarkup = right ? (
-    <Item position={ItemPosition.Right}>{right}</Item>
+    <Item position="right">{right}</Item>
   ) : null;
 
   return (
     <div className={styles.Connected}>
       {leftConnectionMarkup}
-      <Item position={ItemPosition.Primary}>{children}</Item>
+      <Item position="primary">{children}</Item>
       {rightConnectionMarkup}
     </div>
   );

--- a/src/components/Connected/components/Item/Item.tsx
+++ b/src/components/Connected/components/Item/Item.tsx
@@ -2,11 +2,7 @@ import React from 'react';
 import {classNames} from '../../../../utilities/css';
 import styles from '../../Connected.scss';
 
-export enum ItemPosition {
-  Left,
-  Primary,
-  Right,
-}
+type ItemPosition = 'left' | 'right' | 'primary';
 
 export interface ItemProps {
   /** Position of the item */
@@ -28,7 +24,7 @@ export class Item extends React.PureComponent<ItemProps, State> {
     const className = classNames(
       styles.Item,
       focused && styles['Item-focused'],
-      position === ItemPosition.Primary
+      position === 'primary'
         ? styles['Item-primary']
         : styles['Item-connection'],
     );

--- a/src/components/Connected/tests/Connected.test.tsx
+++ b/src/components/Connected/tests/Connected.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {mountWithApp} from 'test-utilities';
 
 import {Connected} from '../Connected';
-import {Item, ItemPosition} from '../components';
+import {Item} from '../components';
 
 describe('<Connected />', () => {
   describe('<Item />', () => {
@@ -10,9 +10,9 @@ describe('<Connected />', () => {
       const expectedContent = 'foo';
       const connected = mountWithApp(<Connected>{expectedContent}</Connected>);
 
-      expect(
-        connected.find(Item, {position: ItemPosition.Primary}),
-      ).toContainReactText(expectedContent);
+      expect(connected.find(Item, {position: 'primary'})).toContainReactText(
+        expectedContent,
+      );
     });
 
     it('includes `rightConnected` markup in an Item component', () => {
@@ -21,18 +21,18 @@ describe('<Connected />', () => {
         <Connected right={rightConnectedContent} />,
       );
 
-      expect(
-        connected.find(Item, {position: ItemPosition.Right}),
-      ).toContainReactText(rightConnectedContent);
+      expect(connected.find(Item, {position: 'right'})).toContainReactText(
+        rightConnectedContent,
+      );
     });
 
     it('includes `leftConnected` markup in an Item component', () => {
       const leftConnectedContent = 'foo';
       const connected = mountWithApp(<Connected left={leftConnectedContent} />);
 
-      expect(
-        connected.find(Item, {position: ItemPosition.Left}),
-      ).toContainReactText(leftConnectedContent);
+      expect(connected.find(Item, {position: 'left'})).toContainReactText(
+        leftConnectedContent,
+      );
     });
 
     it('`leftConnected` and `rightConnected` are not mutually exclusive', () => {
@@ -42,13 +42,13 @@ describe('<Connected />', () => {
         <Connected right={rightConnectedContent} left={leftConnectedContent} />,
       );
 
-      expect(
-        connected.find(Item, {position: ItemPosition.Right}),
-      ).toContainReactText(rightConnectedContent);
+      expect(connected.find(Item, {position: 'right'})).toContainReactText(
+        rightConnectedContent,
+      );
 
-      expect(
-        connected.find(Item, {position: ItemPosition.Left}),
-      ).toContainReactText(leftConnectedContent);
+      expect(connected.find(Item, {position: 'left'})).toContainReactText(
+        leftConnectedContent,
+      );
     });
   });
 });

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -16,6 +16,8 @@ import {measureColumn, getPrevAndCurrentColumns} from './utilities';
 import {DataTableState, SortDirection, VerticalAlign} from './types';
 import styles from './DataTable.scss';
 
+export {SortDirection};
+
 type CombinedProps = DataTableProps & WithAppProviderProps;
 export type TableRow =
   | DataTableProps['headings']

--- a/src/components/DataTable/index.ts
+++ b/src/components/DataTable/index.ts
@@ -1,3 +1,1 @@
 export * from './DataTable';
-
-export {SortDirection} from './types';

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -24,7 +24,7 @@ import {Stack} from '../Stack';
 import {Caption} from '../Caption';
 import {DisplayText} from '../DisplayText';
 import {VisuallyHidden} from '../VisuallyHidden';
-import {Labelled, Action} from '../Labelled';
+import {Labelled, LabelledProps} from '../Labelled';
 import {useI18n} from '../../utilities/i18n';
 import {isServer} from '../../utilities/target';
 import {useUniqueId} from '../../utilities/unique-id';
@@ -44,7 +44,7 @@ export interface DropZoneProps {
   /** Label for the file input */
   label?: string;
   /** Adds an action to the label */
-  labelAction?: Action;
+  labelAction?: LabelledProps['action'];
   /** Visually hide the label */
   labelHidden?: boolean;
   /** ID for file input */

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -25,7 +25,6 @@ import {
   Loading,
   ContextualSaveBar,
   CSSAnimation,
-  AnimationType,
 } from './components';
 
 import styles from './Frame.scss';
@@ -182,7 +181,7 @@ class FrameInner extends React.PureComponent<CombinedProps, State> {
       <CSSAnimation
         in={showContextualSaveBar}
         className={styles.ContextualSaveBar}
-        type={AnimationType.Fade}
+        type="fade"
       >
         <ContextualSaveBar {...this.contextualSaveBar} />
       </CSSAnimation>

--- a/src/components/Frame/components/CSSAnimation/CSSAnimation.tsx
+++ b/src/components/Frame/components/CSSAnimation/CSSAnimation.tsx
@@ -3,9 +3,7 @@ import {classNames, variationName} from '../../../../utilities/css';
 
 import styles from './CSSAnimation.scss';
 
-export enum AnimationType {
-  Fade = 'fade',
-}
+type AnimationType = 'fade';
 
 export interface CSSAnimationProps {
   in: boolean;

--- a/src/components/KeypressListener/KeypressListener.tsx
+++ b/src/components/KeypressListener/KeypressListener.tsx
@@ -11,15 +11,12 @@ export interface KeypressListenerProps {
   keyEvent?: KeyEvent;
 }
 
-export enum KeyEvent {
-  KeyDown = 'keydown',
-  KeyUp = 'keyup',
-}
+type KeyEvent = 'keydown' | 'keyup';
 
 export function KeypressListener({
   keyCode,
   handler,
-  keyEvent = KeyEvent.KeyUp,
+  keyEvent = 'keyup',
 }: KeypressListenerProps) {
   const handleKeyEvent = (event: KeyboardEvent) => {
     if (event.keyCode === keyCode) {

--- a/src/components/Labelled/Labelled.tsx
+++ b/src/components/Labelled/Labelled.tsx
@@ -9,7 +9,7 @@ import {InlineError} from '../InlineError';
 
 import styles from './Labelled.scss';
 
-export {Action, labelID};
+export {labelID};
 
 export interface LabelledProps {
   /** A unique identifier for the label */

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -25,7 +25,7 @@ export interface OptionDescriptor {
   media?: React.ReactElement<IconProps | ThumbnailProps | AvatarProps>;
 }
 
-export interface SectionDescriptor {
+interface SectionDescriptor {
   /** Collection of options within the section */
   options: OptionDescriptor[];
   /** Section title */

--- a/src/components/OptionList/tests/OptionList.test.tsx
+++ b/src/components/OptionList/tests/OptionList.test.tsx
@@ -2,12 +2,7 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Option} from '../components';
-import {
-  OptionList,
-  OptionListProps,
-  OptionDescriptor,
-  SectionDescriptor,
-} from '../OptionList';
+import {OptionList, OptionListProps, OptionDescriptor} from '../OptionList';
 
 describe('<OptionList />', () => {
   const defaultProps: OptionListProps = {
@@ -81,7 +76,7 @@ describe('<OptionList />', () => {
 
   it('renders options', () => {
     const {options} = defaultProps;
-    const sections: SectionDescriptor[] = [];
+    const sections: OptionListProps['sections'] = [];
     const optionWrappers = mountWithAppProvider<OptionListProps>(
       <OptionList {...defaultProps} sections={sections} />,
     ).find(Option);
@@ -119,7 +114,7 @@ describe('<OptionList />', () => {
       <OptionList {...defaultProps} />,
     );
 
-    const newSections: SectionDescriptor[] = [
+    const newSections: OptionListProps['sections'] = [
       {
         title: 'Other products',
         options: [
@@ -158,7 +153,7 @@ describe('<OptionList />', () => {
       },
     ];
 
-    const newSections: SectionDescriptor[] = [
+    const newSections: OptionListProps['sections'] = [
       {
         title: 'Other products',
         options: [
@@ -209,7 +204,7 @@ describe('<OptionList />', () => {
       <OptionList {...defaultProps} />,
     );
 
-    const newSections: SectionDescriptor[] = [
+    const newSections: OptionListProps['sections'] = [
       {
         title: 'Other products',
         options: [
@@ -290,7 +285,7 @@ describe('<OptionList />', () => {
 
     it('renders options', () => {
       const {options} = defaultProps;
-      const sections: SectionDescriptor[] = [];
+      const sections: OptionListProps['sections'] = [];
       const optionWrappers = mountWithAppProvider<OptionListProps>(
         <OptionList {...defaultProps} sections={sections} allowMultiple />,
       ).find(Option);
@@ -328,7 +323,7 @@ describe('<OptionList />', () => {
         <OptionList {...defaultProps} allowMultiple />,
       );
 
-      const newSections: SectionDescriptor[] = [
+      const newSections: OptionListProps['sections'] = [
         {
           title: 'Other products',
           options: [
@@ -367,7 +362,7 @@ describe('<OptionList />', () => {
         },
       ];
 
-      const newSections: SectionDescriptor[] = [
+      const newSections: OptionListProps['sections'] = [
         {
           title: 'Other products',
           options: [
@@ -420,7 +415,7 @@ describe('<OptionList />', () => {
         <OptionList {...defaultProps} allowMultiple />,
       );
 
-      const newSections: SectionDescriptor[] = [
+      const newSections: OptionListProps['sections'] = [
         {
           title: 'Other products',
           options: [
@@ -533,7 +528,7 @@ function noop() {}
 
 function firstOption(
   options?: OptionDescriptor[],
-  sections?: SectionDescriptor[],
+  sections?: OptionListProps['sections'],
 ): string {
   const firstOptionsValue =
     options == null || options === [] ? '' : options[0].value;
@@ -546,7 +541,7 @@ function firstOption(
 
 function totalOptions(
   options?: OptionDescriptor[],
-  sections?: SectionDescriptor[],
+  sections?: OptionListProps['sections'],
 ): number {
   return (
     (options == null ? 0 : options.length) +

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {useUniqueId} from '../../utilities/unique-id';
 import {RangeSliderProps, RangeSliderValue, DualValue} from './types';
-import {RangeSliderDefault} from './utilities';
 
 import {SingleThumb, DualThumb} from './components';
 
@@ -14,9 +13,9 @@ export {RangeSliderProps};
 interface Props extends RangeSliderProps {}
 
 export function RangeSlider({
-  min = RangeSliderDefault.Min,
-  max = RangeSliderDefault.Max,
-  step = RangeSliderDefault.Step,
+  min = 0,
+  max = 100,
+  step = 1,
   value,
   ...rest
 }: Props) {

--- a/src/components/RangeSlider/RangeSlider.tsx
+++ b/src/components/RangeSlider/RangeSlider.tsx
@@ -5,6 +5,8 @@ import {RangeSliderDefault} from './utilities';
 
 import {SingleThumb, DualThumb} from './components';
 
+export {RangeSliderProps};
+
 // The script in the styleguide that generates the Props Explorer data expects
 // that the interface defining the props is defined in this file, not imported
 // from elsewhere. This silly workaround ensures that the Props Explorer table

--- a/src/components/RangeSlider/index.ts
+++ b/src/components/RangeSlider/index.ts
@@ -1,2 +1,1 @@
 export * from './RangeSlider';
-export {RangeSliderProps, RangeSliderValue, DualValue} from './types';

--- a/src/components/RangeSlider/tests/RangeSlider.test.tsx
+++ b/src/components/RangeSlider/tests/RangeSlider.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {RangeSlider} from '../RangeSlider';
 import {DualThumb, SingleThumb} from '../components';
-import {RangeSliderDefault} from '../utilities';
 
 const mockRangeSliderProps = {
   label: 'RangeSlider',
@@ -27,15 +26,7 @@ describe('<RangeSlider />', () => {
 
       const {min, max, step} = element.find(DualThumb).props();
 
-      expect({
-        min,
-        max,
-        step,
-      }).toStrictEqual({
-        min: RangeSliderDefault.Min,
-        max: RangeSliderDefault.Max,
-        step: RangeSliderDefault.Step,
-      });
+      expect({min, max, step}).toStrictEqual({min: 0, max: 100, step: 1});
     });
 
     it('passes overrides to default props to dual thumb', () => {
@@ -88,15 +79,7 @@ describe('<RangeSlider />', () => {
 
       const {min, max, step} = element.find(SingleThumb).props();
 
-      expect({
-        min,
-        max,
-        step,
-      }).toStrictEqual({
-        min: RangeSliderDefault.Min,
-        max: RangeSliderDefault.Max,
-        step: RangeSliderDefault.Step,
-      });
+      expect({min, max, step}).toStrictEqual({min: 0, max: 100, step: 1});
     });
 
     it('passes an id to single thumb', () => {

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -1,4 +1,4 @@
-import {Action} from '../Labelled';
+import {LabelledProps} from '../Labelled';
 
 import {Error} from '../../types';
 
@@ -10,7 +10,7 @@ export interface RangeSliderProps {
   /** Label for the range input */
   label: string;
   /** Adds an action to the label */
-  labelAction?: Action;
+  labelAction?: LabelledProps['action'];
   /** Visually hide the label */
   labelHidden?: boolean;
   /** ID for range input */

--- a/src/components/RangeSlider/utilities/index.ts
+++ b/src/components/RangeSlider/utilities/index.ts
@@ -1,9 +1,3 @@
 export const CSS_VAR_PREFIX = '--Polaris-RangeSlider-';
 
-export enum RangeSliderDefault {
-  Min = 0,
-  Max = 100,
-  Step = 1,
-}
-
 export {invertNumber} from './invertNumber';

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -29,9 +29,12 @@ import {
   CheckableButton,
   // eslint-disable-next-line import/no-deprecated
   FilterControl,
+  FilterControlProps,
 } from './components';
 
 import styles from './ResourceList.scss';
+
+export {FilterControlProps};
 
 const SMALL_SCREEN_WIDTH = 458;
 const SMALL_SPINNER_HEIGHT = 28;

--- a/src/components/ResourceList/components/FilterControl/types.ts
+++ b/src/components/ResourceList/components/FilterControl/types.ts
@@ -1,5 +1,5 @@
 import {SelectOption} from '../../../Select';
-import {Type} from '../../../TextField';
+import {TextFieldProps} from '../../../TextField';
 
 export interface Operator {
   key: string;
@@ -34,7 +34,7 @@ export interface FilterSelect<FilterKeys = {}> extends FilterBase<FilterKeys> {
 export interface FilterTextField<FilterKeys = {}>
   extends FilterBase<FilterKeys> {
   type: FilterType.TextField;
-  textFieldType?: Type;
+  textFieldType?: TextFieldProps['type'];
 }
 
 export interface FilterDateSelector<FilterKeys = {}>

--- a/src/components/ResourceList/index.ts
+++ b/src/components/ResourceList/index.ts
@@ -1,3 +1,2 @@
 export * from './ResourceList';
 export * from './components/FilterControl/types';
-export {FilterControlProps} from './components/FilterControl';

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {ArrowUpDownMinor} from '@shopify/polaris-icons';
 import {classNames} from '../../utilities/css';
 import {useUniqueId} from '../../utilities/unique-id';
-import {Labelled, Action, helpTextID} from '../Labelled';
+import {Labelled, LabelledProps, helpTextID} from '../Labelled';
 import {Icon} from '../Icon';
 import {Error} from '../../types';
 
@@ -41,7 +41,7 @@ export interface SelectProps {
   /** Label for the select */
   label: string;
   /** Adds an action to the label */
-  labelAction?: Action;
+  labelAction?: LabelledProps['action'];
   /** Visually hide the label */
   labelHidden?: boolean;
   /** Show the label to the left of the value, inside the control */

--- a/src/components/Sheet/Sheet.tsx
+++ b/src/components/Sheet/Sheet.tsx
@@ -1,11 +1,11 @@
 import React, {useCallback, useRef} from 'react';
-
+import {durationSlow} from '@shopify/polaris-tokens';
 import {CSSTransition} from '@material-ui/react-transition-group';
 import {useMediaQuery} from '../../utilities/media-query';
 import {classNames} from '../../utilities/css';
 
 import {Key} from '../../types';
-import {layer, overlay, Duration} from '../shared';
+import {layer, overlay} from '../shared';
 
 import {Backdrop} from '../Backdrop';
 import {TrapFocus} from '../TrapFocus';
@@ -62,7 +62,7 @@ export function Sheet({
         classNames={
           isNavigationCollapsed ? BOTTOM_CLASS_NAMES : RIGHT_CLASS_NAMES
         }
-        timeout={Duration.Slow}
+        timeout={durationSlow}
         in={open}
         mountOnEnter
         unmountOnExit

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -7,7 +7,7 @@ import {useFeatures} from '../../utilities/features';
 import {useI18n} from '../../utilities/i18n';
 import {useUniqueId} from '../../utilities/unique-id';
 import {useIsAfterInitialMount} from '../../utilities/use-is-after-initial-mount';
-import {Labelled, Action, helpTextID, labelID} from '../Labelled';
+import {Labelled, LabelledProps, helpTextID, labelID} from '../Labelled';
 import {Connected} from '../Connected';
 
 import {Error, Key} from '../../types';
@@ -15,7 +15,7 @@ import {Icon} from '../Icon';
 import {Resizer, Spinner} from './components';
 import styles from './TextField.scss';
 
-export type Type =
+type Type =
   | 'text'
   | 'email'
   | 'number'
@@ -46,7 +46,7 @@ interface NonMutuallyExclusiveProps {
   /** Label for the input */
   label: string;
   /** Adds an action to the label */
-  labelAction?: Action;
+  labelAction?: LabelledProps['action'];
   /** Visually hide the label */
   labelHidden?: boolean;
   /** Disable the input */

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -11,9 +11,19 @@ import {Icon} from '../Icon';
 import {Image} from '../Image';
 import {UnstyledLink} from '../UnstyledLink';
 
-import {SearchField, UserMenu, Search, SearchProps, Menu} from './components';
+import {
+  SearchField,
+  SearchFieldProps,
+  UserMenu,
+  UserMenuProps,
+  Search,
+  SearchProps,
+  Menu,
+} from './components';
 
 import styles from './TopBar.scss';
+
+export {UserMenuProps, SearchFieldProps};
 
 export interface TopBarProps {
   /** Toggles whether or not a navigation component has been provided. Controls the presence of the mobile nav toggle button */

--- a/src/components/TopBar/index.ts
+++ b/src/components/TopBar/index.ts
@@ -1,2 +1,1 @@
 export * from './TopBar';
-export {UserMenuProps, SearchFieldProps} from './components';

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -4,7 +4,7 @@ import {Key} from '../../types';
 
 import {useComponentDidMount} from '../../utilities/use-component-did-mount';
 import {EventListener} from '../EventListener';
-import {KeypressListener, KeyEvent} from '../KeypressListener';
+import {KeypressListener} from '../KeypressListener';
 import {Focus} from '../Focus';
 
 import {
@@ -99,7 +99,7 @@ export function TrapFocus({trapping = true, children}: TrapFocusProps) {
         <EventListener event="focusin" handler={handleFocusIn} />
         <KeypressListener
           keyCode={Key.Tab}
-          keyEvent={KeyEvent.KeyDown}
+          keyEvent="keydown"
           handler={handleTab}
         />
         {children}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -34,25 +34,7 @@ export {ChoiceList, ChoiceListProps} from './ChoiceList';
 
 export {Collapsible, CollapsibleProps} from './Collapsible';
 
-export {
-  ColorPicker,
-  ColorPickerProps,
-  RGBColor,
-  HSBColor,
-  RGBAColor,
-  HSBAColor,
-  HSLColor,
-  HSLAColor,
-  HSBLAColor,
-  rgbToHex,
-  rgbToHsb,
-  rgbToHsl,
-  hsbToRgb,
-  hsbToHex,
-  hslToRgb,
-  rgbString,
-  rgbaString,
-} from './ColorPicker';
+export {ColorPicker, ColorPickerProps} from './ColorPicker';
 
 export {Connected, ConnectedProps} from './Connected';
 

--- a/src/components/shared.ts
+++ b/src/components/shared.ts
@@ -37,13 +37,3 @@ export const DATA_ATTRIBUTE = {
   overlay,
   layer,
 };
-
-// these match our values in duration.scss
-export enum Duration {
-  Instant = 0,
-  Fast = 100,
-  Base = 200,
-  Slow = 300,
-  Slower = 400,
-  Slowest = 500,
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,26 @@ export * from './types';
 
 export * from './components';
 
+export {
+  RGBColor,
+  HSBColor,
+  RGBAColor,
+  HSBAColor,
+  HSLColor,
+  HSLAColor,
+  HSBLAColor,
+} from './utilities/color-types';
+export {
+  rgbToHex,
+  rgbToHsb,
+  rgbToHsl,
+  hsbToRgb,
+  hsbToHex,
+  hslToRgb,
+  rgbString,
+  rgbaString,
+} from './utilities/color-transformers';
+
 export {ScrollLockManagerContext as _SECRET_INTERNAL_SCROLL_LOCK_MANAGER_CONTEXT} from './utilities/scroll-lock-manager';
 export {WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT} from './utilities/within-content-context';
 

--- a/src/utilities/is-input-focused.ts
+++ b/src/utilities/is-input-focused.ts
@@ -1,4 +1,4 @@
-export enum EditableTarget {
+enum EditableTarget {
   Input = 'INPUT',
   Textarea = 'TEXTAREA',
   Select = 'SELECT',


### PR DESCRIPTION
### WHY are these changes introduced?

Avoiding exporting a few types that don't need to be

### WHAT is this pull request doing?

- Removing exports from types that are never used outside the current file
- Use types based upon props types instead of the underlying type, so the underlying type doesn't need to be exported
- Moving color utility exports so they are exported from `src/index.ts` instead of `src/components/index.ts` via `src/components/ColorPicker/index.ts`
- Replace some internal enum usage with types containing constant strings, so that internal components follow the same patterns as our publicly consumable components.