### PR TITLE
Ship it task to unpublish the latest version

### DIFF
--- a/shipit.yml
+++ b/shipit.yml
@@ -12,8 +12,6 @@ ci:
 
 tasks:
   unpublish:
-    override:
-      - echo 'nothing to install'
     variables:
       - name: VERSION
         title: 'Unpublish a version from NPM and remove the tag from GitHub'

--- a/shipit.yml
+++ b/shipit.yml
@@ -12,6 +12,8 @@ ci:
 
 tasks:
   unpublish:
+    override:
+      - echo 'nothing to install'
     variables:
       - name: VERSION
         title: 'Unpublish a version from NPM and remove the tag from GitHub'

--- a/shipit.yml
+++ b/shipit.yml
@@ -12,11 +12,13 @@ ci:
 
 tasks:
   unpublish:
-    action: 'Unpublish latest version'
-    description: 'Unpublish the latest version from NPM and remove the latest git tag from origin.'
+    variables:
+      - name: VERSION
+        title: 'Unpublish a version from NPM and remove the tag from GitHub'
+        default: 'v0.0.0'
+    action: 'Unpublish a version'
     steps:
-      - npm unpublish @shopify/polaris@latest
-      - git push --delete origin `git describe --exact-match --abbrev=0`
+      - npm unpublish @shopify/polaris@${VERSION}
 
 merge:
   require:

--- a/shipit.yml
+++ b/shipit.yml
@@ -10,6 +10,14 @@ ci:
   allow_failures:
     - 'buildkite/polaris-react-system-integration-test'
 
+tasks:
+  unpublish:
+    action: 'Unpublish latest version'
+    description: 'Unpublish the latest version from NPM and remove the latest git tag from origin.'
+    steps:
+      - npm unpublish @shopify/polaris@latest
+      - git push --delete origin `git describe --exact-match --abbrev=0`
+
 merge:
   require:
     - 'Travis CI - Branch'


### PR DESCRIPTION
Co-Authored-By: Kyle Durand <kyledurand@users.noreply.github.com>

### WHY are these changes introduced?

Sometimes releases go wrong. This helps by allowing the users to unpublish and remove the latest tag from GitHub and NPM.

### WHAT is this pull request doing?

Adds a custom task to ShipIt.

### How to TopHat

Check the tasks tab on ShipIt, don't run the task please:
https://shipit.shopify.io/shopify/polaris-react/test-unpublish
