### PR TITLE
Loosen Pagination label type

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@
 ### Enhancements
 
 - Truncated long sort options in `ResourceList` ([#2957](https://github.com/Shopify/polaris-react/pull/2957)
+- Updated type restrictions for `Pagination` to allow its `label` prop to accept `React.ReactNode` instead of `string` ([#2972](https://github.com/Shopify/polaris-react/pull/2972))
 
 ### Bug fixes
 

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -47,7 +47,7 @@ export interface PaginationDescriptor {
   /** Callback when previous button is clicked */
   onPrevious?(): void;
   /** Text to provide more context in between the arrow buttons */
-  label?: string;
+  label?: React.ReactNode;
 }
 
 export interface PaginationProps extends PaginationDescriptor {


### PR DESCRIPTION
### WHY are these changes introduced?

I want to put some chunkier text into the Pagination label

### WHAT is this pull request doing?

Loosen the type of Pagination label to allow for React.ReactNode instead of only strings.

### How to 🎩

See that the below code type checks.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Pagination, DisplayText} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Pagination
        hasNext
        hasPrevious
        label={<DisplayText>CHONK</DisplayText>}
      />
    </Page>
  );
}
```

</details>
