### PR TITLE
[Contextual save bar] Full width when no Navigation is present

### DIFF
--- a/src/components/Frame/Frame.scss
+++ b/src/components/Frame/Frame.scss
@@ -144,8 +144,10 @@ $skip-vertical-offset: rem(10px);
 
 .ContextualSaveBar-newDesignLanguage {
   @include frame-when-nav-displayed {
-    left: layout-width(unstable-nav);
-    max-width: calc(100% - #{layout-width(unstable-nav)});
+    .hasNav & {
+      left: layout-width(unstable-nav);
+      max-width: calc(100% - #{layout-width(unstable-nav)});
+    }
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue where the contextual save bar doesn't span full width when no nav is present and new design language is true

![image](https://screenshot.click/screencast_2020-03-16_09-54-44.gif)

![image](https://screenshot.click/screencast_2020-03-16_09-55-21.gif)

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Comment out line 528 in `DetailsPage.tsx`
`// navigation={navigationMarkup}` and type into the first text input box on the page: `Title`

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
