### PR TITLE
Fixed side effects from Dialog

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@
 ### Bug fixes
 
 - Fixed scrolling with scrollbar not working in Popover when content changes on scroll ([#2627](https://github.com/Shopify/polaris-react/pull/2627))
+- Fixed side-effects from being create during `Modal`s render ([#2644](https://github.com/Shopify/polaris-react/pull/2644))
 - Work around a build crash when using create-react-app due to a bug in css parsing in `postcss-custom-properties` ([#2643](https://github.com/Shopify/polaris-react/pull/2643))
 - Removed the `visited` CSS styling for tabs using the `url` prop ([#2639](https://github.com/Shopify/polaris-react/pull/2639))
 

--- a/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/src/components/Modal/components/Dialog/Dialog.tsx
@@ -45,7 +45,9 @@ export function Dialog({
   const TransitionChild = instant ? Transition : FadeUp;
 
   useEffect(() => {
-    containerNode.current && focusFirstFocusableNode(containerNode.current);
+    containerNode.current &&
+      !containerNode.current.contains(document.activeElement) &&
+      focusFirstFocusableNode(containerNode.current);
   }, []);
 
   return (

--- a/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/src/components/Modal/components/Dialog/Dialog.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useCallback} from 'react';
+import React, {useRef, useCallback, useEffect} from 'react';
 import {durationBase} from '@shopify/polaris-tokens';
 import {Transition, CSSTransition} from '@material-ui/react-transition-group';
 import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
@@ -9,7 +9,6 @@ import {AnimationProps, Key} from '../../../../types';
 import {KeypressListener} from '../../../KeypressListener';
 import {TrapFocus} from '../../../TrapFocus';
 
-import {useComponentDidMount} from '../../../../utilities/use-component-did-mount';
 import styles from './Dialog.scss';
 
 interface BaseDialogProps {
@@ -45,9 +44,9 @@ export function Dialog({
   );
   const TransitionChild = instant ? Transition : FadeUp;
 
-  useComponentDidMount(() => {
+  useEffect(() => {
     containerNode.current && focusFirstFocusableNode(containerNode.current);
-  });
+  }, []);
 
   return (
     <TransitionChild

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -1,8 +1,7 @@
-import React, {useState, useRef} from 'react';
+import React, {useState, useRef, useEffect} from 'react';
 import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
 import {Key} from '../../types';
 
-import {useComponentDidMount} from '../../utilities/use-component-did-mount';
 import {EventListener} from '../EventListener';
 import {KeypressListener, KeyEvent} from '../KeypressListener';
 import {Focus} from '../Focus';
@@ -26,17 +25,14 @@ export function TrapFocus({trapping = true, children}: TrapFocusProps) {
 
   const focusTrapWrapper = useRef<HTMLDivElement>(null);
 
-  const handleTrappingChange = () => {
-    if (
-      focusTrapWrapper.current &&
-      focusTrapWrapper.current.contains(document.activeElement)
-    ) {
-      return false;
-    }
-    return trapping;
-  };
-
-  useComponentDidMount(() => setFocusSelf(handleTrappingChange()));
+  useEffect(() => {
+    setFocusSelf(
+      !(
+        focusTrapWrapper.current &&
+        focusTrapWrapper.current.contains(document.activeElement)
+      ),
+    );
+  }, []);
 
   const shouldDisableFirstElementFocus = () => {
     if (shouldFocusSelf === undefined) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Closes https://github.com/Shopify/polaris-react/issues/2644

### WHAT is this pull request doing?

Moving focus logic into an effect

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Example code below
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, { useState } from "react";
import {
  Button,
  Card,
  Stack,
  Modal,
  TextContainer,
  TextField
} from "../src";

export default function Playground() {
  const [open, setOpen] = useState(false);
  return (
    <div>
      <Card sectioned>
        <Stack vertical>
          <Button onClick={() => setOpen(true)}>Open</Button>
          <Modal open={open} onClose={() => setOpen(false)}>
            <Modal.Section>
              <TextContainer>
                <TextField label="test" autoFocus />
              </TextContainer>
            </Modal.Section>
          </Modal>
        </Stack>
      </Card>
    </div>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
