### PR TITLE
[Page] Apply design language

### DIFF
--- a/documentation/Color system.md
+++ b/documentation/Color system.md
@@ -273,3 +273,4 @@ Used to decorate elements where color does convey a specific meaning in componen
 | `--p-range-slider-thumb-size-base`        | `1.6rem`                                                                                                     |
 | `--p-range-slider-thumb-size-active`      | `2.4rem`                                                                                                     |
 | `--p-range-slider-thumb-scale`            | `1.5`                                                                                                        |
+| `--p-badge-font-weight`                   | `500`                                                                                                        |

--- a/src/components/ActionMenu/ActionMenu.scss
+++ b/src/components/ActionMenu/ActionMenu.scss
@@ -3,7 +3,7 @@
 
 .ActionMenu {
   &:not(.rollup) {
-    margin-left: -$menu-action-padding-x;
+    margin-left: var(--p-override-zero, -$menu-action-padding-x);
   }
 }
 

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -6,10 +6,10 @@ import {
   MenuActionDescriptor,
   MenuGroupDescriptor,
 } from '../../types';
-
 import {FeaturesContext} from '../../utilities/features';
 import {Button} from '../Button';
 import {ButtonGroup} from '../ButtonGroup';
+
 import {sortAndOverrideActionOrder} from './utilities';
 import {MenuAction, MenuGroup, RollupActions} from './components';
 import styles from './ActionMenu.scss';

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -7,6 +7,9 @@ import {
   MenuGroupDescriptor,
 } from '../../types';
 
+import {FeaturesContext} from '../../utilities/features';
+import {Button} from '../Button';
+import {ButtonGroup} from '../ButtonGroup';
 import {sortAndOverrideActionOrder} from './utilities';
 import {MenuAction, MenuGroup, RollupActions} from './components';
 import styles from './ActionMenu.scss';
@@ -25,6 +28,9 @@ interface State {
 }
 
 export class ActionMenu extends React.PureComponent<ActionMenuProps, State> {
+  static contextType = FeaturesContext;
+  context!: React.ContextType<typeof FeaturesContext>;
+
   state: State = {
     activeMenuGroup: undefined,
   };
@@ -55,6 +61,7 @@ export class ActionMenu extends React.PureComponent<ActionMenuProps, State> {
   }
 
   private renderActions = () => {
+    const {newDesignLanguage} = this.context || {};
     const {actions = [], groups = []} = this.props;
     const {activeMenuGroup} = this.state;
     const menuActions = [...actions, ...groups];
@@ -79,12 +86,24 @@ export class ActionMenu extends React.PureComponent<ActionMenuProps, State> {
       }
 
       const {content, ...rest} = action;
-      return (
+      return newDesignLanguage ? (
+        <Button key={index} {...rest}>
+          {content}
+        </Button>
+      ) : (
         <MenuAction key={`MenuAction-${index}`} content={content} {...rest} />
       );
     });
 
-    return <div className={styles.ActionsLayout}>{actionMarkup}</div>;
+    return (
+      <div className={styles.ActionsLayout}>
+        {newDesignLanguage ? (
+          <ButtonGroup>{actionMarkup}</ButtonGroup>
+        ) : (
+          actionMarkup
+        )}
+      </div>
+    );
   };
 
   private handleMenuGroupToggle = (group: string) => {

--- a/src/components/ActionMenu/components/MenuAction/MenuAction.scss
+++ b/src/components/ActionMenu/components/MenuAction/MenuAction.scss
@@ -15,7 +15,6 @@ $difference-between-touch-area-and-backdrop: control-height() -
   text-decoration: none;
   color: var(--p-text, color('ink', 'light'));
 
-  // Start - Delete below me when rolling out newDesignLanguage
   &:hover,
   &:active {
     color: color('ink');
@@ -57,71 +56,6 @@ $difference-between-touch-area-and-backdrop: control-height() -
     .IconWrapper {
       @include recolor-icon(color('ink', 'lightest'));
     }
-  }
-  // End - Delete after me when rolling out newDesignLanguage
-
-  &.newDesignLanguage {
-    @include focus-ring;
-    border-radius: var(--p-border-radius-base);
-
-    &:hover {
-      background: var(--p-action-secondary-hovered);
-      @include high-contrast-outline;
-    }
-
-    &:focus {
-      background-color: transparent;
-    }
-
-    // stylelint-disable-next-line selector-max-specificity
-    &:focus:not(:active) {
-      @include focus-ring($style: 'focused');
-    }
-
-    &:active {
-      background: var(--p-action-secondary-pressed);
-    }
-
-    // stylelint-disable-next-line selector-max-class
-    &.disabled {
-      color: var(--p-text-disabled);
-      cursor: default;
-      pointer-events: none;
-
-      // stylelint-disable-next-line selector-max-specificity, selector-max-class
-      .IconWrapper {
-        @include recolor-icon(var(--p-icon-disabled));
-      }
-    }
-
-    // stylelint-disable-next-line selector-max-class
-    .IconWrapper {
-      @include recolor-icon(--p-icon);
-    }
-
-    // Start - overrides than can be deleted during newDesignLanguage rollout
-    &:hover,
-    &:active {
-      color: var(--p-text);
-
-      // stylelint-disable-next-line selector-max-specificity, selector-max-class
-      .IconWrapper {
-        @include recolor-icon(var(--p-icon));
-      }
-    }
-
-    &:focus,
-    &:active {
-      // stylelint-disable-next-line selector-max-specificity
-      &::after {
-        background: transparent;
-      }
-    }
-
-    &::after {
-      height: auto;
-    }
-    // End - overrides than can be deleted during newDesignLanguage rollout
   }
 }
 

--- a/src/components/ActionMenu/components/MenuAction/MenuAction.tsx
+++ b/src/components/ActionMenu/components/MenuAction/MenuAction.tsx
@@ -3,7 +3,6 @@ import {CaretDownMinor} from '@shopify/polaris-icons';
 
 import {classNames} from '../../../../utilities/css';
 import {handleMouseUpByBlurring} from '../../../../utilities/focus';
-import {useFeatures} from '../../../../utilities/features';
 import {ComplexAction} from '../../../../types';
 import {Icon} from '../../../Icon';
 import {UnstyledLink} from '../../../UnstyledLink';
@@ -25,8 +24,6 @@ export function MenuAction({
   disabled,
   onAction,
 }: MenuActionProps) {
-  const {newDesignLanguage} = useFeatures();
-
   const iconMarkup = icon && (
     <span className={styles.IconWrapper}>
       <Icon source={icon} />
@@ -52,7 +49,6 @@ export function MenuAction({
 
   const menuActionClassNames = classNames(
     styles.MenuAction,
-    newDesignLanguage && styles.newDesignLanguage,
     disabled && styles.disabled,
   );
 

--- a/src/components/ActionMenu/components/MenuAction/tests/MenuAction.test.tsx
+++ b/src/components/ActionMenu/components/MenuAction/tests/MenuAction.test.tsx
@@ -119,24 +119,4 @@ describe('<MenuAction />', () => {
       expect(onActionSpy).toHaveBeenCalledTimes(1);
     });
   });
-
-  describe('newDesignLanguage', () => {
-    it('adds a newDesignLanguage class when newDesignLanguage is enabled', () => {
-      const menuAction = mountWithApp(<MenuAction />, {
-        features: {newDesignLanguage: true},
-      });
-      expect(menuAction).toContainReactComponent('button', {
-        className: 'MenuAction newDesignLanguage',
-      });
-    });
-
-    it('does not add a newDesignLanguage class when newDesignLanguage is disabled', () => {
-      const menuAction = mountWithApp(<MenuAction />, {
-        features: {newDesignLanguage: false},
-      });
-      expect(menuAction).toContainReactComponent('button', {
-        className: 'MenuAction',
-      });
-    });
-  });
 });

