### PR TITLE
[ResourceItem] Remove children from the equality check in shouldComponentUpdate

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@
 
 ### Bug fixes
 
+- Fixed performance of `ResourceItem` due to inclusion of `children` in deep prop comparison within `shouldComponentUpdate` ([#2936](https://github.com/Shopify/polaris-react/pull/2936))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/ResourceItem/ResourceItem.tsx
+++ b/src/components/ResourceItem/ResourceItem.tsx
@@ -111,15 +111,19 @@ class BaseResourceItem extends React.Component<CombinedProps, State> {
 
   shouldComponentUpdate(nextProps: CombinedProps, nextState: State) {
     const {
+      children: nextChildren,
       context: {selectedItems: nextSelectedItems, ...restNextContext},
       ...restNextProps
     } = nextProps;
+
     const {
+      children,
       context: {selectedItems, ...restContext},
       ...restProps
     } = this.props;
 
     const nextSelectMode = nextProps.context.selectMode;
+
     return (
       !isEqual(this.state, nextState) ||
       this.props.context.selectMode !== nextSelectMode ||


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #2164 <!-- link to issue if one exists -->

The resource item component does a deep equality check of previous and next props in the `shouldComponentUpdate` lifecycle method. This causes significant performance issues in production because `children` are included in that check. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

The ideal way to fix this forward would be to rewrite `ResourceItem` as a functional component and 🔥`shouldComponentUpdate` entirely. Even more ideally, it shouldn't be handling its own selected state but instead rely on a `selected` boolean prop. But we don't have cycles for that effort right now. 

This PR hot fixes the problem by stripping `children` out of the check to reduce complexity of the comparison down to only the explicit props. 

- [x] Keeping this a draft until I've tested in a production environment, as I need to verify whether the deep comparison remains laggy due to the fact that the optional `media` prop expects either an `Avatar` or a `Thumbnail`.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

To tophat this change, I made a release candidate and pushed the [`web` upgrade branch to Web staging](https://shipit.shopify.io/shopify/web/staging/deploys/974701) to enable performance analysis in a production environment.

| |  Before | After  |
|---|---|---|
|Render time| 5.2sec  | 2.2sec  |
|Browser freezing| Yes  | No  |
|`shouldComponentUpdate` calls / highest call time| >1000 / 2.2ms|5 / 0.5ms|
