### PR TITLE
High contrast border for button

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+- Added high contrast border to `Button` ([#2712](https://github.com/Shopify/polaris-react/pull/2712))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -96,6 +96,10 @@
         border: none;
       }
     }
+
+    @media (-ms-high-contrast: active) {
+      border: 1px solid ms-high-contrast-color('text');
+    }
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

High contrast for button https://github.com/Shopify/polaris-ux/issues/371

### WHAT is this pull request doing?

Add high contrast border to button.

**Button**
<img width="84" alt="Screen Shot 2020-02-04 at 1 42 32 PM" src="https://user-images.githubusercontent.com/19199063/73775789-915f7a80-4754-11ea-8d91-6bab8d4f6f4a.png">

**Button hovered**
<img width="72" alt="Screen Shot 2020-02-04 at 1 42 39 PM" src="https://user-images.githubusercontent.com/19199063/73775787-915f7a80-4754-11ea-8e7e-2b9ffddfb68e.png">

**Button focused**
<img width="72" alt="Screen Shot 2020-02-04 at 1 42 48 PM" src="https://user-images.githubusercontent.com/19199063/73775788-915f7a80-4754-11ea-904e-1eb317430d73.png">

