### PR TITLE
[Focus] and [Filters] Fixing initial reference focusing

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@
 
 - Fixed `Tag` submitting forms when `onClick` is set ([#2895](https://github.com/Shopify/polaris-react/pull/2895))
 - Fixed `DescriptionList` content overflowing when `term` or `description` have long unbroken words ([#2880](https://github.com/Shopify/polaris-react/pull/2880))
+- Fixed focusing bug on Filters where a newly opened filter would not initially focus the first input, and a newly opened filter would incorrectly focus after an input selection ([#2871](https://github.com/Shopify/polaris-react/pull/2871))
 
 ### Documentation
 

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -208,7 +208,7 @@ class FiltersInner extends React.Component<ComposedProps, State> {
             <div className={styles.FilterNodeContainer}>
               <Focus
                 disabled={!filterIsOpen || !readyForFocus || !open}
-                root={this.focusNode.current}
+                root={this.focusNode}
               >
                 {this.generateFilterMarkup(filter)}
               </Focus>

--- a/src/components/Focus/Focus.tsx
+++ b/src/components/Focus/Focus.tsx
@@ -4,7 +4,7 @@ import {focusFirstFocusableNode} from '@shopify/javascript-utilities/focus';
 export interface FocusProps {
   children?: React.ReactNode;
   disabled?: boolean;
-  root: HTMLElement | null;
+  root: React.RefObject<HTMLElement> | HTMLElement | null;
 }
 
 export const Focus = memo(function Focus({
@@ -13,9 +13,24 @@ export const Focus = memo(function Focus({
   root,
 }: FocusProps) {
   useEffect(() => {
-    if (disabled || !root || root.querySelector('[autofocus]')) return;
-    focusFirstFocusableNode(root, false);
+    if (disabled || !root) {
+      return;
+    }
+
+    const node = isRef(root) ? root.current : root;
+
+    if (!node || node.querySelector('[autofocus]')) {
+      return;
+    }
+
+    focusFirstFocusableNode(node, false);
   }, [disabled, root]);
 
   return <React.Fragment>{children}</React.Fragment>;
 });
+
+function isRef(
+  ref: React.RefObject<HTMLElement> | HTMLElement,
+): ref is React.RefObject<HTMLElement> {
+  return (ref as React.RefObject<HTMLElement>).current !== undefined;
+}

--- a/src/components/Focus/tests/Focus.test.tsx
+++ b/src/components/Focus/tests/Focus.test.tsx
@@ -21,11 +21,22 @@ describe('<Focus />', () => {
     expect(document.body).toBe(document.activeElement);
   });
 
-  it('will focus first focusable node', () => {
+  it('will focus first focusable node when passing current node', () => {
     const focus = mountWithAppProvider(
       <FocusTestWrapper>
         <input />
       </FocusTestWrapper>,
+    );
+
+    const input = focus.find('input').getDOMNode();
+    expect(input).toBe(document.activeElement);
+  });
+
+  it('will focus first focusable node when passing ref', () => {
+    const focus = mountWithAppProvider(
+      <FocusTestWrapperRootReference>
+        <input />
+      </FocusTestWrapperRootReference>,
     );
 
     const input = focus.find('input').getDOMNode();
@@ -37,6 +48,17 @@ describe('<Focus />', () => {
       <FocusTestWrapper disabled>
         <input />
       </FocusTestWrapper>,
+    );
+
+    const input = focus.find('input').getDOMNode();
+    expect(input).not.toBe(document.activeElement);
+  });
+
+  it('will not focus if there is no node', () => {
+    const focus = mountWithAppProvider(
+      <FocusTestWrapperNoNode>
+        <input />
+      </FocusTestWrapperNoNode>,
     );
 
     const input = focus.find('input').getDOMNode();
@@ -55,6 +77,32 @@ function FocusTestWrapper({children, ...props}: Omit<FocusProps, 'root'>) {
   return (
     <Focus {...props} root={root.current}>
       <div ref={root}>{children}</div>
+    </Focus>
+  );
+}
+
+function FocusTestWrapperRootReference({
+  children,
+  ...props
+}: Omit<FocusProps, 'root'>) {
+  const root = useRef<HTMLDivElement>(null);
+
+  return (
+    <Focus {...props} root={root}>
+      <div ref={root}>{children}</div>
+    </Focus>
+  );
+}
+
+function FocusTestWrapperNoNode({
+  children,
+  ...props
+}: Omit<FocusProps, 'root'>) {
+  const root = useRef<HTMLDivElement>(null);
+
+  return (
+    <Focus {...props} root={root}>
+      <div>{children}</div>
     </Focus>
   );
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/2741

There are two issues with the current behavior:
- When toggling open a new filter, it does not focus the first selectable input (it does so after selecting and re-toggling)
- When selecting an input on a newly toggled filter, it will force a focus away
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

The reference being passed to the `<Focus />` component from `<Filters />` was the direct reference to it's `current` value, which would be a stale reference by the time the component is mounted and rendered, forcing that focused element to be "one step behind."

This PR adds an union type to be passed to the `root` of `<Focus />`, which is the entire `React.RefObject`, and lets the `Focus` component grab it's `current` node instead, so that we are sure that the `current` node we want to focus on is the node value of the current reference we passed.

Choosing to union the type onto the prop for backwards compatibility and not break current consumers.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

To :tophat:
- Run `yarn dev`
- Select the `Filters` component and then `Filter with resource list`
- This renders a default resource list in the sandbox
- Toggle the `More filters`
- Toggle open the `Account status`
- It will focus on the first selectable input (did not do that before)
- Select another option and it will stay focused on that input (before it would focus the first input)

|![filtersFocusFix](https://user-images.githubusercontent.com/5506721/77449114-f5530680-6dc7-11ea-8a70-5c5be66e3850.gif)|
|---|

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.


<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>
-->
### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
