### PR TITLE
♻️[Spinner] Do not render <span /> when there is no label

### DIFF
--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -63,14 +63,12 @@ export function Spinner({
 
   const spinnerSVG = size === 'large' ? spinnerLarge : spinnerSmall;
 
-  const spanAttributes = {
-    ...(!hasFocusableParent && {role: 'status'}),
-  };
-
-  const accessibilityLabelMarkup = (isAfterInitialMount ||
-    !hasFocusableParent) && (
-    <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>
-  );
+  const accessibilityLabelMarkup =
+    (isAfterInitialMount || !hasFocusableParent) && accessibilityLabel ? (
+      <span role={!hasFocusableParent ? 'status' : undefined}>
+        <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>
+      </span>
+    ) : null;
 
   return (
     <React.Fragment>
@@ -80,7 +78,7 @@ export function Spinner({
         className={className}
         draggable={false}
       />
-      <span {...spanAttributes}>{accessibilityLabelMarkup}</span>
+      {accessibilityLabelMarkup}
     </React.Fragment>
   );
 }

--- a/src/components/Spinner/tests/Spinner.test.tsx
+++ b/src/components/Spinner/tests/Spinner.test.tsx
@@ -8,13 +8,18 @@ import {VisuallyHidden} from '../../VisuallyHidden';
 
 describe('<Spinner />', () => {
   describe('accessibilityLabel', () => {
-    it('uses the label as the aria-label for the spinner', () => {
+    it('does not render by default', () => {
+      const spinner = mountWithApp(<Spinner />);
+      expect(spinner).not.toContainReactComponent(VisuallyHidden);
+    });
+
+    it('renders when provided', () => {
       const spinner = mountWithApp(
         <Spinner accessibilityLabel="Content is loading" />,
       );
-      expect(spinner.find(VisuallyHidden)).toContainReactText(
-        'Content is loading',
-      );
+      expect(spinner).toContainReactComponent(VisuallyHidden, {
+        children: 'Content is loading',
+      });
     });
   });
 
@@ -43,13 +48,24 @@ describe('<Spinner />', () => {
   });
 
   describe('role', () => {
+    const mockAccessibilityLabel = 'mock a11y label';
     it('sets the role to status to denote advisory information to screen readers when a live region is not active', () => {
-      const spinner = mountWithApp(<Spinner hasFocusableParent={false} />);
+      const spinner = mountWithApp(
+        <Spinner
+          accessibilityLabel={mockAccessibilityLabel}
+          hasFocusableParent={false}
+        />,
+      );
       expect(spinner).toContainReactComponentTimes('span', 1, {role: 'status'});
     });
 
     it('does not set role to status when a live region is active', () => {
-      const spinner = mountWithApp(<Spinner hasFocusableParent />);
+      const spinner = mountWithApp(
+        <Spinner
+          accessibilityLabel={mockAccessibilityLabel}
+          hasFocusableParent
+        />,
+      );
       expect(spinner).not.toContainReactComponent('span', {role: 'status'});
     });
   });


### PR DESCRIPTION
Just a small thing I noticed while using this component. `accessibilityLabel` is optional - but we are rendering the markup for it regardless. This PR changes the markup to only output the `span + VisuallyHidden` when `accessbilityLabel` is present.

It's possible that maybe the intention was to always render this empty `<span />` so that you can at least toggle the `role="status"` prop. If so, I feel that it would be better to replace the `React.Fragment` with that `span` so we wrap the entire component. Perhaps someone can enlighten me on the best practice for this `role` markup?