### PR TITLE
[Navigation] Add min-height to context control wrapper

### DIFF
--- a/src/components/Navigation/Navigation.scss
+++ b/src/components/Navigation/Navigation.scss
@@ -49,6 +49,7 @@ $unstable-nav-max-width: rem(258px);
 
     .Navigation-newDesignLanguage & {
       display: block;
+      min-height: unstable-top-bar-height();
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes: https://github.com/Shopify/polaris-ux/issues/404

Chose min-height over height for apps or channels that might want to show more content or a larger logo

What this change will look like in production:
![image](https://screenshot.click/Felted_-_Slim_Wallets__Home__Shopify_2020-03-16_16-28-47.png)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
