### PR TITLE
Updated CONTRIBUTING.md WebFoundation urls

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -85,7 +85,7 @@ Each contributor is required to [sign a CLA](https://cla.shopify.com/). This pro
 
 ### Best practices
 
-Take a look at [our best practices](https://github.com/Shopify/web-foundation/tree/master/Best%20practices) which include [testing](https://github.com/Shopify/web-foundation/blob/master/Best%20practices/Testing.md), [React testing](https://github.com/Shopify/web-foundation/blob/master/Best%20practices/React/Testing.md), [Jest](https://github.com/Shopify/web-foundation/blob/master/Best%20practices/Jest.md), and [Enzyme](https://github.com/Shopify/web-foundation/blob/master/Best%20practices/Enzyme.md). We will continue to add best practices here.
+Take a look at [our best practices](https://github.com/Shopify/web-foundation/tree/master/handbook/Best%20practices) which include [testing](https://github.com/Shopify/web-foundation/blob/master/handbook/Best%20practices/Testing.md), [React testing](https://github.com/Shopify/web-foundation/blob/master/handbook/Best%20practices/React/Testing.md), [Jest](https://github.com/Shopify/web-foundation/blob/master/handbook/Best%20practices/Jest.md), and [Enzyme](https://github.com/Shopify/web-foundation/blob/master/handbook/Best%20practices/Enzyme.md). We will continue to add best practices here.
 
 ### Development workflow
 


### PR DESCRIPTION
Documentation - Add /handbook/ directory to webfoundation urls 

[Web-Foundation](github.com/Shopify/web-foundation) was restructured so links in the 'Best practices' section 
of  [.github/CONTRIBUTING.md](https://github.com/Shopify/polaris-react/blob/master/.github/CONTRIBUTING.md) were outdated.
Old urls
`github.com/Shopify/web-foundation/tree/master/Best%20practices`
New handbook urls
`github.com/Shopify/web-foundation/tree/master/`**handbook/**`Best%20practices`

related commit for web-foundation
https://github.com/Shopify/web-foundation/commit/357d8311b9e952fc677f368a83741159577e5abb

### WHY are these changes introduced?

External project changed it's repo structure so github urls became outdated resulting 404's when visting old links
