### PR TITLE
Adds Banner example to <Layout />

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@
 ### Development workflow
 
 - Fixed automatic pull request generation for `web` and `styleguide` when updating Polaris ([#2892](https://github.com/Shopify/polaris-react/pull/2892))
+- Added an example to `Layout` that showcases how to space a banner ([#2929](https://github.com/Shopify/polaris-react/pull/2929))
 
 ### Dependency upgrades
 

--- a/src/components/Layout/README.md
+++ b/src/components/Layout/README.md
@@ -424,6 +424,31 @@ Use for settings pages. When settings are grouped thematically in annotated sect
 </Layout>
 ```
 
+### Annotated layout with Banner at the top
+
+Use for settings pages that need a banner or other content at the top.
+
+```jsx
+<Layout>
+  <Layout.Section>
+    <Banner title="Order archived" onDismiss={() => {}}>
+      <p>This order was archived on March 7, 2017 at 3:12pm EDT.</p>
+    </Banner>
+  </Layout.Section>
+  <Layout.AnnotatedSection
+    title="Store details"
+    description="Shopify and your customers will use this information to contact you."
+  >
+    <Card sectioned>
+      <FormLayout>
+        <TextField label="Store name" onChange={() => {}} />
+        <TextField type="email" label="Account email" onChange={() => {}} />
+      </FormLayout>
+    </Card>
+  </Layout.AnnotatedSection>
+</Layout>
+```
+
 ---
 
 ## Related components


### PR DESCRIPTION
### WHY are these changes introduced?
Let's add an example to clear up for folks how we recommend they space content that lives above the first section.

### WHAT is this pull request doing?
Adds an example to `Layout`

### How to 🎩
1. `yarn dev`
1. Open the example and make sure it looks and works as expected