### PR TITLE
Omit AppProvider from some examples

### DIFF
--- a/.storybook/polaris-readme-loader.js
+++ b/.storybook/polaris-readme-loader.js
@@ -24,13 +24,22 @@ module.exports = function loader(source) {
 
   const readme = parseCodeExamples(source);
 
-  const testIndividualExamples = ['Modal', 'Card'].includes(readme.name);
+  const testIndividualExamples = [
+    'Modal',
+    'Card',
+    'Top bar',
+    'App provider',
+    'Contextual save bar',
+    'Frame',
+    'Loading',
+    'Sheet',
+  ].includes(readme.name);
 
   const csfExports = readme.examples.map((example) => {
     return `
 const ${example.storyName}Component = (${example.code})();
 export function ${example.storyName}() {
-  return <${example.storyName}Component/>;
+  return <${example.storyName}Component key="${readme.name}"/>;
 }
 ${example.storyName}.story = {
   name: ${JSON.stringify(example.name)},

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -35,14 +35,6 @@ const COMPONENTS_TO_OMIT_APP_PROVIDER = [
 ];
 
 function AppProviderWithKnobs({newDesignLanguage, colorScheme, children}) {
-  const colors = Object.entries(DefaultThemeColors).reduce(
-    (accumulator, [key, value]) => ({
-      ...accumulator,
-      [key]: strToHex(color(key, value, 'Theme')),
-    }),
-    {},
-  );
-
   const componentName = (() => {
     try {
       return children.props.children.key;
@@ -51,9 +43,17 @@ function AppProviderWithKnobs({newDesignLanguage, colorScheme, children}) {
     }
   })();
 
-  return COMPONENTS_TO_OMIT_APP_PROVIDER.includes(componentName) ? (
-    children
-  ) : (
+  if (COMPONENTS_TO_OMIT_APP_PROVIDER.includes(componentName)) return children;
+
+  const colors = Object.entries(DefaultThemeColors).reduce(
+    (accumulator, [key, value]) => ({
+      ...accumulator,
+      [key]: strToHex(color(key, value, 'Theme')),
+    }),
+    {},
+  );
+
+  return (
     <AppProvider
       i18n={enTranslations}
       features={{newDesignLanguage}}

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -27,6 +27,13 @@ function StrictModeToggle({isStrict = false, children}) {
   return <Wrapper>{children}</Wrapper>;
 }
 
+const COMPONENTS_TO_OMIT_APP_PROVIDER = [
+  'Top bar',
+  'App provider',
+  'Contextual save bar',
+  'Frame',
+];
+
 function AppProviderWithKnobs({newDesignLanguage, colorScheme, children}) {
   const colors = Object.entries(DefaultThemeColors).reduce(
     (accumulator, [key, value]) => ({
@@ -36,7 +43,17 @@ function AppProviderWithKnobs({newDesignLanguage, colorScheme, children}) {
     {},
   );
 
-  return (
+  const componentName = (() => {
+    try {
+      return children.props.children.key;
+    } catch (e) {
+      return undefined;
+    }
+  })();
+
+  return COMPONENTS_TO_OMIT_APP_PROVIDER.includes(componentName) ? (
+    children
+  ) : (
     <AppProvider
       i18n={enTranslations}
       features={{newDesignLanguage}}

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@
 
 - Added `check:custom-property` job in travis ([#2778](https://github.com/Shopify/polaris-react/pull/2778))
 - Exported missing OptionListProps ([#2777](https://github.com/Shopify/polaris-react/pull/2777))
+- Omitted the Storybook `AppProvider` decorator for examples which already contain an `AppProvider` ([#2807](https://github.com/Shopify/polaris-react/pull/2807))
 
 ### Dependency upgrades
 


### PR DESCRIPTION
### WHY are these changes introduced?

Unblocks #2756. Some examples already contain an AppProvider so we want to omit the AppProvider added by the contexts decorator.

### WHAT is this pull request doing?

Creates an omit list for components’ stories which already have AppProvider’s in their examples. This applies to certain "All examples" stories, too. There were also a few other "All examples" stories which we should never have rendered like top bar, sheet, loading, etc which have fixed position elements thus the elements in each story were stacking on top of each other.

### Considerations for review

This is a step forward in the quality of stories, although a better solution would remove the "New Design Language" context for stories which don’t support it. That requires some extra hoop jumping and given the temporary nature of the "New Design Language" context, I opted for a minimally invasive approach.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

- Check out stories both with and without an AppProvider

### 🎩 checklist

- [x] 🎩 