### PR TITLE
[Form] Fix two typo errors

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,7 +10,7 @@
 
 ### Documentation
 
-- Fixed two typos in the `Form` documentation.
+- Fixed two typos in the `Form` documentation ([#2879](https://github.com/Shopify/polaris-react/pull/2879))
 
 ### Development workflow
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@
 
 ### Documentation
 
+- Fixed two typos in the `Form` documentation.
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -17,11 +17,11 @@ export interface FormProps {
   acceptCharset?: string;
   /** Where to send form-data on submittal */
   action?: string;
-  /** Grants the broswer the ability to autocomplete input elements */
+  /** Grants the browser the ability to autocomplete input elements */
   autoComplete?: boolean;
   /** The content to display inside the form. */
   children?: React.ReactNode;
-  /** Media type when submiting content to server */
+  /** Media type when submitting content to server */
   encType?: Enctype;
   /** Toggles if form submits on Enter keypress. Defaults to true. */
   implicitSubmit?: boolean;


### PR DESCRIPTION
This PR fixes two typo errors in the `Form` documentation string.

### WHY are these changes introduced?

There were two typo errors. It's better to fix them.

### WHAT is this pull request doing?

![image](https://user-images.githubusercontent.com/750998/77929931-86374f80-72aa-11ea-93ed-7e3fddc8a98a.png)