### PR TITLE
[Button] Fix color icon red if button is plain and destructive

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@
 - Added an outline on `Banner` for Windows high contrast mode ([#2878](https://github.com/Shopify/polaris-react/pull/2878))
 - Fixed Autocomplete / ComboBox focus ([#1089](https://github.com/Shopify/polaris-react/issues/1089))
 - Fixed typing for EmptyState action ([#2977](https://github.com/Shopify/polaris-react/pull/2977))
+- Fixed coloring issue for button icons ([#2958](https://github.com/Shopify/polaris-react/issues/2958))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,7 +8,7 @@
 
 ### Bug fixes
 
-- Fixed incorrect `icon` color of `Button` when `destructive` and `plain`   ([#2958](https://github.com/Shopify/polaris-react/issues/2958))
+- Fixed incorrect `icon` color of `Button` when `destructive` and `plain` ([#2958](https://github.com/Shopify/polaris-react/issues/2958))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,7 +14,7 @@
 - Added an outline on `Banner` for Windows high contrast mode ([#2878](https://github.com/Shopify/polaris-react/pull/2878))
 - Fixed Autocomplete / ComboBox focus ([#1089](https://github.com/Shopify/polaris-react/issues/1089))
 - Fixed typing for EmptyState action ([#2977](https://github.com/Shopify/polaris-react/pull/2977))
-- Fixed coloring issue for button icons ([#2958](https://github.com/Shopify/polaris-react/issues/2958))
+- Fixed incorrect `icon` color of `Button` when `destructive` and `plain`   ([#2958](https://github.com/Shopify/polaris-react/issues/2958))
 
 ### Documentation
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -364,6 +364,7 @@ $stacking-order: (
   }
 
   &.destructive {
+    @include recolor-icon(color('red', 'dark'));
     color: var(--p-action-critical, color('red', 'dark'));
     &:focus,
     &:active {


### PR DESCRIPTION
### WHY are these changes introduced?
In cases that a button was passed the props destructive = true and plain
= true you would end up with a button that had text in one color (red /
destructive) and an icon in another color (blue / primary?).

This was not the intentional behaviour. I've added some CSS to color the
icon the same color as the destructive text.
Fixes https://github.com/Shopify/polaris-react/issues/2958

### WHAT is this pull request doing?

#### UI
| Before | After |
| ------- | ------ |
| <img width="200" alt="Screen Shot 2020-05-09 at 9 50 12 PM" src="https://user-images.githubusercontent.com/13607675/81491122-1ae48400-923f-11ea-8ef6-49e1e7fdf082.png"> | <img width="213" alt="Screen Shot 2020-05-09 at 9 49 46 PM" src="https://user-images.githubusercontent.com/13607675/81491124-2172fb80-923f-11ea-973a-e010d8ba5a85.png"> |

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {DeleteMinor} from '@shopify/polaris-icons';

import {Page} from '../src';
import {Button} from '../src/components/Button';

export function Playground() {
  return (
    <Page title="Playground">
      <Button destructive plain icon={DeleteMinor}>
        Delete
      </Button>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
