### PR TITLE
[Avatar] fix initial server / client render mismatch

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@
 - Fixed container's width on `Modal` ([#2692](https://github.com/Shopify/polaris-react/pull/2692))
 - Fixed the position property for the backdrop on `Select` from being overwritten by the focus ring ([#2748](https://github.com/Shopify/polaris-react/pull/2748))
 - Fixed `ResourceItem` `Actions` visibility on mouse out ([#2742](https://github.com/Shopify/polaris-react/pull/2742))
+- Fixed initial server / client render mismatch in `Avatar` ([#2751](https://github.com/Shopify/polaris-react/pull/2751))
 
 ### Documentation
 

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -3,7 +3,8 @@ import React, {useState, useCallback, useEffect} from 'react';
 import {classNames, variationName} from '../../utilities/css';
 import {useFeatures} from '../../utilities/features';
 import {useI18n} from '../../utilities/i18n';
-import {isServer} from '../../utilities/target';
+import {useIsAfterInitialMount} from '../../utilities/use-is-after-initial-mount';
+
 import {Image} from '../Image';
 
 import styles from './Avatar.scss';
@@ -46,6 +47,7 @@ export function Avatar({
 }: AvatarProps) {
   const i18n = useI18n();
   const {newDesignLanguage} = useFeatures();
+  const isAfterInitialMount = useIsAfterInitialMount();
 
   function styleClass(name?: string) {
     const finalStyleClasses = newDesignLanguage
@@ -100,7 +102,7 @@ export function Avatar({
   );
 
   const imageMarkUp =
-    source && !isServer && status !== Status.Errored ? (
+    source && isAfterInitialMount && status !== Status.Errored ? (
       <Image
         className={styles.Image}
         source={source}

--- a/src/components/Avatar/tests/Avatar-ssr.test.tsx
+++ b/src/components/Avatar/tests/Avatar-ssr.test.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Avatar, Image} from 'components';
 
-jest.mock('../../../utilities/target', () => ({
-  get isServer() {
-    return true;
-  },
-}));
+jest.mock('../../../utilities/use-is-after-initial-mount', () => {
+  return {
+    useIsAfterInitialMount: () => {
+      return false;
+    },
+  };
+});
 
 describe('<Avatar /> Server-side only', () => {
   it('does not render an Image', () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1419 

In every project that uses/renders the Avatar component on server and client, we get a React warning about the initial rendering not being equal.

While mismatches in server-rendered in client-rendered results usually don't seem to be as much of an issue anymore as of react 16, they can be if nodes are missing in the server-rendered output, which I think is precisely the case here.

> Also, React 16 is better at hydrating server-rendered HTML once it reaches the client. It no longer requires the initial render to exactly match the result from the server.
**However, it's dangerous to have missing nodes on the server render as this might cause sibling nodes to be created with incorrect attributes.**

https://reactjs.org/blog/2017/09/26/react-v16.0.html
Example issue: https://github.com/facebook/react/issues/10591

There's another issue. Unfortunately, it seems like React only ever warns for the first mismatch. In some projects, (almost) all pages contain the Avatar component, and since it always produces an error, we might have been missing others.

### WHAT is this pull request doing?

Instead of not rendering the image on the server and rendering it on the client, we now wait for the component to be mounted to render the image. So it won't be part of the server render, but also not part of the initial client side render anymore. 

This does cause an addional rerender, but I'd assume that's ok(?)
The change should have no effect on the UX/behavior of the component.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Avatar} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Avatar source="https://example.com/does-not-exist" initials="WE" />
      <Avatar source="http://placekitten.com/200/200" initials="WE" />
    </Page>
  );
}

```

</details>

First avatar will fail to load the image and show the initials.
Second avatar loads and shows image.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
