### PR TITLE
Unify the output of the styles folder build

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,8 @@
 
 ### Development workflow
 
+- Updated how we reference global animations so we can have one public sass API for all consumers instead one entrypoint (`styles/_public-api.scss`) for consumers using plain scss and one entrypoint (`styles/esnext/_public-api.scss`) for consumers using css modules ([#3032](https://github.com/Shopify/polaris-react/pull/3032))
+
 ### Dependency upgrades
 
 ### Code quality

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,7 +18,7 @@
 
 ### Development workflow
 
-- Updated how we reference global animations so we can have one public sass API for all consumers instead one entrypoint (`styles/_public-api.scss`) for consumers using plain scss and one entrypoint (`styles/esnext/_public-api.scss`) for consumers using css modules ([#3032](https://github.com/Shopify/polaris-react/pull/3032))
+- Updated how global animations are referenced, in order to publish a single entrypoint for the public Sass API (`styles/_public-api.scss`), instead of two (`styles/_public-api.scss` for “vanilla” SCSS and `styles/esnext/_public-api.scss` for CSS Modules) ([#3032](https://github.com/Shopify/polaris-react/pull/3032))
 
 ### Dependency upgrades
 

--- a/config/rollup/plugins/styles.js
+++ b/config/rollup/plugins/styles.js
@@ -149,16 +149,10 @@ function generateMinifiedCss(sourceFilePath, css) {
 async function generateSass(inputFolder, outputFolder, cssByFile) {
   // Copy contents of $inputFolder/styles/shared.scss and $inputFolder/styles/foundation.scss
   // and the foundation, shared and polaris-tokens folders into into build/styles
-  // We need to transform the contents of the files as some of them contain
-  // `:global` css modules definitions that we want to strip out
-  const stripGlobalRegex = /:global\s*\(([^)]+)\)|:global\s*{\s*([^}]+)\s*}\s*/g;
   const globOptions = {cwd: inputFolder, ignore: 'styles/_common.scss'};
   await Promise.all(
     glob.sync(`styles/**/*.scss`, globOptions).map((filePath) => {
-      const file = readFileSync(`${inputFolder}/${filePath}`, 'utf8').replace(
-        stripGlobalRegex,
-        '$1$2',
-      );
+      const file = readFileSync(`${inputFolder}/${filePath}`, 'utf8');
       return outputFile(`${outputFolder}/${filePath}`, file);
     }),
   );

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -8,13 +8,13 @@
   // This value matches the name of the animation defined below.
   // The animation name is stored in a custom property so that the scss mixins
   // in our public api that reference this animation can do so with
-  // `var(--polaris-SkeletonShimmerAnimationName)` instead of
+  // `var(--polaris-animation-skeleton-shimmer)` instead of
   // `:global(polaris-SkeletonShimmerAnimation)`. This allows us to expose a
   // single set of public sass API files instead of needing distinct sass API
   // entrypoints for consumers that use css-modules in locals mode (such as scss
   // files in apps using sewing-kit) and for consumers not using css-modules.
   // stylelint-disable-next-line value-keyword-case
-  --polaris-SkeletonShimmerAnimationName: polaris-SkeletonShimmerAnimation;
+  --polaris-animation-skeleton-shimmer: polaris-SkeletonShimmerAnimation;
 }
 
 html,

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -5,6 +5,16 @@
 
 :root {
   --polaris-version-number: '{{POLARIS_VERSION}}';
+  // This value matches the name of the animation defined below.
+  // The animation name is stored in a custom property so that the scss mixins
+  // in our public api that reference this animation can do so with
+  // `var(--polaris-SkeletonShimmerAnimationName)` instead of
+  // `:global(polaris-SkeletonShimmerAnimation)`. This allows us to expose a
+  // single set of public sass API files instead of needing distinct sass API
+  // entrypoints for consumers that use css-modules in locals mode (such as scss
+  // files in apps using sewing-kit) and for consumers not using css-modules.
+  // stylelint-disable-next-line value-keyword-case
+  --polaris-SkeletonShimmerAnimationName: polaris-SkeletonShimmerAnimation;
 }
 
 html,

--- a/src/styles/shared/_skeleton.scss
+++ b/src/styles/shared/_skeleton.scss
@@ -20,7 +20,7 @@ $thumbnail-sizes: (
   // This is a global animation, defined in /src/components/AppProvider/AppProvider.scss
   // See that file for why this is referenced as a custom property instead of
   // by name
-  animation: var(--polaris-SkeletonShimmerAnimationName)
+  animation: var(--polaris-animation-skeleton-shimmer)
     $skeleton-shimmer-duration linear infinite alternate;
   will-change: opacity;
 }

--- a/src/styles/shared/_skeleton.scss
+++ b/src/styles/shared/_skeleton.scss
@@ -17,12 +17,11 @@ $thumbnail-sizes: (
 }
 
 @mixin skeleton-shimmer {
-  :global {
-    // This is a global animation, defined in /src/styles/global.scss
-    // stylelint-disable-next-line no-unknown-animations
-    animation: polaris-SkeletonShimmerAnimation $skeleton-shimmer-duration
-      linear infinite alternate;
-  }
+  // This is a global animation, defined in /src/components/AppProvider/AppProvider.scss
+  // See that file for why this is referenced as a custom property instead of
+  // by name
+  animation: var(--polaris-SkeletonShimmerAnimationName)
+    $skeleton-shimmer-duration linear infinite alternate;
   will-change: opacity;
 }
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -29,18 +29,6 @@ describe('build', () => {
     expect(fs.existsSync('./styles.min.css')).toBe(true);
   });
 
-  it('generates a ./styles/foundation dir with spacing.scss', () => {
-    expect(fs.existsSync('./styles/foundation/_spacing.scss')).toBe(true);
-  });
-
-  it('generates sass entries files in ./styles dir', () => {
-    expect(fs.existsSync('./styles/global.scss')).toBe(true);
-    expect(fs.existsSync('./styles/foundation.scss')).toBe(true);
-    expect(fs.existsSync('./styles/shared.scss')).toBe(true);
-    expect(fs.existsSync('./styles/_public-api.scss')).toBe(true);
-    expect(fs.existsSync('./styles/components.scss')).toBe(true);
-  });
-
   it('generates a ./styles.scss sass entry point in root', () => {
     expect(fs.existsSync('./styles.scss')).toBe(true);
   });
@@ -148,6 +136,36 @@ describe('build', () => {
     it('gives consumers control over global.scss', () => {
       const indexContents = fs.readFileSync('esnext/index.js', 'utf8');
       expect(indexContents).not.toMatch(/import '.+\.scss'/);
+    });
+  });
+
+  describe('Sass Public API', () => {
+    it('generates a ./styles/foundation dir with spacing.scss', () => {
+      expect(fs.existsSync('./styles/foundation/_spacing.scss')).toBe(true);
+    });
+
+    it('generates sass entries files in ./styles dir', () => {
+      expect(fs.existsSync('./styles/global.scss')).toBe(true);
+      expect(fs.existsSync('./styles/foundation.scss')).toBe(true);
+      expect(fs.existsSync('./styles/shared.scss')).toBe(true);
+      expect(fs.existsSync('./styles/_public-api.scss')).toBe(true);
+      expect(fs.existsSync('./styles/components.scss')).toBe(true);
+    });
+
+    it('does not contain any :global definitions', () => {
+      const files = glob.sync(`./{styles,esnext/styles}/**/*.scss`);
+
+      expect(files).not.toHaveLength(0);
+
+      const filesWithGlobalDefinitions = files.filter((file) => {
+        return fs.readFileSync(file, 'utf-8').includes(':global');
+      });
+
+      // esnext/styles/global.scss is expected to have a :global definition for now
+      // When that is moved into AppProvider.scss in v5 this will become an empty array
+      expect(filesWithGlobalDefinitions).toStrictEqual([
+        './esnext/styles/global.scss',
+      ]);
     });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

A step towards #3009.

We have two locations for our public sass API

- `styles/_public-api.scss` for consumers that don't use css-modules
- `esnext/styles/_public-api.scss` for consumers that do use css-modules (e.g. folks using sewing-kit)

Having two locations is confusing to document, adds complexity to our build, and is ripe for confusing our consumers.

It is this way because in one of our mixins we use css-modules' `:global {}` pseudo-selector to get at a globally defined animation name. If we can remove the need for that then we don't need to strip that selector out at build time and then the contents of the api files in `styles/{shared,foundation}/` and `esnext/styles/{shared,foundation}/` become identical.

Let's unify our mixin files so they don't need to differ between these locations.

By doing this we ca tell all consumers to pull in the sass files via`styles/_public-api.scss` instead of `esnext/styles/_public-api.scss`.

We can't fully delete `esnext/styles` just yet as the raw scss files in the esnext folder still reference the contents of that folder.
Once we start shipping built instead of source scss files in the esnext folder we would be able to remove esnext/styles entirely (see my v5 build plotting PR).

### WHAT is this pull request doing?

- Updates our scss api to use a custom-property to reference the shimmer animation name instead of `:global`


### How to 🎩

- In storybook ensure that the shimmer effect still applies to skeleton components e.g. SkeletonDisplay text.
- Run a build then run `diff -ru {,esnext/}styles/shared` and `diff -ru {,esnext/}styles/foundation` and note that those two sets of folders are now identical