### PR TITLE
High contrast actionlist hover

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+- Added high contrast outline to `ActionList` ([#2713](https://github.com/Shopify/polaris-react/pull/2713))
+
 ### Bug fixes
 
 - Fixed focus state color on monochrome `Buttons` ([#2684](https://github.com/Shopify/polaris-react/pull/2684))

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -192,6 +192,10 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
     &:hover {
       background-image: none;
       background-color: var(--p-surface-hovered);
+
+      @media (-ms-high-contrast: active) {
+        outline: 1px solid ms-high-contrast-color('text');
+      }
     }
     // Active (.active, :active)
     // We need to decide if the .active state appears as pressed or focused


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes high contrast for https://github.com/Shopify/polaris-ux/issues/332

### WHAT is this pull request doing?
Adding outline to hovered items in action list

**Default button**
<img width="110" alt="Screen Shot 2020-02-04 at 1 58 00 PM" src="https://user-images.githubusercontent.com/19199063/73777036-bc4ace00-4756-11ea-9041-d5d86735ab06.png">

**Hovered button**
<img width="101" alt="Screen Shot 2020-02-04 at 1 57 44 PM" src="https://user-images.githubusercontent.com/19199063/73777037-bc4ace00-4756-11ea-9c38-b38e5c8fd3f3.png">

**Open action list**
<img width="84" alt="Screen Shot 2020-02-04 at 1 57 32 PM" src="https://user-images.githubusercontent.com/19199063/73777038-bce36480-4756-11ea-93e3-690103ec0b67.png">

**Hovered item in action list**
<img width="86" alt="Screen Shot 2020-02-04 at 1 57 17 PM" src="https://user-images.githubusercontent.com/19199063/73777039-bce36480-4756-11ea-9461-40d361ca4df4.png">

