### PR TITLE
[Select] Apply design language to Select

### DIFF
--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -26,7 +26,7 @@ $stacking-order: (
 
   .Icon {
     opacity: var(--override-one, 0.4);
-    @include recolor-icon(var(--p-icon-disabled, color('ink', 'lightest')));
+    @include recolor-icon(var(--p-icon-disabled, color('ink', 'lighter')));
   }
 
   &.globalTheming {

--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -17,7 +17,7 @@ $stacking-order: (
 
 .disabled {
   .Content {
-    color: color('ink', 'lightest');
+    color: var(--p-text-disabled, color('ink', 'lightest'));
   }
 
   .InlineLabel {
@@ -25,24 +25,22 @@ $stacking-order: (
   }
 
   .Icon {
-    opacity: 0.4;
+    opacity: var(--override-one, 0.4);
+    @include recolor-icon(var(--p-icon-disabled, color('ink', 'lightest')));
   }
 
-  .Backdrop {
-    @include control-backdrop(disabled);
-  }
-}
-
-.error {
-  .Backdrop {
-    @include control-backdrop(error);
-  }
-
-  // Need to override the higher specificity of the sibling selector
-  // so that errors still have red borders.
-  // stylelint-disable-next-line selector-max-specificity
-  .Input:focus ~ .Backdrop {
-    @include control-backdrop(focused-error);
+  &.globalTheming {
+    .Backdrop {
+      border-color: var(--p-border-secondary-disabled);
+      // stylelint-disable-next-line selector-max-class, selector-max-specificity
+      &::before {
+        background-color: var(--p-action-secondary-disabled);
+      }
+      // stylelint-disable-next-line selector-max-class, selector-max-specificity
+      &:hover {
+        cursor: default;
+      }
+    }
   }
 }
 
@@ -57,7 +55,7 @@ $stacking-order: (
   // stylelint-disable-next-line selector-max-class, selector-max-specificity
   &.error .Input:-moz-focusring {
     color: transparent;
-    text-shadow: 0 0 0 color('ink', 'base');
+    text-shadow: var(--p-override-none, 0 0 0 color('ink', 'base'));
   }
 }
 
@@ -87,17 +85,7 @@ $stacking-order: (
 }
 
 .Icon {
-  @include recolor-icon(color('ink', 'lighter'));
-}
-
-.Backdrop {
-  @include control-backdrop;
-  position: absolute;
-  z-index: z-index(backdrop, $stacking-order);
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  @include recolor-icon(var(--p-icon, color('ink', 'lighter')));
 }
 
 .Input {
@@ -115,10 +103,87 @@ $stacking-order: (
   // ChromeVox may hide content set to opacity: 0
   opacity: 0.001;
   appearance: none;
+}
 
-  &:focus {
+.Select:not(.globalTheming) {
+  .Backdrop {
+    @include control-backdrop;
+    position: absolute;
+    z-index: z-index(backdrop, $stacking-order);
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+  }
+
+  &.error {
+    // stylelint-disable-next-line selector-max-specificity
+    .Backdrop {
+      @include control-backdrop(error);
+    }
+
+    // Need to override the higher specificity of the sibling selector
+    // so that errors still have red borders.
+    // stylelint-disable-next-line selector-max-combinators, selector-max-specificity
+    .Input:focus ~ .Backdrop {
+      @include control-backdrop(focused-error);
+    }
+  }
+
+  &.disabled {
+    // stylelint-disable-next-line selector-max-specificity
+    .Backdrop {
+      @include control-backdrop(disabled);
+    }
+  }
+
+  // stylelint-disable-next-line selector-max-specificity
+  .Input:focus {
+    // stylelint-disable-next-line selector-max-specificity, selector-max-combinators
     ~ .Backdrop {
       @include control-backdrop(focused);
+    }
+  }
+}
+
+.globalTheming {
+  .Backdrop {
+    z-index: z-index(backdrop, $stacking-order);
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    border: border-width() solid var(--p-border-secondary);
+    border-radius: var(--p-border-radius-base);
+    background-color: var(--p-surface);
+    @include focus-ring($border-width: rem(1px));
+    // stylelint-disable-next-line order/properties-order
+    position: absolute;
+  }
+
+  &.error {
+    .Backdrop {
+      border-color: var(--p-border-critical);
+      background-color: var(--p-surface-critical);
+      // stylelint-disable-next-line selector-max-class, selector-max-specificity
+      &.hover,
+      &:hover {
+        border-color: var(--p-border-critical);
+      }
+    }
+
+    // Need to override the higher specificity of the sibling selector
+    // so that errors still have red borders.
+    // stylelint-disable-next-line selector-max-combinators, selector-max-specificity
+    .Input:focus ~ .Backdrop {
+      @include focus-ring($style: 'focused');
+    }
+  }
+
+  .Input:focus {
+    // stylelint-disable-next-line selector-max-specificity, selector-max-combinators
+    ~ .Backdrop {
+      @include focus-ring($style: 'focused');
     }
   }
 }

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {ArrowUpDownMinor} from '@shopify/polaris-icons';
 import {classNames} from '../../utilities/css';
+import {useFeatures} from '../../utilities/features';
 import {useUniqueId} from '../../utilities/unique-id';
 import {Labelled, LabelledProps, helpTextID} from '../Labelled';
 import {Icon} from '../Icon';
@@ -88,13 +89,14 @@ export function Select({
   onBlur,
 }: SelectProps) {
   const id = useUniqueId('Select', idProp);
-
   const labelHidden = labelInline ? true : labelHiddenProp;
+  const {newDesignLanguage = false} = useFeatures();
 
   const className = classNames(
     styles.Select,
     error && styles.error,
     disabled && styles.disabled,
+    newDesignLanguage && styles.newDesignLanguage,
   );
 
   const handleChange = onChange

--- a/src/components/Select/tests/Select.test.tsx
+++ b/src/components/Select/tests/Select.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {InlineError} from 'components';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {Select} from '../Select';
 
 describe('<Select />', () => {
@@ -332,6 +333,32 @@ describe('<Select />', () => {
       );
 
       expect(select.find(InlineError)).toHaveLength(0);
+    });
+  });
+
+  describe('newDesignLanguage', () => {
+    it('adds a newDesignLanguage class when newDesignLanguage is enabled', () => {
+      const select = mountWithApp(
+        <Select label="Select" options={[]} onChange={noop} />,
+        {
+          features: {newDesignLanguage: true},
+        },
+      );
+      expect(select).toContainReactComponent('div', {
+        className: 'Select newDesignLanguage',
+      });
+    });
+
+    it('does not add a newDesignLanguage class when newDesignLanguage is disabled', () => {
+      const select = mountWithApp(
+        <Select label="Select" options={[]} onChange={noop} />,
+        {
+          features: {newDesignLanguage: false},
+        },
+      );
+      expect(select).not.toContainReactComponent('div', {
+        className: 'Select newDesignLanguage',
+      });
     });
   });
 });


### PR DESCRIPTION
**Design still pending, no need to review until [WIP] is removed**

![select](https://user-images.githubusercontent.com/1229901/73298638-ae87cc80-41db-11ea-8d23-515d0e2ef00e.gif)

### WHY are these changes introduced?

partly addresses: https://github.com/Shopify/polaris-ux/issues/363


### WHAT is this pull request doing?

Applying design language to Select. Current Select shouldn't be affected.

I'm also removing the Design Language modification from Backdrop. Once we roll this out, we'll be able to delete that mixin.

The icons have not been updated. My understanding is that these will be updated when icons get updated.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
