### PR TITLE
Updating changelog for 4.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [these versioning and changelog guidelines](https://git.i
 
 ---
 
+## 4.21.0 - 2020-04-28
+
+### Enhancements
+
+- Added `additionalNavigation` prop to `Page` ([#2942](https://github.com/Shopify/polaris-react/pull/2942))
+
+## 4.20.1 - 2020-04-23
+
+### Bug fixes
+
+- Fixed performance of `ResourceItem` due to inclusion of `children` in deep prop comparison within `shouldComponentUpdate` ([#2936](https://github.com/Shopify/polaris-react/pull/2936))
+
 ## 4.20.0 - 2020-04-22
 
 ### Enhancements

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,11 +6,7 @@
 
 ### Enhancements
 
-- Added `additionalNavigation` prop to `Page` ([#2942](https://github.com/Shopify/polaris-react/pull/2942))
-
 ### Bug fixes
-
-- Fixed performance of `ResourceItem` due to inclusion of `children` in deep prop comparison within `shouldComponentUpdate` ([#2936](https://github.com/Shopify/polaris-react/pull/2936))
 
 ### Documentation
 


### PR DESCRIPTION
This updates the changelog for v4.21.0. It looks like we missed this in 4.20.1. Does that look right to you @chloerice?