### PR TITLE
[Popover] Revert to type assertion to handle SVGElements

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,7 +10,7 @@
 ### Bug fixes
 
 - Fixed issue with passed to `ComboBox` component options prop was mutated ([#2818](https://github.com/Shopify/polaris-react/pull/2818))
-- Revert to type assertion in `PopoverOverlay` to handle SVGElements ([#2827]https://github.com/Shopify/polaris-react/pull/2827)
+- Fixed an issue which caused `Popover` to close when clicking on a descendant SVG ([#2827](https://github.com/Shopify/polaris-react/pull/2827))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,7 @@
 ### Bug fixes
 
 - Fixed issue with passed to `ComboBox` component options prop was mutated ([#2818](https://github.com/Shopify/polaris-react/pull/2818))
+- Revert to type assertion in `PopoverOverlay` to handle SVGElements ([#2827]https://github.com/Shopify/polaris-react/pull/2827)
 
 ### Documentation
 

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -242,18 +242,15 @@ export class PopoverOverlay extends React.PureComponent<
   };
 
   private handleClick = (event: Event) => {
-    const target = event.target;
+    const target = event.target as HTMLElement;
     const {
       contentNode,
       props: {activator, onClose},
     } = this;
     const isDescendant =
-      target instanceof HTMLElement &&
       contentNode.current != null &&
       nodeContainsDescendant(contentNode.current, target);
-    const isActivatorDescendant =
-      target instanceof HTMLElement &&
-      nodeContainsDescendant(activator, target);
+    const isActivatorDescendant = nodeContainsDescendant(activator, target);
     if (
       isDescendant ||
       isActivatorDescendant ||

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
-import {TextContainer} from 'components';
+import {
+  mountWithAppProvider,
+  ReactWrapper,
+  trigger,
+} from 'test-utilities/legacy';
+import {TextContainer, TextField, EventListener} from 'components';
 import {Key} from '../../../../../types';
 import {PositionedOverlay} from '../../../../PositionedOverlay';
 import {PopoverOverlay} from '../PopoverOverlay';
@@ -178,6 +182,72 @@ describe('<PopoverOverlay />', () => {
 
     listenerMap.keyup({keyCode: Key.Escape});
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call the onClose callback when a descendent HTMLElement is clicked', () => {
+    const spy = jest.fn();
+
+    const popoverOverlay = mountWithAppProvider(
+      <PopoverOverlay
+        active
+        id="PopoverOverlay-1"
+        activator={activator}
+        onClose={spy}
+      >
+        (<TextField label="Store name" value="Click me" onChange={() => {}} />)
+      </PopoverOverlay>,
+    );
+
+    const target = popoverOverlay
+      .find(TextField)
+      .find('input')
+      .getDOMNode();
+
+    const clickEventListener = popoverOverlay
+      .find(EventListener)
+      .findWhere((node) => node.prop('event') === 'click');
+
+    trigger(clickEventListener, 'handler', {target});
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not call the onClose callback when a descendent SVGElement is clicked', () => {
+    const spy = jest.fn();
+
+    const popoverOverlay = mountWithAppProvider(
+      <PopoverOverlay
+        active
+        id="PopoverOverlay-1"
+        activator={activator}
+        onClose={spy}
+      >
+        (
+        <TextField
+          type="number"
+          label="Store name"
+          value="Click me"
+          onChange={() => {}}
+        />
+        )
+      </PopoverOverlay>,
+    );
+
+    const target = popoverOverlay
+      .find(TextField)
+      .find('svg')
+      .first()
+      .getDOMNode();
+
+    const clickEventListener = popoverOverlay
+      .find(EventListener)
+      .findWhere((node) => node.prop('event') === 'click');
+
+    trigger(clickEventListener, 'handler', {
+      target,
+    });
+
+    expect(spy).not.toHaveBeenCalled();
   });
 
   it('starts animating in immediately', () => {


### PR DESCRIPTION
Replacing type assertion with type check introduced a small issue in case of the `<PopoverOverlay /> ` click handler. 
If the target element is an SVGElement the descendent check is not even invoked and the Popover get's closed similarly when you click outside of it.

Reported issue:
https://github.com/Shopify/web/issues/24540

Partially reverting changes from #2638 

### WHY are these changes introduced?


### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
