### PR TITLE
[Navigation] Fix secondary navigation spacing when no icon is present

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 
 - Fixed right padding styling issue with the `Tag` component and remove right padding on a removable `Tag` ([#2860](https://github.com/Shopify/polaris-react/pull/2860)).
+- Fixed secondary navigation spacing when no icon is present ([#2874](https://github.com/Shopify/polaris-react/pull/2874)).
 
 ### Documentation
 

--- a/src/components/Navigation/Navigation.scss
+++ b/src/components/Navigation/Navigation.scss
@@ -378,6 +378,10 @@ $secondary-item-font-size: rem(15px);
   }
 }
 
+.SecondaryNavigation-noIcon {
+  margin-left: spacing();
+}
+
 // Section styles
 .Section {
   @include unstyled-list;

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -236,8 +236,13 @@ export function Item({
       ({url: firstUrl}, {url: secondUrl}) => secondUrl.length - firstUrl.length,
     )[0];
 
+    const SecondaryNavigationClassName = classNames(
+      styles.SecondaryNavigation,
+      !icon && styles['SecondaryNavigation-noIcon'],
+    );
+
     secondaryNavigationMarkup = (
-      <div className={styles.SecondaryNavigation}>
+      <div className={SecondaryNavigationClassName}>
         <Secondary expanded={showExpanded}>
           {subNavigationItems.map((item) => {
             const {label, ...rest} = item;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/destinations/issues/569

### WHAT is this pull request doing?
This removes unnecessary margin for secondary navigation when no icon is present.

Before:
![image](https://user-images.githubusercontent.com/37906860/77772312-4b20ec00-701e-11ea-932b-32c4f8527fb1.png)

After:
![image](https://user-images.githubusercontent.com/37906860/77772347-5aa03500-701e-11ea-8fb5-f88ac41b2312.png)

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Comment out all the icons in DetailsPage.tsx

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
