### PR TITLE
[Color system] consume new design language in footer help

### DIFF
--- a/src/components/FooterHelp/FooterHelp.scss
+++ b/src/components/FooterHelp/FooterHelp.scss
@@ -19,16 +19,20 @@ $border-radius: 999px;
   display: inline-flex;
   align-items: center;
   padding: spacing() spacing(loose) spacing() spacing();
-  border-top: border();
-  border-bottom: border();
+  border-top: var(--p-override-none, border());
+  border-bottom: var(--p-override-none, border());
   width: 100%;
   justify-content: center;
 
   @include page-content-when-not-fully-condensed {
     width: auto;
-    border: border();
-    border-radius: $border-radius;
+    border: var(--p-override-none, border());
+    border-radius: var(--p-override-none, $border-radius);
   }
+}
+
+.newDesignLanguage .Content {
+  padding: spacing(loose) spacing(loose) spacing(loose) spacing();
 }
 
 .Icon {

--- a/src/components/FooterHelp/FooterHelp.tsx
+++ b/src/components/FooterHelp/FooterHelp.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import {QuestionMarkMajorTwotone} from '@shopify/polaris-icons';
+import {QuestionMarkMajorTwotone, InfoMinor} from '@shopify/polaris-icons';
 import {useFeatures} from '../../utilities/features';
 import {classNames} from '../../utilities/css';
+import {IconProps} from '../../types';
 import {Icon} from '../Icon';
 import styles from './FooterHelp.scss';
 
@@ -17,11 +18,17 @@ export function FooterHelp({children}: FooterHelpProps) {
     newDesignLanguage && styles.newDesignLanguage,
   );
 
+  const iconProps: IconProps = {
+    source: newDesignLanguage ? InfoMinor : QuestionMarkMajorTwotone,
+    color: newDesignLanguage ? 'highlight' : 'teal',
+    backdrop: !newDesignLanguage,
+  };
+
   return (
     <div className={className}>
       <div className={styles.Content}>
         <div className={styles.Icon}>
-          <Icon source={QuestionMarkMajorTwotone} color="teal" backdrop />
+          <Icon {...iconProps} />
         </div>
         <div className={styles.Text}>{children}</div>
       </div>

--- a/src/components/FooterHelp/FooterHelp.tsx
+++ b/src/components/FooterHelp/FooterHelp.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import {QuestionMarkMajorTwotone} from '@shopify/polaris-icons';
+import {useFeatures} from '../../utilities/features';
+import {classNames} from '../../utilities/css';
 import {Icon} from '../Icon';
 import styles from './FooterHelp.scss';
 
@@ -9,8 +11,14 @@ export interface FooterHelpProps {
 }
 
 export function FooterHelp({children}: FooterHelpProps) {
+  const {newDesignLanguage} = useFeatures();
+  const className = classNames(
+    styles.FooterHelp,
+    newDesignLanguage && styles.newDesignLanguage,
+  );
+
   return (
-    <div className={styles.FooterHelp}>
+    <div className={className}>
       <div className={styles.Content}>
         <div className={styles.Icon}>
           <Icon source={QuestionMarkMajorTwotone} color="teal" backdrop />

--- a/src/components/FooterHelp/tests/FooterHelp.test.tsx
+++ b/src/components/FooterHelp/tests/FooterHelp.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {QuestionMarkMajorTwotone} from '@shopify/polaris-icons';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {Icon} from 'components';
 import {FooterHelp} from '../FooterHelp';
 
@@ -20,5 +21,25 @@ describe('<FooterHelp />', () => {
 
   it('renders the help icon', () => {
     expect(footerHelp.find(Icon).prop('source')).toBe(QuestionMarkMajorTwotone);
+  });
+
+  describe('newDesignLanguage', () => {
+    it('adds a newDesignLanguage class when newDesignLanguage is enabled', () => {
+      const footerHelp = mountWithApp(<FooterHelp />, {
+        features: {newDesignLanguage: true},
+      });
+      expect(footerHelp).toContainReactComponent('div', {
+        className: 'FooterHelp newDesignLanguage',
+      });
+    });
+
+    it('does not add a newDesignLanguage class when newDesignLanguage is disabled', () => {
+      const footerHelp = mountWithApp(<FooterHelp />, {
+        features: {newDesignLanguage: false},
+      });
+      expect(footerHelp).not.toContainReactComponent('div', {
+        className: 'FooterHelp newDesignLanguage',
+      });
+    });
   });
 });


### PR DESCRIPTION
|Old DL|New DL - light|New DL - dark|New DL - box
|-|-|-|-|
|<img width="457" alt="Screen Shot 2020-03-10 at 10 11 34 AM" src="https://user-images.githubusercontent.com/1403188/76320971-c6ad3a00-62b7-11ea-8381-6593802f6cc9.png">|<img width="387" alt="Screen Shot 2020-03-10 at 10 11 08 AM" src="https://user-images.githubusercontent.com/1403188/76321000-d298fc00-62b7-11ea-89b9-4fbcb48aa91b.png">|<img width="444" alt="Screen Shot 2020-03-10 at 10 11 46 AM" src="https://user-images.githubusercontent.com/1403188/76321058-e2b0db80-62b7-11ea-9d9a-1622706d7203.png">|<img width="572" alt="Screen Shot 2020-03-10 at 10 11 17 AM" src="https://user-images.githubusercontent.com/1403188/76321088-ec3a4380-62b7-11ea-8d8a-3fb5f635b0e8.png">|

Figma: https://www.figma.com/file/4dAAt5iFPSaxUKiYVKrkYj/DL%E2%80%93Polaris-(Web)%3A-Components?node-id=931%3A63

Addresses https://github.com/Shopify/polaris-ux/issues/401