### PR TITLE
[Select] Fix position being overwritten by the focus ring

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@
 - Fixed `TrapFocus` stealing focus from other `TrapFocus`'s ([#2681](https://github.com/Shopify/polaris-react/pull/2681))
 - Fixed focus state color on monochrome `Buttons` ([#2684](https://github.com/Shopify/polaris-react/pull/2684))
 - Fixed container's width on `Modal` ([#2692](https://github.com/Shopify/polaris-react/pull/2692))
+- Fixed the position property for the backdrop on `Select` from being overwritten by the focus ring ([#2748](https://github.com/Shopify/polaris-react/pull/2748))
 
 ### Documentation
 

--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -148,8 +148,6 @@ $stacking-order: (
 
 .newDesignLanguage {
   .Backdrop {
-    // stylelint-disable-next-line order/properties-order
-    position: absolute;
     z-index: z-index(backdrop, $stacking-order);
     top: 0;
     right: 0;
@@ -159,6 +157,11 @@ $stacking-order: (
     border-radius: var(--p-border-radius-base);
     background-color: var(--p-surface);
     @include focus-ring($border-width: rem(1px));
+
+    // 'position' needs to sit below focus-ring since it will be overwritten
+    // with relative when the focus ring style is 'base'
+    // stylelint-disable-next-line order/properties-order
+    position: absolute;
   }
 
   &.error {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes the `Select` from appearing like,

![image](https://user-images.githubusercontent.com/22782157/74567295-79051200-4f43-11ea-97ce-3a759190fa8b.png)


### WHAT is this pull request doing?

In [this commit](https://github.com/Shopify/polaris-react/commit/1be5ea13e0816026da8d268d43738a89aabe44cb#diff-5d08ed568b63ab57718732512bd1058fR152) the order of the position property was moved above the focus ring mixin.

Since the focus ring applies a relative position when it is not focused, this was overwriting the position value for the `Select` component's `Backdrop`.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
