### PR TITLE
Prep v4.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format is based on [these versioning and changelog guidelines](https://git.i
 
 ---
 
+## 4.16.0 - 2020-03-13
+
+### Enhancements
+
+- Added optional `onClick` prop to `Tag` ([#2774](https://github.com/Shopify/polaris-react/pull/2774))
+- Added transition properties to `Collapsible` ([#2835](https://github.com/Shopify/polaris-react/pull/2835))
+
+### Bug fixes
+
+- Fixed issue with passed to `ComboBox` component options prop was mutated ([#2818](https://github.com/Shopify/polaris-react/pull/2818))
+- Fixed an issue which caused `Popover` to close when clicking on a descendant SVG ([#2827](https://github.com/Shopify/polaris-react/pull/2827))
+
+### Code quality
+
+- Removed redundant null check in `TextField` ([#2783](https://github.com/Shopify/polaris-react/pull/2783))
+
 ## 4.15.2 - 2020-03-09
 
 ### Code quality

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,13 +4,7 @@
 
 ### Enhancements
 
-- Added optional `onClick` prop to `Tag` ([#2774](https://github.com/Shopify/polaris-react/pull/2774))
-- Added transition properties to `Collapsible` ([#2835](https://github.com/Shopify/polaris-react/pull/2835))
-
 ### Bug fixes
-
-- Fixed issue with passed to `ComboBox` component options prop was mutated ([#2818](https://github.com/Shopify/polaris-react/pull/2818))
-- Fixed an issue which caused `Popover` to close when clicking on a descendant SVG ([#2827](https://github.com/Shopify/polaris-react/pull/2827))
 
 ### Documentation
 
@@ -19,7 +13,5 @@
 ### Dependency upgrades
 
 ### Code quality
-
-- Removed redundant null check in `TextField` ([#2783](https://github.com/Shopify/polaris-react/pull/2783))
 
 ### Deprecations


### PR DESCRIPTION
Want to get this out mainly for https://github.com/Shopify/polaris-react/pull/2827 and to get Shopify Web back on the latest.