### PR TITLE
[Page] Adding additionalNavigation prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@
 
 ### Enhancements
 
+- Added `additionalNavigation` prop to `Page` ([#2942](https://github.com/Shopify/polaris-react/pull/2942))
+
 ### Bug fixes
 
 - Fixed performance of `ResourceItem` due to inclusion of `children` in deep prop comparison within `shouldComponentUpdate` ([#2936](https://github.com/Shopify/polaris-react/pull/2936))

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -219,6 +219,7 @@ Use for detail pages, which should have pagination and breadcrumbs, and also oft
     hasPrevious: true,
     hasNext: true,
   }}
+  additionalNavigation={<Avatar size="small" initials="CD" customer={false} />}
   separator
 >
   <p>Page content</p>

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -59,6 +59,10 @@ $action-menu-rollup-computed-width: icon-size();
   margin: 0 spacing(tight);
   display: flex;
   justify-content: flex-end;
+
+  @include page-content-when-not-fully-condensed {
+    margin: 0 spacing(extra-loose);
+  }
 }
 
 ///

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -1,7 +1,7 @@
 @import '../../../../styles/common';
 
 $individual-action-padding-x: (1.5 * spacing(tight));
-$action-menu-rollup-computed-width: icon-size() + (spacing(tight) * 2);
+$action-menu-rollup-computed-width: icon-size();
 
 .Header {
   @include page-header-layout;
@@ -52,6 +52,13 @@ $action-menu-rollup-computed-width: icon-size() + (spacing(tight) * 2);
   flex: 0 0 auto;
   margin-left: auto;
   line-height: 1;
+}
+
+.AdditionalNavigationWrapper {
+  flex: 1 0 auto;
+  margin: 0 spacing(tight);
+  display: flex;
+  justify-content: flex-end;
 }
 
 ///

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -99,7 +99,7 @@ export function Header({
   ) : null;
 
   const navigationMarkup =
-    breadcrumbMarkup || paginationMarkup ? (
+    breadcrumbMarkup || paginationMarkup || additionalNavigationMarkup ? (
       <div className={styles.Navigation}>
         {breadcrumbMarkup}
         {additionalNavigationMarkup}

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -52,6 +52,8 @@ export interface HeaderProps extends TitleProps {
   secondaryActions?: MenuActionDescriptor[];
   /** Collection of page-level groups of secondary actions */
   actionGroups?: MenuGroupDescriptor[];
+  /** Additional navigation markup */
+  additionalNavigation?: React.ReactNode;
 }
 
 export function Header({
@@ -63,6 +65,7 @@ export function Header({
   separator,
   primaryAction,
   pagination,
+  additionalNavigation,
   breadcrumbs = [],
   secondaryActions = [],
   actionGroups = [],
@@ -89,10 +92,17 @@ export function Header({
       </div>
     ) : null;
 
+  const additionalNavigationMarkup = additionalNavigation ? (
+    <div className={styles.AdditionalNavigationWrapper}>
+      {additionalNavigation}
+    </div>
+  ) : null;
+
   const navigationMarkup =
     breadcrumbMarkup || paginationMarkup ? (
       <div className={styles.Navigation}>
         {breadcrumbMarkup}
+        {additionalNavigationMarkup}
         {paginationMarkup}
       </div>
     ) : null;

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -158,6 +158,18 @@ describe('<Header />', () => {
     });
   });
 
+  describe('additionalNavigation', () => {
+    it('renders element if passed', () => {
+      const TestComponent = () => <div />;
+
+      const header = mountWithAppProvider(
+        <Header {...mockProps} additionalNavigation={<TestComponent />} />,
+      );
+
+      expect(header.find(TestComponent).exists()).toBe(true);
+    });
+  });
+
   describe('<ActionMenu />', () => {
     const mockSecondaryActions: HeaderProps['secondaryActions'] = [
       {content: 'mock content 1'},


### PR DESCRIPTION
### WHY are these changes introduced?

For a project I am working on currently, we need to make better use of the space between the breadcrumbs and pagination/actions menu. Currently we have some hacks with absolute positioning, but I would rather this be a part of the page component so we can make it more reliable and also re-arrange if needed (probably in the new design language too). My current implementation gets the wrong tab order as well because I need to place the elements inside the page content instead of in the proper place in the header.

### WHAT is this pull request doing?

This adds a new `additionalNavigation` prop to `<Page>` that accepts a React Node and renders it in the correct space.

This is what it looks like with an avatar in that spot:

<img width="1027" alt="Screen Shot 2020-04-24 at 12 21 12 PM" src="https://user-images.githubusercontent.com/478990/80235159-55d39e80-8627-11ea-813f-b5456fec038c.png">

<img width="311" alt="Screen Shot 2020-04-24 at 12 21 21 PM" src="https://user-images.githubusercontent.com/478990/80235173-5835f880-8627-11ea-8a56-b2d644643919.png">

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

I added an example to our `Page with all header elements` example in the README

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)



### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit