### PR TITLE
Update typescript to 3.9 and enable skipLibCheck

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,7 +12,11 @@
 
 ### Development workflow
 
+- Improved speed of type-check and build by enabling TypeScript's `skipLibCheck` option ([#2981](https://github.com/Shopify/polaris-react/pull/2981))
+
 ### Dependency upgrades
+
+- Updated TypeScript to 3.9.2 ([#2981](https://github.com/Shopify/polaris-react/pull/2981))
 
 ### Code quality
 

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "shx": "^0.3.2",
     "storybook-chromatic": "^3.4.1",
     "svgo": "^1.3.0",
-    "typescript": "~3.8.3"
+    "typescript": "~3.9.2"
   },
   "peerDependencies": {
     "react": "^16.8.6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
     // strictFunctionTypes is implictly enabled by strict mode but
     // we're not yet compliant, so disable for now
     "strictFunctionTypes": false,
-    "importHelpers": true,
-    "skipLibCheck": false
+    "importHelpers": true
   },
   "include": ["./config/typescript", "./src", "./tests", "./playground"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17846,15 +17846,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.2:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
-
-typescript@^3.8.0-dev.20200111, typescript@~3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@^3.7.2, typescript@^3.8.0-dev.20200111, typescript@~3.9.2:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"
+  integrity sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
### WHY are these changes introduced?

Keeping up to date. tyepscript 3.9 is hot off the presses. Speeding up builds

### WHAT is this pull request doing?
TS 3.9 offers a few speed improvements. Nothing huuuuuge, but it shaves 3
seconds of our build and type-check commands.

Enabling skipLibCheck (as set by our parent TS configs) meanwhile saves
an additional 10 seconds as we don't bother checking TS declaration files
that we don't use. Recently TS's init scripts were updated so now this
is set to true in newly creacted configs so I'm now more confident in
following suit.

On master: type-check took ~38s, build took ~52s
This commit: type-check took ~24.5s, build took ~37s

TypeScript 3.9 Release blog: https://devblogs.microsoft.com/typescript/announcing-typescript-3-9/
PR where TypeScript changed the value of skipLibCheck in new projects to be true: https://github.com/microsoft/TypeScript/pull/37808
More info on what skipLibCheck does: https://swatinem.de/blog/js-tooling/#explaining-skiplibcheck

### How to 🎩

Check build tests and type-check pass. Do a quick tophat in a consuming app.