### PR TITLE
[Radio, Checkbox] Fix high contrast mode

### DIFF
--- a/src/components/RadioButton/RadioButton.scss
+++ b/src/components/RadioButton/RadioButton.scss
@@ -103,10 +103,10 @@
       border-radius: 50%;
       transition: opacity var(--p-duration-1-0-0) var(--p-ease),
         transform var(--p-duration-1-0-0) var(--p-ease);
-    }
 
-    @media (-ms-high-contrast: active) {
-      background: ms-high-contrast-color('text');
+      @media (-ms-high-contrast: active) {
+        border: rem(5px) solid ms-high-contrast-color('text');
+      }
     }
 
     @include focus-ring($border-width: var(--p-control-border-width));

--- a/src/styles/shared/_controls.scss
+++ b/src/styles/shared/_controls.scss
@@ -130,6 +130,9 @@
       &::before {
         opacity: 1;
         transform: scale(1);
+        @media (-ms-high-contrast: active) {
+          border: 2px solid ms-high-contrast-color('text');
+        }
       }
     } @else if $style == disabled {
       border-color: var(--p-border-secondary-disabled);


### PR DESCRIPTION
### WHY are these changes introduced?

The radio button wasn't displaying a checked state. This was because a background-color was being set on a pseudo element for high contrast mode, but high contrast mode ignores background rules. To fix this I changed `background` to a `border` that is wide enough to fill the radio.

The checkbox was a little simpler. The border was being removed on checked which I felt a little strange so I added one for the checked state.

![Radio](https://user-images.githubusercontent.com/6844391/73781166-ccb27700-475d-11ea-9e99-a2d2f51c3c49.gif)
![Checkbox](https://user-images.githubusercontent.com/6844391/73781167-cd4b0d80-475d-11ea-8b6b-bab6c2927e94.gif)


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
