### PR TITLE
[Frame, Navigation, AppProvider] elevate nested components and utils 

### DIFF
--- a/src/atomic.ts
+++ b/src/atomic.ts
@@ -1,0 +1,12 @@
+export {I18n, I18nContext} from './utilities/i18n';
+export {useToggle} from './utilities/use-toggle';
+export {navigationBarCollapsed} from './utilities/breakpoints';
+export {FrameContext, ToastID, ToastPropsWithID} from './utilities/frame';
+export {setRootProperty} from './utilities/set-root-property';
+export {useMediaQuery} from './utilities/media-query';
+
+export {layer, dataPolarisTopBar} from './components/shared';
+
+export {ToastManager, CSSAnimation} from './components/Frame/components';
+export {NavigationContext} from './components/Navigation/context';
+export {Secondary} from './components/Navigation/components/Item/components';

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,3 +36,6 @@ export {
   Tokens as UNSTABLE_Tokens,
 } from './utilities/theme';
 /* eslint-enable @typescript-eslint/camelcase */
+
+/* Atomic exports */
+export * from './atomic';


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
We are currently deep linking into the `esnext` folder for certain parts of the `Frame`, `Navigation` and `AppProvider`. Trying to create a new path that lets us expose subcomponents and utils that are needed to replicate top level components that are to be used with Polaris.

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

moves sub components and utils to a level that can be accessed via the proper `@shopify/polaris` import path.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

```
export {I18n, I18nContext} from './utilities/i18n';
export {useToggle} from './utilities/use-toggle';
export {navigationBarCollapsed} from './utilities/breakpoints';
export {FrameContext, ToastID, ToastPropsWithID} from './utilities/frame';
export {setRootProperty} from './utilities/set-root-property';
export {useMediaQuery} from './utilities/media-query';

export {layer, dataPolarisTopBar} from './components/shared';

export {ToastManager, CSSAnimation} from './components/Frame/components';
export {NavigationContext} from './components/Navigation/context';
export {Secondary} from './components/Navigation/components/Item/components';
```

```
/* Atomic exports */
export * from './atomic';
```

