### PR TITLE
[ContextualSaveBar] Apply design language

### DIFF
--- a/documentation/Color system.md
+++ b/documentation/Color system.md
@@ -247,6 +247,8 @@ Used to decorate elements where color does convey a specific meaning in componen
 | `--p-text-field-focus-ring-offset`        | `-0.4rem`                                                                                         |
 | `--p-text-field-focus-ring-border-radius` | `0.7rem`                                                                                          |
 | `--p-button-group-item-spacing`           | `0.2rem`                                                                                          |
+| `--p-top-bar-height`                      | `68px`                                                                                            |
+| `--p-contextual-save-bar-height`          | `64px`                                                                                            |
 | `--p-duration-1-0-0`                      | `100ms`                                                                                           |
 | `--p-duration-1-5-0`                      | `150ms`                                                                                           |
 | `--p-ease-in`                             | `cubic-bezier(0.5, 0.1, 1, 1)`                                                                    |

--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -369,7 +369,11 @@ export function DetailsPage() {
         <Layout.Section>
           <Card sectioned>
             <FormLayout>
-              <TextField label="Title" value="M60-A" onChange={() => {}} />
+              <TextField
+                label="Title"
+                value="M60-A"
+                onChange={() => setIsDirty(true)}
+              />
               <TextField
                 label="Description"
                 value={DescriptionValue}

--- a/src/components/Frame/Frame.scss
+++ b/src/components/Frame/Frame.scss
@@ -142,7 +142,7 @@ $skip-vertical-offset: rem(10px);
   width: 100%;
 }
 
