### PR TITLE
[Empty State] Add full width prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,7 +6,7 @@
 
 ### Enhancements
 
-- Added a `fullWidth` prop to `EmptyState` to support full width content within a content context ([#2992](https://github.com/Shopify/polaris-react/pull/2992))
+- Added a `fullWidth` prop to `EmptyState` to support full width layout within a content context ([#2992](https://github.com/Shopify/polaris-react/pull/2992))
 - Added an `emptyState` prop to `ResourceList` to support in context empty states in list views ([#2569](https://github.com/Shopify/polaris-react/pull/2569))
 
 ### Bug fixes

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@
 
 ### Enhancements
 
+- Added a full width property to empty state component with centered layout ([#2992](https://github.com/Shopify/polaris-react/pull/2992))
+
 ### Bug fixes
 
 ### Documentation

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,7 +6,7 @@
 
 ### Enhancements
 
-- Added a full width property to empty state component with centered layout ([#2992](https://github.com/Shopify/polaris-react/pull/2992))
+- Added a `fullWidth` prop to `EmptyState` to support full width content within a content context ([#2992](https://github.com/Shopify/polaris-react/pull/2992))
 - Added an `emptyState` prop to `ResourceList` to support in context empty states in list views ([#2569](https://github.com/Shopify/polaris-react/pull/2569))
 
 ### Bug fixes

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -140,6 +140,7 @@ $centered-illustration-width: rem(226px);
 
 .centeredLayout {
   .Section {
+    left: 0;
     flex-direction: column-reverse;
     justify-content: center;
     align-items: center;
@@ -159,6 +160,10 @@ $centered-illustration-width: rem(226px);
   .Details {
     text-align: center;
     width: 100%;
+  }
+
+  &.fullWidth .Details {
+    max-width: 100%;
   }
 }
 

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -165,8 +165,10 @@ $centered-illustration-width: rem(226px);
   }
 }
 
-.fullWidth .Details {
-  max-width: 100%;
+.fullWidth {
+  .Details {
+    max-width: 100%;
+  }
 }
 
 .Content {

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -163,10 +163,10 @@ $centered-illustration-width: rem(226px);
     text-align: center;
     width: 100%;
   }
+}
 
-  &.fullWidth .Details {
-    max-width: 100%;
-  }
+.fullWidth .Details {
+  max-width: 100%;
 }
 
 .Content {

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -23,7 +23,7 @@ export interface EmptyStateProps {
    * Whether or not to limit the image to the size of its container on large screens.
    */
   imageContained?: boolean;
-  /** Overrides the max-width on the empty state with centered layout within content container */
+  /** Whether or not the content should span the full width of its container  */
   fullWidth?: boolean;
   /** Whether or not the layout is stacked and centered vs justified apart */
   centeredLayout?: boolean;

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -23,6 +23,8 @@ export interface EmptyStateProps {
    * Whether or not to limit the image to the size of its container on large screens.
    */
   imageContained?: boolean;
+  /** Overrides the max-width on the empty state with centered layout within content container */
+  fullWidth?: boolean;
   /** Whether or not the layout is stacked and centered vs justified apart */
   centeredLayout?: boolean;
   /** Elements to display inside empty state */
@@ -42,6 +44,7 @@ export function EmptyState({
   largeImage,
   imageContained,
   centeredLayout = false,
+  fullWidth = false,
   action,
   secondaryAction,
   footerContent,
@@ -51,6 +54,7 @@ export function EmptyState({
   const newLayout = centeredLayout || newDesignLanguage;
   const className = classNames(
     styles.EmptyState,
+    fullWidth && styles.fullWidth,
     newLayout && styles.centeredLayout,
     imageContained && styles.imageContained,
     withinContentContainer ? styles.withinContentContainer : styles.withinPage,

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -252,7 +252,8 @@ Stacked image over centered content and actions
     >
       <p>
         You can use the Files section to upload images, videos, and other
-        documents. This shows the content with a centered layout and full width.
+        documents. This example shows the content with a centered layout and
+        full width.
       </p>
     </EmptyState>
   </Card.Section>

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -211,7 +211,7 @@ Use to provide additional but non-critical context for a new product or feature.
     >
       <p>
         You can use the Files section to upload images, videos, and other
-        documents!!! This is where we're doing the changes
+        documents
       </p>
     </EmptyState>
   </Card.Section>
@@ -253,7 +253,7 @@ Stacked image over centered content and actions
     >
       <p>
         You can use the Files section to upload images, videos, and other
-        documents!!! This is where we're doing the changes
+        documents. This shows the content with a centered layout and full width.
       </p>
     </EmptyState>
   </Card.Section>

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -237,7 +237,7 @@ Stacked image over centered content and actions
 </EmptyState>
 ```
 
-### Empty state within a content context with centered layout and full width
+### Empty state with full width layout in a content context
 
 <!-- example-for: web -->
 
@@ -249,7 +249,6 @@ Stacked image over centered content and actions
       action={{content: 'Upload files'}}
       image="https://cdn.shopify.com/s/files/1/2376/3301/products/emptystate-files.png"
       fullWidth
-      centeredLayout
     >
       <p>
         You can use the Files section to upload images, videos, and other

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -211,7 +211,7 @@ Use to provide additional but non-critical context for a new product or feature.
     >
       <p>
         You can use the Files section to upload images, videos, and other
-        documents
+        documents!!! This is where we're doing the changes
       </p>
     </EmptyState>
   </Card.Section>
@@ -235,6 +235,29 @@ Stacked image over centered content and actions
     You can use the Files section to upload images, videos, and other documents
   </p>
 </EmptyState>
+```
+
+### Empty state within a content context with centered layout and full width
+
+<!-- example-for: web -->
+
+```jsx
+<Card>
+  <Card.Section>
+    <EmptyState
+      heading="Upload a file to get started"
+      action={{content: 'Upload files'}}
+      image="https://cdn.shopify.com/s/files/1/2376/3301/products/emptystate-files.png"
+      fullWidth
+      centeredLayout
+    >
+      <p>
+        You can use the Files section to upload images, videos, and other
+        documents!!! This is where we're doing the changes
+      </p>
+    </EmptyState>
+  </Card.Section>
+</Card>
 ```
 
 ---


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes: https://github.com/Shopify/deliveries/issues/206

### WHAT is this pull request doing?
This change is adding another empty state component with a full width property. This full width property works with the centered layout property on the empty state component to provide the user with full width of the content. 

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

I've added an example in the README.txt file that shows how the property is supposed to be used.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit