### PR TITLE
Update container image for styleguide integration test

### DIFF
--- a/.shopify-build/polaris-react.yml
+++ b/.shopify-build/polaris-react.yml
@@ -2,7 +2,7 @@ containers:
   default:
     docker: gcr.io/shopify-docker-images/apps/production/web-platform-ci-node:10.18.0-yarn-1.21.1
   styleguide:
-    docker: circleci/node:10.13.0
+    docker: gcr.io/shopify-docker-images/apps/production/web-platform-ci-node:10.13.0-yarn-1.21.1
 
 shared:
   build-web: &build-web


### PR DESCRIPTION

### WHY are these changes introduced?

Keeping in sync with polaris-styleguide

### WHAT is this pull request doing?
 Updates the styleguide build container to match https://github.com/Shopify/polaris-styleguide/blob/master/.shopify-build/polaris-styleguide.yml (that's a private repo)
