### PR TITLE
[TopBar] Show secondary menu on small screens

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@
 ### Enhancements
 
 - Updated `Filters` to only show the "More filters" button if necessary ([#2856](https://github.com/Shopify/polaris-react/pull/2856)).
+- Updated `TopBar` component to show `secondaryMenu` on small screens ([#2913](https://github.com/Shopify/polaris-react/pull/2913))
 
 ### Bug fixes
 

--- a/src/components/TopBar/README.md
+++ b/src/components/TopBar/README.md
@@ -149,11 +149,17 @@ Use to provide structure for the top of an application. Style the top bar compon
 ```jsx
 function TopBarExample() {
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+  const [isSecondaryMenuOpen, setIsSecondaryMenuOpen] = useState(false);
   const [isSearchActive, setIsSearchActive] = useState(false);
   const [searchValue, setSearchValue] = useState('');
 
   const toggleIsUserMenuOpen = useCallback(
     () => setIsUserMenuOpen((isUserMenuOpen) => !isUserMenuOpen),
+    [],
+  );
+
+  const toggleIsSecondaryMenuOpen = useCallback(
+    () => setIsSecondaryMenuOpen((isSecondaryMenuOpen) => !isSecondaryMenuOpen),
     [],
   );
 
@@ -224,10 +230,30 @@ function TopBarExample() {
     />
   );
 
+  const secondaryMenuMarkup = (
+    <TopBar.Menu
+      activatorContent={
+        <span>
+          <Icon source={QuestionMarkMajorTwotone} />
+          <VisuallyHidden>Secondary menu</VisuallyHidden>
+        </span>
+      }
+      open={isSecondaryMenuOpen}
+      onOpen={toggleIsSecondaryMenuOpen}
+      onClose={toggleIsSecondaryMenuOpen}
+      actions={[
+        {
+          items: [{content: 'Community forums'}],
+        },
+      ]}
+    />
+  );
+
   const topBarMarkup = (
     <TopBar
       showNavigationToggle
       userMenu={userMenuMarkup}
+      secondaryMenu={secondaryMenuMarkup}
       searchResultsVisible={isSearchActive}
       searchField={searchFieldMarkup}
       searchResults={searchResultsMarkup}

--- a/src/components/TopBar/TopBar.scss
+++ b/src/components/TopBar/TopBar.scss
@@ -120,6 +120,7 @@ $context-control-expand-after: 1400px;
 
   @media (max-width: $page-left-alignment-breakpoint-max) {
     margin-left: 0;
+    margin-right: spacing(extra-tight);
   }
 
   .TopBar-newDesignLanguage & {
@@ -128,7 +129,8 @@ $context-control-expand-after: 1400px;
 }
 
 .SecondaryMenu {
-  @include breakpoint-before(layout-width(page-with-nav), false) {
-    display: none;
+  svg {
+    color: transparent;
+    fill: var(--p-icon, var(--top-bar-color));
   }
 }

--- a/src/components/TopBar/TopBar.scss
+++ b/src/components/TopBar/TopBar.scss
@@ -129,8 +129,5 @@ $context-control-expand-after: 1400px;
 }
 
 .SecondaryMenu {
-  svg {
-    color: transparent;
-    fill: var(--p-icon, var(--top-bar-color));
-  }
+  @include recolor-icon(var(--p-icon, var(--top-bar-color)), transparent);
 }

--- a/src/components/TopBar/components/Menu/Menu.scss
+++ b/src/components/TopBar/components/Menu/Menu.scss
@@ -61,7 +61,7 @@ $activator-variables: (
   }
 
   @include breakpoint-before(layout-width(page-with-nav), false) {
-    margin: 0 spacing(extra-tight);
+    margin: 0;
 
     &:focus,
     &:hover,


### PR DESCRIPTION
### WHY are these changes introduced?

Currently we hide the `secondaryMenu` in the top bar on small screens. We need to use this for a feature we are working on, but it needs to show on small screens too.

### WHAT is this pull request doing?

This PR removes the styles on the secondary menu that was hiding it at a breakpoint. I also added an example to the `TopBar` readme.

This is what it looks like now:

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-13 at 11 13 25](https://user-images.githubusercontent.com/478990/79132183-da950180-7d77-11ea-89de-3bae70e59ccd.png)


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Look at the [example in storybook](http://localhost:6006/?path=/story/all-components-top-bar--top-bar-with-all-of-its-elements) on a small screen and make sure the menu still shows.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide