### PR TITLE
[Page] Add ReactNode as an accepted primaryAction prop value

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,10 @@
 
 ### Enhancements
 
+- Added `ReactNode` as an accepted prop type to `primaryAction` on the `Page` component ([#3002](https://github.com/Shopify/polaris-react/pull/3002))
+- Added a `fullWidth` prop to `EmptyState` to support full width layout within a content context ([#2992](https://github.com/Shopify/polaris-react/pull/2992))
+- Added an `emptyState` prop to `ResourceList` to support in context empty states in list views ([#2569](https://github.com/Shopify/polaris-react/pull/2569))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -16,7 +16,7 @@ import {
   WithAppProviderProps,
 } from '../../utilities/with-app-provider';
 
-import {Header, HeaderProps} from './components';
+import {Header, HeaderProps, isPrimaryAction} from './components';
 import styles from './Page.scss';
 
 export interface PageProps extends HeaderProps {
@@ -166,7 +166,7 @@ class PageInner extends React.PureComponent<ComposedProps, never> {
     return {
       title,
       buttons: transformActions(appBridge, {
-        primaryAction,
+        ...(isPrimaryAction(primaryAction) && {primaryAction}),
         secondaryActions,
         actionGroups,
       }),

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -248,6 +248,32 @@ Use for building any page on iOS.
 
 <!-- /content-for -->
 
+### Page with custom primary action
+
+<!-- example-for: web -->
+
+Use to create a custom primary action.
+
+```jsx
+<Page
+  breadcrumbs={[{content: 'Settings', url: '/settings'}]}
+  title="General"
+  primaryAction={
+    <Button
+      primary
+      connectedDisclosure={{
+        accessibilityLabel: 'Other save actions',
+        actions: [{content: 'Save as new'}],
+      }}
+    >
+      Save
+    </Button>
+  }
+>
+  <p>Page content</p>
+</Page>
+```
+
 ### Page without primary action in header
 
 <!-- example-for: web -->

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -43,7 +43,7 @@ export interface HeaderProps extends TitleProps {
   /** Adds a border to the bottom of the page header (stand-alone app use only) */
   separator?: boolean;
   /** Primary page-level action */
-  primaryAction?: PrimaryAction;
+  primaryAction?: PrimaryAction | React.ReactNode;
   /** Page-level pagination (stand-alone app use only) */
   pagination?: PaginationDescriptor;
   /** Collection of breadcrumbs */
@@ -54,6 +54,12 @@ export interface HeaderProps extends TitleProps {
   actionGroups?: MenuGroupDescriptor[];
   /** Additional navigation markup */
   additionalNavigation?: React.ReactNode;
+}
+
+export function isPrimaryAction(
+  x: PrimaryAction | React.ReactNode,
+): x is PrimaryAction {
+  return !React.isValidElement(x) && x !== undefined;
 }
 
 export function Header({
@@ -116,28 +122,8 @@ export function Header({
     />
   );
 
-  const primary =
-    primaryAction &&
-    (primaryAction.primary === undefined ? true : primaryAction.primary);
-
   const primaryActionMarkup = primaryAction ? (
-    <ConditionalWrapper
-      condition={newDesignLanguage === false}
-      wrapper={(children) => (
-        <div className={styles.PrimaryActionWrapper}>{children}</div>
-      )}
-    >
-      {buttonsFrom(
-        shouldShowIconOnly(
-          newDesignLanguage,
-          isNavigationCollapsed,
-          primaryAction,
-        ),
-        {
-          primary,
-        },
-      )}
-    </ConditionalWrapper>
+    <PrimaryActionMarkup primaryAction={primaryAction} />
   ) : null;
 
   const actionMenuMarkup =
@@ -225,6 +211,42 @@ export function Header({
         {primaryActionMarkup}
       </div>
     </div>
+  );
+}
+
+function PrimaryActionMarkup({
+  primaryAction,
+}: {
+  primaryAction: PrimaryAction | React.ReactNode;
+}) {
+  const {isNavigationCollapsed} = useMediaQuery();
+  const {newDesignLanguage} = useFeatures();
+  let content = primaryAction;
+  if (isPrimaryAction(primaryAction)) {
+    const primary =
+      primaryAction.primary === undefined ? true : primaryAction.primary;
+
+    content = buttonsFrom(
+      shouldShowIconOnly(
+        newDesignLanguage,
+        isNavigationCollapsed,
+        primaryAction,
+      ),
+      {
+        primary,
+      },
+    );
+  }
+
+  return (
+    <ConditionalWrapper
+      condition={newDesignLanguage === false}
+      wrapper={(children) => (
+        <div className={styles.PrimaryActionWrapper}>{children}</div>
+      )}
+    >
+      {content}
+    </ConditionalWrapper>
   );
 }
 

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -12,6 +12,7 @@ import {
 } from 'components';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import type {LinkAction} from '../../../../../types';
 import {Header, HeaderProps} from '../Header';
@@ -97,6 +98,16 @@ describe('<Header />', () => {
 
       const expectedButton = buttonsFrom(primaryAction, {primary: false});
       expect(header.contains(expectedButton)).toBeTruthy();
+    });
+
+    it('renders a `ReactNode`', () => {
+      const PrimaryAction = () => null;
+
+      const header = mountWithApp(
+        <Header {...mockProps} primaryAction={<PrimaryAction />} />,
+      );
+
+      expect(header).toContainReactComponent(PrimaryAction);
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
The current `primaryAction` on `Page` only allows for one button, I'm currently working on a project that has a need for more flexible primary actions.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
This PR maintains the existing `primaryAction` prop, while adding the option to pass a `ReactNode` instead for customizability.

#### What other approaches were considered?
We had considered building the API/UI for `primaryAction` to suit our specific need. We decided against this because we are not sure it's the right solution for everyone.  This way if the provided option `PrimaryAction` doesn't cover every scenario, a custom option can be implemented. 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Button} from '../src';

export function Playground() {
  return (
    <Page
      title="Playground"
      primaryAction={
        <Button
          primary
          connectedDisclosure={{
            accessibilityLabel: 'Other save actions',
            actions: [{content: 'Save as new'}],
          }}
        >
          Save
        </Button>
      }
    >
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
