### PR TITLE
Adding fixed height to frame with offset example

### DIFF
--- a/src/components/Frame/README.md
+++ b/src/components/Frame/README.md
@@ -671,15 +671,7 @@ function FrameExample() {
   };
 
   return (
-    <div style={{height: '500px', background: '#DE1373'}}>
-      <h3
-        style={{
-          position: 'absolute',
-          transform: 'rotate(-90deg) translate(-50%, -50%)',
-        }}
-      >
-        Frame offset
-      </h3>
+    <div style={{height: '500px', background: '#DE1373', margin: '-8px'}}>
       <AppProvider
         theme={theme}
         i18n={{

--- a/src/components/Frame/README.md
+++ b/src/components/Frame/README.md
@@ -671,7 +671,7 @@ function FrameExample() {
   };
 
   return (
-    <div style={{background: '#DE1373', margin: '-8px'}}>
+    <div style={{height: '500px', background: '#DE1373'}}>
       <h3
         style={{
           position: 'absolute',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/422

This change fixes a problem where the frame would continually grow in height in the style guide:
![image](https://user-images.githubusercontent.com/6471064/79754027-c53b4c80-830e-11ea-9367-194dfc20b83f.gif)

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
