### PR TITLE
[EmptyState] Add spacing within content

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,7 @@
 
 ### Enhancements
 
+- Added spacing to `EmptyState` when within content to account for new illustration styles ([#3047](https://github.com/Shopify/polaris-react/pull/3047))
 - Changed Resource List to a generic functional component ([#2843](https://github.com/Shopify/polaris-react/pull/2843))
 - Made the `renderItem` function infer the type of the items prop ([#2843](https://github.com/Shopify/polaris-react/pull/2843))
 - Added a `fullWidth` prop to `EmptyState` to support full width layout within a content context ([#2992](https://github.com/Shopify/polaris-react/pull/2992))

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -64,6 +64,7 @@ $centered-illustration-width: rem(226px);
 
 .withinContentContainer {
   margin: 0 auto;
+  padding: spacing(loose) 0 spacing(loose) * 3;
 
   .Section {
     position: unset;

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -64,7 +64,8 @@ $centered-illustration-width: rem(226px);
 
 .withinContentContainer {
   margin: 0 auto;
-  padding: spacing(loose) 0 spacing(loose) * 3;
+  padding-top: spacing(loose);
+  padding-bottom: spacing(loose) * 3;
 
   .Section {
     position: unset;

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -16,12 +16,11 @@ export interface EmptyStateProps {
   /** The empty state heading */
   heading?: string;
   /** The path to the image to display */
+  /** The image should have ~40px of white space above when empty state is used within a card, modal, or navigation component */
   image: string;
   /** The path to the image to display on large screens */
   largeImage?: string;
-  /**
-   * Whether or not to limit the image to the size of its container on large screens.
-   */
+  /** Whether or not to limit the image to the size of its container on large screens */
   imageContained?: boolean;
   /** Whether or not the content should span the full width of its container  */
   fullWidth?: boolean;

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -15,8 +15,10 @@ import styles from './EmptyState.scss';
 export interface EmptyStateProps {
   /** The empty state heading */
   heading?: string;
-  /** The path to the image to display */
-  /** The image should have ~40px of white space above when empty state is used within a card, modal, or navigation component */
+  /**
+   * The path to the image to display.
+   * The image should have ~40px of white space above when empty state is used within a card, modal, or navigation component
+   */
   image: string;
   /** The path to the image to display on large screens */
   largeImage?: string;

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -47,6 +47,9 @@ Empty states should:
 - Explain the steps merchants need to take to activate a product or feature
 - Use illustrations thoughtfully as outlined in our [illustration guidelines](https://polaris.shopify.com/design/illustrations)
 - Use only one primary call-to-action button
+- Provide extra spacing at the bottom of an empty state that is within content
+  (card, modal, or navigation) to match the image that was passed into the component
+  with a white space above it of 40px
 
 ---
 


### PR DESCRIPTION
### WHY are these changes introduced?

The new illustration styles have ~40px of white space between them and their viewbox. We need some additional padding below for visual balance.

I experimented with an aspect ratio wrapper component that could handle this but I think it would be too much added work for teams across the company to implement. 

Instead I'm adding more context to the empty state props regarding spacing while within content

![image](https://screenshot.click/Storybook_2020-06-11_10-14-39.png)

![image](https://screenshot.click/Storybook_2020-06-11_10-15-01.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->



Copy-paste this image into its own file called image.svg as a sibling to Playground
```jsx

  <svg
    width="226"
    height="226"
    viewBox="0 0 226 226"
    fill="none"
    xmlns="http://www.w3.org/2000/svg"
  >
    <path
      d="M187 113C187 153.9 153.9 187 113 187C72.1 187 39 153.9 39 113C39 72.1 72.1 39 113 39C153.9 39 187 72.1 187 113Z"
      fill="#F0F1F2"
    />
    <mask
      id="mask0"
      mask-type="alpha"
      maskUnits="userSpaceOnUse"
      x="41"
      y="39"
      width="146"
      height="148"
    >
      <path
        d="M187 113C187 153.9 153.9 187 113 187H41.8716V39L113 39C153.9 39 187 72.1 187 113Z"
        fill="white"
      />
    </mask>
    <g mask="url(#mask0)">
      <g filter="url(#filter0_d)">
        <path
          d="M184.012 57H56.3593C54.5117 57 53 58.8 53 61V165C53 167.2 54.5117 169 56.3593 169H184.012C185.86 169 187.372 167.2 187.372 165V61C187.372 58.8 185.86 57 184.012 57Z"
          fill="white"
        />
      </g>
    </g>
    <path
      d="M56.3716 57C54.1716 57 52.3716 58.8 52.3716 61V165C52.3716 167.2 54.1716 169 56.3716 169H132.372V57H56.3716Z"
      fill="#5BA7B1"
    />
    <path
      d="M52.3716 120.488V61C52.3716 58.8 54.1716 57 56.3716 57H132.372V123.799C122.539 133.678 108.928 139.793 93.8893 139.793C77.2345 139.793 62.3311 132.293 52.3716 120.488Z"
      fill="#7FBEC6"
    />
    <path
      fill-rule="evenodd"
      clip-rule="evenodd"
      d="M72.0567 143.589L85.7737 149.108L98.1386 156.372L99.8207 128.608C99.8207 128.608 114.962 132.483 117.288 128.353C119.22 124.926 116.714 122.745 117.954 122.165C118.688 121.821 119.917 119.433 118.394 118.243C119.509 117.745 119.33 115.958 119.132 115.407C118.84 114.6 118.082 114.887 118.61 113.537C119.013 112.509 120.895 112.505 120.828 110.451C120.763 108.397 115.042 103.102 114.175 101.219C113.625 100.028 113.278 94.4675 112.182 92.1515C110.273 88.1182 106.992 85.2357 103.596 83.5735C101.88 82.7345 100.031 82.1733 98.1386 81.9506C96.2212 81.7297 94.1317 81.5693 92.209 81.6816C87.5278 81.9577 83.0801 84.1436 79.4665 87.0885C76.392 89.5968 73.73 92.7679 72.4447 96.55C70.8469 101.25 71.5598 106.635 74.0777 110.898C75.8037 113.82 84.9027 117.069 85.7666 120.363L72.0567 143.589Z"
      fill="#975D48"
    />
    <path
      fill-rule="evenodd"
      clip-rule="evenodd"
      d="M58.3716 169C58.3716 169 90.7464 169 110.372 169C110.372 169 96.8716 130 75.8716 136.5L58.3716 169Z"
      fill="#181C21"
    />
    <path
      fill-rule="evenodd"
      clip-rule="evenodd"
      d="M63.3716 130.5C69.8716 134.5 76.8972 139.378 96.1578 139.378C96.1578 139.378 96.1578 125.817 96.1578 123.064C96.1578 119.301 92.4488 113.838 91.3016 111.515C90.6398 110.169 90.1438 108.541 90.8414 107.216C91.1946 106.55 91.803 106.058 92.4113 105.607C95.8117 103.092 99.7188 101.184 102.613 98.0992C105.485 95.0355 107.148 90.8856 107.24 86.7037C112.391 89.8277 113.492 97.3697 113.504 97.4052C114.814 96.2514 116.352 94.961 116.352 92.3216C116.352 82.4704 93.009 68.132 74.0784 83.6383C55.3494 98.976 63.3716 130.5 63.3716 130.5Z"
      fill="#F0F1F2"
    />
    <path
      d="M182.372 109H148.372C147.272 109 146.372 108.1 146.372 107C146.372 105.9 147.272 105 148.372 105H182.372C183.472 105 184.372 105.9 184.372 107C184.372 108.1 183.472 109 182.372 109Z"
      fill="#E8E9EB"
    />
    <path
      d="M182.372 99H148.372C147.272 99 146.372 98.1 146.372 97C146.372 95.9 147.272 95 148.372 95H182.372C183.472 95 184.372 95.9 184.372 97C184.372 98.1 183.472 99 182.372 99Z"
      fill="#E8E9EB"
    />
    <path
      d="M171.372 147H151.372C148.572 147 146.372 144.8 146.372 142C146.372 139.2 148.572 137 151.372 137H171.372C174.172 137 176.372 139.2 176.372 142C176.372 144.8 174.172 147 171.372 147Z"
      fill="#108060"
    />
    <path
      d="M178.757 79C179.767 80.9508 180.692 82.9524 181.529 85H149.372C147.672 85 146.372 83.7 146.372 82C146.372 80.3 147.672 79 149.372 79H178.757Z"
      fill="#E8E9EB"
    />
    <defs>
      <filter
        id="filter0_d"
        x="48"
        y="53"
        width="144.372"
        height="122"
        filterUnits="userSpaceOnUse"
        color-interpolation-filters="sRGB"
      >
        <feFlood flood-opacity="0" result="BackgroundImageFix" />
        <feColorMatrix
          in="SourceAlpha"
          type="matrix"
          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
        />
        <feOffset dy="1" />
        <feGaussianBlur stdDeviation="2.5" />
        <feColorMatrix
          type="matrix"
          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"
        />
        <feBlend
          mode="normal"
          in2="BackgroundImageFix"
          result="effect1_dropShadow"
        />
        <feBlend
          mode="normal"
          in="SourceGraphic"
          in2="effect1_dropShadow"
          result="shape"
        />
      </filter>
    </defs>
  </svg>


```

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Card, EmptyState, Page} from '../src';

// eslint-disable-next-line shopify/images-no-direct-imports
import image from './image.svg';

export function Playground() {
  return (
    <Page title="Playground">
      <Card>
        <Card.Section>
          <EmptyState
            heading="Upload a file to get started"
            action={{content: 'Upload files'}}
            image={image}
          >
            <p>
              You can use the Files section to upload images, videos, and other
              documents
            </p>
          </EmptyState>
        </Card.Section>
      </Card>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
