### PR TITLE
Navigation.Section: Use useUniqueId

### DIFF
--- a/src/components/Navigation/components/Section/Section.tsx
+++ b/src/components/Navigation/components/Section/Section.tsx
@@ -1,9 +1,9 @@
 import React, {useEffect, useRef} from 'react';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
-import {createUniqueIDFactory} from '@shopify/javascript-utilities/other';
 
 import {classNames} from '../../../../utilities/css';
 import {navigationBarCollapsed} from '../../../../utilities/breakpoints';
+import {useUniqueId} from '../../../../utilities/unique-id';
 import {useToggle} from '../../../../utilities/use-toggle';
 import {Collapsible} from '../../../Collapsible';
 import {Icon} from '../../../Icon';
@@ -12,8 +12,6 @@ import {IconProps} from '../../../../types';
 import {Item, ItemProps} from '../Item';
 
 import styles from '../../Navigation.scss';
-
-const createAdditionalItemsId = createUniqueIDFactory('AdditionalItems');
 
 export interface SectionProps {
   items: ItemProps[];
@@ -161,7 +159,7 @@ export function Section({
     );
   }
 
-  const additionalItemsId = createAdditionalItemsId();
+  const additionalItemsId = useUniqueId('AdditionalItems');
 
   const activeItemsMarkup = rollup && additionalItems.length > 0 && (
     <li className={styles.RollupSection}>


### PR DESCRIPTION

### WHY are these changes introduced?

This avoids having an Collapsible id that increments on every rerender
of the Navigation.Section

### WHAT is this pull request doing?

Replace createUniqueIDFactory usage with useUniqueId();


### How to 🎩

The following playground has a toy in it that triggers a rerender once a second to make the Navigation.Section rerender.

Find the `Collapsible` component that renders by as part of the Navigation rollup by running `document.querySelector('[class^=Collapsible-Collapsible]')` in your console.
Note that the id of the Collapsible div remains constant across multiple rerenders (compare this with master where the id increments on each render).

Note: the id will be "PolarisAdditionalItems2" not "PolarisAdditionalItems1" because by default the playground renders in strict mode which [double invokes render calls](https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects), you can disable that in storybook settings bar.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useRef, useEffect} from 'react';
import {HomeMajorMonotone, OrdersMajorTwotone} from '@shopify/polaris-icons';
import {Page, Navigation} from '../src';
import {useUniqueId} from '../src/utilities/unique-id';

function noop() {}

export function Playground() {
  const [count, setCount] = useState(0);

  useInterval(() => {
    setCount((count) => count + 1);
  }, 1000);

  return (
    <Page title="Playground">
      <Test renderCount={count} />
      <hr />
      <Test renderCount={count} />
      <hr />
      <Test renderCount={count} />
      <hr />
      <hr />

      <Navigation.Section
        title="Hi"
        items={[
          {
            url: '/path/to/place',
            label: 'Home ',
            icon: HomeMajorMonotone,
          },
          {
            url: '/path/to/place',
            label: 'Orders',
            icon: OrdersMajorTwotone,
            badge: count,
          },
        ]}
        rollup={{
          after: 1,
          view: 'view',
          hide: 'hide',
          activePath: '/',
        }}
      />
    </Page>
  );
}

function Test({renderCount}) {
  // const id = useUniqueId();
  const id = useUniqueId();
  const idPrefix = useUniqueId('prefix-');
  const idPrefix2 = useUniqueId('prefix2-');

  return (
    <div>
      {renderCount} :: {id} | {idPrefix} | {idPrefix2}
    </div>
  );
}

function useInterval(callback: () => void, delay: number) {
  const savedCallback = useRef<typeof callback>();

  // Remember the latest callback.
  useEffect(() => {
    savedCallback.current = callback;
  }, [callback]);

  // Set up the interval.
  useEffect(() => {
    function tick() {
      savedCallback.current();
    }
    if (delay !== null) {
      const id = setInterval(tick, delay);
      return () => clearInterval(id);
    }
  }, [delay]);
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
