### PR TITLE
[Tag] Fixing styling of base Tag padding

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+- Fixed right padding styling issue with the `Tag` component and remove right padding on a removable `Tag` ([#2860](https://github.com/Shopify/polaris-react/pull/2860)).
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -8,7 +8,7 @@ $icon-size: rem(16px);
   max-width: 100%;
   align-items: center;
   min-height: $height;
-  padding-left: spacing(tight);
+  padding: 0 spacing(tight);
   background-color: var(--p-action-secondary, color('sky'));
   border-radius: border-radius();
   color: var(--p-text, color('ink'));
@@ -18,6 +18,10 @@ $icon-size: rem(16px);
     transition: none;
     background: var(--p-action-secondary-disabled, color('sky', 'light'));
     color: var(--p-text-disabled, color('ink', 'lightest'));
+  }
+
+  &.removable {
+    padding-right: 0;
   }
 
   &.clickable {

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -33,6 +33,7 @@ export function Tag({children, disabled = false, onClick, onRemove}: TagProps) {
     styles.Tag,
     disabled && styles.disabled,
     onClick && styles.clickable,
+    onRemove && styles.removable,
     newDesignLanguage && styles.newDesignLanguage,
   );
 


### PR DESCRIPTION
### WHY are these changes introduced?

On the `<Tag />` [component](https://polaris.shopify.com/components/forms/tag), when no props are passed, the styling for the padding is missing on the right side.

[Can be seen on the sandbox](https://codesandbox.io/s/twelv?module=App.js)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR adds a padding to the base `Tag` so that it has an even styling, and removes padding when a `Tag` is removable to not have right padding when there is an `<Icon />`.

|  Before |  After |
|---|---|
|<img width="89" alt="Screen Shot 2020-03-19 at 10 56 19 AM" src="https://user-images.githubusercontent.com/5506721/77081060-7711f100-69d0-11ea-808a-19d11ad2a25a.png">| <img width="101" alt="Screen Shot 2020-03-19 at 10 56 31 AM" src="https://user-images.githubusercontent.com/5506721/77081076-7bd6a500-69d0-11ea-91dc-303995ade0e7.png">|

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Tag, Stack} from '../src';

export function Playground() {
  const onClick = () => console.log('Clicking');
  const onRemove = () => console.log('Removing');

  return (
    <Page title="Playground">
      <Stack vertical>
        <Stack alignment="center">
          <h2>Enabled tags:</h2>
          <Tag onRemove={onRemove}>Has onRemove</Tag>
          <Tag onClick={onClick}>Has onClick</Tag>
        </Stack>
        <Stack>
          <h2>Disabled tags:</h2>
          <Tag onRemove={onRemove} disabled>
            Has onRemove
          </Tag>
          <Tag onClick={onClick} disabled>
            Has onClick
          </Tag>
          <Tag>Base tag</Tag>
        </Stack>
      </Stack>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
