### PR TITLE
[MediaCard] Add border-radius when necessary

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,7 +12,7 @@
 
 ### Bug fixes
 
-- `VideoThumbnail` has top left and top right `border-radius` ([#2919](https://github.com/Shopify/polaris-react/pull/2919))
+- `VideoThumbnail` add the top left and top right `border-radius` ([#2919](https://github.com/Shopify/polaris-react/pull/2919))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,7 +12,7 @@
 
 ### Bug fixes
 
-- `VideoThumbnail` has top left and top right `border-radius` ([#](https://github.com/Shopify/polaris-react/pull/))
+- `VideoThumbnail` has top left and top right `border-radius` ([#2919](https://github.com/Shopify/polaris-react/pull/2919))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,7 +12,7 @@
 
 ### Bug fixes
 
-- `MediaThumbnail` add the correct `border-radius` to the container ([#2919](https://github.com/Shopify/polaris-react/pull/2919))
+- `MediaCard` add the correct `border-radius` to the container ([#2919](https://github.com/Shopify/polaris-react/pull/2919))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,7 +12,7 @@
 
 ### Bug fixes
 
-- `VideoThumbnail` add the top left and top right `border-radius` ([#2919](https://github.com/Shopify/polaris-react/pull/2919))
+- `MediaThumbnail` add the correct `border-radius` to the container ([#2919](https://github.com/Shopify/polaris-react/pull/2919))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@
 
 ### Bug fixes
 
+- `VideoThumbnail` has top left and top right `border-radius` ([#](https://github.com/Shopify/polaris-react/pull/))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/MediaCard/MediaCard.scss
+++ b/src/components/MediaCard/MediaCard.scss
@@ -7,6 +7,7 @@ $portrait-breakpoint: 804px;
   width: 100%;
   display: flex;
   flex-flow: row wrap;
+  overflow: hidden;
 
   &.portrait {
     flex-flow: column nowrap;
@@ -18,8 +19,20 @@ $portrait-breakpoint: 804px;
 }
 
 .MediaContainer {
-  &:not(.portrait) {
-    flex-basis: 40%;
+  overflow: hidden;
+
+  @include breakpoint-after($portrait-breakpoint, inclusive) {
+    &.portrait {
+      border-top-left-radius: border-radius();
+      border-top-right-radius: border-radius();
+    }
+
+    &:not(.portrait) {
+      flex-basis: 40%;
+      border-top-right-radius: 0;
+      border-top-left-radius: border-radius();
+      border-bottom-left-radius: border-radius();
+    }
   }
 }
 

--- a/src/components/MediaCard/MediaCard.scss
+++ b/src/components/MediaCard/MediaCard.scss
@@ -18,13 +18,13 @@ $portrait-breakpoint: 804px;
 }
 
 .MediaContainer {
-  overflow: hidden;
-
   &:not(.portrait) {
     flex-basis: 40%;
   }
 
   @include breakpoint-after($portrait-breakpoint, inclusive) {
+    overflow: hidden;
+
     &.portrait {
       border-top-left-radius: border-radius();
       border-top-right-radius: border-radius();

--- a/src/components/MediaCard/MediaCard.scss
+++ b/src/components/MediaCard/MediaCard.scss
@@ -21,6 +21,10 @@ $portrait-breakpoint: 804px;
 .MediaContainer {
   overflow: hidden;
 
+  &:not(.portrait) {
+    flex-basis: 40%;
+  }
+
   @include breakpoint-after($portrait-breakpoint, inclusive) {
     &.portrait {
       border-top-left-radius: border-radius();
@@ -28,8 +32,6 @@ $portrait-breakpoint: 804px;
     }
 
     &:not(.portrait) {
-      flex-basis: 40%;
-      border-top-right-radius: 0;
       border-top-left-radius: border-radius();
       border-bottom-left-radius: border-radius();
     }

--- a/src/components/VideoThumbnail/VideoThumbnail.scss
+++ b/src/components/VideoThumbnail/VideoThumbnail.scss
@@ -10,8 +10,6 @@ $start-button-size: 60px;
   background-repeat: no-repeat;
   width: 100%;
   height: 100%;
-  border-top-left-radius: border-radius();
-  border-top-right-radius: border-radius();
 
   &.WithPlayer {
     position: absolute;

--- a/src/components/VideoThumbnail/VideoThumbnail.scss
+++ b/src/components/VideoThumbnail/VideoThumbnail.scss
@@ -10,6 +10,8 @@ $start-button-size: 60px;
   background-repeat: no-repeat;
   width: 100%;
   height: 100%;
+  border-top-left-radius: border-radius();
+  border-top-right-radius: border-radius();
 
   &.WithPlayer {
     position: absolute;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes minor visual bug with VideoThumbnail

### WHAT is this pull request doing?

Adds a top left and right border-radius to the image in the VideoThumbnail
## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Look at the VideoThumbnail example in Storybook

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
