### PR TITLE
[Banner] Fix rounded corners on banners

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@
 
 - Added an outline on `Banner` for Windows high contrast mode ([#2878](https://github.com/Shopify/polaris-react/pull/2878))
 - Fixed Autocomplete / ComboBox focus ([#1089](https://github.com/Shopify/polaris-react/issues/1089))
+- Fixed missing rounded corners on `Banner` ([#2975](https://github.com/Shopify/polaris-react/pull/2975))
 
 ### Documentation
 

--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -10,7 +10,6 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 @mixin banner-attributes($highlight, $background, $in-page, $tint) {
   transition: box-shadow duration() easing();
   transition-delay: duration(fast);
-  border-radius: var(--p-border-radius-wide, inherit);
   box-shadow: var(--p-banner-border, none);
 
   @media (-ms-high-contrast: active) {
@@ -18,12 +17,18 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
   }
 
   @if $in-page {
+    border-radius: var(
+      --p-border-radius-wide,
+      0 0 border-radius() border-radius()
+    );
     box-shadow: var(
       --p-banner-border,
       inset 0 $accent-height 0 0 $highlight,
       inset shadow(transparent),
       shadow()
     );
+  } @else {
+    border-radius: var(--p-border-radius-base, border-radius());
   }
 
   @if $tint {


### PR DESCRIPTION
### WHY are these changes introduced?

Rounded corners on banners were missing

### WHAT is this pull request doing?

A fallback to `inherit` doesn’t appear to work, also border-radius is different for in-context banner so putting those properties in the if-else.