### PR TITLE
[TextField] Flatten focus ring on connected TextField

### DIFF
--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -388,6 +388,16 @@ $stacking-order: (
     }
   }
 
+  .Backdrop-connectedLeft::after {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  .Backdrop-connectedRight::after {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
   .Spinner {
     --p-text-field-spinner-offset-large: calc(
       var(--p-text-field-spinner-offset) + #{border-width()}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -410,6 +410,12 @@ export function TextField({
     'aria-multiline': normalizeAriaMultiline(multiline),
   });
 
+  const backdropClassName = classNames(
+    styles.Backdrop,
+    newDesignLanguage && connectedLeft && styles['Backdrop-connectedLeft'],
+    newDesignLanguage && connectedRight && styles['Backdrop-connectedRight'],
+  );
+
   return (
     <Labelled
       label={label}
@@ -432,7 +438,7 @@ export function TextField({
           {characterCountMarkup}
           {clearButtonMarkup}
           {spinnerMarkup}
-          <div className={styles.Backdrop} />
+          <div className={backdropClassName} />
           {resizer}
         </div>
       </Connected>

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1195,7 +1195,7 @@ describe('<TextField />', () => {
       },
     );
     expect(textField).toContainReactComponent('div', {
-      className: 'Backdrop ConnectedLeft ConnectedRight',
+      className: 'Backdrop Backdrop-connectedLeft Backdrop-connectedRight',
     });
   });
 });

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1181,6 +1181,23 @@ describe('<TextField />', () => {
       });
     });
   });
+
+  it('adds a connected left and right class when a connected element is present', () => {
+    const textField = mountWithApp(
+      <TextField
+        label="TextField"
+        onChange={noop}
+        connectedLeft={<div />}
+        connectedRight={<div />}
+      />,
+      {
+        features: {newDesignLanguage: true},
+      },
+    );
+    expect(textField).toContainReactComponent('div', {
+      className: 'Backdrop ConnectedLeft ConnectedRight',
+    });
+  });
 });
 
 function noop() {}


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses https://github.com/Shopify/polaris-ux/issues/379

### WHAT is this pull request doing?

- Modifies the border radius of the `Backdrop` when there are connected elements

![image](https://user-images.githubusercontent.com/22782157/73957089-da8a0880-48d3-11ea-853f-dc1b275a9692.png)

![image](https://user-images.githubusercontent.com/22782157/73957097-dc53cc00-48d3-11ea-8013-3dc181614df3.png)

![image](https://user-images.githubusercontent.com/22782157/73957108-e1b11680-48d3-11ea-8d68-7b3e832203ab.png)

![image](https://user-images.githubusercontent.com/22782157/73957100-de1d8f80-48d3-11ea-93a6-d803470b2708.png)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers) (Chrome, Firefox)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
