### PR TITLE
[DataTable] Add optional totalsMarkupLabel prop and fixing Totals plurality

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -5,11 +5,13 @@
 ### Enhancements
 
 - Replaced customer avatar images ([#2453](https://github.com/Shopify/polaris-react/pull/2453/files))
+- Added an optional `totalsLabel` prop to `DataTable` to support custom headings in the totals row ([#2660](https://github.com/Shopify/polaris-react/pull/2660))
 
 ### Bug fixes
 
 - Fixed `Uncaught TypeError: Cannot read property 'rightEdge' of undefined` in `DataTable` ([#2672](https://github.com/Shopify/polaris-react/pull/2672))
 - Fixed excessive rendering in `DatePicker` ([#2671](https://github.com/Shopify/polaris-react/pull/2671))
+- Fixed plurality of `DataTable` totals row heading ([#2660](https://github.com/Shopify/polaris-react/pull/2660))
 
 ### Documentation
 

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "seřadit {direction} podle",
       "navAccessibilityLabel": "Posunout tabulku o jeden sloupec {direction}",
-      "totalsRowHeading": "Celkem"
+      "totalsRowHeading": "Celkem",
+      "totalRowHeading": "Celkem"
     },
     "DatePicker": {
       "previousMonth": "Zobrazit předchozí měsíc, {previousMonthName} {showPreviousYear}",

--- a/locales/da.json
+++ b/locales/da.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "sortér {direction} efter",
       "navAccessibilityLabel": "Rul tabel én kolonne mod {direction}",
-      "totalsRowHeading": "I alt"
+      "totalsRowHeading": "I alt",
+      "totalRowHeading": "I alt"
     },
     "DatePicker": {
       "previousMonth": "Vis tidligere måned, {previousMonthName} {showPreviousYear}",

--- a/locales/de.json
+++ b/locales/de.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "von {direction} sortieren nach",
       "navAccessibilityLabel": "Tabelle eine Spalte nach {direction} scrollen",
-      "totalsRowHeading": "Gesamt"
+      "totalsRowHeading": "Gesamt",
+      "totalRowHeading": "Gesamtsumme"
     },
     "DatePicker": {
       "previousMonth": "Vormonat anzeigen, {previousMonthName} {showPreviousYear}",

--- a/locales/en.json
+++ b/locales/en.json
@@ -48,7 +48,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "sort {direction} by",
       "navAccessibilityLabel": "Scroll table {direction} one column",
-      "totalsRowHeading": "Totals"
+      "totalsRowHeading": "Totals",
+      "totalRowHeading": "Total"
     },
 
     "DatePicker": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "ordenar {direction} por",
       "navAccessibilityLabel": "Desplaza la tabla una columna {direction}",
-      "totalsRowHeading": "Totales"
+      "totalsRowHeading": "Totales",
+      "totalRowHeading": "total"
     },
     "DatePicker": {
       "previousMonth": "Mostrar el mes anterior, {previousMonthName} {showPreviousYear}",

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "lajittele {direction}:",
       "navAccessibilityLabel": "Selaa taulukkoa {direction} yksi sarake",
-      "totalsRowHeading": "Yhteenlasketut"
+      "totalsRowHeading": "Yhteenlasketut",
+      "totalRowHeading": "Yhteensä"
     },
     "DatePicker": {
       "previousMonth": "Näytä edellinen kuukausi, {previousMonthName} {showPreviousYear}",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "trier {direction} par",
       "navAccessibilityLabel": "Faire défiler le tableau {direction} une colonne",
-      "totalsRowHeading": "Totaux"
+      "totalsRowHeading": "Totaux",
+      "totalRowHeading": "total"
     },
     "DatePicker": {
       "previousMonth": "Afficher le mois précédent, {previousMonthName} {showPreviousYear}",

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "{direction} के अनुसार क्रमबद्ध करें",
       "navAccessibilityLabel": "तालिका को एक कॉलम {direction} ओर स्क्रॉल करें",
-      "totalsRowHeading": "कुल"
+      "totalsRowHeading": "कुल",
+      "totalRowHeading": "कुल"
     },
     "DatePicker": {
       "previousMonth": "पिछला महीना दिखाएं, {previousMonthName} {showPreviousYear}",

--- a/locales/it.json
+++ b/locales/it.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "ordina per {direction}",
       "navAccessibilityLabel": "Scorri la tabella {direction} una colonna",
-      "totalsRowHeading": "Totali"
+      "totalsRowHeading": "Totali",
+      "totalRowHeading": "totale"
     },
     "DatePicker": {
       "previousMonth": "Mostra il mese precedente, {previousMonthName} {showPreviousYear}",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "で{direction}を並び替える",
       "navAccessibilityLabel": "表{direction}を1列スクロールする",
-      "totalsRowHeading": "合計"
+      "totalsRowHeading": "合計",
+      "totalRowHeading": "総"
     },
     "DatePicker": {
       "previousMonth": "先月{showPreviousYear}{previousMonthName}を表示する",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "{direction} 정렬 기준",
       "navAccessibilityLabel": "표를 {direction} 방향으로 1열 스크롤",
-      "totalsRowHeading": "총계"
+      "totalsRowHeading": "총계",
+      "totalRowHeading": "총계"
     },
     "DatePicker": {
       "previousMonth": "지난 달, {previousMonthName} {showPreviousYear} 표시",

--- a/locales/ms.json
+++ b/locales/ms.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "isih {direction} mengikut",
       "navAccessibilityLabel": "Tatal jadual {direction} satu lajur",
-      "totalsRowHeading": "Jumlah"
+      "totalsRowHeading": "Jumlah",
+      "totalRowHeading": "Jumlah"
     },
     "DatePicker": {
       "previousMonth": "Tunjuk bulan sebelumnya, {previousMonthName} {showPreviousYear}",

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "sortere {direction} etter",
       "navAccessibilityLabel": "Rull tabell {direction} en kolonne",
-      "totalsRowHeading": "Totalt"
+      "totalsRowHeading": "Totalt",
+      "totalRowHeading": "Totalt"
     },
     "DatePicker": {
       "previousMonth": "Vis forrige måned, {previousMonthName} {showPreviousYear}",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "sorteer {direction} op",
       "navAccessibilityLabel": "Scroll tabel {direction} één kolom",
-      "totalsRowHeading": "Totalen"
+      "totalsRowHeading": "Totalen",
+      "totalRowHeading": "Totaal"
     },
     "DatePicker": {
       "previousMonth": "Vorige maand weergeven, {previousMonthName} {showPreviousYear}",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "sortuj {direction} według",
       "navAccessibilityLabel": "Przewiń tabelę {direction} - jedna kolumna",
-      "totalsRowHeading": "Sumy"
+      "totalsRowHeading": "Sumy",
+      "totalRowHeading": "Suma"
     },
     "DatePicker": {
       "previousMonth": "Pokaż poprzedni miesiąc, {previousMonthName} {showPreviousYear}",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "organizar {direction} por",
       "navAccessibilityLabel": "Rolar tabela uma coluna para {direction}",
-      "totalsRowHeading": "Totais"
+      "totalsRowHeading": "Totais",
+      "totalRowHeading": "total"
     },
     "DatePicker": {
       "previousMonth": "Mostrar mês anterior, {previousMonthName} {showPreviousYear}",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "ordenar {direction} por",
       "navAccessibilityLabel": "Deslocar tabela {direction} de uma coluna",
-      "totalsRowHeading": "Totais"
+      "totalsRowHeading": "Totais",
+      "totalRowHeading": "Total"
     },
     "DatePicker": {
       "previousMonth": "Mostrar mês anterior, {previousMonthName} {showPreviousYear}",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "sortera {direction} efter",
       "navAccessibilityLabel": "Skrolla tabellen {direction} en kolumn",
-      "totalsRowHeading": "Totalt"
+      "totalsRowHeading": "Totalt",
+      "totalRowHeading": "Totalt"
     },
     "DatePicker": {
       "previousMonth": "Visa föregående månad {previousMonthName} {showPreviousYear}",

--- a/locales/th.json
+++ b/locales/th.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "จัดเรียง {direction} ตาม",
       "navAccessibilityLabel": "เลื่อนตาราง {direction} หนึ่งคอลัมน์",
-      "totalsRowHeading": "รวม"
+      "totalsRowHeading": "รวม",
+      "totalRowHeading": "ยอดรวม"
     },
     "DatePicker": {
       "previousMonth": "แสดงเดือนก่อนหน้า {previousMonthName} {showPreviousYear}",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "{direction} tarafı şuna göre sırala:",
       "navAccessibilityLabel": "Tabloyu bir sütun {direction} tarafa kaydır",
-      "totalsRowHeading": "Toplamlar"
+      "totalsRowHeading": "Toplamlar",
+      "totalRowHeading": "Toplam"
     },
     "DatePicker": {
       "previousMonth": "Önceki ayı göster, {previousMonthName} {showPreviousYear}",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "向 {direction} 排序",
       "navAccessibilityLabel": "将表向 {direction} 滚动一列",
-      "totalsRowHeading": "总计"
+      "totalsRowHeading": "总计",
+      "totalRowHeading": "总计"
     },
     "DatePicker": {
       "previousMonth": "显示上个月，{showPreviousYear} 年 {previousMonthName}",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -42,7 +42,8 @@
     "DataTable": {
       "sortAccessibilityLabel": "向 {direction} 排序，依據",
       "navAccessibilityLabel": "向 {direction} 捲動表格一欄",
-      "totalsRowHeading": "總計"
+      "totalsRowHeading": "總計",
+      "totalRowHeading": "總計"
     },
     "DatePicker": {
       "previousMonth": "顯示上個月，{previousMonthName} {showPreviousYear}",

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -34,6 +34,11 @@ export interface DataTableProps {
   headings: React.ReactNode[];
   /** List of numeric column totals, highlighted in the table’s header below column headings. Use empty strings as placeholders for columns with no total. */
   totals?: TableData[];
+  /** Custom totals row heading */
+  totalsName?: {
+    singular: string;
+    plural: string;
+  };
   /** Placement of totals row within table */
   showTotalsInFooter?: boolean;
   /** Lists of data points which map to table body rows. */
@@ -82,7 +87,6 @@ class DataTableInner extends React.PureComponent<
   private dataTable = React.createRef<HTMLDivElement>();
   private scrollContainer = React.createRef<HTMLDivElement>();
   private table = React.createRef<HTMLTableElement>();
-  private totalsRowHeading: string;
 
   private handleResize = debounce(() => {
     const {
@@ -101,16 +105,6 @@ class DataTableInner extends React.PureComponent<
       ...this.calculateColumnVisibilityData(condensed),
     });
   });
-
-  constructor(props: CombinedProps) {
-    super(props);
-    const {
-      polaris: {intl},
-    } = props;
-    this.totalsRowHeading = intl.translate(
-      'Polaris.DataTable.totalsRowHeading',
-    );
-  }
 
   componentDidMount() {
     // We need to defer the calculation in development so the styles have time to be injected.
@@ -334,6 +328,25 @@ class DataTableInner extends React.PureComponent<
     );
   };
 
+  private totalsRowHeading = () => {
+    const {
+      polaris: {intl},
+      totals,
+      totalsName,
+    } = this.props;
+
+    const totalsLabel = totalsName
+      ? totalsName
+      : {
+          singular: intl.translate('Polaris.DataTable.totalRowHeading'),
+          plural: intl.translate('Polaris.DataTable.totalsRowHeading'),
+        };
+
+    return totals && totals.filter((total) => total !== '').length > 1
+      ? totalsLabel.plural
+      : totalsLabel.singular;
+  };
+
   private renderTotals = (total: TableData, index: number) => {
     const id = `totals-cell-${index}`;
     const {truncate = false, verticalAlign} = this.props;
@@ -342,7 +355,7 @@ class DataTableInner extends React.PureComponent<
     let contentType;
 
     if (index === 0) {
-      content = this.totalsRowHeading;
+      content = this.totalsRowHeading();
     }
 
     if (total !== '' && index > 0) {

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -174,6 +174,56 @@ function DataTableFooterExample() {
 }
 ```
 
+### Data table with custom totals heading
+
+Use to provide a custom heading for the totals row.
+
+```jsx
+function DataTableExample() {
+  const rows = [
+    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+    [
+      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+      '$445.00',
+      124518,
+      32,
+      '$14,240.00',
+    ],
+  ];
+
+  return (
+    <Page title="Sales by product">
+      <Card>
+        <DataTable
+          showTotalsInFooter
+          columnContentTypes={[
+            'text',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+          ]}
+          headings={[
+            'Product',
+            'Price',
+            'SKU Number',
+            'Net quantity',
+            'Net sales',
+          ]}
+          rows={rows}
+          totals={['', '', '', '', '$155,830.00']}
+          totalsName={{
+            singular: 'Total net sales',
+            plural: 'Total net sales',
+          }}
+        />
+      </Card>
+    </Page>
+  );
+}
+```
+
 ### Data table with totals in footer
 
 Use to reposition the totals row in a more appropriate location based on the data stored in the

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -151,8 +151,24 @@ describe('<DataTable />', () => {
       expect(totalsRow.text()).toContain(totals.join(''));
     });
 
-    it('sets the content of the first total Cell to the totals row heading', () => {
-      const totals = ['', '', ''];
+    it('renders the singular default totals row label when only one total is provided', () => {
+      const totals = ['', '', '', '', '$155,830.00'];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} totals={totals} />,
+      );
+
+      expect(dataTable.find('thead tr')).toHaveLength(2);
+
+      const firstTotalCell = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.prop('total') === true)
+        .first();
+
+      expect(firstTotalCell.prop('content')).toBe('Total');
+    });
+
+    it('renders the plural default totals label when more than one total is provided', () => {
+      const totals = ['', '', '', '255', '$155,830.00'];
       const dataTable = mountWithAppProvider(
         <DataTable {...defaultProps} totals={totals} />,
       );
@@ -211,6 +227,50 @@ describe('<DataTable />', () => {
       );
 
       expect(dataTable.find('tfoot')).toHaveLength(1);
+    });
+  });
+
+  describe('totalsName', () => {
+    it('renders the singular custom totals label when only one total provided', () => {
+      const totals = ['', '', '', '', '$155,830.00'];
+      const totalsName = {
+        singular: 'Price',
+        plural: 'Prices',
+      };
+
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} totals={totals} totalsName={totalsName} />,
+      );
+
+      expect(dataTable.find('thead tr')).toHaveLength(2);
+
+      const firstTotalCell = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.prop('total') === true)
+        .first();
+
+      expect(firstTotalCell.prop('content')).toBe('Price');
+    });
+
+    it('renders the plural custom totals label when more than one total is provided', () => {
+      const totals = ['', '', '', '255', '$155,830.00'];
+      const totalsName = {
+        singular: 'Price',
+        plural: 'Prices',
+      };
+
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} totals={totals} totalsName={totalsName} />,
+      );
+
+      expect(dataTable.find('thead tr')).toHaveLength(2);
+
+      const firstTotalCell = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.prop('total') === true)
+        .first();
+
+      expect(firstTotalCell.prop('content')).toBe('Prices');
     });
   });
 


### PR DESCRIPTION
### Changes

- Fixes plurality of **Totals** content - the plurality of the **Totals** content is determined by the `totals` array prop that is passed in.

- Adds an optional `totalsMarkupLabel` prop for custom **Totals** content labels on the `<DataTable />` [component](https://github.com/Shopify/polaris-react/tree/master/src/components/DataTable).  

### WHY are these changes introduced?
Fixes https://github.com/Shopify/polaris-react/issues/2614.  The **Totals** content was not pluralized initially, and so this PR fixes this initial bug.

It also adds the ability for consumers to pass in a `totalsMarkupLabel` for custom labeling of the **Totals**, using a similar pattern as the `<ResourceList />`.

For example, these are the labels being changed:

| Singular  | Plural  |
|---|---|
| <img width="156" alt="Screen Shot 2020-01-24 at 2 46 05 PM" src="https://user-images.githubusercontent.com/5506721/73098941-6a818880-3eb8-11ea-8459-c39f6dbdf138.png">| <img width="195" alt="Screen Shot 2020-01-24 at 2 46 09 PM" src="https://user-images.githubusercontent.com/5506721/73098953-6f463c80-3eb8-11ea-9062-76cda6d19ce7.png">|

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:
-->
<details>
 <summary>Click to view demo gif </summary>
<img src="https://user-images.githubusercontent.com/5506721/73099198-f72c4680-3eb8-11ea-958d-33d93380c4bb.gif" alt="Demo of playground code, showing a custom totals label implemented as well as pluralization of the label when more than one total is set in the totals array.">
</details>


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';
import {Page, DataTable, Button, Stack} from '../src';

export function Playground() {
  const singularTotal = ['', 2];
  const pluralTotals = ['', 2, 3];

  const [total, setTotal] = useState(singularTotal);

  return (
    <Page title="Playground">
      <Button
        onClick={() => {
          total.length > 2 ? setTotal(singularTotal) : setTotal(pluralTotals);
        }}
      >
        Change totals plurality
      </Button>
      <Stack distribution="equalSpacing">
        <Stack>
          <h1>Totals without custom labels:</h1>
          <DataTable
            totals={total}
            columnContentTypes={['text']}
            headings={['heading']}
            rows={[['row']]}
          />
        </Stack>
        <Stack>
          <h1>Totals with custom labels:</h1>
          <DataTable
            totals={total}
            totalsName={{
              singular: 'Custom total label:',
              plural: 'Custom totals label:',
            }}
            columnContentTypes={['text']}
            headings={['heading']}
            rows={[['row']]}
          />
        </Stack>
      </Stack>
    </Page>
  );
}


```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
