### PR TITLE
Add customizable empty state prop in resource list

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,7 +8,7 @@
 
 - Truncated long sort options in `ResourceList` ([#2957](https://github.com/Shopify/polaris-react/pull/2957)
 - Updated type restrictions for `Pagination` to allow its `label` prop to accept `React.ReactNode` instead of `string` ([#2972](https://github.com/Shopify/polaris-react/pull/2972))
-- Added a `emptySearchState` prop to `ResourceList` to enable the customization of the empty search state ([#2971](https://github.com/Shopify/polaris-react/pull/2971))
+- Added an `emptySearchState` prop to `ResourceList` to enable the customization of the empty search state ([#2971](https://github.com/Shopify/polaris-react/pull/2971))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@
 - Truncated long sort options in `ResourceList` ([#2957](https://github.com/Shopify/polaris-react/pull/2957)
 - Updated type restrictions for `Pagination` to allow its `label` prop to accept `React.ReactNode` instead of `string` ([#2972](https://github.com/Shopify/polaris-react/pull/2972))
 - Added a prop to `ResourceList` to enable the customization of the empty search state ([#2971](https://github.com/Shopify/polaris-react/pull/2971))
+- Added a `emptySearchState` prop to `ResourceList` to enable the customization of the empty search state ([#2971](https://github.com/Shopify/polaris-react/pull/2971))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,7 +8,6 @@
 
 - Truncated long sort options in `ResourceList` ([#2957](https://github.com/Shopify/polaris-react/pull/2957)
 - Updated type restrictions for `Pagination` to allow its `label` prop to accept `React.ReactNode` instead of `string` ([#2972](https://github.com/Shopify/polaris-react/pull/2972))
-- Added a prop to `ResourceList` to enable the customization of the empty search state ([#2971](https://github.com/Shopify/polaris-react/pull/2971))
 - Added a `emptySearchState` prop to `ResourceList` to enable the customization of the empty search state ([#2971](https://github.com/Shopify/polaris-react/pull/2971))
 
 ### Bug fixes

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@
 
 - Truncated long sort options in `ResourceList` ([#2957](https://github.com/Shopify/polaris-react/pull/2957)
 - Updated type restrictions for `Pagination` to allow its `label` prop to accept `React.ReactNode` instead of `string` ([#2972](https://github.com/Shopify/polaris-react/pull/2972))
+- Added a prop to `ResourceList` to enable the customization of the empty search state ([#2971](https://github.com/Shopify/polaris-react/pull/2971))
 
 ### Bug fixes
 

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -507,7 +507,8 @@ function ResourceListWithFilteringExample() {
     [],
   );
   const handleQueryValueChange = useCallback(
-    (value) => setQueryValue(value),
+    (value) =>
+      setQueryValue(value),
     [],
   );
   const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
@@ -534,7 +535,7 @@ function ResourceListWithFilteringExample() {
       url: 'customers/256',
       name: 'Ellen Ochoa',
       location: 'Los Angeles, USA',
-    },
+    }
   ];
 
   const filters = [
@@ -585,6 +586,128 @@ function ResourceListWithFilteringExample() {
         items={items}
         renderItem={renderItem}
         filterControl={filterControl}
+      />
+    </Card>
+  );
+
+  function renderItem(item) {
+    const {id, url, name, location} = item;
+    const media = <Avatar customer size="medium" name={name} />;
+
+    return (
+      <ResourceItem id={id} url={url} media={media}>
+        <h3>
+          <TextStyle variation="strong">{name}</TextStyle>
+        </h3>
+        <div>{location}</div>
+      </ResourceItem>
+    );
+  }
+
+  function disambiguateLabel(key, value) {
+    switch (key) {
+      case 'taggedWith':
+        return `Tagged with ${value}`;
+      default:
+        return value;
+    }
+  }
+
+  function isEmpty(value) {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else {
+      return value === '' || value == null;
+    }
+  }
+}
+```
+
+### Resource list with a custom empty state
+
+Allows merchants to narrow the resource list to a subset of the original items.
+
+```jsx
+function ResourceListWithFilteringExample() {
+  const [taggedWith, setTaggedWith] = useState('VIP');
+  const [queryValue, setQueryValue] = useState(null);
+  const [items, setItems] = useState([
+  ]);
+
+  const handleTaggedWithChange = useCallback(
+    (value) => setTaggedWith(value),
+    [],
+  );
+  const handleQueryValueChange = useCallback(
+    (value) => {
+      setQueryValue(value);
+      setItems([]);
+    },
+    [],
+  );
+  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+  const handleClearAll = useCallback(() => {
+    handleTaggedWithRemove();
+    handleQueryValueRemove();
+  }, [handleQueryValueRemove, handleTaggedWithRemove]);
+
+  const resourceName = {
+    singular: 'customer',
+    plural: 'customers',
+  };
+
+  const filters = [
+    {
+      key: 'taggedWith',
+      label: 'Tagged with',
+      filter: (
+        <TextField
+          label="Tagged with"
+          value={taggedWith}
+          onChange={handleTaggedWithChange}
+          labelHidden
+        />
+      ),
+      shortcut: true,
+    },
+  ];
+
+  const appliedFilters = !isEmpty(taggedWith)
+    ? [
+        {
+          key: 'taggedWith',
+          label: disambiguateLabel('taggedWith', taggedWith),
+          onRemove: handleTaggedWithRemove,
+        },
+      ]
+    : [];
+
+  const filterControl = (
+    <Filters
+      queryValue={queryValue}
+      filters={filters}
+      appliedFilters={appliedFilters}
+      onQueryChange={handleQueryValueChange}
+      onQueryClear={handleQueryValueRemove}
+      onClearAll={handleClearAll}
+    >
+      <div style={{paddingLeft: '8px'}}>
+        <Button onClick={() => console.log('New filter saved')}>Save</Button>
+      </div>
+    </Filters>
+  );
+
+  return (
+    <Card>
+      <ResourceList
+        resourceName={resourceName}
+        items={items}
+        renderItem={renderItem}
+        filterControl={filterControl}
+        alternateEmptyState={
+          <div>This is a custom empty state</div>
+        }
       />
     </Card>
   );

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -507,8 +507,7 @@ function ResourceListWithFilteringExample() {
     [],
   );
   const handleQueryValueChange = useCallback(
-    (value) =>
-      setQueryValue(value),
+    (value) => setQueryValue(value),
     [],
   );
   const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
@@ -535,7 +534,7 @@ function ResourceListWithFilteringExample() {
       url: 'customers/256',
       name: 'Ellen Ochoa',
       location: 'Los Angeles, USA',
-    }
+    },
   ];
 
   const filters = [
@@ -631,20 +630,16 @@ Allows merchants to narrow the resource list to a subset of the original items.
 function ResourceListWithFilteringExample() {
   const [taggedWith, setTaggedWith] = useState('VIP');
   const [queryValue, setQueryValue] = useState(null);
-  const [items, setItems] = useState([
-  ]);
+  const [items, setItems] = useState([]);
 
   const handleTaggedWithChange = useCallback(
     (value) => setTaggedWith(value),
     [],
   );
-  const handleQueryValueChange = useCallback(
-    (value) => {
-      setQueryValue(value);
-      setItems([]);
-    },
-    [],
-  );
+  const handleQueryValueChange = useCallback((value) => {
+    setQueryValue(value);
+    setItems([]);
+  }, []);
   const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
   const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
   const handleClearAll = useCallback(() => {
@@ -705,9 +700,7 @@ function ResourceListWithFilteringExample() {
         items={items}
         renderItem={renderItem}
         filterControl={filterControl}
-        alternateEmptyState={
-          <div>This is a custom empty state</div>
-        }
+        alternateEmptyState={<div>This is a custom empty state</div>}
       />
     </Card>
   );

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -696,7 +696,7 @@ function ResourceListWithFilteringExample() {
         items={items}
         renderItem={renderItem}
         filterControl={filterControl}
-        emptySearchStateMarkup={<div>This is a custom empty state</div>}
+        emptySearchState={<div>This is a custom empty state</div>}
       />
     </Card>
   );

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -623,7 +623,7 @@ function ResourceListWithFilteringExample() {
 }
 ```
 
-### Resource list with a custom empty state
+### Resource list with a custom empty search result state
 
 Allows merchants to narrow the resource list to a subset of the original items.
 

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -620,7 +620,7 @@ function ResourceListWithFilteringExample() {
 
 ### Resource list with a custom empty search result state
 
-Allows merchants to narrow the resource list to a subset of the original items.
+Allows merchants to narrow the resource list to a subset of the original items. If the filters or search applied return no results, then display a custom empty search state.
 
 ```jsx
 function ResourceListWithFilteringExample() {

--- a/src/components/ResourceList/README.md
+++ b/src/components/ResourceList/README.md
@@ -506,10 +506,6 @@ function ResourceListWithFilteringExample() {
     (value) => setTaggedWith(value),
     [],
   );
-  const handleQueryValueChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
   const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
   const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
   const handleClearAll = useCallback(() => {
@@ -568,7 +564,7 @@ function ResourceListWithFilteringExample() {
       queryValue={queryValue}
       filters={filters}
       appliedFilters={appliedFilters}
-      onQueryChange={handleQueryValueChange}
+      onQueryChange={setQueryValue}
       onQueryClear={handleQueryValueRemove}
       onClearAll={handleClearAll}
     >
@@ -700,7 +696,7 @@ function ResourceListWithFilteringExample() {
         items={items}
         renderItem={renderItem}
         filterControl={filterControl}
-        alternateEmptyState={<div>This is a custom empty state</div>}
+        emptySearchStateMarkup={<div>This is a custom empty state</div>}
       />
     </Card>
   );

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -90,6 +90,8 @@ export interface ResourceListProps {
   idForItem?(item: any, index: number): string;
   /** Function to resolve an id from a item */
   resolveItemId?(item: any): string;
+  /** React node to display instead of the default empty state */
+  alternateEmptyState?: React.ReactNode;
 }
 
 type CombinedProps = ResourceListProps & WithAppProviderProps;
@@ -391,6 +393,7 @@ class ResourceListInner extends React.Component<CombinedProps, State> {
       selectedItems,
       resourceName = this.defaultResourceName,
       onSortChange,
+      alternateEmptyState,
       polaris: {intl},
     } = this.props;
     const {selectMode, loadingPosition, smallScreen} = this.state;
@@ -518,6 +521,7 @@ class ResourceListInner extends React.Component<CombinedProps, State> {
       );
 
     const emptyStateMarkup = showEmptyState ? (
+      alternateEmptyState ||
       <div className={styles.EmptySearchResultWrapper}>
         <EmptySearchResult {...this.emptySearchResultText()} withIllustration />
       </div>

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -520,12 +520,16 @@ class ResourceListInner extends React.Component<CombinedProps, State> {
         </div>
       );
 
-    const emptyStateMarkup = showEmptyState ? (
-      alternateEmptyState ||
-      <div className={styles.EmptySearchResultWrapper}>
-        <EmptySearchResult {...this.emptySearchResultText()} withIllustration />
-      </div>
-    ) : null;
+    const emptyStateMarkup = showEmptyState
+      ? alternateEmptyState || (
+          <div className={styles.EmptySearchResultWrapper}>
+            <EmptySearchResult
+              {...this.emptySearchResultText()}
+              withIllustration
+            />
+          </div>
+        )
+      : null;
 
     const defaultTopPadding = 8;
     const topPadding =

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -91,7 +91,7 @@ export interface ResourceListProps {
   /** Function to resolve an id from a item */
   resolveItemId?(item: any): string;
   /** React node to display when `filterControl` is set and no results are returned on search or filter of the list. */
-  emptySearchStateMarkup?: React.ReactNode;
+  emptySearchState?: React.ReactNode;
 }
 
 type CombinedProps = ResourceListProps & WithAppProviderProps;
@@ -393,7 +393,7 @@ class ResourceListInner extends React.Component<CombinedProps, State> {
       selectedItems,
       resourceName = this.defaultResourceName,
       onSortChange,
-      emptySearchStateMarkup,
+      emptySearchState,
       polaris: {intl},
     } = this.props;
     const {selectMode, loadingPosition, smallScreen} = this.state;
@@ -479,9 +479,10 @@ class ResourceListInner extends React.Component<CombinedProps, State> {
       <div className={styles['HeaderWrapper-overlay']} />
     ) : null;
 
-    const showEmptyState = filterControl && !this.itemsExist() && !loading;
+    const showEmptySearchState =
+      filterControl && !this.itemsExist() && !loading;
 
-    const headerMarkup = !showEmptyState &&
+    const headerMarkup = !showEmptySearchState &&
       (showHeader || needsHeader) &&
       this.listRef.current && (
         <div className={styles.HeaderOuterWrapper}>
@@ -520,8 +521,8 @@ class ResourceListInner extends React.Component<CombinedProps, State> {
         </div>
       );
 
-    const emptyStateMarkup = showEmptyState
-      ? emptySearchStateMarkup || (
+    const emptySearchStateMarkup = showEmptySearchState
+      ? emptySearchState || (
           <div className={styles.EmptySearchResultWrapper}>
             <EmptySearchResult
               {...this.emptySearchResultText()}
@@ -575,7 +576,7 @@ class ResourceListInner extends React.Component<CombinedProps, State> {
         {items.map(this.renderItem)}
       </ul>
     ) : (
-      emptyStateMarkup
+      emptySearchStateMarkup
     );
 
     const context = {

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -90,8 +90,8 @@ export interface ResourceListProps {
   idForItem?(item: any, index: number): string;
   /** Function to resolve an id from a item */
   resolveItemId?(item: any): string;
-  /** React node to display instead of the default empty state */
-  alternateEmptyState?: React.ReactNode;
+  /** React node to display when `filterControl` is set and no results are returned on search or filter of the list. */
+  emptySearchStateMarkup?: React.ReactNode;
 }
 
 type CombinedProps = ResourceListProps & WithAppProviderProps;
@@ -393,7 +393,7 @@ class ResourceListInner extends React.Component<CombinedProps, State> {
       selectedItems,
       resourceName = this.defaultResourceName,
       onSortChange,
-      alternateEmptyState,
+      emptySearchStateMarkup,
       polaris: {intl},
     } = this.props;
     const {selectMode, loadingPosition, smallScreen} = this.state;
@@ -521,7 +521,7 @@ class ResourceListInner extends React.Component<CombinedProps, State> {
       );
 
     const emptyStateMarkup = showEmptyState
-      ? alternateEmptyState || (
+      ? emptySearchStateMarkup || (
           <div className={styles.EmptySearchResultWrapper}>
             <EmptySearchResult
               {...this.emptySearchResultText()}

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -59,9 +59,13 @@ describe('<ResourceList />', () => {
       const resourceList = mountWithAppProvider(
         <ResourceList items={itemsWithID} renderItem={renderCustomMarkup} />,
       );
-      expect(resourceList.find('li').first().children().html()).toBe(
-        '<p>title 1</p>',
-      );
+      expect(
+        resourceList
+          .find('li')
+          .first()
+          .children()
+          .html(),
+      ).toBe('<p>title 1</p>');
     });
   });
 
@@ -319,14 +323,24 @@ describe('<ResourceList />', () => {
       const resourceList = mountWithAppProvider(
         <ResourceList items={itemsNoID} renderItem={renderItem} />,
       );
-      expect(resourceList.find('li').first().key()).toBe('0');
+      expect(
+        resourceList
+          .find('li')
+          .first()
+          .key(),
+      ).toBe('0');
     });
 
     it('generates a key using the ID if there’s no idForItem prop but there and ID key in the data', () => {
       const resourceList = mountWithAppProvider(
         <ResourceList items={itemsWithID} renderItem={renderItem} />,
       );
-      expect(resourceList.find('li').first().key()).toBe('5');
+      expect(
+        resourceList
+          .find('li')
+          .first()
+          .key(),
+      ).toBe('5');
     });
 
     it('generates a key using the idForItem prop callback when one is provided', () => {
@@ -337,9 +351,12 @@ describe('<ResourceList />', () => {
           renderItem={renderItem}
         />,
       );
-      expect(resourceList.find('li').first().key()).toBe(
-        idForItem(itemsWithID[0]),
-      );
+      expect(
+        resourceList
+          .find('li')
+          .first()
+          .key(),
+      ).toBe(idForItem(itemsWithID[0]));
     });
   });
 
@@ -524,6 +541,24 @@ describe('<ResourceList />', () => {
         />,
       );
       expect(resourceList.find(EmptySearchResult).exists()).toBe(false);
+    });
+
+    it('does not render when alternateEmptyState is set', () => {
+      const resourceList = mountWithAppProvider(
+        <ResourceList
+          items={[]}
+          renderItem={renderItem}
+          filterControl={<div>fake filterControl</div>}
+          alternateEmptyState={
+            <div id="alternateEmptyState">Alternate empty state</div>
+          }
+        />,
+      );
+
+      console.log(resourceList.debug());
+
+      expect(resourceList.find(EmptySearchResult).exists()).toBe(false);
+      expect(resourceList.find('div#alternateEmptyState').exists()).toBe(true);
     });
   });
 
@@ -1041,7 +1076,12 @@ describe('<ResourceList />', () => {
       setSmallScreen();
       trigger(resourceList.find(EventListener), 'handler');
 
-      expect(resourceList.find(Select).first().prop('labelInline')).toBe(false);
+      expect(
+        resourceList
+          .find(Select)
+          .first()
+          .prop('labelInline'),
+      ).toBe(false);
     });
 
     it('select mode is turned off on large screen when no items are selected', () => {

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -555,8 +555,6 @@ describe('<ResourceList />', () => {
         />,
       );
 
-      console.log(resourceList.debug());
-
       expect(resourceList.find(EmptySearchResult).exists()).toBe(false);
       expect(resourceList.find('div#alternateEmptyState').exists()).toBe(true);
     });

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -526,20 +526,22 @@ describe('<ResourceList />', () => {
       expect(resourceList.find(EmptySearchResult).exists()).toBe(false);
     });
 
-    it('does not render when alternateEmptyState is set', () => {
+    it('does not render when emptySearchStateMarkup is set', () => {
       const resourceList = mountWithAppProvider(
         <ResourceList
           items={[]}
           renderItem={renderItem}
           filterControl={<div>fake filterControl</div>}
-          alternateEmptyState={
-            <div id="alternateEmptyState">Alternate empty state</div>
+          emptySearchStateMarkup={
+            <div id="emptySearchStateMarkup">Alternate empty state</div>
           }
         />,
       );
 
       expect(resourceList.find(EmptySearchResult).exists()).toBe(false);
-      expect(resourceList.find('div#alternateEmptyState').exists()).toBe(true);
+      expect(resourceList.find('div#emptySearchStateMarkup').exists()).toBe(
+        true,
+      );
     });
   });
 

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -526,22 +526,20 @@ describe('<ResourceList />', () => {
       expect(resourceList.find(EmptySearchResult).exists()).toBe(false);
     });
 
-    it('does not render when emptySearchStateMarkup is set', () => {
+    it('renders the provided markup when emptySearchState is set', () => {
       const resourceList = mountWithAppProvider(
         <ResourceList
           items={[]}
           renderItem={renderItem}
           filterControl={<div>fake filterControl</div>}
-          emptySearchStateMarkup={
-            <div id="emptySearchStateMarkup">Alternate empty state</div>
+          emptySearchState={
+            <div id="emptySearchState">Alternate empty state</div>
           }
         />,
       );
 
       expect(resourceList.find(EmptySearchResult).exists()).toBe(false);
-      expect(resourceList.find('div#emptySearchStateMarkup').exists()).toBe(
-        true,
-      );
+      expect(resourceList.find('div#emptySearchState').exists()).toBe(true);
     });
   });
 

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -59,13 +59,9 @@ describe('<ResourceList />', () => {
       const resourceList = mountWithAppProvider(
         <ResourceList items={itemsWithID} renderItem={renderCustomMarkup} />,
       );
-      expect(
-        resourceList
-          .find('li')
-          .first()
-          .children()
-          .html(),
-      ).toBe('<p>title 1</p>');
+      expect(resourceList.find('li').first().children().html()).toBe(
+        '<p>title 1</p>',
+      );
     });
   });
 
@@ -323,24 +319,14 @@ describe('<ResourceList />', () => {
       const resourceList = mountWithAppProvider(
         <ResourceList items={itemsNoID} renderItem={renderItem} />,
       );
-      expect(
-        resourceList
-          .find('li')
-          .first()
-          .key(),
-      ).toBe('0');
+      expect(resourceList.find('li').first().key()).toBe('0');
     });
 
     it('generates a key using the ID if there’s no idForItem prop but there and ID key in the data', () => {
       const resourceList = mountWithAppProvider(
         <ResourceList items={itemsWithID} renderItem={renderItem} />,
       );
-      expect(
-        resourceList
-          .find('li')
-          .first()
-          .key(),
-      ).toBe('5');
+      expect(resourceList.find('li').first().key()).toBe('5');
     });
 
     it('generates a key using the idForItem prop callback when one is provided', () => {
@@ -351,12 +337,9 @@ describe('<ResourceList />', () => {
           renderItem={renderItem}
         />,
       );
-      expect(
-        resourceList
-          .find('li')
-          .first()
-          .key(),
-      ).toBe(idForItem(itemsWithID[0]));
+      expect(resourceList.find('li').first().key()).toBe(
+        idForItem(itemsWithID[0]),
+      );
     });
   });
 
@@ -1074,12 +1057,7 @@ describe('<ResourceList />', () => {
       setSmallScreen();
       trigger(resourceList.find(EventListener), 'handler');
 
-      expect(
-        resourceList
-          .find(Select)
-          .first()
-          .prop('labelInline'),
-      ).toBe(false);
+      expect(resourceList.find(Select).first().prop('labelInline')).toBe(false);
     });
 
     it('select mode is turned off on large screen when no items are selected', () => {

--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -150,7 +150,6 @@ $stacking-order: (
 
 .newDesignLanguage {
   .Backdrop {
-
     // 'position' needs to sit below focus-ring since it will be overwritten
     // with relative when the focus ring style is 'base'
     // stylelint-disable-next-line order/properties-order

--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -150,6 +150,11 @@ $stacking-order: (
 
 .newDesignLanguage {
   .Backdrop {
+
+    // 'position' needs to sit below focus-ring since it will be overwritten
+    // with relative when the focus ring style is 'base'
+    // stylelint-disable-next-line order/properties-order
+    position: absolute;
     z-index: z-index(backdrop, $stacking-order);
     top: 0;
     right: 0;
@@ -159,11 +164,6 @@ $stacking-order: (
     border-radius: var(--p-border-radius-base);
     background-color: var(--p-surface);
     @include focus-ring($border-width: rem(1px));
-
-    // 'position' needs to sit below focus-ring since it will be overwritten
-    // with relative when the focus ring style is 'base'
-    // stylelint-disable-next-line order/properties-order
-    position: absolute;
   }
 
   &.error {

--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -150,10 +150,6 @@ $stacking-order: (
 
 .newDesignLanguage {
   .Backdrop {
-    // 'position' needs to sit below focus-ring since it will be overwritten
-    // with relative when the focus ring style is 'base'
-    // stylelint-disable-next-line order/properties-order
-    position: absolute;
     z-index: z-index(backdrop, $stacking-order);
     top: 0;
     right: 0;
@@ -163,6 +159,10 @@ $stacking-order: (
     border-radius: var(--p-border-radius-base);
     background-color: var(--p-surface);
     @include focus-ring($border-width: rem(1px));
+    // 'position' needs to sit below focus-ring since it will be overwritten
+    // with relative when the focus ring style is 'base'
+    // stylelint-disable-next-line order/properties-order
+    position: absolute;
   }
 
   &.error {


### PR DESCRIPTION
### WHY are these changes introduced?

The plus global nav team wants the ability to customize the empty state of the resource list.

### WHAT is this pull request doing?

Add a prop that takes in a react node to be rendered instead of the default empty state

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
