### PR TITLE
[EmptyState] Set max-width to 400px

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@
 - Added a `fullWidth` prop to `EmptyState` to support full width layout within a content context ([#2992](https://github.com/Shopify/polaris-react/pull/2992))
 - Added an `emptyState` prop to `ResourceList` to support in context empty states in list views ([#2569](https://github.com/Shopify/polaris-react/pull/2569))
 - Set `active` prop of `Popover` to true on keyDown in `ComboBox` to fix `Autocomplete` suggestions not showing when searching and selecting via keyboard ([#3028](https://github.com/Shopify/polaris-react/pull/3028))
+  Set `active` prop of `Popover` to true on keyDown in `ComboBox` to fix `Autocomplete` suggestions not showing when searching and selecting via keyboard ([#3028](https://github.com/Shopify/polaris-react/pull/3028))
+- Increased the max-width of the `EmptyState` content to 400px (https://github.com/Shopify/polaris-react/pull/3040)
 
 ### Bug fixes
 

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -1,6 +1,8 @@
 @import '../../styles/common';
 
 $detail-width: rem(400px);
+$within-page-detail-width: rem(336px);
+
 $stacking-order: (
   illustration: 0,
   details: 10,
@@ -105,7 +107,7 @@ $centered-illustration-width: rem(226px);
     position: relative;
     z-index: z-index(details, $stacking-order);
     padding: 0 spacing();
-    width: $detail-width;
+    width: $within-page-detail-width;
 
     @include page-content-when-not-fully-condensed {
       padding: 0;

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -1,7 +1,7 @@
 @import '../../styles/common';
 
-$detail-width: rem(400px);
 $within-page-detail-width: rem(336px);
+$detail-width: rem(400px);
 
 $stacking-order: (
   illustration: 0,

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -1,6 +1,6 @@
 @import '../../styles/common';
 
-$detail-width: rem(336px);
+$detail-width: rem(400px);
 $stacking-order: (
   illustration: 0,
   details: 10,


### PR DESCRIPTION
### WHAT is this pull request doing?
This pull request is changing the max-width to 400px for the Empty State content. 

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

You can check out this on the StoryBoard under the Empty state within context component.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
