### PR TITLE
[ResourceList] Default to any for ItemType

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,4 +16,6 @@
 
 ### Code quality
 
+- Default to `any` for ItemType in resource list ([#3059](https://github.com/Shopify/polaris-react/pull/3059))
+
 ### Deprecations

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -68,7 +68,7 @@ function defaultIdForItem<ItemType extends {id?: any}>(
     : index.toString();
 }
 
-export interface ResourceListProps<ItemType> {
+export interface ResourceListProps<ItemType = any> {
   /** Item data; each item is passed to renderItem */
   items: ItemType[];
   filterControl?: React.ReactNode;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue where consumers would have to add an <any> type argument in order to access resource list props. i.e. `ResourceListProps<any>['bulk-actions']`

### WHAT is this pull request doing?


    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
