### PR TITLE
[Popover] Add preferInputActivator prop to Popover

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@
 - Fixed the position property for the backdrop on `Select` from being overwritten by the focus ring ([#2748](https://github.com/Shopify/polaris-react/pull/2748))
 - Fixed `ResourceItem` `Actions` visibility on mouse out ([#2742](https://github.com/Shopify/polaris-react/pull/2742))
 - Fixed initial server / client render mismatch in `Avatar` ([#2751](https://github.com/Shopify/polaris-react/pull/2751))
+- Fixed the `Popover` reference position calculation ([#2752](https://github.com/Shopify/polaris-react/issues/2752)) ([#1415](https://github.com/Shopify/polaris-react/issues/1415))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@
 - Added high contrast outline to `ActionList` ([#2713](https://github.com/Shopify/polaris-react/pull/2713))
 - Added high contrast border to `Button` ([#2712](https://github.com/Shopify/polaris-react/pull/2712))
 - Added styled placeholder image to `Avatar` when initials are blank ([#2693](https://github.com/Shopify/polaris-react/pull/2693))
+- Added a `preferInputActivator` prop to `Popover` to allow better positioning of the overlay ([#2754](https://github.com/Shopify/polaris-react/pull/2754))
 
 ### Bug fixes
 
@@ -16,7 +17,6 @@
 - Fixed the position property for the backdrop on `Select` from being overwritten by the focus ring ([#2748](https://github.com/Shopify/polaris-react/pull/2748))
 - Fixed `ResourceItem` `Actions` visibility on mouse out ([#2742](https://github.com/Shopify/polaris-react/pull/2742))
 - Fixed initial server / client render mismatch in `Avatar` ([#2751](https://github.com/Shopify/polaris-react/pull/2751))
-- Fixed the `Popover` reference position calculation ([#2752](https://github.com/Shopify/polaris-react/issues/2752)) ([#1415](https://github.com/Shopify/polaris-react/issues/1415))
 
 ### Documentation
 

--- a/src/components/Card/tests/Card.test.tsx
+++ b/src/components/Card/tests/Card.test.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import {
-  mountWithAppProvider,
-  trigger,
-  findByTestID,
-} from 'test-utilities/legacy';
+import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {Card, Badge, Button, Popover, ActionList} from 'components';
 import {WithinContentContext} from '../../../utilities/within-content-context';
@@ -177,35 +173,28 @@ describe('<Card />', () => {
         {content: 'Most important action'},
         {content: 'Second most important action'},
       ];
-      const card = mountWithAppProvider(
+      const card = mountWithApp(
         <Card secondaryFooterActions={footerActions}>
           <p>Some card content.</p>
         </Card>,
       );
 
-      const disclosureButton = card.find(Button).first();
-      expect(disclosureButton).toHaveLength(1);
-      expect(disclosureButton.text()).toBe('More');
+      const disclosureButton = card.findAll(Button)[0];
+      expect(disclosureButton).toContainReactText('More');
 
-      const popover = card.find(Popover).first();
-      expect(popover).toHaveLength(1);
-      expect(popover.prop('active')).toBe(false);
+      expect(card).toContainReactComponent(Popover, {
+        active: false,
+      });
 
-      trigger(disclosureButton, 'onClick');
+      disclosureButton.trigger('onClick');
 
-      expect(
-        card
-          .find(Popover)
-          .first()
-          .prop('active'),
-      ).toBe(true);
+      expect(card).toContainReactComponent(Popover, {
+        active: true,
+      });
 
-      const overlay = findByTestID(card, 'popoverOverlay');
-      expect(overlay).toHaveLength(1);
-
-      const actionList = overlay.find(ActionList).first();
-      expect(actionList).toHaveLength(1);
-      expect(actionList.prop('items')).toBe(footerActions);
+      expect(card).toContainReactComponent(ActionList, {
+        items: footerActions,
+      });
     });
 
     it('sets the disclosure button content to the value set on secondaryFooterActionsDisclosureText', () => {

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -133,9 +133,8 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
   }, [activatorNode, setAccessibilityAttributes]);
 
   const portal = activatorNode ? (
-    <Portal idPrefix="popover" testID="portal">
+    <Portal idPrefix="popover">
       <PopoverOverlay
-        testID="popoverOverlay"
         id={id}
         activator={activatorNode}
         preferInputActivator={preferInputActivator}

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -32,6 +32,10 @@ export interface PopoverProps {
   active: boolean;
   /** The element to activate the Popover */
   activator: React.ReactElement;
+  /**
+   * Use the activator's input element to calculate the Popover position
+   * @default true
+   */
   preferInputActivator?: PopoverOverlayProps['preferInputActivator'];
   /**
    * The element type to wrap the activator with

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -32,6 +32,7 @@ export interface PopoverProps {
   active: boolean;
   /** The element to activate the Popover */
   activator: React.ReactElement;
+  preferInputActivator?: PopoverOverlayProps['preferInputActivator'];
   /**
    * The element type to wrap the activator with
    * @default 'div'
@@ -71,6 +72,7 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
   active,
   fixed,
   ariaHaspopup,
+  preferInputActivator = true,
   ...rest
 }: PopoverProps) {
   const [activatorNode, setActivatorNode] = useState();
@@ -136,6 +138,7 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
         testID="popoverOverlay"
         id={id}
         activator={activatorNode}
+        preferInputActivator={preferInputActivator}
         onClose={handleClose}
         active={active}
         fixed={fixed}

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -44,6 +44,7 @@ export interface PopoverOverlayProps {
   active: boolean;
   id: string;
   activator: HTMLElement;
+  preferInputActivator?: PositionedOverlayProps['preferInputActivator'];
   preventAutofocus?: boolean;
   sectioned?: boolean;
   fixed?: boolean;
@@ -115,6 +116,7 @@ export class PopoverOverlay extends React.PureComponent<
       fullWidth,
       preferredPosition = 'below',
       preferredAlignment = 'center',
+      preferInputActivator = true,
       fixed,
     } = this.props;
     const {transitionStatus} = this.state;
@@ -136,6 +138,7 @@ export class PopoverOverlay extends React.PureComponent<
         fullWidth={fullWidth}
         active={active}
         activator={activator}
+        preferInputActivator={preferInputActivator}
         preferredPosition={preferredPosition}
         preferredAlignment={preferredAlignment}
         render={this.renderPopover.bind(this)}

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -143,6 +143,25 @@ describe('<PopoverOverlay />', () => {
     ).toBe('center');
   });
 
+  it('passes preferInputActivator to PositionedOverlay when false', () => {
+    const popoverOverlay = mountWithAppProvider(
+      <PopoverOverlay
+        active
+        id="PopoverOverlay-1"
+        activator={activator}
+        onClose={noop}
+        fixed
+        preferInputActivator={false}
+      >
+        {children}
+      </PopoverOverlay>,
+    );
+
+    expect(
+      popoverOverlay.find(PositionedOverlay).prop('preferInputActivator'),
+    ).toBe(false);
+  });
+
   it('calls the onClose callback when the escape key is pressed', () => {
     const spy = jest.fn();
 

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -95,6 +95,21 @@ describe('<Popover />', () => {
     expect(popoverOverlay.prop('preferredAlignment')).toBe('left');
   });
 
+  it("passes 'preferInputActivator' to PopoverOverlay", () => {
+    const popover = mountWithAppProvider(
+      <Popover
+        active={false}
+        preferredPosition="above"
+        activator={<div>Activator</div>}
+        onClose={spy}
+        preferInputActivator={false}
+      />,
+    );
+
+    const popoverOverlay = findByTestID(popover, 'popoverOverlay');
+    expect(popoverOverlay.prop('preferInputActivator')).toBe(false);
+  });
+
   it('has a div as activatorWrapper by default', () => {
     const popover = mountWithAppProvider(
       <Popover

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useCallback} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
+import {PositionedOverlay} from 'components/PositionedOverlay';
+import {Portal} from 'components';
 import {Popover} from '../Popover';
 import {PopoverOverlay} from '../components';
 import * as setActivatorAttributes from '../set-activator-attributes';
@@ -22,7 +22,7 @@ describe('<Popover />', () => {
   });
 
   it('invokes setActivatorAttributes with active, ariaHasPopup and id', () => {
-    mountWithAppProvider(
+    mountWithApp(
       <Popover active={false} activator={<div>Activator</div>} onClose={spy} />,
     );
 
@@ -33,43 +33,39 @@ describe('<Popover />', () => {
   });
 
   it('renders a portal', () => {
-    const popover = mountWithAppProvider(
+    const popover = mountWithApp(
       <Popover active={false} activator={<div>Activator</div>} onClose={spy} />,
     );
-    const portal = findByTestID(popover, 'portal');
-    expect(portal.exists()).toBeTruthy();
+    expect(popover).toContainReactComponent(Portal);
   });
 
   it('renders an activator', () => {
-    const popover = mountWithAppProvider(
+    const popover = mountWithApp(
       <Popover
         active
         activator={<div testID="activator">Activator</div>}
         onClose={spy}
       />,
     );
-    const activator = findByTestID(popover, 'activator');
-    expect(activator.exists()).toBeTruthy();
+    expect(popover).toContainReactComponent('div', {testID: 'activator'});
   });
 
   it('renders a positionedOverlay when active is true', () => {
-    const popover = mountWithAppProvider(
+    const popover = mountWithApp(
       <Popover active activator={<div>Activator</div>} onClose={spy} />,
     );
-    const positionedOverlay = findByTestID(popover, 'positionedOverlay');
-    expect(positionedOverlay.exists()).toBeTruthy();
+    expect(popover).toContainReactComponent(PositionedOverlay);
   });
 
   it('doesn’t render a popover when active is false', () => {
-    const popover = mountWithAppProvider(
+    const popover = mountWithApp(
       <Popover active={false} activator={<div>Activator</div>} onClose={spy} />,
     );
-    const positionedOverlay = findByTestID(popover, 'positionedOverlay');
-    expect(positionedOverlay.exists()).toBeFalsy();
+    expect(popover).not.toContainReactComponent(PositionedOverlay);
   });
 
   it("passes 'preferredPosition' to PopoverOverlay", () => {
-    const popover = mountWithAppProvider(
+    const popover = mountWithApp(
       <Popover
         active={false}
         preferredPosition="above"
@@ -77,12 +73,14 @@ describe('<Popover />', () => {
         onClose={spy}
       />,
     );
-    const popoverOverlay = findByTestID(popover, 'popoverOverlay');
-    expect(popoverOverlay.prop('preferredPosition')).toBe('above');
+
+    expect(popover).toContainReactComponent(PopoverOverlay, {
+      preferredPosition: 'above',
+    });
   });
 
   it("passes 'preferredAlignment' to PopoverOverlay", () => {
-    const popover = mountWithAppProvider(
+    const popover = mountWithApp(
       <Popover
         active={false}
         preferredPosition="above"
@@ -91,12 +89,14 @@ describe('<Popover />', () => {
         preferredAlignment="left"
       />,
     );
-    const popoverOverlay = findByTestID(popover, 'popoverOverlay');
-    expect(popoverOverlay.prop('preferredAlignment')).toBe('left');
+
+    expect(popover).toContainReactComponent(PopoverOverlay, {
+      preferredAlignment: 'left',
+    });
   });
 
   it("passes 'preferInputActivator' to PopoverOverlay", () => {
-    const popover = mountWithAppProvider(
+    const popover = mountWithApp(
       <Popover
         active={false}
         preferredPosition="above"
@@ -106,12 +106,13 @@ describe('<Popover />', () => {
       />,
     );
 
-    const popoverOverlay = findByTestID(popover, 'popoverOverlay');
-    expect(popoverOverlay.prop('preferInputActivator')).toBe(false);
+    expect(popover).toContainReactComponent(PopoverOverlay, {
+      preferInputActivator: false,
+    });
   });
 
   it('has a div as activatorWrapper by default', () => {
-    const popover = mountWithAppProvider(
+    const popover = mountWithApp(
       <Popover
         active={false}
         preferredPosition="above"
@@ -119,11 +120,11 @@ describe('<Popover />', () => {
         onClose={spy}
       />,
     );
-    expect(popover.childAt(0).type()).toBe('div');
+    expect(popover.children[0].type).toBe('div');
   });
 
   it('has a span as activatorWrapper when activatorWrapper prop is set to span', () => {
-    const popover = mountWithAppProvider(
+    const popover = mountWithApp(
       <Popover
         active={false}
         activatorWrapper="span"
@@ -132,11 +133,11 @@ describe('<Popover />', () => {
         onClose={spy}
       />,
     );
-    expect(popover.childAt(0).type()).toBe('span');
+    expect(popover.children[0].type).toBe('span');
   });
 
   it('passes preventAutofocus to PopoverOverlay', () => {
-    const popover = mountWithAppProvider(
+    const popover = mountWithApp(
       <Popover
         active={false}
         preventAutofocus
@@ -144,12 +145,14 @@ describe('<Popover />', () => {
         onClose={spy}
       />,
     );
-    const popoverOverlay = findByTestID(popover, 'popoverOverlay');
-    expect(popoverOverlay.prop('preventAutofocus')).toBe(true);
+
+    expect(popover).toContainReactComponent(PopoverOverlay, {
+      preventAutofocus: true,
+    });
   });
 
   it('passes sectioned to PopoverOverlay', () => {
-    const popover = mountWithAppProvider(
+    const popover = mountWithApp(
       <Popover
         active={false}
         sectioned
@@ -157,12 +160,14 @@ describe('<Popover />', () => {
         onClose={spy}
       />,
     );
-    const popoverOverlay = findByTestID(popover, 'popoverOverlay');
-    expect(popoverOverlay.prop('sectioned')).toBe(true);
+
+    expect(popover).toContainReactComponent(PopoverOverlay, {
+      sectioned: true,
+    });
   });
 
   it('passes fullWidth to PopoverOverlay', () => {
-    const popover = mountWithAppProvider(
+    const popover = mountWithApp(
       <Popover
         active={false}
         fullWidth
@@ -170,12 +175,14 @@ describe('<Popover />', () => {
         onClose={spy}
       />,
     );
-    const popoverOverlay = findByTestID(popover, 'popoverOverlay');
-    expect(popoverOverlay.prop('fullWidth')).toBe(true);
+
+    expect(popover).toContainReactComponent(PopoverOverlay, {
+      fullWidth: true,
+    });
   });
 
   it('passes fluidContent to PopoverOverlay', () => {
-    const popover = mountWithAppProvider(
+    const popover = mountWithApp(
       <Popover
         active
         fluidContent
@@ -183,12 +190,13 @@ describe('<Popover />', () => {
         onClose={spy}
       />,
     );
-    const popoverOverlay = findByTestID(popover, 'popoverOverlay');
-    expect(popoverOverlay.prop('fluidContent')).toBe(true);
+    expect(popover).toContainReactComponent(PopoverOverlay, {
+      fluidContent: true,
+    });
   });
 
   it('calls onClose when you click outside the Popover', () => {
-    mountWithAppProvider(
+    mountWithApp(
       <Popover
         active
         fullWidth
@@ -216,11 +224,11 @@ describe('<Popover />', () => {
 
     const onCloseSpy = jest.fn();
 
-    const popoverWithDisconnectedActivator = mountWithAppProvider(
+    const popoverWithDisconnectedActivator = mountWithApp(
       <PopoverWithDisconnectedActivator />,
     );
 
-    popoverWithDisconnectedActivator.find('button').simulate('click');
+    popoverWithDisconnectedActivator.find('button')!.trigger('onClick');
     const evt = new CustomEvent('click');
     window.dispatchEvent(evt);
 

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -33,6 +33,7 @@ interface OverlayDetails {
 export interface PositionedOverlayProps {
   active: boolean;
   activator: HTMLElement;
+  preferInputActivator?: boolean;
   preferredPosition?: PreferredPosition;
   preferredAlignment?: PreferredAlignment;
   fullWidth?: boolean;
@@ -195,12 +196,13 @@ export class PositionedOverlay extends React.PureComponent<
           onScrollOut,
           fullWidth,
           fixed,
+          preferInputActivator = true,
         } = this.props;
 
         const textFieldActivator = activator.querySelector('input');
 
         const activatorRect =
-          textFieldActivator != null
+          textFieldActivator != null && preferInputActivator
             ? getRectForNode(textFieldActivator)
             : getRectForNode(activator);
 

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -199,12 +199,11 @@ export class PositionedOverlay extends React.PureComponent<
           preferInputActivator = true,
         } = this.props;
 
-        const textFieldActivator = activator.querySelector('input');
+        const preferredActivator = preferInputActivator
+          ? activator.querySelector('input') || activator
+          : activator;
 
-        const activatorRect =
-          textFieldActivator != null && preferInputActivator
-            ? getRectForNode(textFieldActivator)
-            : getRectForNode(activator);
+        const activatorRect = getRectForNode(preferredActivator);
 
         const currentOverlayRect = getRectForNode(this.overlay);
         const scrollableElement = isDocument(this.scrollableContainer)

--- a/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import * as geometry from '@shopify/javascript-utilities/geometry';
 import {EventListener} from '../../EventListener';
 import {PositionedOverlay} from '../PositionedOverlay';
 import * as mathModule from '../utilities/math';
@@ -129,6 +130,51 @@ describe('<PositionedOverlay />', () => {
       expect(positionedOverlay.find(EventListener).prop('event')).toBe(
         'resize',
       );
+    });
+  });
+
+  describe('preferInputActivator', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('uses the input to calculate its dimensions when true', () => {
+      const getRectForNodeSpy = jest.spyOn(geometry, 'getRectForNode');
+
+      const activator = document.createElement('div');
+      const input = document.createElement('input');
+      activator.appendChild(input);
+
+      mountWithAppProvider(
+        <PositionedOverlay
+          {...mockProps}
+          preferInputActivator
+          activator={activator}
+        />,
+      );
+
+      expect(
+        getRectForNodeSpy.mock.calls.some(([node]) => node === input),
+      ).toBe(true);
+    });
+
+    it('does not use the input to calculate its dimensions when false', () => {
+      const getRectForNodeSpy = jest.spyOn(geometry, 'getRectForNode');
+      const activator = document.createElement('div');
+      const input = document.createElement('input');
+      activator.appendChild(input);
+
+      mountWithAppProvider(
+        <PositionedOverlay
+          {...mockProps}
+          preferInputActivator={false}
+          activator={activator}
+        />,
+      );
+
+      expect(
+        getRectForNodeSpy.mock.calls.some(([node]) => node === input),
+      ).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Co-authored-by: Robin Drexler <robin.drexler@shopify.com>

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/2752
Fixes https://github.com/Shopify/polaris-react/issues/1415

When the activator of a Popover (or PositonedOverlay) contains an input element, the Overlay always uses said element to calculate its position and width/height.


### WHAT is this pull request doing?

Introduces a `preferInputActivator` prop to the `Popover` (and hence `PositonedOverlay` component). This prop would be `true` by default to not introduce a breaking change. 

   When it's `true`, the behavior does not change. The Overlay will continue to search for an `input`, and if it finds one, use it.  If the consumer sets the prop to `false`, the Overlay will never search for an `input` and always use the `activator` to calculate its dimensions.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

If you set the `preferActivatorInput` to false the Popover should expand to the size of the Textfield. By removing the property it should only have the width of the nested input node.

Before:
![image](https://user-images.githubusercontent.com/6481236/74778566-d661d180-5269-11ea-8593-ef1857f870c0.png)

After:
![image](https://user-images.githubusercontent.com/6481236/74778586-e24d9380-5269-11ea-8d4c-44a0d51172fe.png)



<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {SearchMinor} from '@shopify/polaris-icons';
import {Page, Popover, TextField, Checkbox, Icon} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Popover
        active
        onClose={() => {}}
        fullWidth
        preferredAlignment="left"
        preferInputActivator={false}
        activatorWrapper="span"
        activator={
          <div>
            <TextField
              label="TextField"
              onChange={() => {}}
              prefix={<Icon source={SearchMinor} color="inkLightest" />}
            />
          </div>
        }
      >
        <div>
          <Checkbox label="Salut" checked={false} onChange={() => {}} />
        </div>
      </Popover>
    </Page>
  );
}


```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
