### PR TITLE
Support consumers using older TS versions

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,4 +18,6 @@
 
 ### Code quality
 
+- Use `downlevel-dts` to produce compatible type definitions for consuming apps using older TypeScript versions ([#2875](https://github.com/Shopify/polaris-react/pull/2875))
+
 ### Deprecations

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
   "main": "index.js",
   "module": "index.es.js",
   "jsnext:main": "index.es.js",
-  "types": "types/index.d.ts",
+  "types": "types/latest/src/index.d.ts",
+  "typesVersions": {
+    "<3.8": { "types/latest/*": ["types/3.4/*"] }
+  },
   "scripts": {
     "lint": "sewing-kit lint",
     "format": "sewing-kit format",
@@ -129,6 +132,7 @@
     "copyfiles": "^2.1.1",
     "core-js": "^2.6.7",
     "cssnano": "^4.1.10",
+    "downlevel-dts": "^0.4.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "fs-extra": "^7.0.1",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,7 +5,7 @@ const {join, resolve: resolvePath} = require('path');
 
 const {ensureDirSync, writeFileSync, readFileSync} = require('fs-extra');
 const {rollup} = require('rollup');
-const {cp, mv, rm} = require('shelljs');
+const {cp, mv} = require('shelljs');
 const copyfiles = require('copyfiles');
 
 const createRollupConfig = require('../config/rollup');
@@ -20,21 +20,18 @@ const intermediateBuild = resolvePath(root, './build-intermediate');
 const mainEntry = resolvePath(intermediateBuild, './index.js');
 
 const scripts = resolvePath(root, 'scripts');
-const types = resolvePath(root, 'types');
 const tsBuild = resolvePath(scripts, 'tsconfig.json');
 
+const execOptions = {stdio: 'inherit', cwd: root};
+
 execSync(
-  `${resolvePath(
-    root,
-    './node_modules/.bin/tsc',
-  )} --outDir ${intermediateBuild} --project ${tsBuild}`,
-  {
-    stdio: 'inherit',
-  },
+  `yarn run tsc --outDir ${intermediateBuild} --project ${tsBuild}`,
+  execOptions,
 );
 
-mv(resolvePath(root, 'types/src/*'), types);
-rm('-rf', resolvePath(root, 'types/src'));
+// Downlevel type declarations to support consuming apps that use older versions
+// of typescript
+execSync(`yarn run downlevel-dts types/latest types/3.4`, execOptions);
 
 mv(resolvePath(intermediateBuild, 'src/*'), intermediateBuild);
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -56,8 +56,11 @@ describe('build', () => {
     );
   });
 
-  it('generates the typescript definition files', () => {
-    expect(fs.existsSync('./types/index.d.ts')).toBe(true);
+  it('generates typescript definition files', () => {
+    expect(fs.existsSync('./types/latest/src/index.d.ts')).toBe(true);
+
+    // Downleveled for consumers on older TypeScript versions
+    expect(fs.existsSync('./types/3.4/src/index.d.ts')).toBe(true);
   });
 
   it('replaces occurrences of POLARIS_VERSION', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./src",
     "rootDir": "./",
-    "declarationDir": "types",
+    "declarationDir": "types/latest",
     "declarationMap": false,
     "jsx": "react-native",
     "isolatedModules": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6765,6 +6765,14 @@ dotenv@^8.0.0, dotenv@^8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
+downlevel-dts@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/downlevel-dts/-/downlevel-dts-0.4.0.tgz#43f9f649c8b137373d76b4ee396d5a0227c10ddb"
+  integrity sha512-nh5vM3n2pRhPwZqh0iWo5gpItPAYEGEWw9yd0YpI+lO60B7A3A6iJlxDbt7kKVNbqBXKsptL+jwE/Yg5Go66WQ==
+  dependencies:
+    shelljs "^0.8.3"
+    typescript "^3.8.0-dev.20200111"
+
 download@^6.2.2:
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/download/-/download-6.2.5.tgz#acd6a542e4cd0bb42ca70cfc98c9e43b07039714"
@@ -17838,7 +17846,7 @@ typescript@^3.7.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
   integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
-typescript@~3.8.3:
+typescript@^3.8.0-dev.20200111, typescript@~3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==


### PR DESCRIPTION
### WHY are these changes introduced?

We want to use new and shiny typescript features. But some of our consumers are on old versions and won't understand the type definition files that use new features, which will cause them to fail. Using [`downlevel-dts`](https://github.com/sandersn/downlevel-dts) we can generate multiple type versions, so that consuming apps using older versions can receive and use type definitions that they understand, while we get to use the new shiny.

An example of this new shiny is `export type` as introduced in 3.8.

### WHAT is this pull request doing?

- Stop moving types from `types/src` to `types/` - TS generates those files at that location, let's just use it.
- Use `downlevel-dts` to generate types compatible with older TS version. The lowest it goes is 3.4 so let's use that.
- Update our types and typeVersions specifications in package.json

Locations: 
- `types/latest/src/...` is where they types for up-to-date (we're using v3.9.x) TS lives
- `types/3.4/src/...` is where the types for older versions lives. `downlevel-dts` doesn't support transforms for any versions older than 3.4

This changes the layout of our distributed files in the types folder, however people should
never be importing content directly from the types folder anyway as it
isn't part of our public API, so I don't consider this a breaking change.


### 🎩 checklist

- Use `build-consumer` to push in these changes into a consuming project that uses an old TS version. `polaris-styleguide` is a good bet.
- Ensure that the con consuming project's `type-check` still passes and you can still access the types from importing `@shopify/polaris` from within that project.