### PR TITLE
[Tag] Add optional onClick handler prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,8 @@
 
 ### Enhancements
 
+- Added optional `onClick` prop to `Tag` ([#2774](https://github.com/Shopify/polaris-react/pull/2774))
+
 ### Bug fixes
 
 - Fixed issue with passed to `ComboBox` component options prop was mutated ([#2818](https://github.com/Shopify/polaris-react/pull/2818))

--- a/src/components/Tag/README.md
+++ b/src/components/Tag/README.md
@@ -39,6 +39,20 @@ Use to allow merchants to add attributes to, and remove attributes from, an obje
 <Tag>Wholesale</Tag>
 ```
 
+### Clickable tag
+
+Use to allow merchants to add attributes to an object.
+
+```jsx
+<Tag
+  onClick={() => {
+    console.log('Clicked');
+  }}
+>
+  Wholesale
+</Tag>
+```
+
 <!-- content-for: android -->
 
 ![Tag for Android](/public_images/components/Tag/android/default@2x.png)

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -20,15 +20,62 @@ $icon-size: rem(16px);
     color: var(--p-text-disabled, color('ink', 'lightest'));
   }
 
-  .TagText {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+  &.clickable {
+    @include unstyled-button;
+    cursor: pointer;
+    padding: 0 spacing(tight);
+    background-color: color('sky');
 
-  @media (-ms-high-contrast: active) {
-    outline: 1px solid ms-high-contrast-color('text');
+    // Start - Delete below me during newDesignLanguage rollout
+    &:hover,
+    &:focus,
+    &:active {
+      background: color('sky', 'dark');
+    }
+    // End - Delete above me during newDesignLanguage rollout
+
+    &:disabled {
+      cursor: default;
+      pointer-events: none;
+      background: none;
+    }
+
+    // stylelint-disable selector-max-specificity
+    // stylelint-disable selector-max-class
+
+    &.newDesignLanguage {
+      background-color: var(--p-action-secondary);
+
+      &:hover {
+        background: var(--p-action-secondary-hovered);
+      }
+
+      @include focus-ring;
+
+      &:focus:not(:active) {
+        @include focus-ring($style: 'focused');
+      }
+
+      &:active {
+        background: var(--p-action-secondary-pressed);
+      }
+
+      &:disabled {
+        background: var(--p-action-secondary-disabled);
+      }
+      // stylelint-enable
+    }
   }
+}
+
+.TagText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (-ms-high-contrast: active) {
+  outline: 1px solid ms-high-contrast-color('text');
 }
 
 .Button {

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -8,19 +8,34 @@ import {useFeatures} from '../../utilities/features';
 
 import styles from './Tag.scss';
 
-export interface TagProps {
+export interface NonMutuallyExclusiveProps {
   /** Content to display in the tag */
   children?: string;
   /** Disables the tag  */
   disabled?: boolean;
-  /** Callback when tag is removed */
+  /** Callback when tag is clicked or keypressed */
+  onClick?(): void;
+  /** Callback when remove button is clicked or keypressed */
   onRemove?(): void;
 }
 
-export function Tag({children, disabled = false, onRemove}: TagProps) {
+export type TagProps = NonMutuallyExclusiveProps &
+  (
+    | {onClick?(): void; onRemove?: undefined}
+    | {onClick?: undefined; onRemove?(): void}
+  );
+
+export function Tag({children, disabled = false, onClick, onRemove}: TagProps) {
   const i18n = useI18n();
   const {newDesignLanguage} = useFeatures();
-  const className = classNames(disabled && styles.disabled, styles.Tag);
+
+  const className = classNames(
+    styles.Tag,
+    disabled && styles.disabled,
+    onClick && styles.clickable,
+    newDesignLanguage && styles.newDesignLanguage,
+  );
+
   const ariaLabel = i18n.translate('Polaris.Tag.ariaLabel', {
     children: children || '',
   });
@@ -30,21 +45,30 @@ export function Tag({children, disabled = false, onRemove}: TagProps) {
     newDesignLanguage && styles.newDesignLanguage,
   );
 
-  return (
+  const removeButton = onRemove ? (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      className={buttonClassName}
+      onClick={onRemove}
+      onMouseUp={handleMouseUpByBlurring}
+      disabled={disabled}
+    >
+      <Icon source={CancelSmallMinor} />
+    </button>
+  ) : null;
+
+  const tagMarkup = onClick ? (
+    <button disabled={disabled} className={className} onClick={onClick}>
+      {children}
+    </button>
+  ) : (
     <span className={className}>
       <span title={children} className={styles.TagText}>
         {children}
       </span>
-      <button
-        type="button"
-        aria-label={ariaLabel}
-        className={buttonClassName}
-        onClick={onRemove}
-        onMouseUp={handleMouseUpByBlurring}
-        disabled={disabled}
-      >
-        <Icon source={CancelSmallMinor} />
-      </button>
+      {removeButton}
     </span>
   );
+  return tagMarkup;
 }

--- a/src/components/Tag/tests/Tag.test.tsx
+++ b/src/components/Tag/tests/Tag.test.tsx
@@ -5,16 +5,41 @@ import {mountWithApp} from 'test-utilities';
 import {Tag} from '../Tag';
 
 describe('<Tag />', () => {
-  it('calls onRemove when remove button is clicked', () => {
-    const spy = jest.fn();
-    const tag = mountWithAppProvider(<Tag onRemove={spy} />);
-    tag.find('button').simulate('click');
-    expect(spy).toHaveBeenCalled();
+  describe('onRemove', () => {
+    it('calls onRemove when remove button is clicked', () => {
+      const spy = jest.fn();
+      const tag = mountWithAppProvider(<Tag onRemove={spy} />);
+      tag.find('button').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('does not call onRemove when remove button is disabled', () => {
+      const spy = jest.fn();
+      const tag = mountWithAppProvider(<Tag onRemove={spy} disabled />);
+      tag.find('button').simulate('click');
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onClick', () => {
+    it('calls onClick when tag is clicked', () => {
+      const spy = jest.fn();
+      const tag = mountWithAppProvider(<Tag onClick={spy} />);
+      tag.find('button').simulate('click');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('does not call onClick when disabled', () => {
+      const spy = jest.fn();
+      const tag = mountWithAppProvider(<Tag onClick={spy} disabled />);
+      tag.find('button').simulate('click');
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 
   describe('newDesignLanguage', () => {
     it('adds a newDesignLanguage class when newDesignLanguage is enabled', () => {
-      const tag = mountWithApp(<Tag />, {
+      const tag = mountWithApp(<Tag onRemove={() => null} />, {
         features: {newDesignLanguage: true},
       });
       expect(tag).toContainReactComponent('button', {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/2772

Exposing an optional `onClick` handler to enable consumers to handle tag actions differently than an explicit remove.  

Because `onRemove` is optional, it had to be prioritized for backwards compatibility.

### WHAT is this pull request doing?

cc @tmlayton for design language 🌈 👀 and @sarahill for UI Kit  🖌🎨👀 

|Current|Light mode|Dark mode|
|---|---|---|
|<img width="389" alt="Screen Shot 2020-03-03 at 4 38 45 PM" src="https://user-images.githubusercontent.com/18447883/75822270-b522da00-5d6d-11ea-8ee5-6019359629bb.png">|<img width="384" alt="Screen Shot 2020-03-03 at 4 38 13 PM" src="https://user-images.githubusercontent.com/18447883/75822285-bbb15180-5d6d-11ea-95a8-d28fe8530277.png">|<img width="389" alt="Screen Shot 2020-03-03 at 4 38 33 PM" src="https://user-images.githubusercontent.com/18447883/75822303-c1a73280-5d6d-11ea-809e-88c636dba9ef.png">|

For the **enabled** states, only one handler is called based on the optional props passed, for example:
- When both the `onClick` and `onRemove` are passed, the component will have a typings error
- When `onClick` is passed, `onClick` handler is called
- When `onRemove` is passed, `onRemove` handler is called

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Tag, Stack} from '../src';

export function Playground() {
  const onClick = () => console.log('Clicking');
  const onRemove = () => console.log('Removing');

  return (
    <Page title="Playground">
      <Stack vertical>
        <Stack alignment="center">
          <h2>Enabled tags:</h2>
          <Tag onRemove={onRemove}>Has onRemove</Tag>
          <Tag onClick={onClick}>Has onClick</Tag>
        </Stack>
        <Stack>
          <h2>Disabled tags:</h2>
          <Tag onRemove={onRemove} disabled>
            Has onRemove
          </Tag>
          <Tag onClick={onClick} disabled>
            Has onClick
          </Tag>
        </Stack>
      </Stack>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
