### PR TITLE
[Icon] Warn when using a new DL color and new DL is disabled

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -44,6 +44,13 @@ export function Icon({source, color, backdrop, accessibilityLabel}: Props) {
     );
   }
 
+  if (color && !newDesignLanguage && isNewDesignLanguageColor(color)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'You have selected a color meant to be used in the new design language but new design language is not enabled.',
+    );
+  }
+
   if (
     color &&
     sourceType === 'external' &&

--- a/src/components/Icon/tests/Icon.test.tsx
+++ b/src/components/Icon/tests/Icon.test.tsx
@@ -62,6 +62,21 @@ describe('<Icon />', () => {
       warningSpy.mockRestore();
     });
 
+    it('warns when a new design language color is used and new design language is not enabled', () => {
+      const warningSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      mountWithApp(<Icon source={PlusMinor} color="warning" />, {
+        features: {newDesignLanguage: false},
+      });
+
+      expect(warningSpy).toHaveBeenCalledWith(
+        'You have selected a color meant to be used in the new design language but new design language is not enabled.',
+      );
+      warningSpy.mockRestore();
+    });
+
     it('uses a specified color when newDesignLanguage is enabled', () => {
       const icon = mountWithApp(<Icon source={PlusMinor} color="subdued" />, {
         features: {newDesignLanguage: true},

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ type NewDesignLanguageColor =
   | 'highlight'
   | 'success'
   | 'primary';
+
 export function isNewDesignLanguageColor(
   color: Color | NewDesignLanguageColor,
 ): color is NewDesignLanguageColor {


### PR DESCRIPTION
`warning` color shows up in TS auto complete when using the Icon component but is unusable without the new DL enabled. I thought about adding a fallback in css but this seems to make more sense to me.

### WHAT is this pull request doing?


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {AlertMinor} from '@shopify/polaris-icons';

import {Icon, Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Icon source={AlertMinor} color="warning" />
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
