### PR TITLE
Improve build-consumer.js' robustness

### DIFF
--- a/scripts/build-consumer.js
+++ b/scripts/build-consumer.js
@@ -1,12 +1,14 @@
 /* eslint-disable no-console */
 
 const {resolve} = require('path');
-const {cp, mkdir, rm} = require('shelljs');
+const {config, cp, mkdir, rm} = require('shelljs');
 
 const packageJSON = require('../package.json');
 
 const root = resolve(__dirname, '..');
 const projectDir = process.argv[2];
+
+config.fatal = true;
 
 if (!projectDir) {
   console.log(

--- a/scripts/build-consumer.js
+++ b/scripts/build-consumer.js
@@ -33,7 +33,7 @@ console.log('Cleaning up old build...');
 rm('-rf', projectPolarisDir);
 
 console.log('Creating new build directory...');
-mkdir(projectPolarisDir);
+mkdir('-p', projectPolarisDir);
 
 console.log('Copying build to node_modules...');
 cp('-R', files, projectPolarisDir);


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

If a developer is following the instructions in the ["Tophatting Documentation" guide](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md), but has never run `dev up` on `Shopify/polaris-styleguide`, an error will occur, but the build script will continue as if everything is fine.

```
Cleaning up old build...
Creating new build directory...
mkdir: no such file or directory: /Users/sambostock/src/github.com/Shopify/polaris-styleguide/node_modules/@shopify
Copying build to node_modules...
cp: dest is not a directory (too many sources)
Build copied to consuming project. You can now run the consuming app and it will include your changes from Polaris.
✨  Done in 50.34s.
```

### WHAT is this pull request doing?

This enables the `config.fatal` setting for `shelljs`, so errors are noisy, and then fixes the `mkdir` error by adding the `-p` flag.

### 🎩 checklist

* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
