### PR TITLE
[MediaCard] Fix children overflowing due to border radius

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@
 
 ### Bug fixes
 
+- Fixed `MediaCard` children overflowing due border radius ([#2920](https://github.com/Shopify/polaris-react/pull/2920))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/MediaCard/MediaCard.scss
+++ b/src/components/MediaCard/MediaCard.scss
@@ -1,7 +1,5 @@
 @import '../../styles/common';
 
-$portrait-breakpoint: 804px;
-
 .MediaCard {
   height: 100%;
   width: 100%;
@@ -11,15 +9,18 @@ $portrait-breakpoint: 804px;
   &.portrait {
     flex-flow: column nowrap;
   }
-
-  @include breakpoint-before($portrait-breakpoint, inclusive) {
-    flex-flow: column nowrap;
-  }
 }
 
 .MediaContainer {
-  &:not(.portrait) {
-    flex-basis: 40%;
+  border-top-left-radius: var(--p-border-radius-base, border-radius());
+  border-bottom-left-radius: var(--p-border-radius-base, border-radius());
+  overflow: hidden;
+  flex-basis: 40%;
+
+  &.portrait {
+    border-bottom-left-radius: 0;
+    border-top-right-radius: var(--p-border-radius-base, border-radius());
+    flex-basis: unset;
   }
 }
 

--- a/src/components/MediaCard/MediaCard.tsx
+++ b/src/components/MediaCard/MediaCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 
+import {useMediaQuery} from '../../utilities/media-query';
 import {useToggle} from '../../utilities/use-toggle';
 import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
@@ -44,6 +45,7 @@ export function MediaCard({
   portrait = false,
 }: MediaCardProps) {
   const i18n = useI18n();
+  const {isNavigationCollapsed} = useMediaQuery();
   const {value: popoverActive, toggle: togglePopoverActive} = useToggle(false);
 
   const popoverActivator = (
@@ -86,7 +88,7 @@ export function MediaCard({
 
   const actionClassName = classNames(
     styles.ActionContainer,
-    portrait && styles.portrait,
+    (portrait || isNavigationCollapsed) && styles.portrait,
   );
 
   const actionMarkup = (


### PR DESCRIPTION
### WHY are these changes introduced?

Since we removed `overflow: hidden` from `Card`, children of `Card` not wrapped in a `Card.Section` need to account for border radius.

### WHAT is this pull request doing?

This pull request adds border radius based on portrait mode to and hides overflow of the container that wraps `children` so that any child automatically respects the border radius. 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

- While still on `master`, copy past the collapsed playground code below, `yarn dev`, and note the overflow of the media section of the media cards in the playground
- `git checkout mediacard-bordercontrol` and note that media is no longer overflowing the media cards

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {Page, Layout, MediaCard, VideoThumbnail} from '../src';

export function Playground() {
  const [customThumbnail, setCustomThumbnail] = useState(false);
  const toggleCustom = useCallback(() => {
    setCustomThumbnail((customThumbnail) => !customThumbnail);
  }, [setCustomThumbnail]);
  const thumbnailMarkup = customThumbnail ? (
    <img
      alt=""
      width="100%"
      height="100%"
      style={{objectFit: 'cover', objectPosition: 'center'}}
      src="https://burst.shopifycdn.com/photos/smiling-businesswoman-in-office.jpg?width=1850"
    />
  ) : (
    <VideoThumbnail
      onClick={() => {}}
      videoLength={80}
      thumbnailUrl="https://burst.shopifycdn.com/photos/smiling-businesswoman-in-office.jpg?width=1850"
    />
  );
  return (
    <Page
      title="Playground"
      primaryAction={{
        content: `View with ${customThumbnail ? 'Media' : 'custom'} thumbnail`,
        onAction: toggleCustom,
      }}
    >
      <Layout>
        <Layout.Section>
          <MediaCard
            title="Getting started, sure, but this could totally possibly be a way longer title though really"
            primaryAction={{
              content: 'Learn about getting started',
              onAction: () => {},
            }}
            secondaryAction={{
              content: 'Do something less important',
              onAction: () => {},
            }}
            description="Discover how Shopify can help you get started on building your business."
            popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
          >
            {thumbnailMarkup}
          </MediaCard>
        </Layout.Section>
        <Layout.Section>
          <MediaCard
            title="Getting started, sure, but this could totally possibly be a way longer title though really"
            primaryAction={{
              content: 'Learn about getting started',
              onAction: () => {},
            }}
            secondaryAction={{
              content: 'Do something less important',
              onAction: () => {},
            }}
            description="Discover how Shopify can help you get started on building your business."
            popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
          >
            {thumbnailMarkup}
          </MediaCard>
          <MediaCard
            portrait
            title="Getting started, sure, but this could totally possibly be a way longer title though really"
            primaryAction={{
              content: 'Learn about getting started',
              onAction: () => {},
            }}
            secondaryAction={{
              content: 'Do something less important',
              onAction: () => {},
            }}
            description="Discover how Shopify can help you get started on building your business."
            popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
          >
            {thumbnailMarkup}
          </MediaCard>
        </Layout.Section>
        <Layout.Section secondary>
          <MediaCard
            portrait
            title="Getting started, sure, but this could totally possibly be a way longer title though really"
            primaryAction={{
              content: 'Learn about getting started',
              onAction: () => {},
            }}
            secondaryAction={{
              content: 'Do something less important',
              onAction: () => {},
            }}
            description="Discover how Shopify can help you get started on building your business."
            popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
          >
            {thumbnailMarkup}
          </MediaCard>
        </Layout.Section>
      </Layout>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
