### PR TITLE
[WIP][Color system] Focus ring z-index 

### DIFF
--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -64,15 +64,6 @@ $control-size: rem(16px);
 
 .Checkbox.globalTheming {
   .Input {
-    &:focus {
-      + .Backdrop {
-        @include focus-ring(
-          $style: 'focused',
-          $offset: var(--p-checkbox-radio-button-focus-ring-offset)
-        );
-      }
-    }
-
     &:active:not(:disabled),
     &:checked,
     &.Input-indeterminate {
@@ -110,9 +101,6 @@ $control-size: rem(16px);
     display: block;
     width: 100%;
     height: 100%;
-    @include focus-ring(
-      $offset: var(--p-checkbox-radio-button-focus-ring-offset)
-    );
   }
 
   .Icon {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,9 @@
-import React, {useRef, useImperativeHandle} from 'react';
+import React, {
+  useRef,
+  useImperativeHandle,
+  useEffect,
+  useCallback,
+} from 'react';
 import {MinusMinor, TickSmallMinor} from '@shopify/polaris-icons';
 import {classNames} from '../../utilities/css';
 import {useFeatures} from '../../utilities/features';
@@ -10,6 +15,32 @@ import {Icon} from '../Icon';
 import {Error, Key, CheckboxHandles} from '../../types';
 
 import styles from './Checkbox.scss';
+
+function useFocusRing(
+  target: React.RefObject<HTMLElement>,
+  trigger?: React.RefObject<HTMLInputElement>,
+) {
+  const {current: targetEl} = target;
+  const triggerEl = trigger && trigger.current ? trigger.current : targetEl;
+
+  const handleFocus = useCallback(() => {
+    console.log('focused: ', triggerEl);
+  }, [triggerEl]);
+
+  const handleBlur = useCallback(() => {
+    console.log('blur: ', triggerEl);
+  }, [triggerEl]);
+
+  useEffect(() => {
+    if (!triggerEl) return;
+    triggerEl.addEventListener('focus', handleFocus);
+    triggerEl.addEventListener('blur', handleBlur);
+    return () => {
+      triggerEl.removeEventListener('focus', handleFocus);
+      triggerEl.removeEventListener('blur', handleBlur);
+    };
+  }, [handleBlur, handleFocus, triggerEl]);
+}
 
 export interface CheckboxProps {
   /** Indicates the ID of the element that describes the checkbox*/
@@ -67,6 +98,10 @@ export const Checkbox = React.forwardRef<CheckboxHandles, CheckboxProps>(
       setTrue: forceTrueMouseOver,
       setFalse: forceFalseMouseOver,
     } = useToggle(false);
+
+    const wrapperNode = useRef<HTMLDivElement>(null);
+
+    const focusRing = useFocusRing(wrapperNode);
 
     useImperativeHandle(ref, () => ({
       focus: () => {
@@ -143,7 +178,7 @@ export const Checkbox = React.forwardRef<CheckboxHandles, CheckboxProps>(
         onMouseOver={forceTrueMouseOver}
         onMouseOut={forceFalseMouseOver}
       >
-        <span className={wrapperClassName}>
+        <span className={wrapperClassName} ref={wrapperNode} tabIndex={-1}>
           <input
             onKeyUp={handleKeyUp}
             ref={inputNode}

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,46 +1,16 @@
-import React, {
-  useRef,
-  useImperativeHandle,
-  useEffect,
-  useCallback,
-} from 'react';
+import React, {useRef, useImperativeHandle} from 'react';
 import {MinusMinor, TickSmallMinor} from '@shopify/polaris-icons';
 import {classNames} from '../../utilities/css';
 import {useFeatures} from '../../utilities/features';
 import {useToggle} from '../../utilities/use-toggle';
 import {useUniqueId} from '../../utilities/unique-id';
+import {useFocusRing} from '../../utilities/focus-ring';
 import {Choice, helpTextID} from '../Choice';
 import {errorTextID} from '../InlineError';
 import {Icon} from '../Icon';
 import {Error, Key, CheckboxHandles} from '../../types';
 
 import styles from './Checkbox.scss';
-
-function useFocusRing(
-  target: React.RefObject<HTMLElement>,
-  trigger?: React.RefObject<HTMLInputElement>,
-) {
-  const {current: targetEl} = target;
-  const triggerEl = trigger && trigger.current ? trigger.current : targetEl;
-
-  const handleFocus = useCallback(() => {
-    console.log('focused: ', triggerEl);
-  }, [triggerEl]);
-
-  const handleBlur = useCallback(() => {
-    console.log('blur: ', triggerEl);
-  }, [triggerEl]);
-
-  useEffect(() => {
-    if (!triggerEl) return;
-    triggerEl.addEventListener('focus', handleFocus);
-    triggerEl.addEventListener('blur', handleBlur);
-    return () => {
-      triggerEl.removeEventListener('focus', handleFocus);
-      triggerEl.removeEventListener('blur', handleBlur);
-    };
-  }, [handleBlur, handleFocus, triggerEl]);
-}
 
 export interface CheckboxProps {
   /** Indicates the ID of the element that describes the checkbox*/
@@ -99,9 +69,9 @@ export const Checkbox = React.forwardRef<CheckboxHandles, CheckboxProps>(
       setFalse: forceFalseMouseOver,
     } = useToggle(false);
 
-    const wrapperNode = useRef<HTMLDivElement>(null);
+    const backdropNode = useRef<HTMLSpanElement>(null);
 
-    const focusRing = useFocusRing(wrapperNode);
+    useFocusRing(backdropNode, inputNode);
 
     useImperativeHandle(ref, () => ({
       focus: () => {
@@ -178,7 +148,7 @@ export const Checkbox = React.forwardRef<CheckboxHandles, CheckboxProps>(
         onMouseOver={forceTrueMouseOver}
         onMouseOut={forceFalseMouseOver}
       >
-        <span className={wrapperClassName} ref={wrapperNode} tabIndex={-1}>
+        <span className={wrapperClassName}>
           <input
             onKeyUp={handleKeyUp}
             ref={inputNode}
@@ -198,7 +168,7 @@ export const Checkbox = React.forwardRef<CheckboxHandles, CheckboxProps>(
             role="checkbox"
             {...indeterminateAttributes}
           />
-          <span className={backdropClassName} />
+          <span className={backdropClassName} ref={backdropNode} />
           <span className={styles.Icon}>
             <Icon source={iconSource} />
           </span>

--- a/src/utilities/focus-ring/FocusRing.scss
+++ b/src/utilities/focus-ring/FocusRing.scss
@@ -1,7 +1,7 @@
 .FocusRing {
   position: absolute;
   display: block;
-  border: 2px solid blue;
+  border: 2px solid#2d72d2;
   pointer-events: none;
   opacity: 0;
   transform: scale(0.8);

--- a/src/utilities/focus-ring/FocusRing.scss
+++ b/src/utilities/focus-ring/FocusRing.scss
@@ -1,0 +1,15 @@
+.FocusRing {
+  position: absolute;
+  display: block;
+  border: 2px solid blue;
+  pointer-events: none;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: all 100ms cubic-bezier(0.4, 0.22, 0.28, 1);
+}
+
+.FocusRing-focus {
+  opacity: 1;
+  transform: scale(1);
+  transition: all 100ms cubic-bezier(0.4, 0.22, 0.28, 1);
+}

--- a/src/utilities/focus-ring/FocusRing.ts
+++ b/src/utilities/focus-ring/FocusRing.ts
@@ -1,0 +1,66 @@
+import React, {useRef, useEffect, useCallback} from 'react';
+import {getRectForNode} from '@shopify/javascript-utilities/geometry';
+import {
+  addEventListener,
+  removeEventListener,
+} from '@shopify/javascript-utilities/events';
+import {Key} from '../../types';
+import {classNames} from '../css';
+import styles from './FocusRing.scss';
+
+export function useFocusRing(
+  target: React.RefObject<HTMLElement | HTMLInputElement>,
+  trigger: React.RefObject<HTMLInputElement>,
+) {
+  const focusRing = useRef<HTMLElement | null>(null);
+  const focusRingClass = useRef(classNames(styles.FocusRing));
+  const focusRingFocusClass = useRef(classNames(styles['FocusRing-focus']));
+  const targetEl = target.current;
+  const triggerEl = trigger.current;
+
+  const handleTabFocus = useCallback((event: KeyboardEvent) => {
+    if (event.keyCode === Key.Tab) {
+      focusRing.current &&
+        focusRing.current.classList.add(focusRingFocusClass.current);
+    }
+  }, []);
+
+  const handleBlur = useCallback(() => {
+    focusRing.current &&
+      focusRing.current.classList.remove(focusRingFocusClass.current);
+  }, []);
+
+  useEffect(() => {
+    if (!targetEl || !triggerEl || !document) return;
+    addEventListener(triggerEl, 'keyup', handleTabFocus);
+    addEventListener(triggerEl, 'blur', handleBlur);
+    const computedStyles = window.getComputedStyle(targetEl);
+    const borderRadius = computedStyles
+      .getPropertyValue('border-radius')
+      .split(' ')
+      .map((radius) => {
+        const num = parseInt(radius, 10);
+        return num === 0 ? '0px' : `${num + 2}px`;
+      });
+
+    const rect = getRectForNode(targetEl);
+    const top = rect.top - 3;
+    const left = rect.left - 3;
+    const width = rect.width + 6;
+    const height = rect.height + 6;
+    const style = `border-radius: ${borderRadius}; top: ${top}px; left: ${left}px; width: ${width}px; height: ${height}px;`;
+
+    if (focusRing.current == null) {
+      focusRing.current = document.createElement('div');
+      focusRing.current.setAttribute('style', style);
+      focusRing.current.setAttribute('class', focusRingClass.current);
+      document.body.appendChild(focusRing.current);
+    }
+
+    return () => {
+      triggerEl && removeEventListener(triggerEl, 'keydown', handleTabFocus);
+      triggerEl && removeEventListener(triggerEl, 'blur', handleBlur);
+      focusRing.current && document.removeChild(focusRing.current);
+    };
+  }, [handleBlur, handleTabFocus, targetEl, triggerEl]);
+}

--- a/src/utilities/focus-ring/index.ts
+++ b/src/utilities/focus-ring/index.ts
@@ -1,0 +1,1 @@
+export {useFocusRing} from './FocusRing';


### PR DESCRIPTION
#WHY are these changes introduced?

**This is not for code review but simply to explore an approach**

The current focus-ring implementation uses the `::after` pseudo-element, absolutely positioned. This poses a few problems:

1. Round corners may vary, the current implementation assumes all 4 corners.
2. Scale animation is inconsistent. Scaling from 80% on a large element like Textarea does not feel like it does on smaller elements.
3. Detecting a click vs a tab focus cannot currently be achieved via CSS because `focus-visible` is not yet supported in browsers other than firefox.
4. When the element in focus is too close to the edge of an `overflow: hidden` element, the focus ring gets cut off.

This solution is simply a rough proof of concept but it does/can solve all of these issues. 

### WHAT is this pull request doing?

TDB...


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
