### PR TITLE
Added high contrast outline to focus ring mixin

### DIFF
--- a/src/styles/_common.scss
+++ b/src/styles/_common.scss
@@ -18,6 +18,7 @@
 @import './foundation/typography';
 @import './foundation/z-index';
 @import './foundation/focus-ring';
+@import './foundation/accessibility';
 
 @import './shared/accessibility';
 @import './shared/breakpoints';

--- a/src/styles/foundation/_accessibility.scss
+++ b/src/styles/foundation/_accessibility.scss
@@ -1,0 +1,5 @@
+@mixin high-contrast-outline {
+  @media (-ms-high-contrast: active) {
+    outline: 1px solid ms-high-contrast-color('text');
+  }
+}

--- a/src/styles/foundation/_focus-ring.scss
+++ b/src/styles/foundation/_focus-ring.scss
@@ -1,3 +1,6 @@
+// stylelint-disable-next-line scss/partial-no-import
+@import './accessibility';
+
 /// Sets the focus ring for an interactive element
 /// @param {String} $size - The size of the border radius on the focus ring.
 /// @param {String} $style - Focus ring state.

--- a/src/styles/foundation/_focus-ring.scss
+++ b/src/styles/foundation/_focus-ring.scss
@@ -34,6 +34,7 @@
   } @else if $style == 'focused' {
     &::after {
       box-shadow: 0 0 0 $stroke var(--p-focused);
+      @include high-contrast-outline;
     }
   }
 }

--- a/src/styles/shared/_accessibility.scss
+++ b/src/styles/shared/_accessibility.scss
@@ -14,3 +14,9 @@
   border: 0 !important;
   // stylelint-enable declaration-no-important
 }
+
+@mixin high-contrast-outline {
+  @media (-ms-high-contrast: active) {
+    outline: 1px solid ms-high-contrast-color('text');
+  }
+}

--- a/src/styles/shared/_accessibility.scss
+++ b/src/styles/shared/_accessibility.scss
@@ -14,9 +14,3 @@
   border: 0 !important;
   // stylelint-enable declaration-no-important
 }
-
-@mixin high-contrast-outline {
-  @media (-ms-high-contrast: active) {
-    outline: 1px solid ms-high-contrast-color('text');
-  }
-}


### PR DESCRIPTION
### WHY are these changes introduced?

*accessibility*

### WHAT is this pull request doing?

* Creating a mixin to apply outline in windows high contrast

### How to 🎩

View focus states in windows high contrast

### Image
![Image 2020-02-25 at 5 22 25 PM](https://user-images.githubusercontent.com/24610840/75293214-c448db80-57f3-11ea-81b7-5d52da3b3fb1.png)
