### PR TITLE
Removed linear-gradient from var

### DIFF
--- a/src/components/Filters/Filters.scss
+++ b/src/components/Filters/Filters.scss
@@ -87,9 +87,9 @@ $seperator-color: var(--p-border, color('sky'));
 
   &:hover {
     cursor: pointer;
-    background-image: var(
-      --p-override-none,
-      linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3))
+    background-image: linear-gradient(
+      rgba(223, 227, 232, 0.3),
+      rgba(223, 227, 232, 0.3)
     );
     background-color: var(--p-surface-hovered);
   }
@@ -97,14 +97,19 @@ $seperator-color: var(--p-border, color('sky'));
   &:focus {
     outline: none;
     box-shadow: inset 0.2rem 0 0 var(--p-override-none, color('indigo'));
-    background-image: var(
-      --p-override-none,
-      linear-gradient(rgba(223, 227, 232, 0.3), rgba(223, 227, 232, 0.3))
+    background-image: linear-gradient(
+      rgba(223, 227, 232, 0.3),
+      rgba(223, 227, 232, 0.3)
     );
   }
 
   &.newDesignLanguage {
     @include focus-ring;
+
+    &:focus,
+    &:hover {
+      background-image: none;
+    }
 
     // stylelint-disable-next-line selector-max-specificity
     &:focus:not(:active) {


### PR DESCRIPTION
### WHY are these changes introduced?

linear-gradients can cause performance issues in safari

