### PR TITLE
[EmptyState] Switched to ComplexAction as type for the EmptyState actions

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@
 
 - Added an outline on `Banner` for Windows high contrast mode ([#2878](https://github.com/Shopify/polaris-react/pull/2878))
 - Fixed Autocomplete / ComboBox focus ([#1089](https://github.com/Shopify/polaris-react/issues/1089))
+- Fixed typing for EmptyState action ([#2977](https://github.com/Shopify/polaris-react/pull/2977))
 
 ### Documentation
 

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -3,7 +3,7 @@ import React, {useContext} from 'react';
 import {classNames} from '../../utilities/css';
 import {WithinContentContext} from '../../utilities/within-content-context';
 import {useFeatures} from '../../utilities/features';
-import type {Action} from '../../types';
+import type {ComplexAction} from '../../types';
 import {Image} from '../Image';
 import {buttonFrom} from '../Button';
 import {Stack} from '../Stack';
@@ -28,9 +28,9 @@ export interface EmptyStateProps {
   /** Elements to display inside empty state */
   children?: React.ReactNode;
   /** Primary action for empty state */
-  action?: Action;
+  action?: ComplexAction;
   /** Secondary action for empty state */
-  secondaryAction?: Action;
+  secondaryAction?: ComplexAction;
   /** Secondary elements to display below empty state actions */
   footerContent?: React.ReactNode;
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

While working on https://github.com/Shopify/email/pull/4656 we had the need to show a Loading indicator on the empty state primary action.

### WHAT is this pull request doing?

This switched the type for the Actions in the EmptyState from Action to ComplexAction.

Two questions: Do we want to add something on this to the Playground? Also, it could be just the LoadableAction but I used the ComplexAction because it was the typing for the button.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

