### PR TITLE
Use a single template style for POLARIS_VERSION

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -46,11 +46,10 @@ copy(['./src/**/*.{scss,svg,png,jpg,jpeg,json}', intermediateBuild], {up: 1})
       resolvePath(intermediateBuild, './styles/global.scss'),
       resolvePath(intermediateBuild, './configure.js'),
     ].forEach((file) => {
+      const fileContents = readFileSync(file, 'utf8');
       writeFileSync(
         file,
-        readFileSync(file, 'utf8')
-          .replace(/\{\{POLARIS_VERSION\}\}/g, packageJSON.version)
-          .replace(/<%= POLARIS_VERSION %>/g, packageJSON.version),
+        fileContents.replace(/\{\{POLARIS_VERSION\}\}/g, packageJSON.version),
       );
     });
   })

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -4,7 +4,7 @@
 @import './common';
 
 :root {
-  --polaris-version-number: '<%= POLARIS_VERSION %>';
+  --polaris-version-number: '{{POLARIS_VERSION}}';
 }
 
 html,

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -65,42 +65,40 @@ describe('build', () => {
   });
 
   it('replaces occurrences of POLARIS_VERSION', () => {
-    const files = glob.sync('./build/**/*.{js,scss,css}', {
+    const files = glob.sync('./{build,esnext}/**/*.{js,scss,css}', {
       ignore: './build/cache/**',
     });
 
-    const total = files.reduce((acc, file) => {
-      const contents = fs.readFileSync(file, 'utf-8');
-      return acc + Number(contents.includes('POLARIS_VERSION'));
-    }, 0);
-    expect(total).toBe(0);
-  });
+    expect(files).not.toHaveLength(0);
 
-  it('features the version of Polaris in compiled files', () => {
-    const files = glob.sync('./build/**/*.{js,scss,css}', {
-      ignore: './build/cache/**',
+    const fileBuckets: Record<string, string[]> = {
+      includesTemplateString: [],
+      includesVersion: [],
+    };
+
+    files.forEach((file) => {
+      const fileContent = fs.readFileSync(file, 'utf-8');
+
+      if (fileContent.includes('POLARIS_VERSION')) {
+        fileBuckets.includesTemplateString.push(file);
+      }
+
+      if (fileContent.includes(packageJSON.version)) {
+        fileBuckets.includesVersion.push(file);
+      }
     });
-    const total = files.reduce((acc, file) => {
-      const contents = fs.readFileSync(file, 'utf-8');
-      return acc + Number(contents.includes(packageJSON.version));
-    }, 0);
-    expect(total).toBe(5);
-  });
 
-  it('features the version of Polaris in those specific files', () => {
-    const globFiles = [
-      'polaris.css',
-      'polaris.es.js',
-      'polaris.js',
-      'polaris.min.css',
-      'styles/global.scss',
-    ].join(',');
-    const files = glob.sync(`./build/{${globFiles}}`);
-    const total = files.reduce((acc, file) => {
-      const contents = fs.readFileSync(file, 'utf-8');
-      return acc + Number(contents.includes(packageJSON.version));
-    }, 0);
-    expect(total).toBe(5);
+    expect(fileBuckets.includesTemplateString).toHaveLength(0);
+
+    expect(fileBuckets.includesVersion).toStrictEqual([
+      './build/polaris.css',
+      './build/polaris.es.js',
+      './build/polaris.js',
+      './build/polaris.min.css',
+      './build/styles/global.scss',
+      './esnext/configure.js',
+      './esnext/styles/global.scss',
+    ]);
   });
 
   describe('esnext', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

In our code we replace `{{POLARIS_VERSION}}` and `<%= POLARIS_VERSION %>` with the actual version of polaris.

Having two formats for that is silly. Lets just have one.

### WHAT is this pull request doing?

- Replaces occurrence of `<%= POLARIS_VERSION %>` with `{{POLARIS_VERSION}}`
- Remove the build step that searches for `<%= POLARIS_VERSION %>` as it is no longer used
- Refactor the tests that prove that the version is replaced so that they give more meaningful output if they fail - they will now list the files that included the template string rather than saying the total number of files was different.

### How to 🎩

Search the codebase for `<%= POLARIS_VERSION %>` and see that no results are found
Ensure tests pass
Do a build and see that the files mentioned in the build test contain all contain the version string (e.g. `4.23.0`) instead of the template (`{{POLARIS_VERSION}}`).