### PR TITLE
Use supported mocking functions in jest.

### DIFF
--- a/src/components/Card/components/Header/tests/Header.test.tsx
+++ b/src/components/Card/components/Header/tests/Header.test.tsx
@@ -6,7 +6,7 @@ import {ButtonGroup, Heading, buttonsFrom} from 'components';
 import {Header} from '../Header';
 
 jest.mock('../../../../Button', () => ({
-  ...require.requireActual('../../../../Button'),
+  ...jest.requireActual('../../../../Button'),
   buttonsFrom: jest.fn(),
 }));
 

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -15,7 +15,7 @@ import {Modal} from '../Modal';
 import {WithinContentContext} from '../../../utilities/within-content-context';
 
 jest.mock('../../../utilities/app-bridge-transformers', () => ({
-  ...require.requireActual('../../../utilities/app-bridge-transformers'),
+  ...jest.requireActual('../../../utilities/app-bridge-transformers'),
   transformActions: jest.fn((...args) => args),
 }));
 

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -22,7 +22,7 @@ window.matchMedia =
   };
 
 jest.mock('../../../utilities/app-bridge-transformers', () => ({
-  ...require.requireActual('../../../utilities/app-bridge-transformers'),
+  ...jest.requireActual('../../../utilities/app-bridge-transformers'),
   generateRedirect: jest.fn((...args) => args),
   transformActions: jest.fn((...args) => args),
 }));

--- a/src/components/PageActions/tests/PageActions.test.tsx
+++ b/src/components/PageActions/tests/PageActions.test.tsx
@@ -9,7 +9,7 @@ import {buttonsFrom} from '../../Button';
 import {PageActions} from '..';
 
 jest.mock('../../Button', () => ({
-  ...require.requireActual('../../Button'),
+  ...jest.requireActual('../../Button'),
   buttonsFrom: jest.fn(),
 }));
 

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -12,7 +12,7 @@ import {PositionedOverlay} from '../../../../PositionedOverlay';
 import {PopoverOverlay} from '../PopoverOverlay';
 
 jest.mock('@shopify/javascript-utilities/fastdom', () => ({
-  ...require.requireActual('@shopify/javascript-utilities/fastdom'),
+  ...jest.requireActual('@shopify/javascript-utilities/fastdom'),
   write: jest.fn((callback) => callback()),
 }));
 

--- a/src/components/Portal/tests/Portal.test.tsx
+++ b/src/components/Portal/tests/Portal.test.tsx
@@ -7,13 +7,13 @@ import {Portal} from '../Portal';
 import {portal} from '../../shared';
 
 jest.mock('react-dom', () => ({
-  ...require.requireActual('react-dom'),
+  ...jest.requireActual('react-dom'),
   createPortal: jest.fn(),
 }));
 
 const {
   createPortal: createPortalSpy,
-}: {[key: string]: jest.Mock} = require.requireMock('react-dom');
+}: {[key: string]: jest.Mock} = jest.requireMock('react-dom');
 
 function lastSpyCall(spy: jest.Mock) {
   return spy.mock.calls.pop() as any[];
@@ -74,7 +74,7 @@ describe('<Portal />', () => {
 
   it('has a child ref defined when onPortalCreated callback is called', () => {
     createPortalSpy.mockImplementation(
-      require.requireActual('react-dom').createPortal,
+      jest.requireActual('react-dom').createPortal,
     );
     const ref: React.RefObject<HTMLDivElement> = React.createRef();
     const handlePortalCreated = jest.fn(() =>

--- a/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -20,7 +20,7 @@ import {TrapFocus} from '../TrapFocus';
 import {Key} from '../../../types';
 
 jest.mock('@shopify/javascript-utilities/fastdom', () => ({
-  ...require.requireActual('@shopify/javascript-utilities/fastdom'),
+  ...jest.requireActual('@shopify/javascript-utilities/fastdom'),
   write: (cb: () => void) => cb(),
 }));
 


### PR DESCRIPTION
### WHY are these changes introduced?

Easing future upgrade paths

### WHAT is this pull request doing?

require.requireActual and require.requireMock have both been deprecated
for ages and have finally been removed in Jest 26.

Let's use the supported functions for doing this.

### How to 🎩
 check tests pass
