### PR TITLE
[DropZone] Allow changing the file if allowMultiple={false} 

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,9 @@
 - Fixed the position property for the backdrop on `Select` from being overwritten by the focus ring ([#2748](https://github.com/Shopify/polaris-react/pull/2748))
 - Fixed `ResourceItem` `Actions` visibility on mouse out ([#2742](https://github.com/Shopify/polaris-react/pull/2742))
 - Fixed initial server / client render mismatch in `Avatar` ([#2751](https://github.com/Shopify/polaris-react/pull/2751))
+- Allow changing the `DropZone` file if allowMultiple is false ([#2737](https://github.com/Shopify/polaris-react/pull/2737))
+- Fixed `DropZone` not supporting new file selection when `allowMultiple` is `false` ([#2737](https://github.com/Shopify/polaris-react/pull/2737)) ([#2737](https://github.com/Shopify/polaris-react/pull/2737))
+- Fixed `DropZone` not supporting new file selection when `allowMultiple` is `false` ([#2737](https://github.com/Shopify/polaris-react/pull/2737))
 
 ### Documentation
 

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -76,7 +76,7 @@ export interface DropZoneProps {
   /** Text that appears in the overlay when set in error state */
   errorOverlayText?: string;
   /**
-   * Allows multiple files to be uploaded
+   * Allows multiple files to be uploaded at once
    * @default true
    */
   allowMultiple?: boolean;
@@ -181,7 +181,6 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
     setTrue: handleFocus,
     setFalse: handleBlur,
   } = useToggle(false);
-  const [numFiles, setNumFiles] = useState(0);
   const [size, setSize] = useState('extraLarge');
   const [measuring, setMeasuring] = useState(true);
 
@@ -212,7 +211,7 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
   const handleDrop = useCallback(
     (event: DragEvent) => {
       stopEvent(event);
-      if (disabled || (!allowMultiple && numFiles > 0)) return;
+      if (disabled) return;
 
       const fileList = getDataTransferFiles(event);
 
@@ -222,7 +221,6 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
 
       setDragging(false);
       setInternalError(rejectedFiles.length > 0);
-      setNumFiles((numFiles) => numFiles + acceptedFiles.length);
 
       onDrop && onDrop(files as File[], acceptedFiles, rejectedFiles);
       onDropAccepted && acceptedFiles.length && onDropAccepted(acceptedFiles);
@@ -230,21 +228,13 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
 
       (event.target as HTMLInputElement).value = '';
     },
-    [
-      allowMultiple,
-      disabled,
-      getValidatedFiles,
-      numFiles,
-      onDrop,
-      onDropAccepted,
-      onDropRejected,
-    ],
+    [disabled, getValidatedFiles, onDrop, onDropAccepted, onDropRejected],
   );
 
   const handleDragEnter = useCallback(
     (event: DragEvent) => {
       stopEvent(event);
-      if (disabled || (!allowMultiple && numFiles > 0)) return;
+      if (disabled) return;
 
       const fileList = getDataTransferFiles(event);
 
@@ -261,30 +251,23 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
 
       onDragEnter && onDragEnter();
     },
-    [
-      allowMultiple,
-      disabled,
-      dragging,
-      getValidatedFiles,
-      numFiles,
-      onDragEnter,
-    ],
+    [disabled, dragging, getValidatedFiles, onDragEnter],
   );
 
   const handleDragOver = useCallback(
     (event: DragEvent) => {
       stopEvent(event);
-      if (disabled || (!allowMultiple && numFiles > 0)) return;
+      if (disabled) return;
       onDragOver && onDragOver();
     },
-    [allowMultiple, disabled, numFiles, onDragOver],
+    [disabled, onDragOver],
   );
 
   const handleDragLeave = useCallback(
     (event: DragEvent) => {
       event.preventDefault();
 
-      if (disabled || (!allowMultiple && numFiles > 0)) return;
+      if (disabled) return;
 
       dragTargets.current = dragTargets.current.filter((el: Node) => {
         const compareNode = dropOnPage && !isServer ? document : node.current;
@@ -299,7 +282,7 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
 
       onDragLeave && onDragLeave();
     },
-    [allowMultiple, dropOnPage, disabled, numFiles, onDragLeave],
+    [dropOnPage, disabled, onDragLeave],
   );
 
   useEffect(() => {
@@ -456,7 +439,7 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
   }
 
   function handleClick(event: React.MouseEvent<HTMLElement>) {
-    if (disabled || (!allowMultiple && numFiles > 0)) return;
+    if (disabled) return;
 
     return onClick ? onClick(event) : open();
   }

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -197,6 +197,49 @@ function DropZoneWithImageFileUpload() {
 }
 ```
 
+### Drop zone with single file upload
+
+Use to accept only one file.
+
+```jsx
+function DropZoneExample() {
+  const [file, setFile] = useState();
+
+  const handleDropZoneDrop = useCallback(
+    (_dropFiles, acceptedFiles, _rejectedFiles) =>
+      setFile((file) => acceptedFiles[0]),
+    [],
+  );
+
+  const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];
+
+  const fileUpload = !file && <DropZone.FileUpload />;
+  const uploadedFile = file && (
+    <Stack>
+      <Thumbnail
+        size="small"
+        alt={file.name}
+        source={
+          validImageTypes.indexOf(file.type) > 0
+            ? window.URL.createObjectURL(file)
+            : 'https://cdn.shopify.com/s/files/1/0757/9955/files/New_Post.png?12678548500147524304'
+        }
+      />
+      <div>
+        {file.name} <Caption>{file.size} bytes</Caption>
+      </div>
+    </Stack>
+  );
+
+  return (
+    <DropZone allowMultiple={false} onDrop={handleDropZoneDrop}>
+      {uploadedFile}
+      {fileUpload}
+    </DropZone>
+  );
+}
+```
+
 ### Drop zone with drop on page
 
 Use to accept files for upload when dropped anywhere on the page.

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -155,7 +155,7 @@ describe('<DropZone />', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it('does not call callbacks when not allowed multiple and a file is uploaded', () => {
+  it('calls callbacks when not allowed multiple and a replacement file is uploaded', () => {
     const dropZone = mountWithAppProvider(
       <DropZone
         allowMultiple={false}
@@ -171,15 +171,15 @@ describe('<DropZone />', () => {
     fireEvent({element: dropZone, spy});
     expect(spy).toHaveBeenCalledWith(files, acceptedFiles, rejectedFiles);
 
-    // All events should now be ignored
+    // Attempt to replace the current file
     fireEvent({element: dropZone, spy});
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(files, acceptedFiles, rejectedFiles);
     fireEvent({element: dropZone, eventType: 'dragenter', spy});
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalled();
     fireEvent({element: dropZone, eventType: 'dragleave', spy});
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalled();
     fireEvent({element: dropZone, eventType: 'dragover', spy});
-    expect(spy).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalled();
   });
 
   it('renders <Labelled /> when `label` is provided', () => {
@@ -217,6 +217,19 @@ describe('<DropZone />', () => {
         .at(4)
         .simulate('click');
       expect(spy).toHaveBeenCalled();
+    });
+
+    it('does not calls the onClick when the dropzone is disabled', () => {
+      const spy = jest.fn();
+      const dropZone = mountWithAppProvider(
+        <DropZone disabled label="My DropZone label" onClick={spy} />,
+      );
+
+      dropZone
+        .find('div')
+        .at(4)
+        .simulate('click');
+      expect(spy).not.toHaveBeenCalled();
     });
 
     it('triggers the file input click event if no onClick is provided', () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Fix https://github.com/Shopify/polaris-react/issues/1860
Fix https://github.com/Shopify/polaris-react/issues/2621
Fix https://github.com/Shopify/polaris-react/issues/1229
Fix https://github.com/Shopify/store/issues/13016
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Removes the `numFiles` state variable. This variable was being used to check if multiple files had already been uploaded and accordingly block the dropzone from allowing more files to be uploaded. From reading the issues, it seems this blocking behaviour is unwanted and should be instead handled outside of the component if needed.


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, DropZone} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <DropZone
        allowMultiple={false}
        dropOnPage
        accept=" , .csv, text/csv, text/comma-separated-values, text/plain, text/x-csv, application/vnd.ms-excel, application/csv, application/x-csv, text/csv, text/comma-separated-values, text/x-comma-separated-values, text/tab-separated-values"
        onDropAccepted={() => {}}
        onDropRejected={() => {}}
        errorOverlayText="Error"
        disabled={false}
      >
        <DropZone.FileUpload />
      </DropZone>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