-.ContextualSaveBar-globalTheming {
+.ContextualSaveBar-newDesignLanguage {
   @include frame-when-nav-displayed {
     left: layout-width(unstable-nav);
     max-width: calc(100% - #{layout-width(unstable-nav)});

--- a/src/components/Frame/Frame.scss
+++ b/src/components/Frame/Frame.scss
@@ -142,6 +142,13 @@ $skip-vertical-offset: rem(10px);
   width: 100%;
 }
 
+.ContextualSaveBar-globalTheming {
+  @include frame-when-nav-displayed {
+    left: layout-width(unstable-nav);
+    max-width: calc(100% - #{layout-width(unstable-nav)});
+  }
+}
+
 .Main {
   flex: 1;
   display: flex;

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -179,14 +179,14 @@ class FrameInner extends React.PureComponent<CombinedProps, State> {
 
     const contextualSaveBarClassName = classNames(
       styles.ContextualSaveBar,
-      unstableGlobalTheming && styles['ContextualSaveBar-globalTheming'],
+      newDesignLanguage && styles['ContextualSaveBar-newDesignLanguage'],
     );
 
     const contextualSaveBarMarkup = (
       <CSSAnimation
         in={showContextualSaveBar}
         className={contextualSaveBarClassName}
-        type="fade"
+        type={newDesignLanguage ? 'fadeUp' : 'fade'}
       >
         <ContextualSaveBar {...this.contextualSaveBar} />
       </CSSAnimation>

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -177,10 +177,15 @@ class FrameInner extends React.PureComponent<CombinedProps, State> {
         </div>
       ) : null;
 
+    const contextualSaveBarClassName = classNames(
+      styles.ContextualSaveBar,
+      unstableGlobalTheming && styles['ContextualSaveBar-globalTheming'],
+    );
+
     const contextualSaveBarMarkup = (
       <CSSAnimation
         in={showContextualSaveBar}
-        className={styles.ContextualSaveBar}
+        className={contextualSaveBarClassName}
         type="fade"
       >
         <ContextualSaveBar {...this.contextualSaveBar} />

--- a/src/components/Frame/components/CSSAnimation/CSSAnimation.scss
+++ b/src/components/Frame/components/CSSAnimation/CSSAnimation.scss
@@ -11,3 +11,20 @@
   opacity: 1;
   pointer-events: auto;
 }
+
+.startFadeUp {
+  opacity: 0;
+  will-change: opacity, transform;
+  transform: translateY(#{rem(25px)});
+  transition: transform var(--p-duration-1-5-0) var(--p-ease),
+    opacity var(--p-duration-1-5-0) var(--p-ease);
+  pointer-events: none;
+}
+
+.endFadeUp {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  transition: transform var(--p-duration-1-0-0) var(--p-ease),
+    opacity var(--p-duration-1-5-0) var(--p-ease);
+}

--- a/src/components/Frame/components/CSSAnimation/CSSAnimation.scss
+++ b/src/components/Frame/components/CSSAnimation/CSSAnimation.scss
@@ -1,5 +1,7 @@
 @import '../../../../styles/common';
 
+$fade-up-offset: rem(25px);
+
 .startFade {
   opacity: 0;
   will-change: opacity;
@@ -15,7 +17,7 @@
 .startFadeUp {
   opacity: 0;
   will-change: opacity, transform;
-  transform: translateY(#{rem(25px)});
+  transform: translateY(#{$fade-up-offset});
   transition: transform var(--p-duration-1-5-0) var(--p-ease),
     opacity var(--p-duration-1-5-0) var(--p-ease);
   pointer-events: none;

--- a/src/components/Frame/components/CSSAnimation/CSSAnimation.tsx
+++ b/src/components/Frame/components/CSSAnimation/CSSAnimation.tsx
@@ -3,7 +3,7 @@ import {classNames, variationName} from '../../../../utilities/css';
 
 import styles from './CSSAnimation.scss';
 
-type AnimationType = 'fade';
+type AnimationType = 'fade' | 'fadeUp';
 
 export interface CSSAnimationProps {
   in: boolean;

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -1,5 +1,4 @@
 @import '../../../../styles/common';
-$height: rem(64px);
 $off-white: rgb(250, 251, 252);
 $off-white-border: rgb(235, 238, 240);
 $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -70,7 +69,7 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 
 .newDesignLanguage {
   background: var(--p-surface);
-  height: $height;
+  height: var(--p-contextual-save-bar-height);
   margin: spacing(tight);
   border-radius: var(--p-border-radius-wide);
 

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -74,6 +74,14 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   margin: spacing(tight);
   border-radius: var(--p-border-radius-wide);
 
+  &::after {
+    border-bottom: none;
+  }
+
+  @media (-ms-high-contrast: active) {
+    border: 1px solid ms-high-contrast-color('text');
+  }
+
   .LogoContainer {
     display: none;
   }

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -67,3 +67,32 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 .Action {
   margin-left: spacing(tight);
 }
+
+.ContextualSaveBar-globalTheming {
+  background: var(--p-surface);
+  height: unstable-top-bar-height();
+  margin: spacing(tight);
+  border-radius: var(--p-border-radius-wide);
+
+  .LogoContainer {
+    display: none;
+  }
+
+  .Contents {
+    margin: 0;
+    padding: 0 spacing();
+    max-width: 100%;
+
+    @include page-content-when-not-fully-condensed {
+      padding: 0 spacing();
+    }
+
+    @include page-content-when-not-partially-condensed {
+      padding: 0 spacing();
+    }
+  }
+
+  .Message {
+    color: var(--p-text);
+  }
+}

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -1,5 +1,5 @@
 @import '../../../../styles/common';
-
+$height: rem(64px);
 $off-white: rgb(250, 251, 252);
 $off-white-border: rgb(235, 238, 240);
 $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -68,9 +68,9 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   margin-left: spacing(tight);
 }
 
-.ContextualSaveBar-globalTheming {
+.newDesignLanguage {
   background: var(--p-surface);
-  height: unstable-top-bar-height();
+  height: $height;
   margin: spacing(tight);
   border-radius: var(--p-border-radius-wide);
 

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -1,14 +1,16 @@
 import React, {useCallback} from 'react';
 
-import {getWidth} from '../../../../utilities/get-width';
-
-import {ContextualSaveBarProps} from '../../../../utilities/frame';
 import {Button} from '../../../Button';
+import {Image} from '../../../Image';
+import {Stack} from '../../../Stack';
+import {ThemeProvider} from '../../../ThemeProvider';
+import {classNames} from '../../../../utilities/css';
+import {useFeatures} from '../../../../utilities/features';
+import {ContextualSaveBarProps} from '../../../../utilities/frame';
+import {getWidth} from '../../../../utilities/get-width';
 import {useI18n} from '../../../../utilities/i18n';
 import {useTheme} from '../../../../utilities/theme';
 import {useToggle} from '../../../../utilities/use-toggle';
-import {Image} from '../../../Image';
-import {Stack} from '../../../Stack';
 
 import {DiscardConfirmationModal} from './components';
 
@@ -22,7 +24,7 @@ export function ContextualSaveBar({
 }: ContextualSaveBarProps) {
   const i18n = useI18n();
   const {logo} = useTheme();
-
+  const {unstableGlobalTheming = false} = useFeatures();
   const {
     value: discardConfirmationModalVisible,
     toggle: toggleDiscardConfirmationModal,
@@ -100,9 +102,14 @@ export function ContextualSaveBar({
     </div>
   );
 
+  const contexualSaveBarClassName = classNames(
+    styles.ContextualSaveBar,
+    unstableGlobalTheming && styles['ContextualSaveBar-globalTheming'],
+  );
+
   return (
-    <React.Fragment>
-      <div className={styles.ContextualSaveBar}>
+    <ThemeProvider theme={{colorScheme: 'inverse'}}>
+      <div className={contexualSaveBarClassName}>
         {logoMarkup}
         <div className={styles.Contents}>
           <h2 className={styles.Message}>{message}</h2>
@@ -115,6 +122,6 @@ export function ContextualSaveBar({
         </div>
       </div>
       {discardConfirmationModalMarkup}
-    </React.Fragment>
+    </ThemeProvider>
   );
 }

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -24,7 +24,7 @@ export function ContextualSaveBar({
 }: ContextualSaveBarProps) {
   const i18n = useI18n();
   const {logo} = useTheme();
-  const {unstableGlobalTheming = false} = useFeatures();
+  const {newDesignLanguage = false} = useFeatures();
   const {
     value: discardConfirmationModalVisible,
     toggle: toggleDiscardConfirmationModal,
@@ -104,7 +104,7 @@ export function ContextualSaveBar({
 
   const contexualSaveBarClassName = classNames(
     styles.ContextualSaveBar,
-    unstableGlobalTheming && styles['ContextualSaveBar-globalTheming'],
+    newDesignLanguage && styles.newDesignLanguage,
   );
 
   return (

--- a/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/tests/ContextualSaveBar.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
-import {Button, Image} from 'components';
+import {Button, Image, ThemeProvider} from 'components';
+import {mountWithApp} from 'test-utilities';
 import {ContextualSaveBar} from '../ContextualSaveBar';
 import {DiscardConfirmationModal} from '../components';
 
@@ -269,6 +270,26 @@ describe('<ContextualSaveBar />', () => {
       );
 
       expect(contextualSaveBar.find(Image).exists()).toBeFalsy();
+    });
+  });
+
+  describe('newDesignLanguage', () => {
+    it('renders a ThemeProvider with inverted theme', () => {
+      const contextualSaveBar = mountWithApp(<ContextualSaveBar />, {
+        features: {newDesignLanguage: true},
+      });
+      expect(contextualSaveBar).toContainReactComponent(ThemeProvider, {
+        theme: {colorScheme: 'inverse'},
+      });
+    });
+
+    it('renders a container with a newDesignLanguage className', () => {
+      const contextualSaveBar = mountWithApp(<ContextualSaveBar />, {
+        features: {newDesignLanguage: true},
+      });
+      expect(contextualSaveBar).toContainReactComponent('div', {
+        className: 'ContextualSaveBar newDesignLanguage',
+      });
     });
   });
 });

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -303,6 +303,21 @@ describe('<Frame />', () => {
       });
     });
 
+    it('renders a ContextualSaveBar with a newDesignLanguage class when newDesignLanguage is true', () => {
+      const frame = mountWithApp(
+        <Frame topBar={<div />}>
+          <PolarisLoading />
+        </Frame>,
+        {
+          features: {newDesignLanguage: true},
+        },
+      );
+      expect(frame).toContainReactComponent('div', {
+        className:
+          'ContextualSaveBar ContextualSaveBar-newDesignLanguage startFadeUp',
+      });
+    });
+
     it('renders a GlobalRibbon container with a newDesignLanguage class when newDesignLanguage is true', () => {
       const frame = mountWithApp(
         <Frame globalRibbon={<div />}>

--- a/src/utilities/theme/tokens.ts
+++ b/src/utilities/theme/tokens.ts
@@ -38,6 +38,7 @@ const Overrides = {
   textFieldFocusRingBorderRadius: rem('7px'),
   buttonGroupItemSpacing: rem('2px'),
   topBarHeight: '68px',
+  contextualSaveBarHeight: '64px',
   duration100: '100ms',
   duration150: '150ms',
   easeIn: 'cubic-bezier(0.5, 0.1, 1, 1)',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/344

### WHAT is this pull request doing?

![image](https://screenshot.click/Storybook_2020-01-30_15-32-18.png)
![CSB-fadeup](https://user-images.githubusercontent.com/6844391/73487857-d01cbb80-4375-11ea-80c5-d1ab319baf52.gif)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

1. Hit the details page in storybook
1. Type something into the product title field
1. Dismiss the save bar

Make sure both fade up and in and fade out and down look alright

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
