### PR TITLE
[RangeSlider] Apply color system to thumb

### DIFF
--- a/src/components/RangeSlider/RangeSlider.scss
+++ b/src/components/RangeSlider/RangeSlider.scss
@@ -1,5 +1,5 @@
 $range-track-height: rem(4px);
-$range-thumb-size: rem(24px);
+$range-thumb-size: var(--p-range-slider-thumb-size-base, rem(24px));
 
 @mixin track-dashed {
   $borderRadius: var(--p-border-radius-base, border-radius());

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -2,18 +2,27 @@
 @import '../../RangeSlider';
 
 $stacking-order: (
-  output: 10,
-  input: 20,
+  input: 10,
+  output: 20,
 );
 
 $range-wrapper: rem(28px);
 
 $range-thumb-border-error: rem(2px) solid color('red');
 
-$range-thumb-shadow: (0 0 0 rem(1px) rgba(black, 0.2), shadow(faint));
-$range-thumb-shadow-hover: (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint));
-$range-thumb-shadow-error: 0 0 0 rem(1px) color('red');
-$range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
+$range-thumb-shadow: var(
+  --p-override-none,
+  (0 0 0 rem(1px) rgba(black, 0.2), shadow(faint))
+);
+$range-thumb-shadow-hover: var(
+  --p-override-none,
+  (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint))
+);
+$range-thumb-shadow-error: var(--p-override-none, 0 0 0 rem(1px) color('red'));
+$range-thumb-shadow-focus: var(
+  --p-override-none,
+  0 0 0 rem(1px) color('indigo')
+);
 
 .Wrapper {
   position: relative;
@@ -83,41 +92,54 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
 .Thumbs {
   position: absolute;
   z-index: z-index('input', $stacking-order);
+  padding: 0;
   width: $range-thumb-size;
   height: $range-thumb-size;
   border-radius: 50%;
-  border: border-width() solid color('sky', 'lighter');
+  border: border-width() solid var(--p-interactive, color('sky', 'lighter'));
   box-shadow: $range-thumb-shadow;
-  background: linear-gradient(color('sky', 'lighter'), color('sky', 'light'));
+  background: linear-gradient(
+    var(--p-interactive, color('sky', 'lighter')),
+    var(--p-interactive, color('sky', 'light'))
+  );
   -webkit-tap-highlight-color: transparent;
 
   // stylelint-disable-next-line value-no-vendor-prefix
   cursor: -webkit-grab;
+  transition: transform var(--p-duration-1-5-0, duration())
+    var(--p-ease, easing());
 
   &.disabled {
     cursor: not-allowed;
-    border-color: color('sky', 'dark');
+    border-color: var(--p-border-secondary-disabled, color('sky', 'dark'));
+    background: var(--p-border-secondary-disabled, color('white'));
   }
 
   &:hover {
-    background: linear-gradient(color('sky', 'lighter'), color('sky', 'light'));
     box-shadow: $range-thumb-shadow-hover;
   }
 
-  .error & {
-    border-color: color('red');
-    box-shadow: $range-thumb-shadow-error;
+  &:active {
+    transform: scale(var(--p-range-slider-thumb-scale, 1));
   }
 
   &:focus {
     outline: 0;
-    background: linear-gradient(color('sky', 'lighter'), color('sky', 'light'));
-    border-color: color('indigo');
-    box-shadow: $range-thumb-shadow-focus;
+    border-color: var(--p-override-transparent, color('indigo'));
+    box-shadow: var(--p-override-none, $range-thumb-shadow-focus);
 
     @media (-ms-high-contrast: active) {
       outline: 1px solid ms-high-contrast-color('text');
     }
+  }
+
+  .error & {
+    border-color: var(--p-action-critical, color('red'));
+    background: linear-gradient(
+      var(--p-action-critical, color('sky', 'lighter')),
+      var(--p-action-critical, color('sky', 'light'))
+    );
+    box-shadow: $range-thumb-shadow-error;
   }
 }
 
@@ -137,20 +159,31 @@ $range-output-spacing: rem(16px);
 .Output {
   position: absolute;
   z-index: z-index('output', $stacking-order);
-  bottom: $range-thumb-size;
+  bottom: var(--p-range-slider-thumb-size-active, $range-thumb-size);
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  transition-property: opacity, visibility;
-  transition-duration: duration();
-  transition-timing-function: easing();
+  transition-property: opacity, visibility, bottom;
+  transition-duration: var(--p-duration-1-5-0, duration());
+  transition-timing-function: var(--p-ease, easing());
   transform: translateX(calc(-50% + #{$range-thumb-size / 2}));
 
   .Thumbs:hover + &,
-  .Thumbs:active + &,
   .Thumbs:focus + & {
+    opacity: var(--p-override-zero, 1);
+    visibility: var(--p-override-none, visible);
+  }
+
+  .Thumbs:active + & {
+    $range-thumb-size-difference: var(
+        --p-range-slider-thumb-size-active,
+        $range-thumb-size
+      ) - var(--p-range-slider-thumb-size-base, $range-thumb-size);
     opacity: 1;
     visibility: visible;
+    bottom: calc(
+      #{var(--p-range-slider-thumb-size-active, $range-thumb-size)} + #{$range-thumb-size-difference}
+    );
   }
 }
 
@@ -160,11 +193,12 @@ $range-output-spacing: rem(16px);
   padding: 0 spacing(tight);
   min-width: $range-output-size;
   height: $range-output-size;
-  background-color: color('ink');
+  background-color: var(--p-surface, color('ink'));
+  box-shadow: var(--p-popover-shadow, --p-override-none);
   border-radius: border-radius();
   transition-property: transform;
-  transition-duration: duration();
-  transition-timing-function: easing();
+  transition-duration: var(--p-duration-1-5-0, duration());
+  transition-timing-function: var(--p-ease, easing());
 
   // stylelint-disable selector-max-specificity
   .Thumbs:hover + .Output &,
@@ -185,5 +219,5 @@ $range-output-spacing: rem(16px);
   flex: 1 1 auto;
   margin: auto;
   text-align: center;
-  color: color('white');
+  color: var(--p-text, color('white'));
 }

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -6,6 +6,7 @@ import {
 } from '@shopify/javascript-utilities/events';
 import isEqual from 'lodash/isEqual';
 import {classNames} from '../../../../utilities/css';
+import {FeaturesContext} from '../../../../utilities/features';
 import {CSS_VAR_PREFIX} from '../../utilities';
 import {RangeSliderProps, DualValue} from '../../types';
 import {Labelled, labelID} from '../../../Labelled';
@@ -38,9 +39,9 @@ enum Control {
   Upper,
 }
 
-const THUMB_SIZE = 24;
-
 export class DualThumb extends React.Component<DualThumbProps, State> {
+  static contextType = FeaturesContext;
+
   static getDerivedStateFromProps(props: DualThumbProps, state: State) {
     const {min, step, max, value, onChange, id} = props;
     const {prevValue} = state;
@@ -61,6 +62,8 @@ export class DualThumb extends React.Component<DualThumbProps, State> {
     };
   }
 
+  context!: React.ContextType<typeof FeaturesContext>;
+
   state: State = {
     value: sanitizeValue(
       this.props.value,
@@ -80,9 +83,14 @@ export class DualThumb extends React.Component<DualThumbProps, State> {
   private setTrackPosition = debounce(
     () => {
       if (this.track.current) {
+        const newDesignLanguage =
+          this.context && this.context.newDesignLanguage;
+        const thumbSize = newDesignLanguage ? 16 : 24;
+
         const {width, left} = this.track.current.getBoundingClientRect();
-        const adjustedTrackWidth = width - THUMB_SIZE;
-        const adjustedTrackLeft = left + THUMB_SIZE / 2;
+        const adjustedTrackWidth = width - thumbSize;
+        const adjustedTrackLeft = left + thumbSize / 2;
+
         this.setState({
           trackWidth: adjustedTrackWidth,
           trackLeft: adjustedTrackLeft,

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -7,6 +7,7 @@ import {
 } from 'test-utilities/legacy';
 import {Key} from 'types';
 import {DualThumb, DualThumbProps} from '../DualThumb';
+import {FeaturesContext} from '../../../../../utilities/features';
 
 describe('<DualThumb />', () => {
   const mockProps: DualThumbProps = {
@@ -20,6 +21,28 @@ describe('<DualThumb />', () => {
     onChange: noop,
     label: 'Dual thumb range slider',
   };
+
+  it('has a different track width and left value when the design system is used', () => {
+    const dualThumbWithDesignLanguage = mountWithAppProvider(
+      <FeaturesContext.Provider value={{newDesignLanguage: true}}>
+        <DualThumb {...mockProps} />
+      </FeaturesContext.Provider>,
+    );
+
+    const dualThumbWithoutDesignLanguage = mountWithAppProvider(
+      <DualThumb {...mockProps} />,
+    );
+
+    const stateWithDesignLanguage = dualThumbWithDesignLanguage.state();
+    const stateWithoutDesignLanguage = dualThumbWithoutDesignLanguage.state();
+
+    expect(stateWithDesignLanguage.trackWidth).not.toStrictEqual(
+      stateWithoutDesignLanguage.trackWidth,
+    );
+    expect(stateWithDesignLanguage.trackLeft).not.toStrictEqual(
+      stateWithoutDesignLanguage.trackLeft,
+    );
+  });
 
   describe('id', () => {
     it('is used on the lower thumb', () => {

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -2,14 +2,23 @@
 @import '../../RangeSlider';
 
 $stacking-order: (
-  output: 10,
-  input: 20,
+  input: 10,
+  output: 20,
 );
 
-$range-thumb-shadow: (0 0 0 rem(1px) rgba(black, 0.2), shadow(faint));
-$range-thumb-shadow-hover: (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint));
-$range-thumb-shadow-error: 0 0 0 rem(1px) color('red');
-$range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
+$range-thumb-shadow: var(
+  --p-override-none,
+  (0 0 0 rem(1px) rgba(black, 0.2), shadow(faint))
+);
+$range-thumb-shadow-hover: var(
+  --p-override-none,
+  (0 0 0 rem(1px) rgba(black, 0.4), shadow(faint))
+);
+$range-thumb-shadow-error: var(--p-override-none, 0 0 0 rem(1px) color('red'));
+$range-thumb-shadow-focus: var(
+  --p-override-none,
+  0 0 0 rem(1px) color('indigo')
+);
 
 .SingleThumb {
   display: flex;
@@ -70,6 +79,10 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
     var(--progress-upper, transparent) var(--Polaris-RangeSlider-progress, 100%),
     var(--progress-upper, transparent) 100%;
 
+  @mixin rangeSliderThumbPosition($size) {
+    margin-top: calc(-1 * (#{$size} - #{$range-track-height}) / 2);
+  }
+
   &::-ms-tooltip {
     display: none;
   }
@@ -93,19 +106,24 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
     cursor: -webkit-grab;
     width: $range-thumb-size;
     height: $range-thumb-size;
-    border: border-width() solid color('sky', 'lighter');
+    border: border-width() solid var(--p-interactive, color('sky', 'lighter'));
     border-radius: 50%;
-    background: linear-gradient(color('white'), color('sky', 'lighter'));
+    background: linear-gradient(
+      var(--p-interactive, color('white')),
+      var(--p-interactive, color('sky', 'lighter'))
+    );
     box-shadow: $range-thumb-shadow;
     appearance: none;
-    transition-property: border-color, box-shadow;
+    transition-property: border-color, box-shadow, transform;
     transition-duration: duration();
     transition-timing-function: easing();
 
+    @include rangeSliderThumbPosition($range-thumb-size);
+
     &:hover {
       background: linear-gradient(
-        color('sky', 'lighter'),
-        color('sky', 'light')
+        var(--p-interactive, color('sky', 'lighter')),
+        var(--p-interactive, color('sky', 'light'))
       );
       box-shadow: $range-thumb-shadow-hover;
     }
@@ -120,6 +138,23 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
     margin-top: -($range-thumb-size - $range-track-height) / 2;
   }
 
+  &:active {
+    @include range-thumb-selectors {
+      transform: scale(var(--p-range-slider-thumb-scale, 1));
+    }
+  }
+
+  &:focus {
+    @include range-thumb-selectors {
+      box-shadow: $range-thumb-shadow-focus;
+      border-color: var(--p-override-transparent, color('indigo'));
+    }
+
+    @media (-ms-high-contrast: active) {
+      outline: 1px solid ms-high-contrast-color('text');
+    }
+  }
+
   .error & {
     --progress-lower: #{var(--p-action-critical, color('red'))};
 
@@ -128,7 +163,8 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
     }
 
     @include range-thumb-selectors {
-      border-color: color('red');
+      border-color: var(--p-action-critical, color('red'));
+      background: var(--p-action-critical, color('white'));
       box-shadow: $range-thumb-shadow-error;
     }
   }
@@ -145,22 +181,8 @@ $range-thumb-shadow-focus: 0 0 0 rem(1px) color('indigo');
 
     @include range-thumb-selectors {
       cursor: not-allowed;
-      border-color: color('sky', 'dark');
-    }
-  }
-
-  &:focus {
-    @include range-thumb-selectors {
-      background: linear-gradient(
-        color('sky', 'lighter'),
-        color('sky', 'light')
-      );
-      border-color: color('indigo');
-      box-shadow: $range-thumb-shadow-focus;
-    }
-
-    @media (-ms-high-contrast: active) {
-      outline: 1px solid ms-high-contrast-color('text');
+      border-color: var(--p-border-secondary-disabled, color('sky', 'dark'));
+      background: var(--p-border-secondary-disabled, color('white'));
     }
   }
 }
@@ -171,6 +193,7 @@ $range-output-size: rem(32px);
 $range-output-translate-x: calc(
   -50% + var(--Polaris-RangeSlider-output-factor, 0) * #{$range-thumb-size}
 );
+
 $range-output-spacing: rem(16px);
 
 .Output {
@@ -182,25 +205,35 @@ $range-output-spacing: rem(16px);
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
-  transition-property: opacity, visibility;
+  transition-property: opacity, visibility, bottom;
   transition-duration: duration();
   transition-timing-function: easing();
 
   .Input:hover + &,
-  .Input:active + &,
   .Input:focus + & {
+    opacity: var(--p-override-zero, 1);
+    visibility: var(--p-override-none, visible);
+  }
+
+  .Input:active + & {
+    $range-thumb-size-difference: var(
+        --p-range-slider-thumb-size-active,
+        $range-thumb-size
+      ) - var(--p-range-slider-thumb-size-base, $range-thumb-size);
     opacity: 1;
     visibility: visible;
+    bottom: calc(#{$range-thumb-size} + #{$range-thumb-size-difference});
   }
 }
 
 .OutputBubble {
   position: relative;
   display: flex;
+  box-shadow: var(--p-popover-shadow, --p-override-none);
   padding: 0 spacing(tight);
   min-width: $range-output-size;
   height: $range-output-size;
-  background-color: color('ink');
+  background-color: var(--p-surface, color('ink'));
   border-radius: border-radius();
   transition-property: transform;
   transition-duration: duration();
@@ -225,5 +258,5 @@ $range-output-spacing: rem(16px);
   flex: 1 1 auto;
   margin: auto;
   text-align: center;
-  color: color('white');
+  color: var(--p-text, color('white'));
 }

--- a/src/utilities/theme/tokens.ts
+++ b/src/utilities/theme/tokens.ts
@@ -43,6 +43,9 @@ const Overrides = {
   duration150: '150ms',
   easeIn: 'cubic-bezier(0.5, 0.1, 1, 1)',
   ease: 'cubic-bezier(0.4, 0.22, 0.28, 1)',
+  rangeSliderThumbSizeBase: rem('16px'),
+  rangeSliderThumbSizeActive: rem('24px'),
+  rangeSliderThumbScale: '1.5',
 };
 
 export const Tokens = {


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-ux/issues/358

### WHAT is this pull request doing?

This applies the color system to the `RangeSlider's` thumb and output bubble (everything else except the track).

Some noticeable differences:
- The thumb size changes depending on if its active or not
- The output bubble only displays when the thumb is active

### Single thumb:

| Light        | Dark           |
| ------------- |:-------------:|
|  ![image](https://user-images.githubusercontent.com/22782157/73105006-d0284180-3ec5-11ea-91c9-8f5831094bd2.png)  |  ![image](https://user-images.githubusercontent.com/22782157/73105014-d4ecf580-3ec5-11ea-925b-c6b9fdeb688c.png) |

### Dual thumb:

| Light        | Dark           |
| ------------- |:-------------:|
|  ![image](https://user-images.githubusercontent.com/22782157/73105034-e7672f00-3ec5-11ea-8d93-18ecd4d0c1c1.png) |  ![image](https://user-images.githubusercontent.com/22782157/73105039-e930f280-3ec5-11ea-9d9d-20064e545520.png) |

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
