### PR TITLE
[OptionList] Export OptionListProps

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,6 +26,7 @@
 - Added first implementation of custom property validation ([#2616](https://github.com/Shopify/polaris-react/pull/2616))
 - Refactored consumer build test (renamed to system integration test) ([#2735](https://github.com/Shopify/polaris-react/pull/2735))
 - Added Storybook Knobs for customizing theme ([#2674](https://github.com/Shopify/polaris-react/pull/2674))
+- Export missing OptionListProps ([#2777](https://github.com/Shopify/polaris-react/pull/2777))
 
 ### Dependency upgrades
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,7 +26,7 @@
 - Added first implementation of custom property validation ([#2616](https://github.com/Shopify/polaris-react/pull/2616))
 - Refactored consumer build test (renamed to system integration test) ([#2735](https://github.com/Shopify/polaris-react/pull/2735))
 - Added Storybook Knobs for customizing theme ([#2674](https://github.com/Shopify/polaris-react/pull/2674))
-- Export missing OptionListProps ([#2777](https://github.com/Shopify/polaris-react/pull/2777))
+- Exported missing OptionListProps ([#2777](https://github.com/Shopify/polaris-react/pull/2777))
 
 ### Dependency upgrades
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -124,7 +124,7 @@ export {
   isNavigationItemActive,
 } from './Navigation';
 
-export {OptionList} from './OptionList';
+export {OptionList, OptionListProps} from './OptionList';
 
 export {Page, PageProps} from './Page';
 


### PR DESCRIPTION
### WHY are these changes introduced?

Wanting to reference the type of an OptionList prop we noticed that OptionListProps wasn't being exported. Looking at `src/components/index.ts` it's seemingly just an omission since the props type of other components are exported.

### WHAT is this pull request doing?

`OptionsListProps` is added to the exports.