### PR TITLE
[Color system] finish applying new design language to banner component

### DIFF
--- a/documentation/Color system.md
+++ b/documentation/Color system.md
@@ -233,43 +233,43 @@ Used to decorate elements where color does convey a specific meaning in componen
 
 [↑ Back to top](#table-of-contents)
 
-| CSS variable                              | Value                                                                                             |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `--p-border-radius-base`                  | `0.4rem`                                                                                          |
-| `--p-border-radius-wide`                  | `0.8rem`                                                                                          |
-| `--p-card-shadow`                         | `0px 0px 5px var(--p-shadow-from-ambient-light), 0px 1px 2px var(--p-shadow-from-direct-light)`   |
-| `--p-popover-shadow`                      | `-1px 0px 20px var(--p-shadow-from-ambient-light), 0px 1px 5px var(--p-shadow-from-direct-light)` |
-| `--p-modal-shadow`                        | `0px 26px 80px var(--p-shadow-from-dim-light), 0px 0px 1px var(--p-shadow-from-dim-light)`        |
-| `--p-top-bar-shadow`                      | `0 2px 2px -1px var(--p-shadow-from-direct-light)`                                                |
-| `--p-override-none`                       | `none`                                                                                            |
-| `--p-override-transparent`                | `transparent`                                                                                     |
-| `--p-override-one`                        | `1`                                                                                               |
-| `--p-override-visible`                    | `visible`                                                                                         |
-| `--p-override-zero`                       | `0`                                                                                               |
-| `--p-override-loading-z-index`            | `514`                                                                                             |
-| `--p-button-font-weight`                  | `500`                                                                                             |
-| `--p-non-null-content`                    | `''`                                                                                              |
-| `--p-choice-size`                         | `2rem`                                                                                            |
-| `--p-icon-size`                           | `1rem`                                                                                            |
-| `--p-choice-margin`                       | `0.1rem`                                                                                          |
-| `--p-control-border-width`                | `0.2rem`                                                                                          |
-| `--p-banner-border-default`               | `inset 0 0.2rem 0 0 var(--p-border), inset 0 0 0 0.2rem var(--p-border)`                          |
-| `--p-banner-border-success`               | `inset 0 0.2rem 0 0 var(--p-border-success), inset 0 0 0 0.2rem var(--p-border-success)`          |
-| `--p-banner-border-highlight`             | `inset 0 0.2rem 0 0 var(--p-border-highlight), inset 0 0 0 0.2rem var(--p-border-highlight)`      |
-| `--p-banner-border-warning`               | `inset 0 0.2rem 0 0 var(--p-border-warning), inset 0 0 0 0.2rem var(--p-border-warning)`          |
-| `--p-banner-border-critical`              | `inset 0 0.2rem 0 0 var(--p-border-critical), inset 0 0 0 0.2rem var(--p-border-critical)`        |
-| `--p-badge-mix-blend-mode`                | `luminosity`                                                                                      |
-| `--p-thin-border-subdued`                 | `0.1rem solid var(--p-border-subdued)`                                                            |
-| `--p-text-field-spinner-offset`           | `0.2rem`                                                                                          |
-| `--p-text-field-focus-ring-offset`        | `-0.4rem`                                                                                         |
-| `--p-text-field-focus-ring-border-radius` | `0.7rem`                                                                                          |
-| `--p-button-group-item-spacing`           | `0.2rem`                                                                                          |
-| `--p-top-bar-height`                      | `68px`                                                                                            |
-| `--p-contextual-save-bar-height`          | `64px`                                                                                            |
-| `--p-duration-1-0-0`                      | `100ms`                                                                                           |
-| `--p-duration-1-5-0`                      | `150ms`                                                                                           |
-| `--p-ease-in`                             | `cubic-bezier(0.5, 0.1, 1, 1)`                                                                    |
-| `--p-ease`                                | `cubic-bezier(0.4, 0.22, 0.28, 1)`                                                                |
-| `--p-range-slider-thumb-size-base`        | `1.6rem`                                                                                          |
-| `--p-range-slider-thumb-size-active`      | `2.4rem`                                                                                          |
-| `--p-range-slider-thumb-scale`            | `1.5`                                                                                             |
+| CSS variable                              | Value                                                                                                        |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `--p-border-radius-base`                  | `0.4rem`                                                                                                     |
+| `--p-border-radius-wide`                  | `0.8rem`                                                                                                     |
+| `--p-card-shadow`                         | `0px 0px 5px var(--p-shadow-from-ambient-light), 0px 1px 2px var(--p-shadow-from-direct-light)`              |
+| `--p-popover-shadow`                      | `-1px 0px 20px var(--p-shadow-from-ambient-light), 0px 1px 5px var(--p-shadow-from-direct-light)`            |
+| `--p-modal-shadow`                        | `0px 26px 80px var(--p-shadow-from-dim-light), 0px 0px 1px var(--p-shadow-from-dim-light)`                   |
+| `--p-top-bar-shadow`                      | `0 2px 2px -1px var(--p-shadow-from-direct-light)`                                                           |
+| `--p-override-none`                       | `none`                                                                                                       |
+| `--p-override-transparent`                | `transparent`                                                                                                |
+| `--p-override-one`                        | `1`                                                                                                          |
+| `--p-override-visible`                    | `visible`                                                                                                    |
+| `--p-override-zero`                       | `0`                                                                                                          |
+| `--p-override-loading-z-index`            | `514`                                                                                                        |
+| `--p-button-font-weight`                  | `500`                                                                                                        |
+| `--p-non-null-content`                    | `''`                                                                                                         |
+| `--p-choice-size`                         | `2rem`                                                                                                       |
+| `--p-icon-size`                           | `1rem`                                                                                                       |
+| `--p-choice-margin`                       | `0.1rem`                                                                                                     |
+| `--p-control-border-width`                | `0.2rem`                                                                                                     |
+| `--p-banner-border-default`               | `inset 0 0.1rem 0 0 var(--p-border-neutral-subdued), inset 0 0 0 0.1rem var(--p-border-neutral-subdued)`     |
+| `--p-banner-border-success`               | `inset 0 0.1rem 0 0 var(--p-border-success-subdued), inset 0 0 0 0.1rem var(--p-border-success-subdued)`     |
+| `--p-banner-border-highlight`             | `inset 0 0.1rem 0 0 var(--p-border-highlight-subdued), inset 0 0 0 0.1rem var(--p-border-highlight-subdued)` |
+| `--p-banner-border-warning`               | `inset 0 0.1rem 0 0 var(--p-border-warning-subdued), inset 0 0 0 0.1rem var(--p-border-warning-subdued)`     |
+| `--p-banner-border-critical`              | `inset 0 0.1rem 0 0 var(--p-border-critical-subdued), inset 0 0 0 0.1rem var(--p-border-critical-subdued)`   |
+| `--p-badge-mix-blend-mode`                | `luminosity`                                                                                                 |
+| `--p-thin-border-subdued`                 | `0.1rem solid var(--p-border-subdued)`                                                                       |
+| `--p-text-field-spinner-offset`           | `0.2rem`                                                                                                     |
+| `--p-text-field-focus-ring-offset`        | `-0.4rem`                                                                                                    |
+| `--p-text-field-focus-ring-border-radius` | `0.7rem`                                                                                                     |
+| `--p-button-group-item-spacing`           | `0.2rem`                                                                                                     |
+| `--p-top-bar-height`                      | `68px`                                                                                                       |
+| `--p-contextual-save-bar-height`          | `64px`                                                                                                       |
+| `--p-duration-1-0-0`                      | `100ms`                                                                                                      |
+| `--p-duration-1-5-0`                      | `150ms`                                                                                                      |
+| `--p-ease-in`                             | `cubic-bezier(0.5, 0.1, 1, 1)`                                                                               |
+| `--p-ease`                                | `cubic-bezier(0.4, 0.22, 0.28, 1)`                                                                           |
+| `--p-range-slider-thumb-size-base`        | `1.6rem`                                                                                                     |
+| `--p-range-slider-thumb-size-active`      | `2.4rem`                                                                                                     |
+| `--p-range-slider-thumb-scale`            | `1.5`                                                                                                        |

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "@material-ui/react-transition-group": "^4.2.0",
     "@shopify/app-bridge": "^1.3.0",
     "@shopify/javascript-utilities": "^2.4.1",
-    "@shopify/polaris-icons": "^3.9.0",
+    "@shopify/polaris-icons": "^3.10.0",
     "@shopify/polaris-tokens": "^2.12.0",
     "@shopify/useful-types": "^1.2.4",
     "@types/hoist-non-react-statics": "^3.3.1",

--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -68,7 +68,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
     --p-banner-background: var(--p-surface-success-subdued);
     --p-banner-border: var(--p-banner-border-success);
     @include banner-attributes(
-      var(--p-border-success, color('green')),
+      var(--p-override-none, color('green')),
       color('green', 'lighter'),
       $in-page,
       true
@@ -79,7 +79,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
     --p-banner-background: var(--p-surface-highlight-subdued);
     --p-banner-border: var(--p-banner-border-highlight);
     @include banner-attributes(
-      var(--p-border-highlight, color('teal')),
+      var(--p-override-none, color('teal')),
       color('teal', 'lighter'),
       $in-page,
       true
@@ -90,7 +90,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
     --p-banner-background: var(--p-surface-warning-subdued);
     --p-banner-border: var(--p-banner-border-warning);
     @include banner-attributes(
-      var(--p-border-warning, color('yellow')),
+      var(--p-override-none, color('yellow')),
       color('yellow', 'lighter'),
       $in-page,
       true
@@ -101,7 +101,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
     --p-banner-background: var(--p-surface-critical-subdued);
     --p-banner-border: var(--p-banner-border-critical);
     @include banner-attributes(
-      var(--p-border-critical, color('red')),
+      var(--p-override-none, color('red')),
       color('red', 'lighter'),
       $in-page,
       true
@@ -115,8 +115,19 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 }
 
 .withinContentContainer {
+  $newDesignLanguageSpacing: rem(14px);
+  $newDesignLanguageOffset: $newDesignLanguageSpacing - spacing();
   border-radius: var(--p-border-radius-wide, border-radius());
   padding: spacing(tight) $intermediate-spacing;
+
+  &.newDesignLanguage {
+    padding: spacing() spacing() $newDesignLanguageSpacing;
+
+    // stylelint-disable-next-line selector-max-class
+    .ContentWrapper {
+      margin-top: $newDesignLanguageOffset;
+    }
+  }
 
   @include banner-variants;
 
@@ -140,8 +151,19 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 }
 
 .withinPage {
+  $newDesignLanguageSpacing: rem(18px);
+  $newDesignLanguageOffset: $newDesignLanguageSpacing - spacing(loose);
   border-radius: 0 0 border-radius() border-radius();
   padding: spacing();
+
+  &.newDesignLanguage {
+    padding: spacing(loose) spacing(loose) $newDesignLanguageSpacing;
+
+    // stylelint-disable-next-line selector-max-class
+    .ContentWrapper {
+      margin-top: $newDesignLanguageOffset;
+    }
+  }
 
   @include banner-variants(true);
 
@@ -169,13 +191,17 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 }
 
 .Heading {
-  padding-top: $heading-offset;
+  padding-top: var(--p-override-none, $heading-offset);
   word-break: break-word;
 }
 
 .Content {
   @include text-breakword;
   padding: spacing(extra-tight) 0;
+
+  .newDesignLanguage & {
+    padding: rem(2px) 0;
+  }
 }
 
 .Ribbon {

--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -115,12 +115,12 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 }
 
 .withinContentContainer {
-  $newDesignLanguageSpacing: rem(14px);
-  $newDesignLanguageOffset: $newDesignLanguageSpacing - spacing();
   border-radius: var(--p-border-radius-wide, border-radius());
   padding: spacing(tight) $intermediate-spacing;
 
   &.newDesignLanguage {
+    $newDesignLanguageSpacing: rem(14px);
+    $newDesignLanguageOffset: $newDesignLanguageSpacing - spacing();
     padding: spacing() spacing() $newDesignLanguageSpacing;
 
     // stylelint-disable-next-line selector-max-class
@@ -156,12 +156,12 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 }
 
 .withinPage {
-  $newDesignLanguageSpacing: rem(18px);
-  $newDesignLanguageOffset: $newDesignLanguageSpacing - spacing(loose);
   border-radius: 0 0 border-radius() border-radius();
   padding: spacing();
 
   &.newDesignLanguage {
+    $newDesignLanguageSpacing: rem(18px);
+    $newDesignLanguageOffset: $newDesignLanguageSpacing - spacing(loose);
     padding: spacing(loose) spacing(loose) $newDesignLanguageSpacing;
 
     // stylelint-disable-next-line selector-max-class

--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -137,6 +137,11 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 
   .Ribbon {
     padding-right: $intermediate-spacing;
+
+    // stylelint-disable-next-line selector-max-combinators, selector-max-class
+    .newDesignLanguage & {
+      padding-right: spacing();
+    }
   }
 
   .Actions {
@@ -173,6 +178,11 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 
   .Ribbon {
     padding-right: spacing();
+
+    // stylelint-disable-next-line selector-max-combinators, selector-max-class
+    .newDesignLanguage & {
+      padding-right: spacing(loose);
+    }
   }
 
   .Actions {

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -113,33 +113,33 @@ export class Banner extends React.PureComponent<BannerProps, State> {
 
             switch (status) {
               case 'success':
-                color = 'greenDark';
+                color = newDesignLanguage ? 'success' : 'greenDark';
                 defaultIcon = newDesignLanguage
                   ? CircleTickMajorFilled
                   : CircleTickMajorTwotone;
                 break;
               case 'info':
-                color = 'tealDark';
+                color = newDesignLanguage ? 'highlight' : 'tealDark';
                 defaultIcon = newDesignLanguage
                   ? CircleInformationMajorFilled
                   : CircleInformationMajorTwotone;
                 break;
               case 'warning':
-                color = 'yellowDark';
+                color = newDesignLanguage ? 'warning' : 'yellowDark';
                 defaultIcon = newDesignLanguage
                   ? CircleAlertMajorFilled
                   : CircleAlertMajorTwotone;
                 ariaRoleType = 'alert';
                 break;
               case 'critical':
-                color = 'redDark';
+                color = newDesignLanguage ? 'critical' : 'redDark';
                 defaultIcon = newDesignLanguage
                   ? CircleDisabledMajorFilled
                   : CircleDisabledMajorTwotone;
                 ariaRoleType = 'alert';
                 break;
               default:
-                color = 'inkLighter';
+                color = newDesignLanguage ? 'base' : 'inkLighter';
                 defaultIcon = newDesignLanguage
                   ? CircleInformationMajorFilled
                   : FlagMajorTwotone;

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -152,6 +152,7 @@ export class Banner extends React.PureComponent<BannerProps, State> {
               withinContentContainer
                 ? styles.withinContentContainer
                 : styles.withinPage,
+              newDesignLanguage && styles.newDesignLanguage,
             );
 
             const id = uniqueID();
@@ -232,7 +233,7 @@ export class Banner extends React.PureComponent<BannerProps, State> {
                     backdrop={!newDesignLanguage}
                   />
                 </div>
-                <div>
+                <div className={styles.ContentWrapper}>
                   {headingMarkup}
                   {contentMarkup}
                 </div>

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -6,8 +6,13 @@ import {
   CircleAlertMajorTwotone,
   CircleDisabledMajorTwotone,
   CircleInformationMajorTwotone,
+  CircleInformationMajorFilled,
+  CircleTickMajorFilled,
+  CircleAlertMajorFilled,
+  CircleDisabledMajorFilled,
 } from '@shopify/polaris-icons';
 
+import {FeaturesContext} from '../../utilities/features';
 import {BannerContext} from '../../utilities/banner-context';
 import {classNames, variationName} from '../../utilities/css';
 import {
@@ -52,6 +57,9 @@ export interface BannerProps {
 }
 
 export class Banner extends React.PureComponent<BannerProps, State> {
+  static contextType = FeaturesContext;
+  context!: React.ContextType<typeof FeaturesContext>;
+
   state: State = {
     showFocus: false,
   };
@@ -64,6 +72,7 @@ export class Banner extends React.PureComponent<BannerProps, State> {
   }
 
   render() {
+    const {newDesignLanguage} = this.context || {};
     const {showFocus} = this.state;
 
     const handleKeyUp = (evt: React.KeyboardEvent<HTMLDivElement>) => {
@@ -105,25 +114,35 @@ export class Banner extends React.PureComponent<BannerProps, State> {
             switch (status) {
               case 'success':
                 color = 'greenDark';
-                defaultIcon = CircleTickMajorTwotone;
+                defaultIcon = newDesignLanguage
+                  ? CircleTickMajorFilled
+                  : CircleTickMajorTwotone;
                 break;
               case 'info':
                 color = 'tealDark';
-                defaultIcon = CircleInformationMajorTwotone;
+                defaultIcon = newDesignLanguage
+                  ? CircleInformationMajorFilled
+                  : CircleInformationMajorTwotone;
                 break;
               case 'warning':
                 color = 'yellowDark';
-                defaultIcon = CircleAlertMajorTwotone;
+                defaultIcon = newDesignLanguage
+                  ? CircleAlertMajorFilled
+                  : CircleAlertMajorTwotone;
                 ariaRoleType = 'alert';
                 break;
               case 'critical':
                 color = 'redDark';
-                defaultIcon = CircleDisabledMajorTwotone;
+                defaultIcon = newDesignLanguage
+                  ? CircleDisabledMajorFilled
+                  : CircleDisabledMajorTwotone;
                 ariaRoleType = 'alert';
                 break;
               default:
                 color = 'inkLighter';
-                defaultIcon = FlagMajorTwotone;
+                defaultIcon = newDesignLanguage
+                  ? CircleInformationMajorFilled
+                  : FlagMajorTwotone;
             }
             const className = classNames(
               styles.Banner,
@@ -207,7 +226,11 @@ export class Banner extends React.PureComponent<BannerProps, State> {
               >
                 {dismissButton}
                 <div className={styles.Ribbon}>
-                  <Icon source={iconName} color={color} backdrop />
+                  <Icon
+                    source={iconName}
+                    color={color}
+                    backdrop={!newDesignLanguage}
+                  />
                 </div>
                 <div>
                   {headingMarkup}

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -6,6 +6,10 @@ import {
   CircleTickMajorTwotone,
   CircleInformationMajorTwotone,
   FlagMajorTwotone,
+  CircleTickMajorFilled,
+  CircleInformationMajorFilled,
+  CircleAlertMajorFilled,
+  CircleDisabledMajorFilled,
 } from '@shopify/polaris-icons';
 import {mountWithApp} from 'test-utilities/react-testing';
 // eslint-disable-next-line no-restricted-imports
@@ -153,7 +157,7 @@ describe('<Banner />', () => {
         });
 
         const bannerDiv = banner.find('div', {
-          className: 'Banner withinPage',
+          className: 'Banner withinPage newDesignLanguage',
         });
 
         bannerDiv!.trigger('onKeyUp', {
@@ -161,7 +165,7 @@ describe('<Banner />', () => {
         });
 
         expect(banner).toContainReactComponent('div', {
-          className: 'Banner keyFocused withinPage',
+          className: 'Banner keyFocused withinPage newDesignLanguage',
         });
       });
 
@@ -171,7 +175,7 @@ describe('<Banner />', () => {
         });
 
         const bannerDiv = banner.find('div', {
-          className: 'Banner withinPage',
+          className: 'Banner withinPage newDesignLanguage',
         });
 
         bannerDiv!.trigger('onMouseUp', {
@@ -179,7 +183,7 @@ describe('<Banner />', () => {
         });
 
         expect(banner).toContainReactComponent('div', {
-          className: 'Banner withinPage',
+          className: 'Banner withinPage newDesignLanguage',
         });
       });
     });
@@ -210,5 +214,53 @@ describe('<Banner />', () => {
 
       expect(div.exists()).toBe(true);
     });
+  });
+
+  describe('Icon', () => {
+    it.each([
+      [
+        'Banner has a default status',
+        null,
+        'base',
+        CircleInformationMajorFilled,
+      ],
+      [
+        'Banner has a success status',
+        'success',
+        'success',
+        CircleTickMajorFilled,
+      ],
+      [
+        'Banner has an info status',
+        'info',
+        'highlight',
+        CircleInformationMajorFilled,
+      ],
+      [
+        'Banner has a warning status',
+        'warning',
+        'warning',
+        CircleAlertMajorFilled,
+      ],
+      [
+        'Banner has a critical status',
+        'critical',
+        'critical',
+        CircleDisabledMajorFilled,
+      ],
+    ])(
+      'Sets Icon props when: %s',
+      (_: any, status: any, color: any, iconSource: any) => {
+        const banner = mountWithApp(<Banner status={status} />, {
+          features: {newDesignLanguage: true},
+        });
+
+        expect(banner.find(Icon)!.props).toStrictEqual({
+          backdrop: false,
+          color,
+          source: iconSource,
+        });
+      },
+    );
   });
 });

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -506,22 +506,22 @@ $stacking-order: (
     }
 
     &.iconOnly {
-      @include recolor-icon(var(--p-interactive));
+      @include recolor-icon(var(--p-icon));
 
       &:hover {
-        @include recolor-icon(var(--p-interactive-hovered));
+        @include recolor-icon(var(--p-icon-hovered));
       }
 
       &:focus {
-        @include recolor-icon(var(--p-interactive));
+        @include recolor-icon(var(--p-icon));
       }
 
       &:active {
-        @include recolor-icon(var(--p-interactive-pressed));
+        @include recolor-icon(var(--p-icon-pressed));
       }
 
       &.disabled {
-        @include recolor-icon(var(--p-interactive-disabled));
+        @include recolor-icon(var(--p-icon-disabled));
       }
     }
 

--- a/src/utilities/theme/tokens.ts
+++ b/src/utilities/theme/tokens.ts
@@ -26,11 +26,11 @@ const Overrides = {
   iconSize: rem('10px'),
   choiceMargin: rem('1px'),
   controlBorderWidth: rem('2px'),
-  bannerBorderDefault: buildBannerBorder('--p-border'),
-  bannerBorderSuccess: buildBannerBorder('--p-border-success'),
-  bannerBorderHighlight: buildBannerBorder('--p-border-highlight'),
-  bannerBorderWarning: buildBannerBorder('--p-border-warning'),
-  bannerBorderCritical: buildBannerBorder('--p-border-critical'),
+  bannerBorderDefault: buildBannerBorder('--p-border-neutral-subdued'),
+  bannerBorderSuccess: buildBannerBorder('--p-border-success-subdued'),
+  bannerBorderHighlight: buildBannerBorder('--p-border-highlight-subdued'),
+  bannerBorderWarning: buildBannerBorder('--p-border-warning-subdued'),
+  bannerBorderCritical: buildBannerBorder('--p-border-critical-subdued'),
   badgeMixBlendMode: 'luminosity',
   thinBorderSubdued: `${rem('1px')} solid var(--p-border-subdued)`,
   textFieldSpinnerOffset: rem('2px'),
@@ -60,7 +60,7 @@ function rem(px: string) {
 }
 
 function buildBannerBorder(cssVar: string) {
-  return `inset 0 ${rem('2px')} 0 0 var(${cssVar}), inset 0 0 0 ${rem(
-    '2px',
+  return `inset 0 ${rem('1px')} 0 0 var(${cssVar}), inset 0 0 0 ${rem(
+    '1px',
   )} var(${cssVar})`;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1584,10 +1584,10 @@
   dependencies:
     tslib "^1.9.3"
 
-"@shopify/polaris-icons@^3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-3.9.0.tgz#7064b234824788972593efcda9ae7b87f2a2da43"
-  integrity sha512-isGvHpkH57IsQl6iAZA81LaIPdGi8gNSON5hLWXSERvP9SwgTenfDrkOD3UvzLY09Hh7m8lkFBMUVv/ta33xrg==
+"@shopify/polaris-icons@^3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-3.10.0.tgz#01fa32853c304c58d768209a74f88ac9d7a51098"
+  integrity sha512-Y8cTtFwIfkUDlCHonCimSxPdHk9AE11PYsh9JqzTKLjsAv6p3De/JQR/gZfAifmAAhg0XBmaaV5K4Y6Z5J6xAw==
 
 "@shopify/polaris-tokens@^2.12.0":
   version "2.12.0"


### PR DESCRIPTION
## What this does

- adds filled icons for new design language
- updates border and background color for new design language
- updates spacing for new design language

Addresses https://github.com/Shopify/polaris-ux/issues/381

Figma: https://www.figma.com/file/4dAAt5iFPSaxUKiYVKrkYj/DL%E2%80%93Polaris-(Web)%3A-Components?node-id=20%3A22

|:tophat:|
|-|
|<img width="995" alt="Screen Shot 2020-03-17 at 1 02 45 PM" src="https://user-images.githubusercontent.com/1403188/76881899-3a1ef080-6850-11ea-8809-84793eff110c.png">|
|<img width="997" alt="Screen Shot 2020-03-17 at 1 03 16 PM" src="https://user-images.githubusercontent.com/1403188/76882062-7c483200-6850-11ea-86a7-b82d453384b5.png">|
|<img width="995" alt="Screen Shot 2020-03-17 at 1 03 01 PM" src="https://user-images.githubusercontent.com/1403188/76881949-502cb100-6850-11ea-9235-1c61b178dca3.png">|
|<img width="995" alt="Screen Shot 2020-03-17 at 1 03 09 PM" src="https://user-images.githubusercontent.com/1403188/76881974-591d8280-6850-11ea-8843-92129353ae7f.png">|
|<img width="994" alt="Screen Shot 2020-03-17 at 1 03 22 PM" src="https://user-images.githubusercontent.com/1403188/76882005-65a1db00-6850-11ea-8ed2-bae7531635c9.png">|
|<img width="996" alt="Screen Shot 2020-03-17 at 1 03 37 PM" src="https://user-images.githubusercontent.com/1403188/76882026-6cc8e900-6850-11ea-96a0-1250c2905980.png">|