### PR TITLE
[Dropzone][Filters][Tag][Pagination][PageActions] Fixed high contrast issues

### DIFF
--- a/src/components/ActionMenu/components/MenuAction/MenuAction.scss
+++ b/src/components/ActionMenu/components/MenuAction/MenuAction.scss
@@ -65,6 +65,7 @@ $difference-between-touch-area-and-backdrop: control-height() -
 
     &:hover {
       background: var(--p-action-secondary-hovered);
+      @include high-contrast-outline;
     }
 
     &:focus {

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -185,6 +185,10 @@ $dropzone-stacking-order: (
         @include reset-after;
       }
     }
+
+    &:hover {
+      @include high-contrast-outline;
+    }
   }
 
   .Container {

--- a/src/components/Filters/Filters.scss
+++ b/src/components/Filters/Filters.scss
@@ -110,6 +110,10 @@ $seperator-color: var(--p-border, color('sky'));
     &:focus:not(:active) {
       @include focus-ring($style: 'focused');
     }
+
+    &:hover {
+      @include high-contrast-outline;
+    }
   }
 }
 

--- a/src/components/Pagination/Pagination.scss
+++ b/src/components/Pagination/Pagination.scss
@@ -109,6 +109,7 @@ $stacking-order: (
 
       &:hover {
         background: var(--p-action-secondary-hovered);
+        @include high-contrast-outline;
       }
 
       &:active {
@@ -211,6 +212,7 @@ $stacking-order: (
 
     &:hover {
       background: var(--p-action-secondary-hovered);
+      @include high-contrast-outline;
     }
 
     &:focus {

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -64,6 +64,7 @@ $icon-size: rem(16px);
 
     &:hover {
       background: var(--p-action-secondary-hovered);
+      @include high-contrast-outline;
     }
 
     &:focus {

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -78,6 +78,7 @@
     &:hover {
       background: var(--p-action-secondary-hovered);
       border-color: transparent;
+      @include high-contrast-outline;
     }
 
     &:focus {


### PR DESCRIPTION
### WHY are these changes introduced?

New design language project

### WHAT is this pull request doing?

Adding high contrast outlines

### Gifs

#### Dropzone
![Screen Recording 2020-03-02 at 03 39 PM](https://user-images.githubusercontent.com/24610840/75718116-62c7b780-5ca0-11ea-836e-f55becc2d583.gif)

#### Filters
![Screen Recording 2020-03-02 at 03 45 PM](https://user-images.githubusercontent.com/24610840/75718123-64917b00-5ca0-11ea-9f1c-c870353ad11b.gif)

#### Tag
![Screen Recording 2020-03-02 at 03 48 PM](https://user-images.githubusercontent.com/24610840/75718128-665b3e80-5ca0-11ea-8d3c-7bc6c4ba36c8.gif)

#### Pagination
![Screen Recording 2020-03-02 at 03 51 PM](https://user-images.githubusercontent.com/24610840/75718131-68250200-5ca0-11ea-93be-04d39719b4bc.gif)

#### PageActions
![Screen Recording 2020-03-02 at 03 52 PM](https://user-images.githubusercontent.com/24610840/75718138-69eec580-5ca0-11ea-8fcc-d7726729f6da.gif)
![Screen Recording 2020-03-02 at 03 12 PM](https://user-images.githubusercontent.com/24610840/75718143-6bb88900-5ca0-11ea-928c-e5b120b80a0d.gif)

### Notes

- You may notice a blue outline, inside a white outline. This blue outline is only shown in chromium edge, so we need the white outline as well for backward compatibility.