### PR TITLE
[Navigation] Only focus items on tab

### DIFF
--- a/src/components/Navigation/Navigation.scss
+++ b/src/components/Navigation/Navigation.scss
@@ -143,7 +143,6 @@ $disabled-fade: 0.6;
 
   &:focus {
     color: var(--p-action-primary, color('indigo', 'dark'));
-    @include focus-ring($style: 'focused');
   }
   &:focus:active {
     @include no-focus-ring;
@@ -312,6 +311,10 @@ $secondary-item-font-size: rem(15px);
       @include breakpoint-after(nav-min-window-corrected()) {
         font-size: $item-font-size-small;
       }
+      // stylelint-disable-next-line selector-max-specificity, selector-max-combinators
+      &.keyFocused {
+        @include focus-ring($style: 'focused');
+      }
     }
 
     &:hover {
@@ -320,7 +323,6 @@ $secondary-item-font-size: rem(15px);
 
     &:focus {
       color: var(--p-text, color('indigo', 'dark'));
-      @include focus-ring($style: 'focused');
     }
     // stylelint-disable selector-max-specificity
     &:focus:hover {
@@ -363,7 +365,6 @@ $secondary-item-font-size: rem(15px);
     }
     &:focus {
       color: var(--p-action-primary, color('indigo', 'dark'));
-      @include focus-ring($style: 'focused');
     }
     &:active {
       color: var(--p-action-primary-pressed, color('indigo', 'dark'));

--- a/src/components/Navigation/_variables.scss
+++ b/src/components/Navigation/_variables.scss
@@ -69,8 +69,11 @@ $nav-animation-variables: (
 
   @include focus-ring;
 
-  &:focus {
+  &.keyFocused {
     @include focus-ring($style: 'focused');
+  }
+
+  &:focus {
     background-image: linear-gradient(color(state, hover), color(state, hover));
     color: var(--p-text, color('indigo', 'dark'));
     text-decoration: none;

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -5,6 +5,7 @@ import React, {
   MouseEvent,
   ReactNode,
   Fragment,
+  useCallback,
 } from 'react';
 
 import {classNames} from '../../../../utilities/css';
@@ -12,7 +13,7 @@ import {classNames} from '../../../../utilities/css';
 import {NavigationContext} from '../../context';
 import {Badge} from '../../../Badge';
 import {Icon} from '../../../Icon';
-import {IconProps} from '../../../../types';
+import {IconProps, Key} from '../../../../types';
 import {Indicator} from '../../../Indicator';
 import {UnstyledLink} from '../../../UnstyledLink';
 import {useI18n} from '../../../../utilities/i18n';
@@ -87,12 +88,26 @@ export function Item({
   const {isNavigationCollapsed} = useMediaQuery();
   const {location, onNavigationDismiss} = useContext(NavigationContext);
   const [expanded, setExpanded] = useState(false);
+  const [keyFocused, setKeyFocused] = useState(false);
 
   useEffect(() => {
     if (!isNavigationCollapsed && expanded) {
       setExpanded(false);
     }
   }, [expanded, isNavigationCollapsed]);
+
+  const handleKeyUp = useCallback(
+    (event) => {
+      if (event.keyCode === Key.Tab) {
+        !keyFocused && setKeyFocused(true);
+      }
+    },
+    [keyFocused],
+  );
+
+  const handleBlur = useCallback(() => {
+    keyFocused && setKeyFocused(false);
+  }, [keyFocused]);
 
   const tabIndex = disabled ? -1 : 0;
 
@@ -149,6 +164,7 @@ export function Item({
     const className = classNames(
       styles.Item,
       disabled && styles['Item-disabled'],
+      keyFocused && styles.keyFocused,
     );
 
     return (
@@ -160,6 +176,8 @@ export function Item({
           aria-disabled={disabled}
           aria-label={accessibilityLabel}
           onClick={getClickHandler(onClick)}
+          onKeyUp={handleKeyUp}
+          onBlur={handleBlur}
         >
           {itemContentMarkup}
         </button>
@@ -210,6 +228,7 @@ export function Item({
     disabled && styles['Item-disabled'],
     selected && subNavigationItems.length === 0 && styles['Item-selected'],
     showExpanded && styles.subNavigationActive,
+    keyFocused && styles.keyFocused,
   );
 
   let secondaryNavigationMarkup: ReactNode = null;
@@ -254,6 +273,8 @@ export function Item({
           aria-disabled={disabled}
           aria-label={accessibilityLabel}
           onClick={getClickHandler(onClick)}
+          onKeyUp={handleKeyUp}
+          onBlur={handleBlur}
         >
           {itemContentMarkup}
         </UnstyledLink>

--- a/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -440,6 +440,32 @@ describe('<Nav.Item />', () => {
       });
     });
   });
+
+  describe('keyFocused', () => {
+    it('adds and removes a class to button when item was tabbed into focus and then blurred', () => {
+      const item = mountWithNavigationProvider(
+        <Item label="some label" disabled={false} />,
+      );
+
+      item.find('button').simulate('keyup', {keyCode: 9});
+      expect(item.find('button').hasClass('keyFocused')).toBe(true);
+
+      item.find('button').simulate('blur');
+      expect(item.find('button').hasClass('keyFocused')).toBe(false);
+    });
+
+    it('adds and removes a class to a link when item was tabbed into focus and then blurred', () => {
+      const item = mountWithNavigationProvider(
+        <Item label="some label" disabled={false} url="https://shopify.com" />,
+      );
+
+      item.find('a').simulate('keyup', {keyCode: 9});
+      expect(item.find('a').hasClass('keyFocused')).toBe(true);
+
+      item.find('a').simulate('blur');
+      expect(item.find('a').hasClass('keyFocused')).toBe(false);
+    });
+  });
 });
 
 function noop() {}


### PR DESCRIPTION
### WHY are these changes introduced?

This addresses the issue where the nav items were receiving a focus state on click. Now the ring only appears on tab

[Screencast](https://screenshot.click/screencast_2020-03-12_23-19-36.mp4)

### WHAT is this pull request doing?

I'm setting state when the item receives a key up and the key is tab. The state adds a class which is then removed on blur.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Run locally and visit the [details page](http://localhost:6006/iframe.html?id=playground-playground--details-page&contexts=New%20Design%20Language=Enabled%20-%20Light%20Mode)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
