### PR TITLE
[OptionList] Fix issue with dummy section being inserted

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@
 
 ### Bug fixes
 
+- Fixed Extra empty LI/UL in sections. [#https://github.com/Shopify/polaris-react/issues/2955](https://github.com/shopify/polaris-react/pull/2959)
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -69,7 +69,7 @@ export function OptionList({
   id: idProp,
 }: OptionListProps) {
   const [normalizedOptions, setNormalizedOptions] = useState(
-    createNormalizedOptions(options, sections, title),
+    createNormalizedOptions(options, sections),
   );
   const id = useUniqueId('OptionList', idProp);
   const {newDesignLanguage} = useFeatures();
@@ -77,12 +77,20 @@ export function OptionList({
   useDeepEffect(
     () => {
       setNormalizedOptions(
-        createNormalizedOptions(options || [], sections || [], title),
+        createNormalizedOptions(options || [], sections || []),
       );
     },
     [options, sections, title],
     optionArraysAreEqual,
   );
+
+  const renderTitle = (title: string | undefined) => {
+    return title ? (
+      <p className={styles.Title} role={role}>
+        {title}
+      </p>
+    ) : null;
+  };
 
   const handleClick = useCallback(
     (sectionIndex: number, optionIndex: number) => {
@@ -109,11 +117,6 @@ export function OptionList({
 
   const optionsMarkup = optionsExist
     ? normalizedOptions.map(({title, options}, sectionIndex) => {
-        const titleMarkup = title ? (
-          <p className={styles.Title} role={role}>
-            {title}
-          </p>
-        ) : null;
         const optionsMarkup =
           options &&
           options.map((option, optionIndex) => {
@@ -138,7 +141,7 @@ export function OptionList({
 
         return (
           <li key={title || `noTitle-${sectionIndex}`}>
-            {titleMarkup}
+            {renderTitle(title)}
             <ul
               className={styles.Options}
               id={`${id}-${sectionIndex}`}
@@ -159,6 +162,7 @@ export function OptionList({
 
   return (
     <ul className={optionListClassName} role={role}>
+      {renderTitle(title)}
       {optionsMarkup}
     </ul>
   );
@@ -167,23 +171,19 @@ export function OptionList({
 function createNormalizedOptions(
   options?: OptionDescriptor[],
   sections?: SectionDescriptor[],
-  title?: string,
 ): SectionDescriptor[] {
-  if (options == null) {
-    const section = {options: [], title};
-    return sections == null ? [] : [section, ...sections];
+  if (options == null || options.length < 1) {
+    return sections == null ? [] : sections;
   }
-  if (sections == null) {
+  if (sections == null || sections.length < 1) {
     return [
       {
-        title,
         options,
       },
     ];
   }
   return [
     {
-      title,
       options,
     },
     ...sections,

--- a/src/components/OptionList/tests/OptionList.test.tsx
+++ b/src/components/OptionList/tests/OptionList.test.tsx
@@ -5,6 +5,7 @@ import {mountWithApp} from 'test-utilities';
 
 import {Option} from '../components';
 import {OptionList, OptionListProps, OptionDescriptor} from '../OptionList';
+import styles from '../OptionList.scss';
 
 describe('<OptionList />', () => {
   const defaultProps: OptionListProps = {
@@ -84,6 +85,20 @@ describe('<OptionList />', () => {
     ).find(Option);
 
     expect(optionWrappers).toHaveLength(totalOptions(options, sections));
+  });
+
+  describe('when there are two sections and no options included in props', () => {
+    // This is a regression test to make sure that the correct amount of
+    // ul.Options lists are rendered. (https://github.com/Shopify/polaris-react/issues/2955)
+    it('renders two ul.Options lists', () => {
+      const options: OptionDescriptor[] = [];
+      const mountedComponent = mountWithAppProvider<OptionListProps>(
+        <OptionList {...defaultProps} options={options} />,
+      );
+
+      // 2 is the amount of sections there are in the defaultProps object.
+      expect(mountedComponent.find(`ul.${styles.Options}`)).toHaveLength(2);
+    });
   });
 
   it('re-renders with new options passed in', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2955

<!--
  Context about the problem that’s being addressed.
-->

In cases that you rendered the `OptionList` component with a number of sections and zero options as props, there would be an extra `ul.Options` rendered. This was because a "dummy" normalized options was being included in the array of options being rendered.

### WHAT is this pull request doing?

This PR does a couple things:

1. It stops including dummy "normalized options" which results in extra markup not making into the DOM.

2. It solidifies the conditional logic of the `normalizedOptions` function a bit. This function can get called with options and sections as null OR empty arrays. Both should be considered empty when they are passed in as either. I also think having options and sections as empty arrays for defaulty 

### Screenshots

#### UI
| Before | After |
| ------- | ------ |
| <img width="1101" alt="Screen Shot 2020-05-02 at 12 23 03 PM" src="https://user-images.githubusercontent.com/13607675/80877025-13860f00-8c70-11ea-8ba9-60f27ac38686.png"> | <img width="1318" alt="Screen Shot 2020-05-02 at 12 23 22 PM" src="https://user-images.githubusercontent.com/13607675/80877100-18e35980-8c70-11ea-955d-e2fc68240684.png"> |

#### Markup
| Before | After |
| ------- | ------ |
| <img width="359" alt="Screen Shot 2020-05-02 at 12 23 42 PM" src="https://user-images.githubusercontent.com/13607675/80877341-2993cf80-8c70-11ea-8d6f-2fe04ad283ba.png"> | <img width="411" alt="Screen Shot 2020-05-02 at 12 24 05 PM" src="https://user-images.githubusercontent.com/13607675/80877424-30224700-8c70-11ea-93fd-b942d02a93c3.png"> |

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

This component has a pretty loose interface that allows for a lot of different scenarios. I would recommend testing this work by including and excluding the title, options and sections props. Things like having all three present, having the title missing but sections missing and the title present but the options missing etc. etc.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page} from '../src';
import {OptionList} from '../src/components/OptionList';

export function Playground() {
  const [selected, setSelected] = React.useState([]);
  return (
    <Page title="Playground">
      <OptionList
        onChange={setSelected}
        title="My OptionList"
        sections={[
          {
            options: [
              {value: 'type', label: 'Sale item type'},
              {value: 'kind', label: 'Sale kind'},
            ],
          },
          {
            title: 'Traffic',
            options: [
              {value: 'source', label: 'Traffic referrer source'},
              {value: 'host', label: 'Traffic referrer host'},
              {value: 'path', label: 'Traffic referrer path'},
            ],
          },
        ]}
        selected={selected}
        allowMultiple
      />
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
