### PR TITLE
[TextField] Apply color system to connected state

### DIFF
--- a/src/components/Connected/Connected.scss
+++ b/src/components/Connected/Connected.scss
@@ -23,6 +23,7 @@ $stacking-order: (
 
 // This is a violation of our component model, but it’s the cleanest
 // way to remove the border radii on connected elements.
+// TextField.scss has a dependency due to this override.
 // stylelint-disable declaration-no-important
 
 .Item-primary {

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -326,6 +326,10 @@ $stacking-order: (
 .globalTheming.TextField {
   color: var(--p-text);
 
+  svg {
+    fill: var(--p-icon);
+  }
+
   .hasValue {
     color: var(--p-text);
   }
@@ -414,13 +418,21 @@ $stacking-order: (
       border-top: none;
     }
 
+    // This is a violation of our component model, but necessary
+    // due to Connected.scss overriding these values.
+    // stylelint-disable declaration-no-important
+
     &:first-child {
-      border-top-right-radius: var(--p-text-field-spinner-border-radius);
+      border-top-right-radius: var(
+        --p-text-field-spinner-border-radius
+      ) !important;
       margin-bottom: var(--p-text-field-spinner-offset);
     }
 
     &:last-child {
-      border-bottom-right-radius: var(--p-text-field-spinner-border-radius);
+      border-bottom-right-radius: var(
+        --p-text-field-spinner-border-radius
+      ) !important;
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-ux/issues/379

### WHAT is this pull request doing?

This is applying the color system to the connected state of the `TextField`.

- Caret is colorized
- Button edges are curved when in a connected state

