### PR TITLE
[Button] Nest split button example in tall enough <div>

### DIFF
--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -321,15 +321,17 @@ function DisclosureButtion() {
 Use when there is only one primary action but other related actions can be taken.
 
 ```jsx
-<Button
-  primary
-  connectedDisclosure={{
-    accessibilityLabel: 'Other save actions',
-    actions: [{content: 'Save as draft'}],
-  }}
->
-  Save
-</Button>
+<div style={{height: '100px'}}>
+  <Button
+    primary
+    connectedDisclosure={{
+      accessibilityLabel: 'Other save actions',
+      actions: [{content: 'Save as draft'}],
+    }}
+  >
+    Save
+  </Button>
+</div>
 ```
 
 ### Disabled state


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
The example currently does not render well when the button dropdown is clicked, as it renders past the boundaries of the host div, and is obscured. Due to this, it appears that the button is broken and does nothing.

### WHAT is this pull request doing?

This follows the pattern in <Autocomplete />'s README and hosts the example in a div with enough height.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/8219340/75488682-cab78e80-597e-11ea-9d9e-00750d817dbf.png)|![image](https://user-images.githubusercontent.com/8219340/75488607-abb8fc80-597e-11ea-991d-7476fd0d411e.png)|

### 🎩 checklist

* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
