### PR TITLE
[VideoThumbnail] Add video progress indicator

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,7 +10,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Added a `dismissOnMouseOut` prop to `Tooltip` to dismiss Tooltip once pointer is no longer over children ([#3086](https://github.com/Shopify/polaris-react/pull/3086))
 - Added an activator prop to `Modal` so that focus can be returned to it when the `Modal` is closed ([#2206](https://github.com/Shopify/polaris-react/pull/2206))
-- Added an optional `videoProgress` and `showVideoProgress` props to `VideoThumbnail` for video progress indicator ([#3057](https://github.com/Shopify/polaris-react/pull/3057))
+- Added optional `videoProgress` and `showVideoProgress` props to `VideoThumbnail` for video progress indicator ([#3057](https://github.com/Shopify/polaris-react/pull/3057))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,10 +10,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Added a `dismissOnMouseOut` prop to `Tooltip` to dismiss Tooltip once pointer is no longer over children ([#3086](https://github.com/Shopify/polaris-react/pull/3086))
 - Added an activator prop to `Modal` so that focus can be returned to it when the `Modal` is closed ([#2206](https://github.com/Shopify/polaris-react/pull/2206))
-- Removed padding from the details container in `EmptyState` to account for new illustration size ([#3069](https://github.com/Shopify/polaris-react/pull/3069))
-- Added `blueDark` to the list of possible `color` values for an `Icon` with a backdrop ([#3076](https://github.com/Shopify/polaris-react/pull/3076))
-- Improved responsive layout for secondary actions in `Banner` ([#3093](https://github.com/Shopify/polaris-react/pull/3093))
-- Added an optional `videoProgress` prop to `VideoThumbnail` for video progress indicator ([#3057](https://github.com/Shopify/polaris-react/pull/3057))
+- Added an optional `videoProgress` and `showVideoProgress` props to `VideoThumbnail` for video progress indicator ([#3057](https://github.com/Shopify/polaris-react/pull/3057))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,13 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added a `dismissOnMouseOut` prop to `Tooltip` to dismiss Tooltip once pointer is no longer over children ([#3086](https://github.com/Shopify/polaris-react/pull/3086))
+- Added an activator prop to `Modal` so that focus can be returned to it when the `Modal` is closed ([#2206](https://github.com/Shopify/polaris-react/pull/2206))
+- Removed padding from the details container in `EmptyState` to account for new illustration size ([#3069](https://github.com/Shopify/polaris-react/pull/3069))
+- Added `blueDark` to the list of possible `color` values for an `Icon` with a backdrop ([#3076](https://github.com/Shopify/polaris-react/pull/3076))
+- Improved responsive layout for secondary actions in `Banner` ([#3093](https://github.com/Shopify/polaris-react/pull/3093))
+- Added an optional `videoProgress` prop to `VideoThumbnail` for video progress indicator ([#3057](https://github.com/Shopify/polaris-react/pull/3057))
+
 ### Bug fixes
 
 ### Documentation

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,8 +8,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-- Added a `dismissOnMouseOut` prop to `Tooltip` to dismiss Tooltip once pointer is no longer over children ([#3086](https://github.com/Shopify/polaris-react/pull/3086))
-- Added an activator prop to `Modal` so that focus can be returned to it when the `Modal` is closed ([#2206](https://github.com/Shopify/polaris-react/pull/2206))
 - Added optional `videoProgress` and `showVideoProgress` props to `VideoThumbnail` for video progress indicator ([#3057](https://github.com/Shopify/polaris-react/pull/3057))
 
 ### Bug fixes

--- a/src/components/VideoThumbnail/README.md
+++ b/src/components/VideoThumbnail/README.md
@@ -54,6 +54,28 @@ Use as a play button for a video player within a media card.
 </MediaCard>
 ```
 
+### Video thumbnail with progress
+
+Use to indicate the video’s play progress in relation to its duration.
+
+```jsx
+<MediaCard
+  title="Turn your side-project into a business"
+  primaryAction={{
+    content: 'Learn more',
+    onAction: () => {},
+  }}
+  description={`In this course, you’ll learn how the Kular family turned their mom’s recipe book into a global business.`}
+  popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
+>
+  <VideoThumbnail
+    videoLength={80}
+    videoProgress={45}
+    thumbnailUrl="https://burst.shopifycdn.com/photos/smiling-businesswoman-in-office.jpg?width=1850"
+  />
+</MediaCard>
+```
+
 ---
 
 ## Required components

--- a/src/components/VideoThumbnail/README.md
+++ b/src/components/VideoThumbnail/README.md
@@ -71,6 +71,7 @@ Use to indicate the video’s play progress in relation to its duration.
   <VideoThumbnail
     videoLength={80}
     videoProgress={45}
+    showVideoProgress
     thumbnailUrl="https://burst.shopifycdn.com/photos/smiling-businesswoman-in-office.jpg?width=1850"
   />
 </MediaCard>

--- a/src/components/VideoThumbnail/VideoThumbnail.scss
+++ b/src/components/VideoThumbnail/VideoThumbnail.scss
@@ -67,10 +67,10 @@ $start-button-size: 60px;
   background-color: var(--p-surface, color('ink'));
   opacity: 0.8;
   text-align: center;
+}
 
-  &.WithProgress {
-    margin-bottom: spacing(base-tight);
-  }
+.withProgress {
+  margin-bottom: spacing(base-tight);
 }
 
 .Progress {

--- a/src/components/VideoThumbnail/VideoThumbnail.scss
+++ b/src/components/VideoThumbnail/VideoThumbnail.scss
@@ -67,4 +67,30 @@ $start-button-size: 60px;
   background-color: var(--p-surface, color('ink'));
   opacity: 0.8;
   text-align: center;
+
+  &.WithProgress {
+    margin-bottom: spacing(base-tight);
+  }
+}
+
+.Progress {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  background-color: var(--p-border-highlight, color('indigo', 'light'));
+  height: spacing(extra-tight);
+  overflow: hidden;
+}
+
+.Indicator {
+  height: inherit;
+  width: 0;
+  will-change: width;
+  background-color: var(--p-border-highlight, color('indigo'));
+  transition: width duration(slowest) easing();
+}
+
+.ProgressBar,
+.Label {
+  @include visually-hidden;
 }

--- a/src/components/VideoThumbnail/VideoThumbnail.scss
+++ b/src/components/VideoThumbnail/VideoThumbnail.scss
@@ -1,5 +1,6 @@
 @import '../../styles/common';
-$start-button-size: 60px;
+$start-button-size: rem(60px);
+$progress-bar-height: rem(6px);
 
 .Thumbnail {
   position: relative;
@@ -77,8 +78,8 @@ $start-button-size: 60px;
   position: absolute;
   bottom: 0;
   width: 100%;
-  background-color: rgba(color('white'), 0.9);
-  height: spacing(extra-tight);
+  background-color: color('white');
+  height: $progress-bar-height;
   overflow: hidden;
 }
 

--- a/src/components/VideoThumbnail/VideoThumbnail.scss
+++ b/src/components/VideoThumbnail/VideoThumbnail.scss
@@ -77,17 +77,18 @@ $start-button-size: 60px;
   position: absolute;
   bottom: 0;
   width: 100%;
-  background-color: var(--p-border-highlight, color('indigo', 'light'));
+  background-color: rgba(color('white'), 0.9);
   height: spacing(extra-tight);
   overflow: hidden;
 }
 
 .Indicator {
   height: inherit;
-  width: 0;
-  will-change: width;
+  width: 100%;
+  transform-origin: left;
+  transform: scaleX(0);
   background-color: var(--p-border-highlight, color('indigo'));
-  transition: width duration(slowest) easing();
+  transition: transform duration(slowest) easing();
 }
 
 .ProgressBar,

--- a/src/components/VideoThumbnail/VideoThumbnail.tsx
+++ b/src/components/VideoThumbnail/VideoThumbnail.tsx
@@ -24,6 +24,11 @@ export interface VideoThumbnailProps {
    * @default 0
    */
   videoProgress?: number;
+  /**
+   * Indicate whether to allow video progress to be displayed
+   * @default true
+   */
+  showVideoProgress?: boolean;
   /** Custom ARIA label for play button.
    * @default 'Play video of length {human readable duration}'
    */
@@ -38,6 +43,7 @@ export function VideoThumbnail({
   thumbnailUrl,
   videoLength = 0,
   videoProgress = 0,
+  showVideoProgress = true,
   accessibilityLabel,
   onClick,
   onBeforeStartPlaying,
@@ -67,6 +73,7 @@ export function VideoThumbnail({
   }
 
   const progressValue = calculateProgress(videoLength, videoProgress);
+  const progressValuePercents = Math.round(progressValue * 100);
 
   const timeStampMarkup = videoLength ? (
     <p
@@ -79,18 +86,22 @@ export function VideoThumbnail({
     </p>
   ) : null;
 
-  const progressMarkup = progressValue ? (
-    <div className={styles.Progress}>
-      <progress
-        className={styles.ProgressBar}
-        value={progressValue}
-        max="100"
-      />
-      <div className={styles.Indicator} style={{width: `${progressValue}%`}}>
-        <span className={styles.Label}>{progressValue}%</span>
+  const progressMarkup =
+    showVideoProgress && progressValue ? (
+      <div className={styles.Progress}>
+        <progress
+          className={styles.ProgressBar}
+          value={progressValuePercents}
+          max="100"
+        />
+        <div
+          className={styles.Indicator}
+          style={{transform: `scaleX(${progressValue})`}}
+        >
+          <span className={styles.Label}>{progressValuePercents}%</span>
+        </div>
       </div>
-    </div>
-  ) : null;
+    ) : null;
 
   return (
     <div
@@ -123,7 +134,8 @@ function calculateProgress(videoLength: number, videoProgress: number) {
   }
 
   if (videoProgress > 0 && videoLength > 0) {
-    return Math.round((videoProgress / videoLength) * 100);
+    const progress = parseFloat((videoProgress / videoLength).toFixed(2));
+    return progress > 1 ? 1 : progress;
   }
 
   return 0;

--- a/src/components/VideoThumbnail/VideoThumbnail.tsx
+++ b/src/components/VideoThumbnail/VideoThumbnail.tsx
@@ -26,7 +26,7 @@ export interface VideoThumbnailProps {
   videoProgress?: number;
   /**
    * Indicate whether to allow video progress to be displayed
-   * @default true
+   * @default false
    */
   showVideoProgress?: boolean;
   /** Custom ARIA label for play button.
@@ -72,22 +72,24 @@ export function VideoThumbnail({
     );
   }
 
-  const progressValue = calculateProgress(videoLength, videoProgress);
-  const progressValuePercents = Math.round(progressValue * 100);
-
   const timeStampMarkup = videoLength ? (
     <p
       className={classNames(
         styles.Timestamp,
-        progressValue && styles.WithProgress,
+        showVideoProgress && styles.withProgress,
       )}
     >
       {secondsToTimestamp(videoLength)}
     </p>
   ) : null;
 
-  const progressMarkup =
-    showVideoProgress && progressValue ? (
+  let progressMarkup = null;
+
+  if (showVideoProgress) {
+    const progressValue = calculateProgress(videoLength, videoProgress);
+    const progressValuePercents = Math.round(progressValue * 100);
+
+    progressMarkup = (
       <div className={styles.Progress}>
         <progress
           className={styles.ProgressBar}
@@ -101,7 +103,8 @@ export function VideoThumbnail({
           <span className={styles.Label}>{progressValuePercents}%</span>
         </div>
       </div>
-    ) : null;
+    );
+  }
 
   return (
     <div

--- a/src/components/VideoThumbnail/VideoThumbnail.tsx
+++ b/src/components/VideoThumbnail/VideoThumbnail.tsx
@@ -43,7 +43,7 @@ export function VideoThumbnail({
   thumbnailUrl,
   videoLength = 0,
   videoProgress = 0,
-  showVideoProgress = true,
+  showVideoProgress = false,
   accessibilityLabel,
   onClick,
   onBeforeStartPlaying,

--- a/src/components/VideoThumbnail/VideoThumbnail.tsx
+++ b/src/components/VideoThumbnail/VideoThumbnail.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {useI18n} from '../../utilities/i18n';
+import {classNames} from '../../utilities/css';
 import {
   secondsToTimeComponents,
   secondsToTimestamp,
@@ -13,8 +14,16 @@ import styles from './VideoThumbnail.scss';
 export interface VideoThumbnailProps {
   /** URL source for thumbnail image. */
   thumbnailUrl: string;
-  /** Length of video in seconds. */
+  /**
+   * Length of video in seconds.
+   * @default 0
+   */
   videoLength?: number;
+  /**
+   * Video progress in seconds. Displays a progress bar at the bottom of the thumbnail. Only renders when videoLength is also set.
+   * @default 0
+   */
+  videoProgress?: number;
   /** Custom ARIA label for play button.
    * @default 'Play video of length {human readable duration}'
    */
@@ -27,7 +36,8 @@ export interface VideoThumbnailProps {
 
 export function VideoThumbnail({
   thumbnailUrl,
-  videoLength,
+  videoLength = 0,
+  videoProgress = 0,
   accessibilityLabel,
   onClick,
   onBeforeStartPlaying,
@@ -56,8 +66,30 @@ export function VideoThumbnail({
     );
   }
 
+  const progressValue = calculateProgress(videoLength, videoProgress);
+
   const timeStampMarkup = videoLength ? (
-    <p className={styles.Timestamp}>{secondsToTimestamp(videoLength)}</p>
+    <p
+      className={classNames(
+        styles.Timestamp,
+        progressValue && styles.WithProgress,
+      )}
+    >
+      {secondsToTimestamp(videoLength)}
+    </p>
+  ) : null;
+
+  const progressMarkup = progressValue ? (
+    <div className={styles.Progress}>
+      <progress
+        className={styles.ProgressBar}
+        value={progressValue}
+        max="100"
+      />
+      <div className={styles.Indicator} style={{width: `${progressValue}%`}}>
+        <span className={styles.Label}>{progressValue}%</span>
+      </div>
+    </div>
   ) : null;
 
   return (
@@ -77,6 +109,22 @@ export function VideoThumbnail({
         <img className={styles.PlayIcon} src={PlayIcon} alt="" />
       </button>
       {timeStampMarkup}
+      {progressMarkup}
     </div>
   );
+}
+
+function calculateProgress(videoLength: number, videoProgress: number) {
+  if (videoProgress > videoLength && process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Value passed to the video progress should not exceed video length. Resetting progress to 100%.',
+    );
+  }
+
+  if (videoProgress > 0 && videoLength > 0) {
+    return Math.round((videoProgress / videoLength) * 100);
+  }
+
+  return 0;
 }

--- a/src/components/VideoThumbnail/tests/VideoThumbnail.test.tsx
+++ b/src/components/VideoThumbnail/tests/VideoThumbnail.test.tsx
@@ -130,7 +130,7 @@ describe('<VideoThumbnail />', () => {
 
       expect(progressIndicator).toHaveReactProps({
         style: expect.objectContaining({
-          width: '50%',
+          transform: 'scaleX(0.5)',
         }),
       });
     });
@@ -155,6 +155,48 @@ describe('<VideoThumbnail />', () => {
       );
 
       expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('showVideoProgress', () => {
+    it('renders progress bar when prop is omitted', () => {
+      const videoThumbnail = mountWithApp(
+        <VideoThumbnail {...mockProps} videoLength={120} videoProgress={60} />,
+      );
+
+      expect(videoThumbnail).toContainReactComponent('div', {
+        className: 'Progress',
+      });
+    });
+
+    it('renders progress bar when prop is set to true', () => {
+      const videoThumbnail = mountWithApp(
+        <VideoThumbnail
+          {...mockProps}
+          videoLength={120}
+          videoProgress={60}
+          showVideoProgress
+        />,
+      );
+
+      expect(videoThumbnail).toContainReactComponent('div', {
+        className: 'Progress',
+      });
+    });
+
+    it('does not render progress bar when prop is set to false', () => {
+      const videoThumbnail = mountWithApp(
+        <VideoThumbnail
+          {...mockProps}
+          videoLength={120}
+          videoProgress={60}
+          showVideoProgress={false}
+        />,
+      );
+
+      expect(videoThumbnail).not.toContainReactComponent('div', {
+        className: 'Progress',
+      });
     });
   });
 

--- a/src/components/VideoThumbnail/tests/VideoThumbnail.test.tsx
+++ b/src/components/VideoThumbnail/tests/VideoThumbnail.test.tsx
@@ -93,31 +93,63 @@ describe('<VideoThumbnail />', () => {
       warnSpy.mockRestore();
     });
 
-    it('does not render a progress bar if progress not provided', () => {
+    it('renders empty progress bar if progress not provided', () => {
       const videoThumbnail = mountWithApp(
-        <VideoThumbnail {...mockProps} videoProgress={undefined} />,
+        <VideoThumbnail
+          {...mockProps}
+          videoProgress={undefined}
+          showVideoProgress
+        />,
       );
-      expect(videoThumbnail).not.toContainReactComponent('div', {
+
+      expect(videoThumbnail).toContainReactComponent('div', {
         className: 'Progress',
+      });
+
+      const progressIndicator = videoThumbnail.find('div', {
+        className: 'Indicator',
+      });
+
+      expect(progressIndicator).toHaveReactProps({
+        style: expect.objectContaining({
+          transform: 'scaleX(0)',
+        }),
       });
     });
 
-    it('does not render a progress bar if video length not provided', () => {
+    it('renders empty progress bar if video length not provided', () => {
       const videoThumbnail = mountWithApp(
         <VideoThumbnail
           {...mockProps}
           videoLength={undefined}
           videoProgress={50}
+          showVideoProgress
         />,
       );
-      expect(videoThumbnail).not.toContainReactComponent('div', {
+
+      expect(videoThumbnail).toContainReactComponent('div', {
         className: 'Progress',
+      });
+
+      const progressIndicator = videoThumbnail.find('div', {
+        className: 'Indicator',
+      });
+
+      expect(progressIndicator).toHaveReactProps({
+        style: expect.objectContaining({
+          transform: 'scaleX(0)',
+        }),
       });
     });
 
-    it('renders progress bar when both video length and progress provided', () => {
+    it('renders non-empty progress bar when both video length and progress provided', () => {
       const videoThumbnail = mountWithApp(
-        <VideoThumbnail {...mockProps} videoLength={120} videoProgress={60} />,
+        <VideoThumbnail
+          {...mockProps}
+          videoLength={120}
+          videoProgress={60}
+          showVideoProgress
+        />,
       );
 
       expect(videoThumbnail).toContainReactComponent('div', {
@@ -139,7 +171,12 @@ describe('<VideoThumbnail />', () => {
       process.env.NODE_ENV = 'development';
 
       mountWithApp(
-        <VideoThumbnail {...mockProps} videoLength={100} videoProgress={101} />,
+        <VideoThumbnail
+          {...mockProps}
+          videoLength={100}
+          videoProgress={101}
+          showVideoProgress
+        />,
       );
 
       expect(warnSpy).toHaveBeenCalledWith(
@@ -151,7 +188,12 @@ describe('<VideoThumbnail />', () => {
       process.env.NODE_ENV = 'production';
 
       mountWithApp(
-        <VideoThumbnail {...mockProps} videoLength={100} videoProgress={101} />,
+        <VideoThumbnail
+          {...mockProps}
+          videoLength={100}
+          videoProgress={101}
+          showVideoProgress
+        />,
       );
 
       expect(warnSpy).not.toHaveBeenCalled();
@@ -159,12 +201,12 @@ describe('<VideoThumbnail />', () => {
   });
 
   describe('showVideoProgress', () => {
-    it('renders progress bar when prop is omitted', () => {
+    it('does not renders progress bar when prop is omitted', () => {
       const videoThumbnail = mountWithApp(
         <VideoThumbnail {...mockProps} videoLength={120} videoProgress={60} />,
       );
 
-      expect(videoThumbnail).toContainReactComponent('div', {
+      expect(videoThumbnail).not.toContainReactComponent('div', {
         className: 'Progress',
       });
     });


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, `VideoThumbnail` displays a video length to set the expectation about how long video is before user starts playing it. Many users are not finishing watching the video at one session, and we are working to allow them to resume the video at the time they left it off.

As a visual confirmation that video has been started, we are adding video progress indicator to the video thumbnail.

### WHAT is this pull request doing?

Add video progress indicator to `VideoThumnbail` component, so it can visualize how far user has gone through the video and set the expectation that video will resume from where it has been left off.

Progress indicator is calculated based on `videoLength` and `videoProgress` values, and represents percentage of video users watched.

<img width="541" alt="Screen Shot 2020-07-23 at 6 44 10 PM" src="https://user-images.githubusercontent.com/1324924/88345748-a8028980-cd14-11ea-8bab-fd3cc6d12b0e.png">

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, MediaCard, VideoThumbnail} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <MediaCard
        title="Turn your side-project into a business"
        primaryAction={{
          content: 'Learn more',
          onAction: () => {},
        }}
        description={`In this course, you’ll learn how the Kular family turned their mom’s recipe book into a global business.`}
        popoverActions={[{content: 'Dismiss', onAction: () => {}}]}
      >
        <VideoThumbnail
          videoLength={80}
          videoProgress={45}
          thumbnailUrl="https://burst.shopifycdn.com/photos/smiling-businesswoman-in-office.jpg?width=1850"
        />
      </MediaCard>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->

Closes https://github.com/Shopify/start/issues/479