### PR TITLE
[Empty state] Add centered layout

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@
 
 - Removed `max-height` property from `Tooltip` ([#2908](https://github.com/Shopify/polaris-react/pull/2908))
 - Update `TopBar.Menu` to be properly themed in active, hover and focused state ([#2928](https://github.com/Shopify/polaris-react/pull/2928))
+- Added a centeredLayout prop to `EmptyState` ([#2939](https://github.com/Shopify/polaris-react/pull/2939))
 
 ### Bug fixes
 

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -139,8 +139,6 @@ $centered-illustration-width: rem(226px);
 }
 
 .centeredLayout {
-  min-height: 80vh;
-
   .Section {
     flex-direction: column-reverse;
     justify-content: center;

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -21,6 +21,8 @@ $illustration-width-cropped: calc(
   #{$illustration-width} + #{$right-offset} * 2
 );
 
+$centered-illustration-width: rem(226px);
+
 .EmptyState {
   display: flex;
   flex-direction: column;
@@ -133,6 +135,31 @@ $illustration-width-cropped: calc(
       position: initial;
       width: 100%;
     }
+  }
+}
+
+.centeredLayout {
+  min-height: 80vh;
+
+  .Section {
+    flex-direction: column-reverse;
+    justify-content: center;
+  }
+
+  .ImageContainer,
+  .DetailsContainer {
+    flex: 0;
+  }
+
+  .Image {
+    margin: unset;
+    width: $centered-illustration-width;
+    max-width: 100%;
+  }
+
+  .Details {
+    text-align: center;
+    width: 100%;
   }
 }
 

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -142,6 +142,7 @@ $centered-illustration-width: rem(226px);
   .Section {
     flex-direction: column-reverse;
     justify-content: center;
+    align-items: center;
   }
 
   .ImageContainer,

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -2,6 +2,7 @@ import React, {useContext} from 'react';
 
 import {classNames} from '../../utilities/css';
 import {WithinContentContext} from '../../utilities/within-content-context';
+import {useFeatures} from '../../utilities/features';
 import type {Action} from '../../types';
 import {Image} from '../Image';
 import {buttonFrom} from '../Button';
@@ -22,6 +23,8 @@ export interface EmptyStateProps {
    * Whether or not to limit the image to the size of its container on large screens.
    */
   imageContained?: boolean;
+  /** Whether or not the layout is stacked and centred vs justified apart */
+  centeredLayout?: boolean;
   /** Elements to display inside empty state */
   children?: React.ReactNode;
   /** Primary action for empty state */
@@ -38,13 +41,17 @@ export function EmptyState({
   image,
   largeImage,
   imageContained,
+  centeredLayout = false,
   action,
   secondaryAction,
   footerContent,
 }: EmptyStateProps) {
   const withinContentContainer = useContext(WithinContentContext);
+  const {newDesignLanguage = false} = useFeatures();
+  const newLayout = centeredLayout || newDesignLanguage;
   const className = classNames(
     styles.EmptyState,
+    newLayout && styles.centeredLayout,
     imageContained && styles.imageContained,
     withinContentContainer ? styles.withinContentContainer : styles.withinPage,
   );
@@ -66,7 +73,7 @@ export function EmptyState({
   );
 
   const secondaryActionMarkup = secondaryAction
-    ? buttonFrom(secondaryAction, {plain: true})
+    ? buttonFrom(secondaryAction, newLayout ? {} : {plain: true})
     : null;
 
   const footerContentMarkup = footerContent ? (
@@ -76,7 +83,8 @@ export function EmptyState({
   ) : null;
 
   const headingSize = withinContentContainer ? 'small' : 'medium';
-  const primaryActionSize = withinContentContainer ? 'medium' : 'large';
+  const primaryActionSize =
+    withinContentContainer || newLayout ? 'medium' : 'large';
 
   const primaryActionMarkup = action
     ? buttonFrom(action, {primary: true, size: primaryActionSize})
@@ -92,7 +100,7 @@ export function EmptyState({
 
   const textContentMarkup =
     headingMarkup || children ? (
-      <TextContainer>
+      <TextContainer spacing={newLayout ? 'tight' : undefined}>
         {headingMarkup}
         {childrenMarkup}
       </TextContainer>
@@ -101,7 +109,11 @@ export function EmptyState({
   const actionsMarkup =
     primaryActionMarkup || secondaryActionMarkup ? (
       <div className={styles.Actions}>
-        <Stack alignment="center">
+        <Stack
+          alignment="center"
+          distribution={newLayout ? 'center' : undefined}
+          spacing={newLayout ? 'tight' : undefined}
+        >
           {primaryActionMarkup}
           {secondaryActionMarkup}
         </Stack>

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -23,7 +23,7 @@ export interface EmptyStateProps {
    * Whether or not to limit the image to the size of its container on large screens.
    */
   imageContained?: boolean;
-  /** Whether or not the layout is stacked and centred vs justified apart */
+  /** Whether or not the layout is stacked and centered vs justified apart */
   centeredLayout?: boolean;
   /** Elements to display inside empty state */
   children?: React.ReactNode;

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -201,8 +201,6 @@ Use to provide additional but non-critical context for a new product or feature.
 
 <!-- example-for: web -->
 
-Use to explain a section or feature before merchants have used it within the context of a content container like a card or a resource list.
-
 ```jsx
 <Card>
   <Card.Section>
@@ -218,6 +216,26 @@ Use to explain a section or feature before merchants have used it within the con
     </EmptyState>
   </Card.Section>
 </Card>
+```
+
+### Empty state with centered layout
+
+<!-- example-for: web -->
+
+Use to explain a section or feature before merchants have used it within the context of a content container like a card or a resource list.
+
+```jsx
+<EmptyState
+  centeredLayout
+  heading="Upload a file to get started"
+  action={{content: 'Upload files'}}
+  image="https://cdn.shopify.com/s/files/1/2376/3301/products/emptystate-files.png"
+>
+  <p>
+    You can use the Files section to upload images, videos, and other
+    documents
+  </p>
+</EmptyState>
 ```
 
 ---

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -222,7 +222,7 @@ Use to provide additional but non-critical context for a new product or feature.
 
 <!-- example-for: web -->
 
-Use to explain a section or feature before merchants have used it within the context of a content container like a card or a resource list.
+Stacked image over centered content and actions
 
 ```jsx
 <EmptyState

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -232,8 +232,7 @@ Stacked image over centered content and actions
   image="https://cdn.shopify.com/s/files/1/2376/3301/products/emptystate-files.png"
 >
   <p>
-    You can use the Files section to upload images, videos, and other
-    documents
+    You can use the Files section to upload images, videos, and other documents
   </p>
 </EmptyState>
 ```

--- a/src/components/EmptyState/tests/EmptyState.test.tsx
+++ b/src/components/EmptyState/tests/EmptyState.test.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import {
-  Image,
+  Button,
   DisplayText,
+  Image,
+  Stack,
   TextContainer,
   UnstyledLink,
-  Button,
 } from 'components';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {WithinContentContext} from '../../../utilities/within-content-context';
 import {EmptyState} from '../EmptyState';
@@ -172,6 +174,76 @@ describe('<EmptyState />', () => {
       const emptyState = mountWithAppProvider(<EmptyState image={imgSrc} />);
 
       expect(emptyState.find(TextContainer)).toHaveLength(0);
+    });
+  });
+
+  describe('centeredLayout', () => {
+    it('adds a classname to the root component', () => {
+      const emptyState = mountWithApp(
+        <EmptyState centeredLayout image={imgSrc} />,
+      );
+      expect(emptyState).toContainReactComponent('div', {
+        className: 'EmptyState centeredLayout withinPage',
+      });
+    });
+
+    it('does not render a plain link as a secondaryAction', () => {
+      const emptyState = mountWithApp(
+        <EmptyState
+          centeredLayout
+          image={imgSrc}
+          secondaryAction={{
+            content: 'Learn more',
+            url: 'https://help.shopify.com',
+          }}
+        />,
+      );
+
+      expect(emptyState).toContainReactComponent(UnstyledLink, {
+        plain: undefined,
+      });
+    });
+
+    it('renders a medium size primary button', () => {
+      const emptyState = mountWithApp(
+        <EmptyState
+          centeredLayout
+          image={imgSrc}
+          action={{content: 'Add transfer'}}
+        />,
+      );
+
+      expect(emptyState).toContainReactComponent(Button, {
+        size: 'medium',
+        primary: true,
+      });
+    });
+
+    it('changes the spacing to "tight" on TextContainer', () => {
+      const emptyState = mountWithApp(
+        <EmptyState centeredLayout image={imgSrc}>
+          Children
+        </EmptyState>,
+      );
+
+      expect(emptyState).toContainReactComponent(TextContainer, {
+        spacing: 'tight',
+      });
+    });
+
+    it('adds center distribution and tight spacing to Stack', () => {
+      const emptyState = mountWithApp(
+        <EmptyState
+          centeredLayout
+          image={imgSrc}
+          action={{content: 'Add transfer'}}
+        />,
+      );
+
+      expect(emptyState).toContainReactComponent(Stack, {
+        spacing: 'tight',
+        distribution: 'center',
+      });
     });
   });
 });

--- a/src/components/EmptyState/tests/EmptyState.test.tsx
+++ b/src/components/EmptyState/tests/EmptyState.test.tsx
@@ -246,4 +246,15 @@ describe('<EmptyState />', () => {
       });
     });
   });
+
+  describe('newDesignLanguage', () => {
+    it('adds a centeredLayout classname to the root component', () => {
+      const emptyState = mountWithApp(<EmptyState image={imgSrc} />, {
+        features: {newDesignLanguage: true},
+      });
+      expect(emptyState).toContainReactComponent('div', {
+        className: 'EmptyState centeredLayout withinPage',
+      });
+    });
+  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/facebook-ads/issues/7751

There is a team trying to ship a new channel for facebook ads. They anticipated the DL rollout would be complete by now. The illustration for their app is already complete in the new DL. They're blocked because the empty state doesn't currently support the new illustration style.

### WHAT is this pull request doing?

This PR adds a new prop to empty state allowing anyone to use this new centered empty state layout. I chose this way to do it because it will actually help us deprecate the justified layout while giving merchants a chance to update their images for the next major release after the new DL.

Before:
![image](https://screenshot.click/Playground__Playground_-_Playground__Storybook_2020-04-22_10-20-09.png)

After: 
![image](https://screenshot.click/Playground__Playground_-_Playground__Storybook_2020-04-22_10-19-10.png)

New DL:
![image](https://screenshot.click/Playground__Playground_-_Playground__Storybook_2020-04-22_10-19-27.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->
Here's the customers image I'm using

```html
<svg viewBox="0 0 226 226" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M113.595 181c40.87 0 74-33.13 74-74s-33.13-74-74-74-74 33.13-74 74 33.13 74 74 74z" fill="#F0F1F2"/><path d="M68 181.802c25.96 0 47-21.04 47-47s-21.04-47-47-47-47 21.04-47 47 21.04 47 47 47z" fill="#E9AF58"/><path d="M89.73 165.682l-6.73-1.38v11.5l-22-16-16.93 15.45a46.736 46.736 0 0023.93 6.55c11.69 0 22.38-4.28 30.61-11.35-2.34-2.47-5.49-4.12-8.88-4.77z" fill="#5AB2AC"/><path d="M100.92 135.812c-1.57-1.34-2.54-2.63-3.06-3.61a4.196 4.196 0 01-.18-3.61c.31-.8.48-1.65.48-2.5 0-.67-.09-1.38-.35-2.01-1.15-3.32-2.71-6.03-4.53-8.2-.04-.05-.08-.11-.13-.16-.81-1.14-1.73-2.2-2.74-3.16l-1.07.52c-1.89.91-3.61 2.19-4.83 3.89-.9 1.25-1.57 2.66-1.96 4.17-.45 1.74-1.03 3.52-1.83 4.77-1.26 2-2.94 3.49-4.39 4.52-.81.58-1.55 1.01-2.09 1.3l-1.36-1.02c-2.73-2.05-6.69-1.03-8.06 2.15-1 2.3-.09 5 1.92 6.5l3.15 2.37-.02.02c-.47.45-.96.87-1.46 1.28-.03.02-.05.05-.08.07-.49.39-1 .76-1.52 1.11-.05.04-.11.07-.16.11-.5.33-1.02.64-1.55.92-.08.04-.16.09-.24.13-.06.03-.13.06-.2.09-.45.23-.91.46-1.39.66-.05.02-.09.05-.14.07.5 2.13.79 4.3.75 6.49-.04 2.77-1.04 5.3-2.88 7.13l22 16v-21.84l5.4 1.84c6.74 2.85 8.5-.77 8.19-3.18-.22-1.65 2.23-2.5 2.23-2.5.96-1.87-.52-2.76-.52-2.76 1.84-.22 1.97-2.45 1.97-2.45-1.22-1.43-.92-2.81.09-3.12 1.78-.6 4.63-2.56.56-5.99z" fill="#AF5947"/><path d="M90.42 112.562c-3.76-3.56-8.83-5.76-14.42-5.76-2.17 0-4.27.33-6.24.94-3.91-3.69-9.08-5.94-14.76-5.94-12.15 0-22 10.3-22 23s9.85 23 22 23c2.87 0 5.61-.58 8.12-1.62h.01c.05-.02.09-.05.14-.07.47-.2.93-.42 1.39-.66.06-.03.13-.06.2-.09.08-.04.16-.09.24-.13.53-.29 1.05-.59 1.55-.92.05-.04.11-.07.16-.11.52-.35 1.03-.72 1.52-1.11.03-.02.05-.04.08-.07.5-.41.99-.83 1.46-1.28l.02-.02-3.15-2.37c-2.01-1.5-2.92-4.2-1.92-6.5 1.37-3.18 5.33-4.2 8.06-2.15l1.36 1.02c.54-.29 1.28-.72 2.09-1.3 1.45-1.03 3.13-2.52 4.39-4.52.8-1.25 1.38-3.03 1.83-4.77.39-1.51 1.06-2.92 1.96-4.17 1.22-1.7 2.94-2.98 4.83-3.89l1.08-.51c1 .96 1.92 2.02 2.73 3.16.04.05.08.11.13.16a21.13 21.13 0 00-2.86-3.32z" fill="#6D493C"/><path d="M130 93.802c20.43 0 37-16.57 37-37s-16.57-37-37-37-37 16.57-37 37 16.57 37 37 37z" fill="#5AB2AC"/><path d="M140.11 68.562c-.86.74-1.94 1.23-3.08 1.24H137c-2.38-.01-4.13-1.87-4.31-4-.06-.75.07-1.54.45-2.29l.47-.93 2.09-4.18c1.26-2.54.16-5.54-2.55-6.4-.47-.15-.94-.2-1.39-.2-1.51 0-2.89.75-3.71 1.99-.1.15-.21.3-.29.47l-2.02 4.04-.74 1.5h-4l1.09-6H111v3c0 .55-.45 1-1 1s-1-.45-1-1v-2.17c-.07.08-.14.16-.2.25-.63.93-1.27 1.86-1.89 2.78-.35.55-.74 1.1-.86 1.72-.12.63.04 1.37.55 1.76.63.47 1.68.27 2.19.9.43.55.18 1.33.04 2.03-.13.66.08 2.43.2 2.86.12.43.39.82.55 1.21.63 1.53-.35 3.6.74 4.81.39.47.83.85 1.68.85h5c1.15 0 2.46.46 3.27 1.27a4.3 4.3 0 011.05 1.7l2.05 6.14L141 67.802v-.01l-.89.77zM111 51.802h11.45l1.98-10.88.11-.61c.07-.37.06-.75.01-1.12-.1-.77-.43-1.5-1.02-2.01a3.26 3.26 0 00-2.89-.7c-.45.11-.88.3-1.25.61l-4.46 3.74a12.548 12.548 0 00-4.42 10.97h.49z" fill="#E9B99E"/><path d="M125 51.802h-16v5c0 .55.45 1 1 1s1-.45 1-1v-3h17.05a4.43 4.43 0 013.71-1.99v-.01H125z" fill="#1F2225"/><path d="M141.98 68.732l-.15-.15c-.28-.27-.55-.53-.83-.78l-17.63 15.11-8.78 7.53c4.69 2.15 9.91 3.36 15.41 3.36 8.46 0 16.26-2.85 22.49-7.63-1.5-6.21-6.03-13.02-10.51-17.44z" fill="#975D48"/><path d="M122.94 53.802h-.85l-1.09 6h4l.74-1.49 2.02-4.04c.08-.17.19-.32.29-.47H122.94z" fill="#fff"/><path d="M148.42 61.152c1.53-.85 2.58-2.47 2.58-4.35 0-1.48-.66-2.79-1.68-3.71.44-1.35.68-2.79.68-4.29 0-7.43-5.79-13.49-13.1-13.95-.19-.92-.64-1.78-1.31-2.46a8.818 8.818 0 00-6.24-2.59c-4.2 0-8.38.68-12.36 2.01l-2.92.97a4.468 4.468 0 00-3.07 4.24v.01c0 1.69.96 3.24 2.47 4 .28.14.58.24.88.32.19-.18.38-.35.58-.52l4.46-3.74c.37-.3.8-.5 1.25-.61a3.23 3.23 0 012.89.7c.59.51.92 1.24 1.02 2.01.05.37.06.75-.01 1.12l-.11.61-1.98 10.88H131.76v.01c.46 0 .93.05 1.39.2 2.7.86 3.8 3.86 2.55 6.4l-2.09 4.18-.47.93c-.38.75-.51 1.54-.45 2.29.17 2.13 1.93 3.99 4.31 4h.03c1.14-.01 2.22-.5 3.08-1.24l.89-.77.01-.01.82.8.15.15.11.11c.82.6 1.82.96 2.92.96 3.11 0 5.56-2.84 4.89-6.07a4.965 4.965 0 00-1.48-2.59z" fill="#fff"/><path d="M144.19 113.282v15h4v-15c0-6.08 4.92-11 11-11s11 4.92 11 11v15h4v-15c0-8.28-6.72-15-15-15-8.28 0-15 6.72-15 15z" fill="#D9942D"/><path d="M194.19 120.282h-58l-12 60h82l-12-60z" fill="#E9AF58"/><path d="M197.79 138.282h-65.2l-3.6 18h72.4l-3.6-18zM126.19 170.282h78l-1.2-6h-75.6l-1.2 6z" fill="#D9942D"/><path d="M136.19 120.282l-12 60h20l4-60h-12z" fill="#D9942D"/><path d="M158.19 113.282v15h4v-15c0-6.08 4.92-11 11-11s11 4.92 11 11v15h4v-15c0-8.28-6.72-15-15-15-8.28 0-15 6.72-15 15z" fill="#E9AF58"/></svg>


```
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {EmptyState, Page} from '../src';

import EmptyStateImage from '/Users/kyledurand/Downloads/customers.svg';

export function Playground() {
  return (
    <Page title="Playground">
      <EmptyState
        centeredLayout
        heading="Manage your inventory transfers"
        action={{content: 'Add transfer'}}
        secondaryAction={{
          content: 'Learn more',
          url: 'https://help.shopify.com',
        }}
        image={EmptyStateImage}
      >
        <p>Track and receive your incoming inventory from suppliers.</p>
      </EmptyState>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
