### PR TITLE
Remove tests and package.json from compiled esnext directory

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "exclude": ["../src/**/*.test.ts", "../src/**/*.test.tsx"]
+  "exclude": ["../src/**/*.test.ts", "../src/**/*.test.tsx", "../tests"]
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Making `tests/built.test.ts` a .ts file means that the package.json gets included in the
esnext directory as part of doing the build. That in turn messes up the
what gets included in the npm package as it redefines the included files
within that folder, which results in most of the files being omitted.


### WHAT is this pull request doing?

Explicitly ignore the tests directory in the build ts config, so that the tests don't get included. This removes the reference to the package.json so it doesn't get included too, 

### How to 🎩

- Run `yarn build` then `npm pack` to create local tgz that represents what will be included in the build.
- Open the tgz and inspect the esnext folder and see that the components and utilities folders are present (in contrast with https://unpkg.com/browse/@shopify/polaris@4.12.0-rc.1/esnext/ where these folders are missing)
