### PR TITLE
[TextField] Remove redundant null check

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,4 +14,6 @@
 
 ### Code quality
 
+- Removed redundant null check in `TextField` ([#2783](https://github.com/Shopify/polaris-react/pull/2783))
+
 ### Deprecations

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -490,9 +490,7 @@ export function TextField({
 }
 
 function normalizeAutoComplete(autoComplete?: boolean | string) {
-  if (autoComplete == null) {
-    return autoComplete;
-  } else if (autoComplete === true) {
+  if (autoComplete === true) {
     return 'on';
   } else if (autoComplete === false) {
     return 'off';


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

There is a redundant `null` check in `<TextField />`'s `normalizeAutocomplete` function. It should already be covered by

```typescript
else {
  return autocomplete;
}
```

### WHAT is this pull request doing?

The redundant condition is removed.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
