### PR TITLE
[Color system] consume design language in keyboard key

### DIFF
--- a/src/components/KeyboardKey/KeyboardKey.scss
+++ b/src/components/KeyboardKey/KeyboardKey.scss
@@ -8,16 +8,16 @@ $bottom-shadow-size: 2px;
   height: $key-base-height;
   margin: 0 (spacing(extra-tight) / 2) $bottom-shadow-size;
   padding: 0 spacing(extra-tight);
-  background-color: color('white', 'base');
-  box-shadow: 0 0 0 1px color('sky', 'dark'),
-    0 $bottom-shadow-size 0 0 color('white'),
-    0 $bottom-shadow-size 0 1px color('sky', 'dark');
-  border-radius: border-radius();
+  background-color: var(--p-surface, color('white', 'base'));
+  box-shadow: 0 0 0 1px var(--p-border-subdued, color('sky', 'dark')),
+    0 $bottom-shadow-size 0 0 var(--p-surface, color('white')),
+    0 $bottom-shadow-size 0 1px var(--p-border-subdued, color('sky', 'dark'));
+  border-radius: var(--p-border-radius-base, border-radius());
   font-family: font-family();
   font-size: rem(12px);
   font-weight: 500;
   line-height: $key-base-height;
-  color: color('ink', 'lighter');
+  color: var(--p-text-subdued, color('ink', 'lighter'));
   text-align: center;
   min-width: $key-base-height;
   user-select: none;


### PR DESCRIPTION
|Old DL|New DL - light|New DL - dark|
|-|-|-|
|<img width="39" alt="Screen Shot 2020-03-10 at 10 28 30 AM" src="https://user-images.githubusercontent.com/1403188/76322742-24db1c80-62ba-11ea-9c69-015805d58a98.png">|<img width="39" alt="Screen Shot 2020-03-10 at 10 28 35 AM" src="https://user-images.githubusercontent.com/1403188/76322761-2b699400-62ba-11ea-9aa0-2efbc1432cad.png">|<img width="43" alt="Screen Shot 2020-03-10 at 10 28 41 AM" src="https://user-images.githubusercontent.com/1403188/76322785-315f7500-62ba-11ea-8598-7a85e9c59526.png">|

Addresses https://github.com/Shopify/polaris-ux/issues/402