### PR TITLE
[ThemeProvider] Allow passing in a custom config

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "@shopify/app-bridge": "^1.3.0",
     "@shopify/javascript-utilities": "^2.4.1",
     "@shopify/polaris-icons": "^3.9.0",
-    "@shopify/polaris-tokens": "^2.8.1",
+    "@shopify/polaris-tokens": "^2.8.2",
     "@shopify/useful-types": "^1.2.4",
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/react": "^16.8.15",

--- a/src/utilities/theme/types.ts
+++ b/src/utilities/theme/types.ts
@@ -1,3 +1,5 @@
+import {Config} from '@shopify/polaris-tokens/dist-modern/types';
+
 export interface ThemeLogo {
   /** Provides a path for a logo used on a dark background */
   topBarSource?: string;
@@ -49,6 +51,7 @@ export interface ThemeConfig {
   logo?: ThemeLogo;
   colors?: Partial<RoleColors> & LegacyColors;
   colorScheme?: ColorScheme;
+  config?: Config;
 }
 
 export type CustomPropertiesLike = Record<string, string>;

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -18,10 +18,10 @@ export function buildCustomProperties(
   newDesignLanguage: boolean,
   tokens?: Record<string, string>,
 ): CustomPropertiesLike {
-  const {colors = {}, colorScheme} = themeConfig;
+  const {colors = {}, colorScheme, config} = themeConfig;
   return newDesignLanguage
     ? customPropertyTransformer({
-        ...colorFactory(colors, colorScheme),
+        ...colorFactory(colors, colorScheme, config),
         ...tokens,
       })
     : buildLegacyColors(themeConfig);

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -1,5 +1,7 @@
 import tokens from '@shopify/polaris-tokens';
 import {colorFactory} from '@shopify/polaris-tokens/dist-modern';
+import {mergeConfigs} from '@shopify/polaris-tokens/dist-modern/utils';
+import {config as base} from '@shopify/polaris-tokens/dist-modern/configs/base';
 import {HSLColor, HSLAColor} from '../color-types';
 import {colorToHsla, hslToString, hslToRgb} from '../color-transformers';
 import {isLight} from '../color-validation';
@@ -19,9 +21,11 @@ export function buildCustomProperties(
   tokens?: Record<string, string>,
 ): CustomPropertiesLike {
   const {colors = {}, colorScheme, config} = themeConfig;
+  const mergedConfig = mergeConfigs(base, config || {});
+
   return newDesignLanguage
     ? customPropertyTransformer({
-        ...colorFactory(colors, colorScheme, config),
+        ...colorFactory(colors, colorScheme, mergedConfig),
         ...tokens,
       })
     : buildLegacyColors(themeConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1589,10 +1589,10 @@
   resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-3.9.0.tgz#7064b234824788972593efcda9ae7b87f2a2da43"
   integrity sha512-isGvHpkH57IsQl6iAZA81LaIPdGi8gNSON5hLWXSERvP9SwgTenfDrkOD3UvzLY09Hh7m8lkFBMUVv/ta33xrg==
 
-"@shopify/polaris-tokens@^2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.8.1.tgz#be1648f22a80f6d21c6b24b7d94847a05d5d1a3c"
-  integrity sha512-MxNSdaVsLlTYmTSzDDiME7b2blx7sWz0Qw51w0LUWSB4bE+iRfFCioXJVY7ky2fdloTJQfuS+eUDZlds5GLfqQ==
+"@shopify/polaris-tokens@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.8.2.tgz#e99f0f91a1a45bfe17edafcf1ba81d6187eae557"
+  integrity sha512-Sd3PT33vewl5lgAMu09tBR3lxipjO1xgxLlt3W3bqbJb0uSuQKPJgA4nqgJMZ1+zzqL5NpglU8g+h3hGUcdQVw==
   dependencies:
     hsluv "^0.1.0"
     tslib "^1.10.0"


### PR DESCRIPTION
### WHY are these changes introduced?

If needed, gives 100% control over color via the blessed path. Fixes https://github.com/Shopify/polaris-ux/issues/399

### WHAT is this pull request doing?

Adding a `config` prop on the `ThemeProvider` and merging its value with the base config from Polaris Tokens. This either overwrites existing variants or adds new ones.

Allows for very custom color like the gif below while adhering to the color system fundamentals.

### Example

![button](https://user-images.githubusercontent.com/344839/75501612-5df3c280-5985-11ea-8538-b956b93a9972.gif)

```tsx
<ThemeProvider
  theme={{
    colors: {primary: '#d0f224'},
    config: {
      primary: [
        {
          name: 'actionPrimary',
          light: {lightness: 90.3},
          dark: {lightness: 90.3},
        },
        {
          name: 'actionPrimaryHovered',
          light: {lightness: 81.3},
          dark: {lightness: 81.3},
        },
        {
          name: 'actionPrimaryPressed',
          light: {lightness: 72.3},
          dark: {lightness: 72.3},
        },
        {
          name: 'textOnPrimary',
          light: {lightness: 0},
          dark: {lightness: 0},
        },
      ],
    },
  }}
>
  <Button primary>Shopify Plus</Button>
</ThemeProvider>
```

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```tsx
import React from 'react';
import {Page, ThemeProvider, Button} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <ThemeProvider
        theme={{
          colors: {primary: '#d0f224'},
          config: {
            primary: [
              {
                name: 'actionPrimary',
                light: {lightness: 90.3},
                dark: {lightness: 90.3},
              },
              {
                name: 'actionPrimaryHovered',
                light: {lightness: 81.3},
                dark: {lightness: 81.3},
              },
              {
                name: 'actionPrimaryPressed',
                light: {lightness: 72.3},
                dark: {lightness: 72.3},
              },
              {
                name: 'textOnPrimary',
                light: {lightness: 0},
                dark: {lightness: 0},
              },
            ],
          },
        }}
      >
        <Button primary>Shopify Plus</Button>
      </ThemeProvider>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
