### PR TITLE
[Checkbox, Radio, Banner] Focus ring on tab and not click

### DIFF
--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -38,6 +38,9 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 
   &:focus {
     outline: none;
+  }
+
+  &.keyFocused {
     box-shadow: var(
       --p-banner-border,
       (

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -28,6 +28,10 @@ import styles from './Banner.scss';
 
 export type BannerStatus = 'success' | 'info' | 'warning' | 'critical';
 
+interface State {
+  showFocus: boolean;
+}
+
 export interface BannerProps {
   /** Title content for the banner. */
   title?: string;
@@ -47,14 +51,39 @@ export interface BannerProps {
   stopAnnouncements?: boolean;
 }
 
-export class Banner extends React.PureComponent<BannerProps, never> {
+export class Banner extends React.PureComponent<BannerProps, State> {
+  state: State = {
+    showFocus: false,
+  };
+
   private wrapper = React.createRef<HTMLDivElement>();
 
   public focus() {
     this.wrapper.current && this.wrapper.current.focus();
+    this.setState({showFocus: true});
   }
 
   render() {
+    const {showFocus} = this.state;
+
+    const handleKeyUp = (evt: React.KeyboardEvent<HTMLDivElement>) => {
+      if (evt.target === this.wrapper.current) {
+        this.setState({showFocus: true});
+      }
+    };
+
+    const handleBlur = () => {
+      this.setState({showFocus: false});
+    };
+
+    const handleMouseUp = ({
+      currentTarget,
+    }: React.MouseEvent<HTMLDivElement>) => {
+      const {showFocus} = this.state;
+      currentTarget.blur();
+      showFocus && this.setState({showFocus: false});
+    };
+
     return (
       <BannerContext.Provider value>
         <WithinContentContext.Consumer>
@@ -100,6 +129,7 @@ export class Banner extends React.PureComponent<BannerProps, never> {
               styles.Banner,
               status && styles[variationName('status', status)],
               onDismiss && styles.hasDismiss,
+              showFocus && styles.keyFocused,
               withinContentContainer
                 ? styles.withinContentContainer
                 : styles.withinPage,
@@ -170,6 +200,8 @@ export class Banner extends React.PureComponent<BannerProps, never> {
                 role={ariaRoleType}
                 aria-live={stopAnnouncements ? 'off' : 'polite'}
                 onMouseUp={handleMouseUp}
+                onKeyUp={handleKeyUp}
+                onBlur={handleBlur}
                 aria-labelledby={headingID}
                 aria-describedby={contentID}
               >
@@ -193,10 +225,6 @@ export class Banner extends React.PureComponent<BannerProps, never> {
 let index = 1;
 function uniqueID() {
   return `Banner${index++}`;
-}
-
-function handleMouseUp({currentTarget}: React.MouseEvent<HTMLDivElement>) {
-  currentTarget.blur();
 }
 
 function secondaryActionFrom(action: Action) {

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -7,6 +7,7 @@ import {
   CircleInformationMajorTwotone,
   FlagMajorTwotone,
 } from '@shopify/polaris-icons';
+import {mountWithApp} from 'test-utilities/react-testing';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {BannerContext} from 'utilities/banner-context';
@@ -143,6 +144,44 @@ describe('<Banner />', () => {
         .filterWhere((element) => element.prop('tabIndex') === 0);
 
       expect(div.getDOMNode()).toBe(document.activeElement);
+    });
+
+    describe('Focus className', () => {
+      it('adds a keyFocused class to the banner on keyUp', () => {
+        const banner = mountWithApp(<Banner />, {
+          features: {unstableGlobalTheming: true},
+        });
+
+        const bannerDiv = banner.find('div', {
+          className: 'Banner withinPage',
+        });
+
+        bannerDiv!.trigger('onKeyUp', {
+          target: bannerDiv!.domNode as HTMLDivElement,
+        });
+
+        expect(banner).toContainReactComponent('div', {
+          className: 'Banner keyFocused withinPage',
+        });
+      });
+
+      it('does not add a keyFocused class onMouseUp', () => {
+        const banner = mountWithApp(<Banner />, {
+          features: {unstableGlobalTheming: true},
+        });
+
+        const bannerDiv = banner.find('div', {
+          className: 'Banner withinPage',
+        });
+
+        bannerDiv!.trigger('onMouseUp', {
+          currentTarget: bannerDiv!.domNode as HTMLDivElement,
+        });
+
+        expect(banner).toContainReactComponent('div', {
+          className: 'Banner withinPage',
+        });
+      });
     });
   });
 

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -64,7 +64,7 @@ $control-size: rem(16px);
 
 .Checkbox.globalTheming {
   .Input {
-    &:focus {
+    &.keyFocused {
       + .Backdrop {
         @include focus-ring($style: 'focused');
       }

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useImperativeHandle} from 'react';
+import React, {useRef, useImperativeHandle, useState} from 'react';
 import {MinusMinor, TickSmallMinor} from '@shopify/polaris-icons';
 import {classNames} from '../../utilities/css';
 import {useFeatures} from '../../utilities/features';
@@ -67,6 +67,7 @@ export const Checkbox = React.forwardRef<CheckboxHandles, CheckboxProps>(
       setTrue: handleMouseOver,
       setFalse: handleMouseOut,
     } = useToggle(false);
+    const [keyFocused, setKeyFocused] = useState(false);
 
     useImperativeHandle(ref, () => ({
       focus: () => {
@@ -75,6 +76,11 @@ export const Checkbox = React.forwardRef<CheckboxHandles, CheckboxProps>(
         }
       },
     }));
+
+    const handleBlur = () => {
+      onBlur && onBlur();
+      setKeyFocused(false);
+    };
 
     const handleInput = () => {
       if (onChange == null || inputNode.current == null || disabled) {
@@ -86,9 +92,10 @@ export const Checkbox = React.forwardRef<CheckboxHandles, CheckboxProps>(
 
     const handleKeyUp = (event: React.KeyboardEvent) => {
       const {keyCode} = event;
-
-      if (keyCode !== Key.Space) return;
-      handleInput();
+      !keyFocused && setKeyFocused(true);
+      if (keyCode === Key.Space) {
+        handleInput();
+      }
     };
 
     const describedBy: string[] = [];
@@ -128,6 +135,7 @@ export const Checkbox = React.forwardRef<CheckboxHandles, CheckboxProps>(
     const inputClassName = classNames(
       styles.Input,
       isIndeterminate && styles['Input-indeterminate'],
+      unstableGlobalTheming && keyFocused && styles.keyFocused,
     );
 
     return (
@@ -155,7 +163,7 @@ export const Checkbox = React.forwardRef<CheckboxHandles, CheckboxProps>(
             disabled={disabled}
             className={inputClassName}
             onFocus={onFocus}
-            onBlur={onBlur}
+            onBlur={handleBlur}
             onClick={stopPropagation}
             onChange={noop}
             aria-invalid={error != null}

--- a/src/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/Checkbox/tests/Checkbox.test.tsx
@@ -287,6 +287,54 @@ describe('<Checkbox />', () => {
       });
     });
   });
+
+  describe('globalTheming', () => {
+    it('adds a global theming class when global theming is enabled', () => {
+      const checkBox = mountWithApp(<Checkbox label="checkbox" />, {
+        features: {unstableGlobalTheming: true},
+      });
+      expect(checkBox).toContainReactComponent('span', {
+        className: 'Checkbox globalTheming',
+      });
+    });
+
+    it('does not add a global theming class when global theming is disabled', () => {
+      const checkBox = mountWithApp(<Checkbox label="checkbox" />, {
+        features: {unstableGlobalTheming: false},
+      });
+      expect(checkBox).not.toContainReactComponent('span', {
+        className: 'Checkbox globalTheming',
+      });
+    });
+  });
+
+  describe('Focus className', () => {
+    it('on keyUp adds a keyFocused class to the input', () => {
+      const checkbox = mountWithApp(<Checkbox label="Checkbox" />, {
+        features: {unstableGlobalTheming: true},
+      });
+      const event: KeyboardEventInit & {keyCode: Key} = {
+        keyCode: Key.Space,
+      };
+      checkbox.find('input')!.trigger('onKeyUp', event);
+      expect(checkbox).toContainReactComponent('input', {
+        className: 'Input keyFocused',
+      });
+    });
+
+    it('on change does not add a keyFocused class to the input', () => {
+      const checkbox = mountWithApp(<Checkbox label="Checkbox" />, {
+        features: {unstableGlobalTheming: true},
+      });
+      const checkboxInput = checkbox.find('input');
+      checkboxInput!.trigger('onChange', {
+        currentTarget: checkboxInput!.domNode as HTMLInputElement,
+      });
+      expect(checkbox).not.toContainReactComponent('input', {
+        className: 'Input keyFocused',
+      });
+    });
+  });
 });
 
 function noop() {}

--- a/src/components/RadioButton/RadioButton.scss
+++ b/src/components/RadioButton/RadioButton.scss
@@ -125,7 +125,7 @@
   }
 
   .Input {
-    &:focus {
+    &.keyFocused {
       + .Backdrop {
         @include focus-ring($style: 'focused');
         &::after {

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useRef, useState} from 'react';
 import {useUniqueId} from '../../utilities/unique-id';
 import {useFeatures} from '../../utilities/features';
 import {useToggle} from '../../utilities/use-toggle';
@@ -50,11 +50,23 @@ export function RadioButton({
   const id = useUniqueId('RadioButton', idProp);
   const name = nameProp || id;
   const {unstableGlobalTheming = false} = useFeatures();
+  const inputNode = useRef<HTMLInputElement>(null);
+  const [keyFocused, setKeyFocused] = useState(false);
+
   const {
     value: mouseOver,
     setTrue: handleMouseOver,
     setFalse: handleMouseOut,
   } = useToggle(false);
+
+  const handleKeyUp = () => {
+    !keyFocused && setKeyFocused(true);
+  };
+
+  const handleBlur = () => {
+    onBlur && onBlur();
+    setKeyFocused(false);
+  };
 
   function handleChange({currentTarget}: React.ChangeEvent<HTMLInputElement>) {
     onChange && onChange(currentTarget.checked, id);
@@ -71,7 +83,10 @@ export function RadioButton({
     ? describedBy.join(' ')
     : undefined;
 
-  const inputClassName = classNames(styles.Input);
+  const inputClassName = classNames(
+    styles.Input,
+    unstableGlobalTheming && keyFocused && styles.keyFocused,
+  );
 
   const wrapperClassName = classNames(
     styles.RadioButton,
@@ -106,8 +121,10 @@ export function RadioButton({
           className={inputClassName}
           onChange={handleChange}
           onFocus={onFocus}
-          onBlur={onBlur}
+          onKeyUp={handleKeyUp}
+          onBlur={handleBlur}
           aria-describedby={ariaDescribedBy}
+          ref={inputNode}
         />
         <span className={backdropClassName} />
         {iconMarkup}

--- a/src/components/RadioButton/tests/RadioButton.test.tsx
+++ b/src/components/RadioButton/tests/RadioButton.test.tsx
@@ -75,6 +75,32 @@ describe('<RadioButton />', () => {
     });
   });
 
+  describe('Focus className', () => {
+    it('on keyUp adds a keyFocused class to the input', () => {
+      const radioButton = mountWithApp(<RadioButton label="Radio" />, {
+        features: {unstableGlobalTheming: true},
+      });
+
+      radioButton.find('input')!.trigger('onKeyUp');
+      expect(radioButton).toContainReactComponent('input', {
+        className: 'Input keyFocused',
+      });
+    });
+
+    it('on change does not add a keyFocused class to the input', () => {
+      const radioButton = mountWithApp(<RadioButton label="Radio" />, {
+        features: {unstableGlobalTheming: true},
+      });
+      const radioInput = radioButton.find('input');
+      radioInput!.trigger('onChange', {
+        currentTarget: radioInput!.domNode as HTMLInputElement,
+      });
+      expect(radioButton).not.toContainReactComponent('input', {
+        className: 'Input keyFocused',
+      });
+    });
+  });
+
   describe('onBlur()', () => {
     it('is called when the input is focused', () => {
       const spy = jest.fn();
@@ -172,6 +198,26 @@ describe('<RadioButton />', () => {
 
       expect(radioButton).toContainReactComponent('span', {
         className: 'Backdrop',
+      });
+    });
+  });
+
+  describe('globalTheming', () => {
+    it('adds a global theming class when global theming is enabled', () => {
+      const radioButton = mountWithApp(<RadioButton label="Radio" />, {
+        features: {unstableGlobalTheming: true},
+      });
+      expect(radioButton).toContainReactComponent('span', {
+        className: 'RadioButton globalTheming',
+      });
+    });
+
+    it('does not add a global theming class when global theming is disabled', () => {
+      const radioButton = mountWithApp(<RadioButton label="Radio" />, {
+        features: {unstableGlobalTheming: false},
+      });
+      expect(radioButton).not.toContainReactComponent('span', {
+        className: 'RadioButton globalTheming',
       });
     });
   });


### PR DESCRIPTION
### WHY are these changes introduced?

Certain elements, when getting the focus ring on focus don't look quite right. There is a CSS selector `focus-visible` that is currently only supported by Firefox that would allow us to show the ring only on keyboard focus. It will take some time for this behavior is available in all our supported browsers.

Currently, Banners, Radio, Checkboxes would benefit from this behavior.

This PR makes use of state to apply the proper style. It would be nice to stick to browser behavior but I think this is an acceptable use of Javascript with very little overhead. **I have not written tests yet, will wait to to see if this is something we want to move forward with first.**

** Percy is complaining about the focus on the banner but I'm thinking something in their rendering is stealing the focus. **



![focus](https://user-images.githubusercontent.com/1229901/73291023-66fa4400-41cd-11ea-83a0-bea2682be2bb.gif)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useRef, useEffect, useState, useCallback} from 'react';
import {Page, Banner, RadioButton, Stack, Checkbox} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Stack vertical>
        <BannerWithFocusExample />
        <RadioButtonExample />
        <CheckboxExample />
      </Stack>
    </Page>
  );
}

function BannerWithFocusExample() {
  const banner = useRef();

  useEffect(() => banner.current.focus(), []);

  return (
    <Banner
      title="High risk of fraud detected"
      onDismiss={() => {}}
      status="critical"
      ref={banner}
    >
      <p>
        Before fulfilling this order or capturing payment, please review the
        fraud analysis and determine if this order is fraudulent
      </p>
    </Banner>
  );
}

function RadioButtonExample() {
  const [value, setValue] = useState('disabled');

  const handleChange = useCallback(
    (_checked, newValue) => setValue(newValue),
    [],
  );

  return (
    <Stack vertical>
      <RadioButton
        label="Accounts are disabled"
        helpText="Customers will only be able to check out as guests."
        checked={value === 'disabled'}
        id="disabled"
        name="accounts"
        onChange={handleChange}
      />
      <RadioButton
        label="Accounts are optional"
        helpText="Customers will be able to check out with a customer account or as a guest."
        id="optional"
        name="accounts"
        checked={value === 'optional'}
        onChange={handleChange}
      />
    </Stack>
  );
}

function CheckboxExample() {
  const [checked, setChecked] = useState(false);
  const handleChange = useCallback((newChecked) => setChecked(newChecked), []);

  return (
    <Checkbox
      label="Basic checkbox"
      checked={checked}
      onChange={handleChange}
    />
  );
}
```
</details>
