### PR TITLE
Fix unexpected module shaking issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Otherwise include the CSS in your HTML. We suggest copying the styles file into 
 ```html
 <link
   rel="stylesheet"
-  href="https://unpkg.com/@shopify/polaris@4.17.0/styles.min.css"
+  href="https://unpkg.com/@shopify/polaris@4.17.1-alpha.1/styles.min.css"
 />
 ```
 
@@ -82,7 +82,7 @@ If React doesn’t make sense for your application, you can use a CSS-only versi
 ```html
 <link
   rel="stylesheet"
-  href="https://unpkg.com/@shopify/polaris@4.17.0/styles.min.css"
+  href="https://unpkg.com/@shopify/polaris@4.17.1-alpha.1/styles.min.css"
 />
 ```
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,4 +16,6 @@
 
 ### Code quality
 
+- Don't use `export *` when exporting from type-only files as importing empty files causes webpack to produce unwanted boilerplate ([#2897](https://github.com/Shopify/polaris-react/pull/2897))
+
 ### Deprecations

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopify/polaris",
   "description": "Shopify’s product component library",
-  "version": "4.17.0",
+  "version": "4.17.1-alpha.1",
   "private": false,
   "license": "SEE LICENSE IN LICENSE.md",
   "author": "Shopify <dev@shopify.com>",

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -66,7 +66,7 @@ Include the CSS in your HTML. We suggest copying the styles file into your own p
 ```html
 <link
   rel="stylesheet"
-  href="https://unpkg.com/@shopify/polaris@4.17.0/styles.min.css"
+  href="https://unpkg.com/@shopify/polaris@4.17.1-alpha.1/styles.min.css"
 />
 ```
 
@@ -100,7 +100,7 @@ Include the CSS stylesheet in your HTML. We suggest copying the styles file into
 ```html
 <link
   rel="stylesheet"
-  href="https://unpkg.com/@shopify/polaris@4.17.0/styles.min.css"
+  href="https://unpkg.com/@shopify/polaris@4.17.1-alpha.1/styles.min.css"
 />
 ```
 

--- a/src/components/ResourceList/components/FilterControl/index.ts
+++ b/src/components/ResourceList/components/FilterControl/index.ts
@@ -1,3 +1,1 @@
 export * from './FilterControl';
-
-export * from './types';

--- a/src/components/ResourceList/index.ts
+++ b/src/components/ResourceList/index.ts
@@ -1,2 +1,9 @@
 export * from './ResourceList';
-export * from './components/FilterControl/types';
+
+export {FilterType} from './components/FilterControl/types';
+export type {
+  Filter,
+  AppliedFilter,
+  FilterSelect,
+  FilterTextField,
+} from './components/FilterControl/types';

--- a/src/utilities/features/index.ts
+++ b/src/utilities/features/index.ts
@@ -1,5 +1,5 @@
 export * from './context';
 
-export * from './types';
+export type {Features, FeaturesConfig} from './types';
 
 export * from './hooks';

--- a/src/utilities/frame/index.ts
+++ b/src/utilities/frame/index.ts
@@ -2,4 +2,9 @@ export * from './hooks';
 
 export * from './context';
 
-export * from './types';
+export type {
+  ContextualSaveBarProps,
+  ToastProps,
+  ToastID,
+  ToastPropsWithID,
+} from './types';

--- a/src/utilities/link/index.ts
+++ b/src/utilities/link/index.ts
@@ -1,5 +1,5 @@
-export * from './types';
+export * from './context';
 
 export * from './hooks';
 
-export * from './context';
+export type {LinkLikeComponent, LinkLikeComponentProps} from './types';

--- a/src/utilities/resource-list/index.ts
+++ b/src/utilities/resource-list/index.ts
@@ -1,3 +1,8 @@
 export * from './context';
 
-export * from './types';
+export {SELECT_ALL_ITEMS} from './types';
+export type {
+  ResourceListSelectedItems,
+  CheckableButtons,
+  CheckableButtonKey,
+} from './types';


### PR DESCRIPTION
### WHY are these changes introduced?

Partial fix for #2896

Web needed some wrangling because we try to import empty files in esnext - this is because those files contained types but they all go stripped away during the build. Let's make sure we don't try to reference empty files so consuming apps complain about us doing so

### WHAT is this pull request doing?

- Don't use export * for files that contain only types, as this may cause issues where you try and `export *` from a types-only file and that will result in the export not being elided

### That's just a band aid! what's the real fix?

We want to get this change out ASAP so we unblock other consumers from updating.

The long-term fix is to urn on `importsNotUsedAsValues: error` in tsconfig.json, which will force us to use `import type`/`export type` when referring to types, which makes these import get elided.

### How to 🎩

Cut a beta release, and try and use it in web while deleting the sewing-kit.config.ts changes added in https://github.com/Shopify/web/pull/25448/files