### PR TITLE
Add support for LoadableAction in AppBridgeAction

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@
 
 ### Bug fixes
 
+- Add support for `IconableAction` and `LoadableAction` in `AppBridgeAction` ([#3021](https://github.com/Shopify/polaris-react/pull/3021))
+
 ### Documentation
 
 ### Development workflow

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,7 +8,7 @@
 
 ### Bug fixes
 
-- Add support for `IconableAction` and `LoadableAction` in `AppBridgeAction` ([#3021](https://github.com/Shopify/polaris-react/pull/3021))
+- Add support for `LoadableAction` in `AppBridgeAction` ([#3021](https://github.com/Shopify/polaris-react/pull/3021))
 
 ### Documentation
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,7 +165,9 @@ export interface AppBridgeAction
   extends Action,
     DisableableAction,
     DestructableAction,
-    AppBridgeActionTarget {}
+    AppBridgeActionTarget,
+    IconableAction,
+    LoadableAction {}
 
 export interface IconableAction extends Action {
   /** Source of the icon */

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,7 +166,6 @@ export interface AppBridgeAction
     DisableableAction,
     DestructableAction,
     AppBridgeActionTarget,
-    IconableAction,
     LoadableAction {}
 
 export interface IconableAction extends Action {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/1410

### WHAT is this pull request doing?

Add support for `LoadableAction` in `AppBridgeAction`. This allows us to have a button with a `loading` prop in a modal for the local delivery app.