### PR TITLE
ContextualSaveBar fullWidth

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@
 ### Enhancements
 
 - Added a `fullWidth` prop to `EmptyState` to support full width layout within a content context ([#2992](https://github.com/Shopify/polaris-react/pull/2992))
+- Added a `fullWidth` prop to `ContextualSaveBar` to support full width layout within a content context ([#3014](https://github.com/Shopify/polaris-react/pull/3014))
 - Added an `emptyState` prop to `ResourceList` to support in context empty states in list views ([#2569](https://github.com/Shopify/polaris-react/pull/2569))
 - Improved top bar transitions when theme changes ([#3007](https://github.com/Shopify/polaris-react/pull/3007))
 

--- a/src/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -16,6 +16,7 @@ export const ContextualSaveBar = React.memo(function ContextualSaveBar({
   saveAction,
   discardAction,
   alignContentFlush,
+  fullWidth,
 }: ContextualSaveBarProps) {
   const {setContextualSaveBar, removeContextualSaveBar} = useFrame();
 
@@ -25,6 +26,7 @@ export const ContextualSaveBar = React.memo(function ContextualSaveBar({
       saveAction,
       discardAction,
       alignContentFlush,
+      fullWidth,
     });
   }, [
     message,
@@ -32,6 +34,7 @@ export const ContextualSaveBar = React.memo(function ContextualSaveBar({
     discardAction,
     alignContentFlush,
     setContextualSaveBar,
+    fullWidth,
   ]);
 
   React.useEffect(() => {

--- a/src/components/ContextualSaveBar/README.md
+++ b/src/components/ContextualSaveBar/README.md
@@ -213,6 +213,50 @@ repurpose that space to extend the message contents fully to the left side of th
 </div>
 ```
 
+### Contextual save bar full width
+
+Use the fullWidth flag when you want to remove the default max-width set on the contextual save bar.
+
+```jsx
+<div style={{height: '250px'}}>
+  <AppProvider
+    theme={{
+      logo: {
+        width: 124,
+        contextualSaveBarSource:
+          'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
+      },
+    }}
+    i18n={{
+      Polaris: {
+        Frame: {
+          skipToContent: 'Skip to content',
+        },
+        ContextualSaveBar: {
+          save: 'Save',
+          discard: 'Discard',
+        },
+      },
+    }}
+  >
+    <Frame>
+      <ContextualSaveBar
+        fullWidth
+        message="Unsaved changes"
+        saveAction={{
+          onAction: () => console.log('add form submit logic'),
+          loading: false,
+          disabled: false,
+        }}
+        discardAction={{
+          onAction: () => console.log('add clear form logic'),
+        }}
+      />
+    </Frame>
+  </AppProvider>
+</div>
+```
+
 ---
 
 ## Related components

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -53,6 +53,11 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   }
 }
 
+.fullWidth {
+  max-width: none;
+  padding: 0 spacing();
+}
+
 .Message {
   @include truncate;
   @include text-style-heading;

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -20,6 +20,7 @@ export function ContextualSaveBar({
   message,
   saveAction,
   discardAction,
+  fullWidth,
 }: ContextualSaveBarProps) {
   const i18n = useI18n();
   const {logo} = useTheme();
@@ -106,11 +107,16 @@ export function ContextualSaveBar({
     newDesignLanguage && styles.newDesignLanguage,
   );
 
+  const contentsClassName = classNames(
+    styles.Contents,
+    fullWidth && styles.fullWidth,
+  );
+
   return (
     <ThemeProvider theme={{colorScheme: 'inverse'}}>
       <div className={contexualSaveBarClassName}>
         {logoMarkup}
-        <div className={styles.Contents}>
+        <div className={contentsClassName}>
           <h2 className={styles.Message}>{message}</h2>
           <div className={styles.ActionContainer}>
             <Stack spacing="tight" wrap={false}>

--- a/src/utilities/frame/types.ts
+++ b/src/utilities/frame/types.ts
@@ -30,6 +30,8 @@ export interface ContextualSaveBarProps {
   saveAction?: ContextualSaveBarAction;
   /** Discard or cancel contextual save bar action with text defaulting to 'Discard' */
   discardAction?: ContextualSaveBarCombinedActionProps;
+  /** Remove the normal max-width on the contextual save bar */
+  fullWidth?: boolean;
 }
 
 // Toast


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/2533 and https://github.com/Shopify/deliveries/issues/695

Contextual save bar looks like garbage on a `fullWidth` page 🗑.
![Screen Shot 2020-05-28 at 9 45 46 PM](https://user-images.githubusercontent.com/19199063/83212193-fb00fb80-a12c-11ea-880c-56215f844043.png)

### WHAT is this pull request doing?

Gives the option to make the contextual savebar `fullWidth` with a prop.

![max-width-removeed](https://user-images.githubusercontent.com/19199063/83212388-782c7080-a12d-11ea-884f-ceb2767c6a88.gif)


### How to 🎩

New example added in `Readme.md`.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