--- a/src/components/ActionMenu/components/MenuAction/tests/MenuAction.test.tsx
+++ b/src/components/ActionMenu/components/MenuAction/tests/MenuAction.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {CaretDownMinor, SaveMinor} from '@shopify/polaris-icons';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
-import {mountWithApp} from 'test-utilities';
 
 import {Icon} from '../../../../Icon';
 import {UnstyledLink} from '../../../../UnstyledLink';

--- a/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
+++ b/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
@@ -2,7 +2,6 @@ import React, {useCallback} from 'react';
 
 import {MenuGroupDescriptor} from '../../../../types';
 import {useFeatures} from '../../../../utilities/features';
-
 import {ActionList} from '../../../ActionList';
 import {Popover} from '../../../Popover';
 import {MenuAction} from '../MenuAction';

--- a/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
+++ b/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
@@ -1,9 +1,12 @@
 import React, {useCallback} from 'react';
 
 import {MenuGroupDescriptor} from '../../../../types';
+import {useFeatures} from '../../../../utilities/features';
+
 import {ActionList} from '../../../ActionList';
 import {Popover} from '../../../Popover';
 import {MenuAction} from '../MenuAction';
+import {Button} from '../../../Button';
 
 import styles from './MenuGroup.scss';
 
@@ -28,6 +31,7 @@ export function MenuGroup({
   onClose,
   onOpen,
 }: MenuGroupProps) {
+  const {newDesignLanguage} = useFeatures();
   const handleClose = useCallback(() => {
     onClose(title);
   }, [onClose, title]);
@@ -40,7 +44,16 @@ export function MenuGroup({
     return null;
   }
 
-  const popoverActivator = (
+  const popoverActivator = newDesignLanguage ? (
+    <Button
+      disclosure
+      icon={icon}
+      accessibilityLabel={accessibilityLabel}
+      onClick={handleOpen}
+    >
+      {title}
+    </Button>
+  ) : (
     <MenuAction
       disclosure
       content={title}

--- a/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
+++ b/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
@@ -6,8 +6,8 @@ import {
   trigger,
   ReactWrapper,
 } from 'test-utilities/legacy';
-
 import {Popover, ActionList, Button} from 'components';
+
 import {MenuAction} from '../../MenuAction';
 import {MenuGroup} from '../MenuGroup';
 

--- a/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
+++ b/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
@@ -6,8 +6,8 @@ import {
   trigger,
   ReactWrapper,
 } from 'test-utilities/legacy';
-import {Popover, ActionList} from 'components';
 
+import {Popover, ActionList, Button} from 'components';
 import {MenuAction} from '../../MenuAction';
 import {MenuGroup} from '../MenuGroup';
 
@@ -131,6 +131,26 @@ describe('<MenuGroup />', () => {
       trigger(wrapper.find(ActionList), 'onActionAnyItem');
 
       expect(onCloseSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('newDesignLanguage', () => {
+    it('uses Button instead of MenuAction as subcomponents', () => {
+      const wrapper = mountWithAppProvider(<MenuGroup {...mockProps} />, {
+        features: {newDesignLanguage: true},
+      });
+
+      expect(wrapper.find(Button)).toHaveLength(1);
+      expect(wrapper.find(MenuAction)).toHaveLength(0);
+    });
+
+    it('uses MenuAction instead of Button as subcomponents when disabled', () => {
+      const wrapper = mountWithAppProvider(<MenuGroup {...mockProps} />, {
+        features: {newDesignLanguage: false},
+      });
+
+      expect(wrapper.find(MenuAction)).toHaveLength(1);
+      expect(wrapper.find(Button)).toHaveLength(0);
     });
   });
 });

--- a/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
+++ b/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
@@ -5,7 +5,6 @@ import {ActionListSection, ActionListItemDescriptor} from '../../../../types';
 import {useI18n} from '../../../../utilities/i18n';
 import {useToggle} from '../../../../utilities/use-toggle';
 import {useFeatures} from '../../../../utilities/features';
-
 import {ActionList} from '../../../ActionList';
 import {Button} from '../../../Button';
 import {Popover} from '../../../Popover';

--- a/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
+++ b/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
@@ -4,6 +4,8 @@ import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 import {ActionListSection, ActionListItemDescriptor} from '../../../../types';
 import {useI18n} from '../../../../utilities/i18n';
 import {useToggle} from '../../../../utilities/use-toggle';
+import {useFeatures} from '../../../../utilities/features';
+
 import {ActionList} from '../../../ActionList';
 import {Button} from '../../../Button';
 import {Popover} from '../../../Popover';
@@ -19,6 +21,7 @@ export interface RollupActionsProps {
 
 export function RollupActions({items = [], sections = []}: RollupActionsProps) {
   const i18n = useI18n();
+  const {newDesignLanguage} = useFeatures();
 
   const {value: rollupOpen, toggle: toggleRollupOpen} = useToggle(false);
 
@@ -29,7 +32,7 @@ export function RollupActions({items = [], sections = []}: RollupActionsProps) {
   const activatorMarkup = (
     <div className={styles.RollupActivator}>
       <Button
-        plain
+        plain={!newDesignLanguage}
         icon={HorizontalDotsMinor}
         accessibilityLabel={i18n.translate(
           'Polaris.ActionMenu.RollupActions.rollupButton',

--- a/src/components/ActionMenu/tests/ActionMenu.test.tsx
+++ b/src/components/ActionMenu/tests/ActionMenu.test.tsx
@@ -5,6 +5,8 @@ import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {MenuGroupDescriptor, ActionListItemDescriptor} from '../../../types';
 import {MenuAction, MenuGroup, RollupActions} from '../components';
 import {ActionMenu, ActionMenuProps} from '../ActionMenu';
+import {Button} from '../../Button';
+import {ButtonGroup} from '../../ButtonGroup';
 
 describe('<ActionMenu />', () => {
   const mockProps: ActionMenuProps = {
@@ -363,6 +365,35 @@ describe('<ActionMenu />', () => {
       trigger(wrapper.find(MenuGroup), 'onClose', mockTitle);
 
       expect(wrapper.find(MenuGroup).prop('active')).toBeFalsy();
+    });
+  });
+
+  describe('newDesignLanguage', () => {
+    const mockActions: ActionMenuProps['actions'] = [
+      {content: 'mock content 1'},
+      {content: 'mock content 2'},
+    ];
+
+    it('uses Button and ButtonGroup instead of MenuAction as subcomponents', () => {
+      const wrapper = mountWithAppProvider(
+        <ActionMenu {...mockProps} actions={mockActions} />,
+        {features: {newDesignLanguage: true}},
+      );
+
+      expect(wrapper.find(Button)).toHaveLength(2);
+      expect(wrapper.find(ButtonGroup)).toHaveLength(1);
+      expect(wrapper.find(MenuAction)).toHaveLength(0);
+    });
+
+    it('uses MenuAction instead of Button and ButtonGroup as subcomponents when disabled', () => {
+      const wrapper = mountWithAppProvider(
+        <ActionMenu {...mockProps} actions={mockActions} />,
+        {features: {newDesignLanguage: false}},
+      );
+
+      expect(wrapper.find(MenuAction)).toHaveLength(2);
+      expect(wrapper.find(Button)).toHaveLength(0);
+      expect(wrapper.find(ButtonGroup)).toHaveLength(0);
     });
   });
 });

--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -24,6 +24,7 @@ $pip-spacing: ($height - $pip-size) / 2;
   font-size: rem(13px);
   line-height: $height;
   color: var(--p-text, color('ink', 'light'));
+  font-weight: var(--p-badge-font-weight, 400);
 }
 
 .sizeSmall {

--- a/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -30,7 +30,7 @@ $difference-between-touch-area-and-backdrop: control-height() -
     text-decoration: none;
 
     .Icon {
-      @include recolor-icon(var(--p-icon, color('ink')));
+      @include recolor-icon(var(--p-icon-pressed, color('ink')));
     }
   }
   // stylelint-disable selector-max-specificity
@@ -74,7 +74,7 @@ $difference-between-touch-area-and-backdrop: control-height() -
 }
 
 .Icon {
-  @include recolor-icon(var(--p-icon-subdued, color('ink', 'lighter')));
+  @include recolor-icon(var(--p-icon, color('ink', 'lighter')));
   width: $icon-size;
   height: $icon-size;
   margin: (-0.5 * $icon-size) 0 (-0.5 * $icon-size) rem(-8px);

--- a/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -24,6 +24,10 @@ $difference-between-touch-area-and-backdrop: control-height() -
   color: var(--p-text-subdued, color('ink', 'lighter'));
   text-decoration: none;
 
+  &.newDesignLanguage {
+    margin-left: 0;
+  }
+
   &:hover,
   &:active {
     color: var(--p-text, color('ink'));

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -6,6 +6,7 @@ import {UnstyledLink} from '../UnstyledLink';
 import {CallbackAction, LinkAction} from '../../types';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 import {FeaturesContext} from '../../utilities/features';
+import {classNames} from '../../utilities/css';
 
 import styles from './Breadcrumbs.scss';
 
@@ -41,12 +42,17 @@ export class Breadcrumbs extends React.PureComponent<BreadcrumbsProps, never> {
       </span>
     );
 
+    const breadcrumbClassNames = classNames(
+      styles.Breadcrumb,
+      newDesignLanguage && styles.newDesignLanguage,
+    );
+
     const breadcrumbMarkup =
       'url' in breadcrumb ? (
         <UnstyledLink
           key={content}
           url={breadcrumb.url}
-          className={styles.Breadcrumb}
+          className={breadcrumbClassNames}
           onMouseUp={handleMouseUpByBlurring}
           aria-label={breadcrumb.accessibilityLabel}
         >
@@ -55,7 +61,7 @@ export class Breadcrumbs extends React.PureComponent<BreadcrumbsProps, never> {
       ) : (
         <button
           key={content}
-          className={styles.Breadcrumb}
+          className={breadcrumbClassNames}
           onClick={breadcrumb.onAction}
           onMouseUp={handleMouseUpByBlurring}
           type="button"

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import {ChevronLeftMinor} from '@shopify/polaris-icons';
+import {ChevronLeftMinor, ArrowLeftMinor} from '@shopify/polaris-icons';
 
 import {Icon} from '../Icon';
 import {UnstyledLink} from '../UnstyledLink';
 import {CallbackAction, LinkAction} from '../../types';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
+import {FeaturesContext} from '../../utilities/features';
 
 import styles from './Breadcrumbs.scss';
 
@@ -14,7 +15,11 @@ export interface BreadcrumbsProps {
 }
 
 export class Breadcrumbs extends React.PureComponent<BreadcrumbsProps, never> {
+  static contextType = FeaturesContext;
+  context!: React.ContextType<typeof FeaturesContext>;
+
   render() {
+    const {newDesignLanguage} = this.context || {};
     const {breadcrumbs} = this.props;
     const breadcrumb = breadcrumbs[breadcrumbs.length - 1];
     if (breadcrumb == null) {
@@ -26,9 +31,13 @@ export class Breadcrumbs extends React.PureComponent<BreadcrumbsProps, never> {
     const contentMarkup = (
       <span className={styles.ContentWrapper}>
         <span className={styles.Icon}>
-          <Icon source={ChevronLeftMinor} />
+          <Icon
+            source={newDesignLanguage ? ArrowLeftMinor : ChevronLeftMinor}
+          />
         </span>
-        <span className={styles.Content}>{content}</span>
+        {newDesignLanguage ? null : (
+          <span className={styles.Content}>{content}</span>
+        )}
       </span>
     );
 

--- a/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 
+import {UnstyledLink} from '../../UnstyledLink';
 import {CallbackAction, LinkAction} from '../../../types';
 import {Breadcrumbs} from '../Breadcrumbs';
 
@@ -92,6 +93,42 @@ describe('<Breadcrumbs />', () => {
 
       breadcrumbs.find('button').simulate('click');
       expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('newDesignLanguage', () => {
+    const linkBreadcrumbs: LinkAction[] = [
+      {
+        content: 'Products',
+        url: 'https://www.shopify.com',
+        target: 'REMOTE',
+      },
+    ];
+
+    it('adds a newDesignLanguage class', () => {
+      const wrapper = mountWithAppProvider(
+        <Breadcrumbs breadcrumbs={linkBreadcrumbs} />,
+        {
+          features: {newDesignLanguage: true},
+        },
+      );
+
+      expect(wrapper.find(UnstyledLink).prop('className')).toStrictEqual(
+        'Breadcrumb newDesignLanguage',
+      );
+    });
+
+    it('does not add a newDesignLanguage class', () => {
+      const wrapper = mountWithAppProvider(
+        <Breadcrumbs breadcrumbs={linkBreadcrumbs} />,
+        {
+          features: {newDesignLanguage: false},
+        },
+      );
+
+      expect(wrapper.find(UnstyledLink).prop('className')).toStrictEqual(
+        'Breadcrumb',
+      );
     });
   });
 });

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -92,7 +92,7 @@ $stacking-order: (
 }
 
 // stylelint-disable selector-max-combinators, selector-max-compound-selectors, selector-max-specificity
-[data-buttongroup-segmented] {
+[data-buttongroup-segmented='true'] {
   .Button,
   .Button::after {
     border-radius: 0;

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -391,7 +391,7 @@ Use for layouts that benefit from more screen width, such as wide tables or list
 <Page
   fullWidth
   title="Orders"
-  primaryAction={{content: 'Create order'}}
+  primaryAction={{content: 'Create order', icon: PlusMinor}}
   secondaryActions={[{content: 'Export'}]}
   pagination={{
     hasNext: true,

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -37,6 +37,10 @@ $action-menu-rollup-computed-width: icon-size() + (spacing(tight) * 2);
 .BreadcrumbWrapper {
   flex: 0 1 auto;
   max-width: 100%;
+
+  &.newDesignLanguage {
+    margin-right: spacing();
+  }
 }
 
 .PaginationWrapper {
@@ -98,4 +102,29 @@ $action-menu-rollup-computed-width: icon-size() + (spacing(tight) * 2);
   }
 
   @include print-hidden;
+
+  &.newDesignLanguage {
+    margin-top: 0;
+  }
+}
+
+.Row {
+  display: flex;
+  justify-content: space-between;
+}
+
+.Bottom {
+  margin-top: spacing();
+}
+
+.LeftAlign {
+  display: flex;
+  align-content: flex-start;
+  align-items: center;
+}
+
+.RightAlign {
+  display: flex;
+  align-content: flex-end;
+  align-items: center;
 }

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -11,6 +11,11 @@ $action-menu-rollup-computed-width: icon-size() + (spacing(tight) * 2);
 .separator {
   padding-bottom: spacing();
   border-bottom: border();
+
+  &.newDesignLanguage {
+    padding-bottom: spacing();
+    border-bottom: border();
+  }
 }
 
 .titleHidden {
@@ -111,10 +116,15 @@ $action-menu-rollup-computed-width: icon-size() + (spacing(tight) * 2);
 .Row {
   display: flex;
   justify-content: space-between;
-}
 
-.Bottom {
-  margin-top: spacing();
+  + .Row {
+    margin-top: spacing();
+
+    // stylelint-disable-next-line selector-max-combinators, selector-max-class
+    .mobileView & {
+      margin-top: spacing(tight);
+    }
+  }
 }
 
 .LeftAlign {
@@ -127,4 +137,5 @@ $action-menu-rollup-computed-width: icon-size() + (spacing(tight) * 2);
   display: flex;
   align-content: flex-end;
   align-items: center;
+  margin-left: spacing(tight);
 }

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -133,19 +133,35 @@ export function Header({
   );
 
   if (newDesignLanguage) {
+    const slot1 = breadcrumbMarkup;
+    const slot2 = pageTitleMarkup;
+    let slot3: JSX.Element | null = null;
+    let slot4: JSX.Element | null = null;
+    let slot5: JSX.Element | null = null;
+
+    if (paginationMarkup == null && actionMenuMarkup == null) {
+      slot3 = primaryActionMarkup;
+    } else if (paginationMarkup != null) {
+      slot3 = paginationMarkup;
+      slot4 = actionMenuMarkup;
+      slot5 = primaryActionMarkup;
+    }
+
     return (
       <div className={headerClassNames}>
         <div className={styles.Row}>
           <div className={styles.LeftAlign}>
-            {breadcrumbMarkup}
-            {pageTitleMarkup}
+            {slot1}
+            {slot2}
           </div>
-          <div className={styles.RightAlign}>{paginationMarkup}</div>
+          <div className={styles.RightAlign}>{slot3}</div>
         </div>
-        <div className={classNames(styles.Row, styles.Bottom)}>
-          <div className={styles.LeftAlign}>{actionMenuMarkup}</div>
-          <div className={styles.RightAlign}>{primaryActionMarkup}</div>
-        </div>
+        {slot4 || slot5 ? (
+          <div className={classNames(styles.Row, styles.Bottom)}>
+            <div className={styles.LeftAlign}>{slot4}</div>
+            <div className={styles.RightAlign}>{slot5}</div>
+          </div>
+        ) : null}
       </div>
     );
   }

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -25,6 +25,8 @@ import {ButtonGroup} from '../../../ButtonGroup';
 import {Title, TitleProps} from './components';
 import styles from './Header.scss';
 
+type MaybeJSX = JSX.Element | null;
+
 interface PrimaryAction
   extends DestructableAction,
     DisableableAction,
@@ -110,7 +112,7 @@ export function Header({
 
   const primaryActionMarkup = primaryAction ? (
     <ConditionalWrapper
-      condition={!newDesignLanguage}
+      condition={newDesignLanguage === false}
       wrapper={(children) => (
         <div className={styles.PrimaryActionWrapper}>{children}</div>
       )}
@@ -131,7 +133,7 @@ export function Header({
   const actionMenuMarkup =
     secondaryActions.length > 0 || hasGroupsWithActions(actionGroups) ? (
       <ConditionalWrapper
-        condition={!newDesignLanguage}
+        condition={newDesignLanguage === false}
         wrapper={(children) => (
           <div className={styles.ActionMenuWrapper}>{children}</div>
         )}
@@ -155,24 +157,40 @@ export function Header({
   );
 
   if (newDesignLanguage) {
+    //
+    //    Header Layout
+    // |----------------------------------------------------|
+    // | slot1 | slot2 |                    | slot3 | slot4 |
+    // |----------------------------------------------------|
+    // | slot5 |                                    | slot6 |
+    // |----------------------------------------------------|
+
     const slot1 = breadcrumbMarkup;
-    let slot2: JSX.Element | null = null;
-    let slot3: JSX.Element | null = null;
-    let slot4: JSX.Element | null = null;
-    let slot5: JSX.Element | null = null;
-    let slot6: JSX.Element | null = null;
+    let slot2: MaybeJSX = null;
+    let slot3: MaybeJSX = null;
+    let slot4: MaybeJSX = null;
+    let slot5: MaybeJSX = null;
+    let slot6: MaybeJSX = null;
+
+    const maxEmsMobile = 8;
+    const maxEmsDesktop = 20;
 
     if (isNavigationCollapsed) {
       slot3 = actionMenuMarkup;
       slot4 = primaryActionMarkup;
-      if (breadcrumbMarkup == null && title && title.length <= 8) {
+      if (breadcrumbMarkup == null && title && title.length <= maxEmsMobile) {
         slot2 = pageTitleMarkup;
       } else {
         slot5 = pageTitleMarkup;
       }
     } else {
       slot2 = pageTitleMarkup;
-      if (paginationMarkup == null && actionMenuMarkup == null) {
+      if (
+        paginationMarkup == null &&
+        actionMenuMarkup == null &&
+        title &&
+        title.length <= maxEmsDesktop
+      ) {
         slot4 = primaryActionMarkup;
       } else {
         slot4 = paginationMarkup;
@@ -184,17 +202,17 @@ export function Header({
     return (
       <div className={headerClassNames}>
         <ConditionalRender
-          condition={[slot1, slot2, slot3, slot4].some((slot) => slot != null)}
+          condition={[slot1, slot2, slot3, slot4].some(notNull)}
         >
           <div className={styles.Row}>
             <div className={styles.LeftAlign}>
               {slot1}
               {slot2}
             </div>
-            <ConditionalRender condition={slot3 != null || slot4 != null}>
+            <ConditionalRender condition={[slot3, slot4].some(notNull)}>
               <div className={styles.RightAlign}>
                 <ConditionalWrapper
-                  condition={slot3 != null && slot4 != null}
+                  condition={[slot3, slot4].every(notNull)}
                   wrapper={(children) => <ButtonGroup>{children}</ButtonGroup>}
                 >
                   {slot3}
@@ -204,10 +222,12 @@ export function Header({
             </ConditionalRender>
           </div>
         </ConditionalRender>
-        <ConditionalRender condition={slot5 != null || slot6 != null}>
+        <ConditionalRender condition={[slot5, slot6].some(notNull)}>
           <div className={styles.Row}>
             <div className={styles.LeftAlign}>{slot5}</div>
-            <div className={styles.RightAlign}>{slot6}</div>
+            <ConditionalRender condition={slot6 != null}>
+              <div className={styles.RightAlign}>{slot6}</div>
+            </ConditionalRender>
           </div>
         </ConditionalRender>
       </div>
@@ -251,4 +271,8 @@ function shouldShowIconOnly(
     accessibilityLabel,
     icon,
   };
+}
+
+function notNull(value: any) {
+  return value != null;
 }

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -157,47 +157,15 @@ export function Header({
   );
 
   if (newDesignLanguage) {
-    //
-    //    Header Layout
-    // |----------------------------------------------------|
-    // | slot1 | slot2 |                    | slot3 | slot4 |
-    // |----------------------------------------------------|
-    // | slot5 |                                    | slot6 |
-    // |----------------------------------------------------|
-
-    const slot1 = breadcrumbMarkup;
-    let slot2: MaybeJSX = null;
-    let slot3: MaybeJSX = null;
-    let slot4: MaybeJSX = null;
-    let slot5: MaybeJSX = null;
-    let slot6: MaybeJSX = null;
-
-    const maxEmsMobile = 8;
-    const maxEmsDesktop = 20;
-
-    if (isNavigationCollapsed) {
-      slot3 = actionMenuMarkup;
-      slot4 = primaryActionMarkup;
-      if (breadcrumbMarkup == null && title && title.length <= maxEmsMobile) {
-        slot2 = pageTitleMarkup;
-      } else {
-        slot5 = pageTitleMarkup;
-      }
-    } else {
-      slot2 = pageTitleMarkup;
-      if (
-        paginationMarkup == null &&
-        actionMenuMarkup == null &&
-        title &&
-        title.length <= maxEmsDesktop
-      ) {
-        slot4 = primaryActionMarkup;
-      } else {
-        slot4 = paginationMarkup;
-        slot5 = actionMenuMarkup;
-        slot6 = primaryActionMarkup;
-      }
-    }
+    const {slot1, slot2, slot3, slot4, slot5, slot6} = determineLayout({
+      breadcrumbMarkup,
+      pageTitleMarkup,
+      paginationMarkup,
+      actionMenuMarkup,
+      primaryActionMarkup,
+      title,
+      isNavigationCollapsed,
+    });
 
     return (
       <div className={headerClassNames}>
@@ -275,4 +243,94 @@ function shouldShowIconOnly(
 
 function notNull(value: any) {
   return value != null;
+}
+
+function determineLayout({
+  breadcrumbMarkup,
+  pageTitleMarkup,
+  title,
+  paginationMarkup,
+  actionMenuMarkup,
+  primaryActionMarkup,
+  isNavigationCollapsed,
+}: {
+  breadcrumbMarkup: MaybeJSX;
+  pageTitleMarkup: JSX.Element;
+  title?: string;
+  paginationMarkup: MaybeJSX;
+  actionMenuMarkup: MaybeJSX;
+  primaryActionMarkup: MaybeJSX;
+  isNavigationCollapsed: boolean;
+}) {
+  const shortTitle = 20;
+  const reallyShortTitle = 8;
+
+  //    Header Layout
+  // |----------------------------------------------------|
+  // | slot1 | slot2 |                    | slot3 | slot4 |
+  // |----------------------------------------------------|
+  // | slot5 |                                    | slot6 |
+  // |----------------------------------------------------|
+  //
+  const layouts = {
+    mobileCompact: {
+      slots: {
+        slot1: null,
+        slot2: pageTitleMarkup,
+        slot3: actionMenuMarkup,
+        slot4: primaryActionMarkup,
+        slot5: null,
+        slot6: null,
+      },
+      condition:
+        isNavigationCollapsed &&
+        breadcrumbMarkup == null &&
+        title != null &&
+        title.length <= reallyShortTitle,
+    },
+    mobileDefault: {
+      slots: {
+        slot1: breadcrumbMarkup,
+        slot2: null,
+        slot3: actionMenuMarkup,
+        slot4: primaryActionMarkup,
+        slot5: pageTitleMarkup,
+        slot6: null,
+      },
+      condition: isNavigationCollapsed,
+    },
+    desktopCompact: {
+      slots: {
+        slot1: breadcrumbMarkup,
+        slot2: pageTitleMarkup,
+        slot3: null,
+        slot4: primaryActionMarkup,
+        slot5: null,
+        slot6: null,
+      },
+      condition:
+        !isNavigationCollapsed &&
+        paginationMarkup == null &&
+        actionMenuMarkup == null &&
+        title != null &&
+        title.length <= shortTitle,
+    },
+    desktopDefault: {
+      slots: {
+        slot1: breadcrumbMarkup,
+        slot2: pageTitleMarkup,
+        slot3: null,
+        slot4: paginationMarkup,
+        slot5: actionMenuMarkup,
+        slot6: primaryActionMarkup,
+      },
+      condition: !isNavigationCollapsed,
+    },
+  };
+
+  const layout =
+    Object.values(layouts).find((layout) => layout.condition) ||
+    layouts.desktopDefault;
+
+  return layout.slots;
 }

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {classNames} from '../../../../utilities/css';
 import {buttonsFrom} from '../../../Button';
 import {useMediaQuery} from '../../../../utilities/media-query';
+import {useFeatures} from '../../../../utilities/features';
 import {
   MenuGroupDescriptor,
   MenuActionDescriptor,
@@ -58,10 +59,16 @@ export function Header({
   actionGroups = [],
 }: HeaderProps) {
   const {isNavigationCollapsed} = useMediaQuery();
+  const {newDesignLanguage} = useFeatures();
 
   const breadcrumbMarkup =
     breadcrumbs.length > 0 ? (
-      <div className={styles.BreadcrumbWrapper}>
+      <div
+        className={classNames(
+          styles.BreadcrumbWrapper,
+          newDesignLanguage && styles.newDesignLanguage,
+        )}
+      >
         <Breadcrumbs breadcrumbs={breadcrumbs} />
       </div>
     ) : null;
@@ -102,7 +109,12 @@ export function Header({
 
   const actionMenuMarkup =
     secondaryActions.length > 0 || hasGroupsWithActions(actionGroups) ? (
-      <div className={styles.ActionMenuWrapper}>
+      <div
+        className={classNames(
+          styles.ActionMenuWrapper,
+          newDesignLanguage && styles.newDesignLanguage,
+        )}
+      >
         <ActionMenu
           actions={secondaryActions}
           groups={actionGroups}
@@ -119,6 +131,24 @@ export function Header({
     actionMenuMarkup && styles.hasActionMenu,
     isNavigationCollapsed && styles.mobileView,
   );
+
+  if (newDesignLanguage) {
+    return (
+      <div className={headerClassNames}>
+        <div className={styles.Row}>
+          <div className={styles.LeftAlign}>
+            {breadcrumbMarkup}
+            {pageTitleMarkup}
+          </div>
+          <div className={styles.RightAlign}>{paginationMarkup}</div>
+        </div>
+        <div className={classNames(styles.Row, styles.Bottom)}>
+          <div className={styles.LeftAlign}>{actionMenuMarkup}</div>
+          <div className={styles.RightAlign}>{primaryActionMarkup}</div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={headerClassNames}>

--- a/src/components/Page/components/Header/components/Title/Title.scss
+++ b/src/components/Page/components/Header/components/Title/Title.scss
@@ -39,7 +39,7 @@
     // stylelint-disable-next-line selector-max-class
     &.newDesignLanguage {
       margin-top: spacing(extra-tight);
-      vertical-align: bottom;
+      vertical-align: text-bottom;
     }
   }
 }

--- a/src/components/Page/components/Header/components/Title/Title.scss
+++ b/src/components/Page/components/Header/components/Title/Title.scss
@@ -6,6 +6,7 @@
 
 .SubTitle {
   margin-top: spacing(tight);
+  color: var(--p-text-subdued, inherit);
 }
 
 .hasThumbnail {
@@ -34,5 +35,11 @@
   .TitleMetadata {
     margin-top: spacing(tight);
     display: inline-block;
+
+    // stylelint-disable-next-line selector-max-class
+    &.newDesignLanguage {
+      margin-top: spacing(extra-tight);
+      vertical-align: bottom;
+    }
   }
 }

--- a/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/src/components/Page/components/Header/components/Title/Title.tsx
@@ -4,6 +4,7 @@ import {classNames} from '../../../../../../utilities/css';
 import {AvatarProps} from '../../../../../Avatar';
 import {ThumbnailProps} from '../../../../../Thumbnail';
 import {DisplayText} from '../../../../../DisplayText';
+import {useFeatures} from '../../../../../../utilities/features';
 
 import styles from './Title.scss';
 
@@ -21,6 +22,7 @@ export interface TitleProps {
 }
 
 export function Title({title, subtitle, titleMetadata, thumbnail}: TitleProps) {
+  const {newDesignLanguage} = useFeatures();
   const titleMarkup = title ? (
     <div className={styles.Title}>
       <DisplayText size="large" element="h1">
@@ -30,7 +32,14 @@ export function Title({title, subtitle, titleMetadata, thumbnail}: TitleProps) {
   ) : null;
 
   const titleMetadataMarkup = titleMetadata ? (
-    <div className={styles.TitleMetadata}>{titleMetadata}</div>
+    <div
+      className={classNames(
+        styles.TitleMetadata,
+        newDesignLanguage && styles.newDesignLanguage,
+      )}
+    >
+      {titleMetadata}
+    </div>
   ) : null;
 
   const wrappedTitleMarkup = titleMetadata ? (

--- a/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
+++ b/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {Badge, DisplayText, Avatar} from 'components';
 
 import {Title} from '../Title';
@@ -59,6 +60,31 @@ describe('<Title />', () => {
     it('renders the thumbnail when defined', () => {
       const pageTitle = mountWithAppProvider(<Title {...propsWithThumbail} />);
       expect(pageTitle.find(Avatar).exists()).toBe(true);
+    });
+  });
+
+  describe('newDesignLanguage', () => {
+    const propsWithMetadata = {
+      ...mockProps,
+      titleMetadata: <Badge>Sold</Badge>,
+    };
+
+    it('adds a newDesignLanguage class when enabled', () => {
+      const title = mountWithApp(<Title {...propsWithMetadata} />, {
+        features: {newDesignLanguage: true},
+      });
+      expect(title).toContainReactComponent('div', {
+        className: 'TitleMetadata newDesignLanguage',
+      });
+    });
+
+    it('does not add a newDesignLanguage class when disabled', () => {
+      const title = mountWithApp(<Title {...propsWithMetadata} />, {
+        features: {newDesignLanguage: false},
+      });
+      expect(title).toContainReactComponent('div', {
+        className: 'TitleMetadata',
+      });
     });
   });
 });

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -249,24 +249,16 @@ describe('<Header />', () => {
       const header = mountWithAppProvider(<Header title="Hello, world!" />, {
         features: {newDesignLanguage: true},
       });
-      expect(
-        header
-          .find('div')
-          .first()
-          .prop('className'),
-      ).toBe('Header newDesignLanguage');
+      expect(header.find('div').first().prop('className')).toBe(
+        'Header newDesignLanguage',
+      );
     });
 
     it('does not add a newDesignLanguage class if disabled', () => {
       const header = mountWithAppProvider(<Header title="Hello, world!" />, {
         features: {newDesignLanguage: false},
       });
-      expect(
-        header
-          .find('div')
-          .first()
-          .prop('className'),
-      ).toBe('Header');
+      expect(header.find('div').first().prop('className')).toBe('Header');
     });
 
     it('removes primary and secondary action wrapper divs', () => {

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {PlusMinor} from '@shopify/polaris-icons';
 import {
   ActionMenu,
   Breadcrumbs,
@@ -6,6 +7,8 @@ import {
   Pagination,
   Badge,
   Avatar,
+  Button,
+  ButtonGroup,
 } from 'components';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
@@ -220,6 +223,143 @@ describe('<Header />', () => {
       );
 
       expect(wrapper.find(ActionMenu).prop('rollup')).toBe(true);
+    });
+  });
+
+  describe('newDesignLanguage', () => {
+    const primaryAction: HeaderProps['primaryAction'] = {
+      content: 'Click me!',
+      icon: PlusMinor,
+    };
+
+    const secondaryActions: HeaderProps['secondaryActions'] = [
+      {content: 'mock content 1'},
+      {content: 'mock content 2'},
+    ];
+
+    const breadcrumbs: LinkAction[] = [
+      {
+        content: 'Products',
+        url: 'https://www.google.com',
+        target: 'REMOTE',
+      },
+    ];
+
+    it('adds a newDesignLanguage class', () => {
+      const header = mountWithAppProvider(<Header title="Hello, world!" />, {
+        features: {newDesignLanguage: true},
+      });
+      expect(
+        header
+          .find('div')
+          .first()
+          .prop('className'),
+      ).toBe('Header newDesignLanguage');
+    });
+
+    it('does not add a newDesignLanguage class if disabled', () => {
+      const header = mountWithAppProvider(<Header title="Hello, world!" />, {
+        features: {newDesignLanguage: false},
+      });
+      expect(
+        header
+          .find('div')
+          .first()
+          .prop('className'),
+      ).toBe('Header');
+    });
+
+    it('removes primary and secondary action wrapper divs', () => {
+      const header = mountWithAppProvider(
+        <Header
+          title="Hello, world!"
+          primaryAction={primaryAction}
+          secondaryActions={secondaryActions}
+        />,
+        {
+          features: {newDesignLanguage: true},
+        },
+      );
+      expect(header.find('.PrimaryActionWrapper')).toHaveLength(0);
+      expect(header.find('.ActionMenuWrapper')).toHaveLength(0);
+    });
+
+    it('adds primary and secondary action wrapper divs when disabled', () => {
+      const header = mountWithAppProvider(
+        <Header
+          title="Hello, world!"
+          primaryAction={primaryAction}
+          secondaryActions={secondaryActions}
+        />,
+        {
+          features: {newDesignLanguage: false},
+        },
+      );
+      expect(header.find('.PrimaryActionWrapper')).toHaveLength(1);
+      expect(header.find('.ActionMenuWrapper')).toHaveLength(1);
+    });
+
+    it('renders a compact mobile layout with icon-only primary action', () => {
+      const header = mountWithAppProvider(
+        <Header title="mmmmmmmm" primaryAction={primaryAction} />,
+        {
+          features: {newDesignLanguage: true},
+          mediaQuery: {isNavigationCollapsed: true},
+        },
+      );
+      expect(header.find('.Row')).toHaveLength(1);
+      expect(header.find(Button).prop('icon')).toStrictEqual(PlusMinor);
+      expect(header.find(Button).text()).toStrictEqual('');
+    });
+
+    it('renders a compact desktop layout and hides primary action icon', () => {
+      const header = mountWithAppProvider(
+        <Header title="mmmmmmmm" primaryAction={primaryAction} />,
+        {
+          features: {newDesignLanguage: true},
+          mediaQuery: {isNavigationCollapsed: false},
+        },
+      );
+      expect(header.find('.Row')).toHaveLength(1);
+      expect(header.find(Button).prop('icon')).toBeUndefined();
+      expect(header.find(Button).text()).toStrictEqual('Click me!');
+    });
+
+    it('renders a default mobile layout', () => {
+      const header = mountWithAppProvider(
+        <Header title="mmmmmmmmm" breadcrumbs={breadcrumbs} />,
+        {
+          features: {newDesignLanguage: true},
+          mediaQuery: {isNavigationCollapsed: true},
+        },
+      );
+      expect(header.find('.Row')).toHaveLength(2);
+    });
+
+    it('renders a default desktop layout', () => {
+      const header = mountWithAppProvider(
+        <Header title="mmmmmmmmmmmmmmmmmmmmm" primaryAction={primaryAction} />,
+        {
+          features: {newDesignLanguage: true},
+          mediaQuery: {isNavigationCollapsed: false},
+        },
+      );
+      expect(header.find('.Row')).toHaveLength(2);
+    });
+
+    it('wraps the secondary activator and primary buttons in a ButtonGroup', () => {
+      const header = mountWithAppProvider(
+        <Header
+          title="Hello, world!"
+          primaryAction={primaryAction}
+          secondaryActions={secondaryActions}
+        />,
+        {
+          features: {newDesignLanguage: true},
+          mediaQuery: {isNavigationCollapsed: true},
+        },
+      );
+      expect(header.find(ButtonGroup)).toHaveLength(1);
     });
   });
 });

--- a/src/components/Pagination/Pagination.scss
+++ b/src/components/Pagination/Pagination.scss
@@ -51,7 +51,6 @@ $stacking-order: (
     appearance: none;
     box-shadow: none;
 
-    // Start - Delete below me when removing newDesignLanguage
     &:hover,
     &:active {
       @include recolor-icon(color('ink'));
@@ -91,38 +90,6 @@ $stacking-order: (
       transition-property: background;
       transition-duration: duration();
       transition-timing-function: easing();
-    }
-    // End - Delete after me when removing newDesignLanguage
-
-    // stylelint-disable selector-max-specificity, selector-max-class
-    &.newDesignLanguage {
-      @include recolor-icon(var(--p-icon));
-      @include focus-ring;
-
-      &:hover,
-      &:active,
-      &:disabled {
-        background: transparent;
-        border: none;
-        box-shadow: none;
-      }
-
-      &:hover {
-        background: var(--p-action-secondary-hovered);
-        @include high-contrast-outline;
-      }
-
-      &:active {
-        background: var(--p-action-secondary-pressed);
-      }
-
-      &:focus:not(:active) {
-        @include focus-ring($style: 'focused');
-      }
-
-      &:disabled {
-        @include recolor-icon(var(--p-icon-disabled));
-      }
     }
   }
 
@@ -199,43 +166,6 @@ $stacking-order: (
     box-shadow: none;
   }
   // Delete above me during newDesignLanguage rollout
-
-  &.newDesignLanguage {
-    @include focus-ring;
-    box-shadow: none;
-    border-color: transparent;
-    border-radius: var(--p-border-radius-base);
-
-    &.rightButton {
-      margin-left: spacing('tight');
-    }
-
-    &:hover {
-      background: var(--p-action-secondary-hovered);
-      @include high-contrast-outline;
-    }
-
-    &:focus {
-      outline: 0;
-    }
-
-    &:focus:not(:active) {
-      z-index: z-index(focused, $stacking-order);
-      @include focus-ring($style: 'focused');
-    }
-
-    &:active {
-      background: var(--p-action-secondary-pressed);
-    }
-
-    &:disabled {
-      @include recolor-icon(var(--p-icon-disabled));
-      background: var(--p-action-secondary-disabled);
-      color: var(--p-text-disabled);
-      cursor: default;
-      box-shadow: none;
-    }
-  }
 }
 
 .PreviousButton {

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import {ArrowLeftMinor, ArrowRightMinor} from '@shopify/polaris-icons';
-
+import {
+  ArrowLeftMinor,
+  ArrowRightMinor,
+  ChevronLeftMinor,
+  ChevronRightMinor,
+} from '@shopify/polaris-icons';
 import {TextStyle} from '../TextStyle';
 import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
@@ -12,6 +16,9 @@ import {KeypressListener} from '../KeypressListener';
 import {Key} from '../../types';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 import {useFeatures} from '../../utilities/features';
+import {Button} from '../Button';
+import {ButtonGroup} from '../ButtonGroup';
+import {ConditionalWrapper} from '../../utilities/components';
 
 import styles from './Pagination.scss';
 
@@ -74,16 +81,10 @@ export function Pagination({
 
   const previousClassName = classNames(
     styles.Button,
-    newDesignLanguage && styles.newDesignLanguage,
     !label && styles.PreviousButton,
   );
 
-  const nextClassName = classNames(
-    styles.Button,
-    newDesignLanguage && styles.newDesignLanguage,
-    newDesignLanguage && styles.rightButton,
-    !label && styles.NextButton,
-  );
+  const nextClassName = classNames(styles.Button, !label && styles.NextButton);
 
   const previousButton = previousURL ? (
     <UnstyledLink
@@ -131,22 +132,46 @@ export function Pagination({
     </button>
   );
 
+  const prev = newDesignLanguage ? (
+    <Button
+      icon={ChevronLeftMinor}
+      accessibilityLabel={i18n.translate('Polaris.Pagination.previous')}
+      url={previousURL}
+      onClick={onPrevious}
+      disabled={!hasPrevious}
+    />
+  ) : (
+    previousButton
+  );
+
   const constructedPrevious =
     previousTooltip && hasPrevious ? (
       <Tooltip activatorWrapper="span" content={previousTooltip}>
-        {previousButton}
+        {prev}
       </Tooltip>
     ) : (
-      previousButton
+      prev
     );
+
+  const next = newDesignLanguage ? (
+    <Button
+      icon={ChevronRightMinor}
+      accessibilityLabel={i18n.translate('Polaris.Pagination.next')}
+      url={nextURL}
+      onClick={onNext}
+      disabled={!hasNext}
+    />
+  ) : (
+    nextButton
+  );
 
   const constructedNext =
     nextTooltip && hasNext ? (
       <Tooltip activatorWrapper="span" content={nextTooltip}>
-        {nextButton}
+        {next}
       </Tooltip>
     ) : (
-      nextButton
+      next
     );
 
   const previousHandler = onPrevious || noop;
@@ -191,18 +216,32 @@ export function Pagination({
     );
 
   const labelMarkup = label ? (
-    <div className={styles.Label} aria-live="polite">
+    <div
+      className={newDesignLanguage ? undefined : styles.Label}
+      aria-live="polite"
+    >
       {labelTextMarkup}
     </div>
   ) : null;
 
   return (
-    <nav className={className} aria-label={navLabel} ref={node}>
+    <nav
+      className={newDesignLanguage ? undefined : className}
+      aria-label={navLabel}
+      ref={node}
+    >
       {previousButtonEvents}
-      {constructedPrevious}
-      {labelMarkup}
       {nextButtonEvents}
-      {constructedNext}
+      <ConditionalWrapper
+        condition={Boolean(newDesignLanguage)}
+        wrapper={(children) => (
+          <ButtonGroup segmented={!label}>{children}</ButtonGroup>
+        )}
+      >
+        {constructedPrevious}
+        {labelMarkup}
+        {constructedNext}
+      </ConditionalWrapper>
     </nav>
   );
 }

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -5,6 +5,7 @@ import {
   ChevronLeftMinor,
   ChevronRightMinor,
 } from '@shopify/polaris-icons';
+
 import {TextStyle} from '../TextStyle';
 import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';

--- a/src/components/Pagination/tests/Pagination.test.tsx
+++ b/src/components/Pagination/tests/Pagination.test.tsx
@@ -11,6 +11,8 @@ import {Tooltip, TextField} from 'components';
 import {Key} from '../../../types';
 import {Pagination} from '../Pagination';
 import {UnstyledLink} from '../../UnstyledLink';
+import {Button} from '../../Button';
+import {ButtonGroup} from '../../ButtonGroup';
 
 interface HandlerMap {
   [eventName: string]: (event: any) => void;
@@ -215,23 +217,39 @@ describe('<Pagination />', () => {
   });
 
   describe('newDesignLanguage', () => {
-    it('adds a newDesignLanguage & rightButton class when newDesignLanguage is enabled', () => {
+    it('uses Button and ButtonGroup as subcomponents', () => {
       const pagination = mountWithApp(
-        <Pagination nextURL="/" previousURL="/" />,
+        <Pagination nextURL="/next" previousURL="/prev" />,
         {
           features: {newDesignLanguage: true},
         },
       );
 
-      expect(pagination).toContainReactComponent(UnstyledLink, {
-        className: 'Button newDesignLanguage rightButton NextButton',
+      expect(pagination).toContainReactComponent(ButtonGroup, {
+        segmented: true,
       });
-      expect(pagination).toContainReactComponent(UnstyledLink, {
-        className: 'Button newDesignLanguage PreviousButton',
+      expect(pagination).toContainReactComponent(Button, {url: '/prev'});
+      expect(pagination).toContainReactComponent(Button, {url: '/next'});
+    });
+
+    it('the ButtonGroup is not segmented when there is a label', () => {
+      const pagination = mountWithApp(
+        <Pagination
+          nextURL="/next"
+          previousURL="/prev"
+          label="Hello, world!"
+        />,
+        {
+          features: {newDesignLanguage: true},
+        },
+      );
+
+      expect(pagination).toContainReactComponent(ButtonGroup, {
+        segmented: false,
       });
     });
 
-    it('does not add a newDesignLanguage class when newDesignLanguage is disabled', () => {
+    it('does not use Button and ButtonGroup as subcomponents when disabled', () => {
       const pagination = mountWithApp(
         <Pagination nextURL="/" previousURL="/" />,
         {
@@ -239,11 +257,11 @@ describe('<Pagination />', () => {
         },
       );
 
-      expect(pagination).not.toContainReactComponent(UnstyledLink, {
-        className: 'Button newDesignLanguage rightButton NextButton',
+      expect(pagination).toContainReactComponent(UnstyledLink, {
+        className: 'Button NextButton',
       });
-      expect(pagination).not.toContainReactComponent(UnstyledLink, {
-        className: 'Button newDesignLanguage PreviousButton',
+      expect(pagination).toContainReactComponent(UnstyledLink, {
+        className: 'Button PreviousButton',
       });
     });
   });

--- a/src/components/ResourceList/components/CheckableButton/CheckableButton.scss
+++ b/src/components/ResourceList/components/CheckableButton/CheckableButton.scss
@@ -26,7 +26,7 @@ $chekbox-label-margin: rem(20px);
   width: 100%;
   box-shadow: var(--p-override-none, shadow(faint));
 
-  [data-buttongroup-segmented] & {
+  [data-buttongroup-segmented='true'] & {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
     border-right: none;

--- a/src/styles/shared/_page.scss
+++ b/src/styles/shared/_page.scss
@@ -48,13 +48,26 @@ $actions-vertical-spacing: spacing(tight);
 @mixin page-header-layout {
   padding: spacing(loose) spacing(loose) 0;
 
+  &.newDesignLanguage {
+    padding: spacing() spacing() 0;
+  }
+
   @include page-content-when-not-fully-condensed {
     padding-left: 0;
     padding-right: 0;
+
+    &.newDesignLanguage {
+      padding-left: 0;
+      padding-right: 0;
+    }
   }
 
   @include page-content-when-not-partially-condensed {
     padding-top: spacing(extra-loose);
+
+    &.newDesignLanguage {
+      padding-top: spacing(extra-loose);
+    }
   }
 }
 

--- a/src/utilities/components.tsx
+++ b/src/utilities/components.tsx
@@ -63,6 +63,20 @@ export function elementChildren<T extends React.ReactElement<{}>>(
   ) as T[];
 }
 
+interface ConditionalWrapperProps {
+  children: any;
+  condition: boolean;
+  wrapper: (children: any) => any;
+}
+
+export function ConditionalWrapper({
+  condition,
+  wrapper,
+  children,
+}: ConditionalWrapperProps): JSX.Element {
+  return condition ? wrapper(children) : children;
+}
+
 function hotReloadComponentCheck(
   AComponent: React.ComponentType<any>,
   AnotherComponent: React.ComponentType<any>,

--- a/src/utilities/components.tsx
+++ b/src/utilities/components.tsx
@@ -77,6 +77,18 @@ export function ConditionalWrapper({
   return condition ? wrapper(children) : children;
 }
 
+interface ConditionalRenderProps {
+  condition: boolean;
+  children: any;
+}
+
+export function ConditionalRender({
+  condition,
+  children,
+}: ConditionalRenderProps): JSX.Element {
+  return condition ? children : null;
+}
+
 function hotReloadComponentCheck(
   AComponent: React.ComponentType<any>,
   AnotherComponent: React.ComponentType<any>,

--- a/src/utilities/theme/tokens.ts
+++ b/src/utilities/theme/tokens.ts
@@ -46,6 +46,7 @@ const Overrides = {
   rangeSliderThumbSizeBase: rem('16px'),
   rangeSliderThumbSizeActive: rem('24px'),
   rangeSliderThumbScale: '1.5',
+  badgeFontWeight: '500',
 };
 
 export const Tokens = {


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/polaris-ux/issues/415

#### Large screen
|Design|Actual|
|---|---|
|<img height="600" src="https://user-images.githubusercontent.com/344839/77625508-f176cf80-6f00-11ea-995b-c54d1bd9da96.png">|<img src="https://user-images.githubusercontent.com/344839/77625193-64cc1180-6f00-11ea-8fab-8cbcf56102e2.png" height="600">|

#### Small screen
|Design|Actual|
|---|---|
|<img height="600" src="https://user-images.githubusercontent.com/344839/77625480-e58b0d80-6f00-11ea-915e-54d8044f985e.png">|<img src="https://user-images.githubusercontent.com/344839/77625224-6f86a680-6f00-11ea-9c22-dad77500b531.png" height="600">|

### WHAT is this pull request doing?

Applies the design language to the `Page` component while keeping the existing page component visually unchanged.

- Uses button and button group subcomponents instead of custom CSS
- Conditionally renders 4 different layouts based on screen size and props
- Adds support for `icon` on a primary action which is used to show an icon-only button on small screen, otherwise it is not displayed on large screen. The icon is ignored entirely in the current design language
- Adds a couple helper components for conditionally rendering blocks and for conditionally wrapping blocks

#### Differences from design

- Always vertically centering the breadcrumb, title, and pagination
  - Reason: breadcrumb and title are two different components and would need to be refactored together to achieve this layout because thumbnail heights are variable. It doable, just wanted to hold off until we chat about it. And this PR already has a lot going on. <br> <br>**This is okay**<br> <br><img width="990" alt="Screen Shot 2020-03-24 at 12 28 55 AM" src="https://user-images.githubusercontent.com/344839/77626952-56cbc000-6f03-11ea-8ac5-6614c6054179.png">
<br> <br>**But this is pretty bad**<br> <br><img width="1003" alt="Screen Shot 2020-03-24 at 12 28 46 AM" src="https://user-images.githubusercontent.com/344839/77626833-297f1200-6f03-11ea-886a-05f8edf8eecf.png">

- Not left aligning the subtitle with the breadcrumb when no thumbnail is present
  - Reason: because this depends on the above<br> <br><img width="356" alt="Screen Shot 2020-03-24 at 12 30 26 AM" src="https://user-images.githubusercontent.com/344839/77627110-9f837900-6f03-11ea-99a0-30acfe64d3eb.png">


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)