### PR TITLE
[Modal] Fix container's width

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@
 
 - Fixed `TrapFocus` stealing focus from other `TrapFocus`'s ([#2681](https://github.com/Shopify/polaris-react/pull/2681))
 - Fixed focus state color on monochrome `Buttons` ([#2684](https://github.com/Shopify/polaris-react/pull/2684))
+- Fixed container's width on `Modal` ([#2692](https://github.com/Shopify/polaris-react/pull/2692))
 
 ### Documentation
 

--- a/src/components/Modal/components/Dialog/Dialog.scss
+++ b/src/components/Modal/components/Dialog/Dialog.scss
@@ -33,7 +33,7 @@ $large-width: rem(980px);
   left: 0;
   display: flex;
   flex-direction: column;
-  width: 100vw;
+  width: 100%;
   max-height: calc(100vh - #{$vertical-spacing});
   background: var(--p-surface, color('white'));
   box-shadow: var(--p-modal-shadow, shadow(layer));
@@ -64,7 +64,7 @@ $large-width: rem(980px);
 
   &.sizeLarge {
     @include breakpoint-after(layout-width(page-with-nav)) {
-      max-width: calc(100vw - #{$horizontal-spacing});
+      max-width: calc(100% - #{$horizontal-spacing});
     }
 
     @include breakpoint-after($large-width + $horizontal-spacing) {


### PR DESCRIPTION
### WHY are these changes introduced?

There is currently an issue with the Modal's width as it doesn't take into account the scroll bar when visible.

![Capture d’écran 2020-01-31 à 15 10 25](https://user-images.githubusercontent.com/14129033/73545656-0c1a5400-443c-11ea-8d39-583c49f2be31.png)

### WHAT is this pull request doing?
I've changed the value from `vw` to `%` as this one take the scroll bar into account

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
