### PR TITLE
[Autocomplete.Combobox] Convert to functional component

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,5 +21,6 @@
 ### Code quality
 
 - Set `importsNotUsedAsValues` to `error` in typescript configuration to force us to be explicit when importing types ([#2901](https://github.com/Shopify/polaris-react/pull/2901))
+- Converted `ComboBox` to a functional component ([#2918](https://github.com/Shopify/polaris-react/pull/2918))
 
 ### Deprecations

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -60,13 +60,13 @@ export function ComboBox({
   const [selectedOption, setSelectedOption] = useState<
     OptionDescriptor | ActionListItemDescriptor | undefined
   >(undefined);
-  const [selectedIndex, setSelectedIndex] = useState<number>(-1);
-  const [selectedOptions, setSelectedOptions] = useState<string[]>(selected);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [selectedOptions, setSelectedOptions] = useState(selected);
   const [navigableOptions, setNavigableOptions] = useState<
     (OptionDescriptor | ActionListItemDescriptor)[]
   >([]);
-  const [popoverActive, setPopoverActive] = useState<boolean>(false);
-  const [popoverWasActive, setPopoverWasActive] = useState<boolean>(false);
+  const [popoverActive, setPopoverActive] = useState(false);
+  const [popoverWasActive, setPopoverWasActive] = useState(false);
 
   const id = useUniqueId('ComboBox', idProp);
 

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -72,10 +72,7 @@ export function ComboBox({
   const id = useUniqueId('ComboBox', idProp);
 
   const getActionsWithIds = useCallback(
-    (
-      actions: ActionListItemDescriptor[],
-      before?: boolean,
-    ): ActionListItemDescriptor[] => {
+    (actions: ActionListItemDescriptor[], before?: boolean) => {
       if (before) {
         return navigableOptions.slice(0, actions.length);
       }
@@ -83,10 +80,6 @@ export function ComboBox({
     },
     [navigableOptions],
   );
-
-  const handlePopoverClose = useCallback(() => {
-    forcePopoverActiveFalse();
-  }, [forcePopoverActiveFalse]);
 
   const visuallyUpdateSelectedOption = useCallback(
     (
@@ -193,14 +186,6 @@ export function ComboBox({
     [allowMultiple, selectOptions, selected],
   );
 
-  const handleDownArrow = useCallback(() => {
-    selectNextOption();
-  }, [selectNextOption]);
-
-  const handleUpArrow = useCallback(() => {
-    selectPreviousOption();
-  }, [selectPreviousOption]);
-
   const handleEnter = useCallback(
     (event: KeyboardEvent) => {
       if (event.keyCode !== Key.Enter) {
@@ -219,10 +204,6 @@ export function ComboBox({
     },
     [handleSelection, navigableOptions, popoverActive, selectedIndex],
   );
-
-  const handleFocus = useCallback(() => {
-    forcePopoverActiveTrue();
-  }, [forcePopoverActiveTrue]);
 
   const handleBlur = useCallback(() => {
     forcePopoverActiveFalse();
@@ -333,18 +314,24 @@ export function ComboBox({
         aria-owns={id}
         aria-controls={id}
         aria-haspopup
-        onFocus={handleFocus}
+        onFocus={forcePopoverActiveTrue}
         onBlur={handleBlur}
         tabIndex={0}
       >
-        <KeypressListener keyCode={Key.DownArrow} handler={handleDownArrow} />
-        <KeypressListener keyCode={Key.UpArrow} handler={handleUpArrow} />
+        <KeypressListener keyCode={Key.DownArrow} handler={selectNextOption} />
+        <KeypressListener
+          keyCode={Key.UpArrow}
+          handler={selectPreviousOption}
+        />
         <EventListener event="keydown" handler={handleEnter} />
-        <KeypressListener keyCode={Key.Escape} handler={handlePopoverClose} />
+        <KeypressListener
+          keyCode={Key.Escape}
+          handler={forcePopoverActiveFalse}
+        />
         <Popover
           activator={textField}
           active={popoverActive}
-          onClose={handlePopoverClose}
+          onClose={forcePopoverActiveFalse}
           preferredPosition={preferredPosition}
           fullWidth
           preventAutofocus

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -58,9 +58,6 @@ export function ComboBox({
   onSelect,
   onEndReached,
 }: ComboBoxProps) {
-  const [selectedOption, setSelectedOption] = useState<
-    OptionDescriptor | ActionListItemDescriptor | undefined
-  >(undefined);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [selectedOptions, setSelectedOptions] = useState(selected);
   const [navigableOptions, setNavigableOptions] = useState<
@@ -107,7 +104,6 @@ export function ComboBox({
   );
 
   const resetVisuallySelectedOptions = useCallback(() => {
-    setSelectedOption(undefined);
     setSelectedIndex(-1);
     navigableOptions.forEach((option) => {
       option.active = false;
@@ -116,18 +112,18 @@ export function ComboBox({
 
   const selectOptionAtIndex = useCallback(
     (newOptionIndex: number) => {
-      if (!navigableOptions || navigableOptions.length === 0) {
+      if (navigableOptions.length === 0) {
         return;
       }
 
+      const oldSelectedOption = navigableOptions[selectedIndex];
       const newSelectedOption = navigableOptions[newOptionIndex];
 
-      visuallyUpdateSelectedOption(newSelectedOption, selectedOption);
+      visuallyUpdateSelectedOption(newSelectedOption, oldSelectedOption);
 
-      setSelectedOption(newSelectedOption);
       setSelectedIndex(newOptionIndex);
     },
-    [navigableOptions, selectedOption, visuallyUpdateSelectedOption],
+    [navigableOptions, selectedIndex, visuallyUpdateSelectedOption],
   );
 
   const selectNextOption = useCallback(() => {
@@ -211,7 +207,8 @@ export function ComboBox({
         return;
       }
 
-      if (popoverActive && selectedOption) {
+      if (popoverActive && selectedIndex > -1) {
+        const selectedOption = navigableOptions[selectedIndex];
         if (isOption(selectedOption)) {
           event.preventDefault();
           handleSelection(selectedOption.value);
@@ -220,7 +217,7 @@ export function ComboBox({
         }
       }
     },
-    [handleSelection, popoverActive, selectedOption],
+    [handleSelection, navigableOptions, popoverActive, selectedIndex],
   );
 
   const handleFocus = useCallback(() => {
@@ -238,6 +235,7 @@ export function ComboBox({
 
   const updateIndexOfSelectedOption = useCallback(
     (newOptions: (OptionDescriptor | ActionListItemDescriptor)[]) => {
+      const selectedOption = navigableOptions[selectedIndex];
       if (selectedOption && newOptions.includes(selectedOption)) {
         selectOptionAtIndex(newOptions.indexOf(selectedOption));
       } else if (selectedIndex > newOptions.length - 1) {
@@ -247,10 +245,10 @@ export function ComboBox({
       }
     },
     [
+      navigableOptions,
       resetVisuallySelectedOptions,
       selectOptionAtIndex,
       selectedIndex,
-      selectedOption,
     ],
   );
 
@@ -318,9 +316,8 @@ export function ComboBox({
     options.length === 0 &&
     emptyState && <div className={styles.EmptyState}>{emptyState}</div>;
 
-  const selectedOptionId = selectedOption
-    ? `${id}-${selectedIndex}`
-    : undefined;
+  const selectedOptionId =
+    selectedIndex > -1 ? `${id}-${selectedIndex}` : undefined;
 
   const context = {
     id,

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -42,6 +42,7 @@ export interface ComboBoxProps {
   /** Callback when the end of the list is reached */
   onEndReached?(): void;
 }
+
 export function ComboBox({
   id: idProp,
   options,

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -82,9 +82,8 @@ export function ComboBox({
     ): ActionListItemDescriptor[] => {
       if (before) {
         return navigableOptions.slice(0, actions.length);
-      } else {
-        return navigableOptions.slice(-actions.length);
       }
+      return navigableOptions.slice(-actions.length);
     },
     [navigableOptions],
   );
@@ -95,7 +94,7 @@ export function ComboBox({
   }, [forcePopoverActiveFalse]);
 
   const handlePopoverOpen = useCallback(() => {
-    if (!popoverActive && navigableOptions && navigableOptions.length > 0) {
+    if (!popoverActive && navigableOptions.length > 0) {
       forcePopoverActiveTrue();
       setPopoverWasActive(true);
     }
@@ -119,12 +118,9 @@ export function ComboBox({
   const resetVisuallySelectedOptions = useCallback(() => {
     setSelectedOption(undefined);
     setSelectedIndex(-1);
-    navigableOptions &&
-      navigableOptions.forEach(
-        (option: OptionDescriptor | ActionListItemDescriptor) => {
-          option.active = false;
-        },
-      );
+    navigableOptions.forEach((option) => {
+      option.active = false;
+    });
   }, [navigableOptions]);
 
   const selectOptionAtIndex = useCallback(
@@ -144,7 +140,7 @@ export function ComboBox({
   );
 
   const selectNextOption = useCallback(() => {
-    if (!navigableOptions || navigableOptions.length === 0) {
+    if (navigableOptions.length === 0) {
       return;
     }
 
@@ -160,7 +156,7 @@ export function ComboBox({
   }, [navigableOptions, selectOptionAtIndex, selectedIndex]);
 
   const selectPreviousOption = useCallback(() => {
-    if (!navigableOptions || navigableOptions.length === 0) {
+    if (navigableOptions.length === 0) {
       return;
     }
 
@@ -213,13 +209,11 @@ export function ComboBox({
 
   const handleDownArrow = useCallback(() => {
     selectNextOption();
-    handlePopoverOpen;
-  }, [handlePopoverOpen, selectNextOption]);
+  }, [selectNextOption]);
 
   const handleUpArrow = useCallback(() => {
     selectPreviousOption();
-    handlePopoverOpen;
-  }, [handlePopoverOpen, selectPreviousOption]);
+  }, [selectPreviousOption]);
 
   const handleEnter = useCallback(
     (event: KeyboardEvent) => {
@@ -235,10 +229,8 @@ export function ComboBox({
           selectedOption.onAction && selectedOption.onAction();
         }
       }
-
-      handlePopoverOpen;
     },
-    [handlePopoverOpen, handleSelection, popoverActive, selectedOption],
+    [handleSelection, popoverActive, selectedOption],
   );
 
   const handleFocus = useCallback(() => {
@@ -304,18 +296,13 @@ export function ComboBox({
 
   useEffect(() => {
     if (
-      navigableOptions &&
       navigableOptions.length === 0 &&
       !contentBefore &&
       !contentAfter &&
       !emptyState
     ) {
       forcePopoverActiveFalse();
-    } else if (
-      popoverWasActive &&
-      navigableOptions &&
-      navigableOptions.length !== 0
-    ) {
+    } else if (popoverWasActive && navigableOptions.length !== 0) {
       forcePopoverActiveTrue();
     }
   }, [
@@ -418,15 +405,10 @@ function assignOptionIds(
   options: (OptionDescriptor | ActionListItemDescriptor)[],
   id: string,
 ): OptionDescriptor[] | ActionListItemDescriptor[] {
-  return options.map(
-    (
-      option: OptionDescriptor | ActionListItemDescriptor,
-      optionIndex: number,
-    ) => ({
-      ...option,
-      id: `${id}-${optionIndex}`,
-    }),
-  );
+  return options.map((option, optionIndex) => ({
+    ...option,
+    id: `${id}-${optionIndex}`,
+  }));
 }
 
 function isOption(

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -71,7 +71,6 @@ export function ComboBox({
     setTrue: forcePopoverActiveTrue,
     setFalse: forcePopoverActiveFalse,
   } = useToggle(false);
-  const [popoverWasActive, setPopoverWasActive] = useState(false);
 
   const id = useUniqueId('ComboBox', idProp);
 
@@ -90,15 +89,7 @@ export function ComboBox({
 
   const handlePopoverClose = useCallback(() => {
     forcePopoverActiveFalse();
-    setPopoverWasActive(false);
   }, [forcePopoverActiveFalse]);
-
-  const handlePopoverOpen = useCallback(() => {
-    if (!popoverActive && navigableOptions.length > 0) {
-      forcePopoverActiveTrue();
-      setPopoverWasActive(true);
-    }
-  }, [forcePopoverActiveTrue, navigableOptions, popoverActive]);
 
   const visuallyUpdateSelectedOption = useCallback(
     (
@@ -177,7 +168,6 @@ export function ComboBox({
       if (!allowMultiple) {
         resetVisuallySelectedOptions();
         forcePopoverActiveFalse();
-        setPopoverWasActive(false);
       }
     },
     [
@@ -235,12 +225,10 @@ export function ComboBox({
 
   const handleFocus = useCallback(() => {
     forcePopoverActiveTrue();
-    setPopoverWasActive(true);
   }, [forcePopoverActiveTrue]);
 
   const handleBlur = useCallback(() => {
     forcePopoverActiveFalse();
-    setPopoverWasActive(false);
     resetVisuallySelectedOptions();
   }, [forcePopoverActiveFalse, resetVisuallySelectedOptions]);
 
@@ -293,27 +281,6 @@ export function ComboBox({
   useEffect(() => {
     updateIndexOfSelectedOption(navigableOptions);
   }, [navigableOptions, updateIndexOfSelectedOption]);
-
-  useEffect(() => {
-    if (
-      navigableOptions.length === 0 &&
-      !contentBefore &&
-      !contentAfter &&
-      !emptyState
-    ) {
-      forcePopoverActiveFalse();
-    } else if (popoverWasActive && navigableOptions.length !== 0) {
-      forcePopoverActiveTrue();
-    }
-  }, [
-    contentAfter,
-    contentBefore,
-    emptyState,
-    forcePopoverActiveFalse,
-    forcePopoverActiveTrue,
-    navigableOptions,
-    popoverWasActive,
-  ]);
 
   let actionsBeforeMarkup: JSX.Element | undefined;
   if (actionsBefore && actionsBefore.length > 0) {

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -42,7 +42,7 @@ export interface ComboBoxProps {
   onEndReached?(): void;
 }
 export function ComboBox({
-  id,
+  id: idProp,
   options,
   selected,
   textField,
@@ -57,9 +57,6 @@ export function ComboBox({
   onSelect,
   onEndReached,
 }: ComboBoxProps) {
-  const [comboBoxId, setComboBoxId] = useState<string>(
-    useUniqueId('ComboBox', id),
-  );
   const [selectedOption, setSelectedOption] = useState<
     OptionDescriptor | ActionListItemDescriptor | undefined
   >(undefined);
@@ -70,6 +67,8 @@ export function ComboBox({
   >([]);
   const [popoverActive, setPopoverActive] = useState<boolean>(false);
   const [popoverWasActive, setPopoverWasActive] = useState<boolean>(false);
+
+  const id = useUniqueId('ComboBox', idProp);
 
   const getActionsWithIds = useCallback(
     (
@@ -266,10 +265,6 @@ export function ComboBox({
   );
 
   useEffect(() => {
-    id && setComboBoxId(id);
-  }, [id]);
-
-  useEffect(() => {
     if (selectedOptions !== selected) {
       setSelectedOptions(selected);
     }
@@ -289,9 +284,9 @@ export function ComboBox({
     if (actionsAfter) {
       newNavigableOptions = newNavigableOptions.concat(actionsAfter);
     }
-    newNavigableOptions = assignOptionIds(newNavigableOptions, comboBoxId);
+    newNavigableOptions = assignOptionIds(newNavigableOptions, id);
     setNavigableOptions(newNavigableOptions);
-  }, [actionsAfter, actionsBefore, comboBoxId, options]);
+  }, [actionsAfter, actionsBefore, id, options]);
 
   useEffect(() => {
     updateIndexOfSelectedOption(navigableOptions);
@@ -358,11 +353,11 @@ export function ComboBox({
     emptyState && <div className={styles.EmptyState}>{emptyState}</div>;
 
   const selectedOptionId = selectedOption
-    ? `${comboBoxId}-${selectedIndex}`
+    ? `${id}-${selectedIndex}`
     : undefined;
 
   const context = {
-    comboBoxId,
+    id,
     selectedOptionId,
   };
 
@@ -372,8 +367,8 @@ export function ComboBox({
         onClick={handleClick}
         role="combobox"
         aria-expanded={popoverActive}
-        aria-owns={comboBoxId}
-        aria-controls={comboBoxId}
+        aria-owns={id}
+        aria-controls={id}
         aria-haspopup
         onFocus={handleFocus}
         onBlur={handleBlur}
@@ -392,11 +387,7 @@ export function ComboBox({
           preventAutofocus
         >
           <Popover.Pane onScrolledToBottom={onEndReached}>
-            <div
-              id={comboBoxId}
-              role="listbox"
-              aria-multiselectable={allowMultiple}
-            >
+            <div id={id} role="listbox" aria-multiselectable={allowMultiple}>
               {contentBefore}
               {actionsBeforeMarkup}
               {optionsMarkup}
@@ -413,7 +404,7 @@ export function ComboBox({
 
 function assignOptionIds(
   options: (OptionDescriptor | ActionListItemDescriptor)[],
-  comboBoxId: string,
+  id: string,
 ): OptionDescriptor[] | ActionListItemDescriptor[] {
   return options.map(
     (
@@ -421,7 +412,7 @@ function assignOptionIds(
       optionIndex: number,
     ) => ({
       ...option,
-      id: `${comboBoxId}-${optionIndex}`,
+      id: `${id}-${optionIndex}`,
     }),
   );
 }

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useEffect, useCallback} from 'react';
 
 import {useUniqueId} from '../../../../utilities/unique-id';
+import {useToggle} from '../../../../utilities/use-toggle';
 import {OptionList, OptionDescriptor} from '../../../OptionList';
 import {ActionList} from '../../../ActionList';
 import {Popover, PopoverProps} from '../../../Popover';
@@ -65,7 +66,11 @@ export function ComboBox({
   const [navigableOptions, setNavigableOptions] = useState<
     (OptionDescriptor | ActionListItemDescriptor)[]
   >([]);
-  const [popoverActive, setPopoverActive] = useState(false);
+  const {
+    value: popoverActive,
+    setTrue: forcePopoverActiveTrue,
+    setFalse: forcePopoverActiveFalse,
+  } = useToggle(false);
   const [popoverWasActive, setPopoverWasActive] = useState(false);
 
   const id = useUniqueId('ComboBox', idProp);
@@ -85,16 +90,16 @@ export function ComboBox({
   );
 
   const handlePopoverClose = useCallback(() => {
-    setPopoverActive(false);
+    forcePopoverActiveFalse();
     setPopoverWasActive(false);
-  }, []);
+  }, [forcePopoverActiveFalse]);
 
   const handlePopoverOpen = useCallback(() => {
     if (!popoverActive && navigableOptions && navigableOptions.length > 0) {
-      setPopoverActive(true);
+      forcePopoverActiveTrue();
       setPopoverWasActive(true);
     }
-  }, [navigableOptions, popoverActive]);
+  }, [forcePopoverActiveTrue, navigableOptions, popoverActive]);
 
   const visuallyUpdateSelectedOption = useCallback(
     (
@@ -175,11 +180,16 @@ export function ComboBox({
       selected && onSelect(selected);
       if (!allowMultiple) {
         resetVisuallySelectedOptions();
-        setPopoverActive(false);
+        forcePopoverActiveFalse();
         setPopoverWasActive(false);
       }
     },
-    [allowMultiple, onSelect, resetVisuallySelectedOptions],
+    [
+      allowMultiple,
+      forcePopoverActiveFalse,
+      onSelect,
+      resetVisuallySelectedOptions,
+    ],
   );
 
   const handleSelection = useCallback(
@@ -232,19 +242,19 @@ export function ComboBox({
   );
 
   const handleFocus = useCallback(() => {
-    setPopoverActive(true);
+    forcePopoverActiveTrue();
     setPopoverWasActive(true);
-  }, []);
+  }, [forcePopoverActiveTrue]);
 
   const handleBlur = useCallback(() => {
-    setPopoverActive(false);
+    forcePopoverActiveFalse();
     setPopoverWasActive(false);
     resetVisuallySelectedOptions();
-  }, [resetVisuallySelectedOptions]);
+  }, [forcePopoverActiveFalse, resetVisuallySelectedOptions]);
 
   const handleClick = useCallback(() => {
-    !popoverActive && setPopoverActive(true);
-  }, [popoverActive]);
+    !popoverActive && forcePopoverActiveTrue();
+  }, [forcePopoverActiveTrue, popoverActive]);
 
   const updateIndexOfSelectedOption = useCallback(
     (newOptions: (OptionDescriptor | ActionListItemDescriptor)[]) => {
@@ -300,18 +310,20 @@ export function ComboBox({
       !contentAfter &&
       !emptyState
     ) {
-      setPopoverActive(false);
+      forcePopoverActiveFalse();
     } else if (
       popoverWasActive &&
       navigableOptions &&
       navigableOptions.length !== 0
     ) {
-      setPopoverActive(true);
+      forcePopoverActiveTrue();
     }
   }, [
     contentAfter,
     contentBefore,
     emptyState,
+    forcePopoverActiveFalse,
+    forcePopoverActiveTrue,
     navigableOptions,
     popoverWasActive,
   ]);

--- a/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
+++ b/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {OptionList, ActionList, Popover} from 'components';
 import {mountWithApp} from 'test-utilities';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithAppProvider, act} from 'test-utilities/legacy';
 
 import {TextField} from '../../TextField';
 import {Key} from '../../../../../types';
@@ -401,8 +401,12 @@ describe('<ComboBox/>', () => {
         />,
       );
       comboBox.find(TextField).simulate('click');
-      dispatchKeyup(Key.DownArrow);
-      dispatchKeydown(Key.Enter);
+      act(() => {
+        dispatchKeyup(Key.DownArrow);
+      });
+      act(() => {
+        dispatchKeydown(Key.Enter);
+      });
       expect(spy).not.toHaveBeenCalled();
 
       comboBox.setProps({
@@ -414,8 +418,12 @@ describe('<ComboBox/>', () => {
       });
       comboBox.update();
       comboBox.find(TextField).simulate('click');
-      dispatchKeyup(Key.DownArrow);
-      dispatchKeydown(Key.Enter);
+      act(() => {
+        dispatchKeyup(Key.DownArrow);
+      });
+      act(() => {
+        dispatchKeydown(Key.Enter);
+      });
       expect(spy).toHaveBeenCalledWith(['cheese_pizza']);
     });
 
@@ -430,8 +438,12 @@ describe('<ComboBox/>', () => {
         />,
       );
       comboBox.find(TextField).simulate('click');
-      dispatchKeyup(Key.DownArrow);
-      dispatchKeydown(Key.Enter);
+      act(() => {
+        dispatchKeyup(Key.DownArrow);
+      });
+      act(() => {
+        dispatchKeydown(Key.Enter);
+      });
       expect(spy).toHaveBeenCalledWith(['cheese_pizza']);
     });
 
@@ -446,8 +458,12 @@ describe('<ComboBox/>', () => {
         />,
       );
       comboBox.find(TextField).simulate('click');
-      dispatchKeyup(Key.DownArrow);
-      dispatchKeydown(Key.RightArrow);
+      act(() => {
+        dispatchKeyup(Key.DownArrow);
+      });
+      act(() => {
+        dispatchKeydown(Key.RightArrow);
+      });
       expect(spy).not.toHaveBeenCalled();
     });
 
@@ -478,7 +494,10 @@ describe('<ComboBox/>', () => {
       comboBox.find(TextField).simulate('click');
       expect(comboBox.find(Popover).prop('active')).toBe(true);
 
-      dispatchKeyup(Key.Escape);
+      act(() => {
+        dispatchKeyup(Key.Escape);
+      });
+
       comboBox.update();
       expect(comboBox.find(Popover).prop('active')).toBe(false);
     });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The Autocomplete component causes the following warning if used with server-side rendering:
```
Warning: Prop `aria-controls` did not match. Server: "ComboBox2" Client: "ComboBox1"
```

This is a known problem: #1761

Although this PR does not directly fix that problem, converting the Combobox to a functional component and having it use the `useUniqueId` hook is a prerequisite for fixing the automatic ID generation in the future.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Converts the Autocomplete Combobox component into a functional component and uses the `useUniqueId` hook.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Not easily testable without server side rendering 🤔 

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';

import {Page, Autocomplete} from '../src';

export function Playground() {
  const [input, setInput] = useState('');
  const [selected, setSelected] = useState<string[]>([]);

  const textFieldMarkup = (
    <Autocomplete.TextField
      label="Textfield"
      value={input}
      onChange={setInput}
    />
  );
  const options = ['one', 'two', 'three'].map((item) => {
    return {value: item, label: item};
  });
  return (
    <Page title="Playground">
      <Autocomplete
        options={options}
        selected={selected}
        onSelect={setSelected}
        textField={textFieldMarkup}
        allowMultiple
      />
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
