### PR TITLE
[ComboBox] set tabIndex depending of number of options

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@
 ### Bug fixes
 
 - Added an outline on `Banner` for Windows high contrast mode ([#2878](https://github.com/Shopify/polaris-react/pull/2878))
+- Fixed Autocomplete / ComboBox focus ([#1089](https://github.com/Shopify/polaris-react/issues/1089))
 
 ### Documentation
 

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -317,7 +317,7 @@ export function ComboBox({
         aria-haspopup
         onFocus={forcePopoverActiveTrue}
         onBlur={handleBlur}
-        tabIndex={0}
+        tabIndex={options.length === 0 ? -1 : 0}
       >
         <KeypressListener keyCode={Key.DownArrow} handler={selectNextOption} />
         <KeypressListener

--- a/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
+++ b/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
@@ -48,6 +48,24 @@ describe('<ComboBox/>', () => {
       expect(optionListOptions[1].value).toBe('macaroni_pizza');
       expect(optionListOptions[1].label).toBe('Macaroni Pizza');
     });
+
+    it.each([
+      [options, 0],
+      [[], -1],
+    ])('sets tabIndex depending of number of options', (options, tabIndex) => {
+      const comboBox = mountWithApp(
+        <ComboBox
+          options={options}
+          selected={[]}
+          textField={renderTextField()}
+          onSelect={noop}
+        />,
+      );
+
+      expect(comboBox.find('div', {role: 'combobox'})).toHaveReactProps({
+        tabIndex,
+      });
+    });
   });
 
   describe('contentBefore and contentAfter', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1089

Allows user to directly focus the textfield when there aren't options while navigating with a keyboard. 

### WHAT is this pull request doing?

It makes the tabindex dynamic based on the number of options. 

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';

import {Page, Card, Autocomplete, TextField, FormLayout, Button} from '../src';

export function Playground() {
  const [options, setOptions] = useState<{value: string; label: string}[]>([]);

  const addOptions = () => {
    setOptions([
      {value: 'montreal', label: 'Montreal'},
      {value: 'tokyo', label: 'Tokyo'},
      {value: 'seoul', label: 'Seoul'},
    ]);
  };

  return (
    <Page title="Playground">
      <Card sectioned>
        <FormLayout>
          <TextField label="Name" />
          <Autocomplete
            options={options}
            selected={[]}
            onSelect={() => null}
            listTitle="Suggested Cities"
            textField={<Autocomplete.TextField label="City" />}
            willLoadMoreResults
          />
          <TextField label="Phone" />
          {options.length === 0 && (
            <Button onClick={addOptions}>Add options</Button>
          )}
        </FormLayout>
      </Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
