### PR TITLE
[Examples] Remove deprecated Container in Next.js

### DIFF
--- a/examples/next.js/pages/_app.js
+++ b/examples/next.js/pages/_app.js
@@ -9,11 +9,9 @@ export default class WrappedApp extends App {
     const {Component, pageProps} = this.props;
 
     return (
-      <Container>
-        <AppProvider i18n={enTranslations}>
-          <Component {...pageProps} />
-        </AppProvider>
-      </Container>
+      <AppProvider i18n={enTranslations}>
+        <Component {...pageProps} />
+      </AppProvider>
     );
   }
 }


### PR DESCRIPTION
App Container has been deprecated in Next.js:
https://github.com/zeit/next.js/blob/master/errors/app-container-deprecated.md
