### PR TITLE
Write sass errors that are valid in dart-sass

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,7 +9,7 @@
 ### Bug fixes
 
 - Added `flex: 1 1 auto` to `Banner` `.ContentWrapper` CSS selector ([#3062](https://github.com/Shopify/polaris-react/pull/3062))
-- Ensured sass mixins can compile in dart sass ([#3064](https://github.com/Shopify/polaris-react/pull/3063))
+- Ensured Sass mixins can compile in Dart Sass ([#3064](https://github.com/Shopify/polaris-react/pull/3063))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 - Added `flex: 1 1 auto` to `Banner` `.ContentWrapper` CSS selector ([#3062](https://github.com/Shopify/polaris-react/pull/3062))
+- Ensured sass mixins can compile in dart sass ([#3064](https://github.com/Shopify/polaris-react/pull/3063))
 
 ### Documentation
 

--- a/src/styles/foundation/_colors.scss
+++ b/src/styles/foundation/_colors.scss
@@ -53,17 +53,7 @@ $color-palette-data: map-extend(
   @if type-of($fetched-color) == color {
     @return $fetched-color;
   } @else {
-    // stylelint-disable string-no-newline
-    $error: "
-Color `#{$hue}, #{$value}` not found. Make sure arguments are strings.
-GOOD: color('yellow')
-BAD: color(yellow)
-
-Available options: #{available-names($color-palette-data)}
-";
-    // stylelint-enable
-
-    @error $error;
+    @error "Color `#{$hue}, #{$value}` not found.\a Make sure arguments are strings.\a GOOD: `color('yellow')`.\a BAD: `color(yellow)`.\a\a Available options: #{available-names($color-palette-data)}";
   }
 }
 
@@ -125,16 +115,6 @@ $ms-high-contrast-color-data: (
   @if $fetched-color {
     @return $fetched-color;
   } @else {
-    // stylelint-disable string-no-newline
-    $error: "
-Color `#{$color}` not found. Make sure argument is a string.
-GOOD: ms-high-contrast-color('selected-text')
-BAD: ms-high-contrast-color(selected-text).
-
-Available options: #{available-names($ms-high-contrast-color-data)}
-";
-    // stylelint-enable
-
-    @error $error;
+    @error "Color `#{$color}` not found.\a Make sure argument is a string.\a GOOD: ms-high-contrast-color('selected-text').\a BAD: ms-high-contrast-color(selected-text).\a\a Available options: #{available-names($ms-high-contrast-color-data)}";
   }
 }

--- a/src/styles/foundation/_filters.scss
+++ b/src/styles/foundation/_filters.scss
@@ -29,16 +29,6 @@ $color-filter-palette-data: $polaris-color-filters;
   @if type-of($fetched-color) == list {
     @return $fetched-color;
   } @else {
-    // stylelint-disable string-no-newline
-    $error: "
-Filter `#{$hue}, #{$value}` not found. Make sure arguments are strings.
-GOOD: filter('yellow')
-BAD: filter(yellow)
-
-Available options: #{available-names($color-filter-palette-data)}
-";
-    // stylelint-enable
-
-    @error $error;
+    @error "Filter `#{$hue}, #{$value}` not found.\a Make sure arguments are strings.\a GOOD: `filter('yellow')`.\a BAD: `filter(yellow)`.\a\a Available options: #{available-names($color-filter-palette-data)}";
   }
 }

--- a/src/styles/foundation/_shadows.scss
+++ b/src/styles/foundation/_shadows.scss
@@ -1,4 +1,4 @@
-/* Shadows are intentionally very subtle gradiations. */
+// Shadows are intentionally very subtle gradiations.
 $shadows-data: (
   faint: (
     0 1px 0 0 rgba(22, 29, 37, 0.05),


### PR DESCRIPTION
### WHY are these changes introduced?

I found out public_api doesn't compile in dart-sass: `npx node-sass src/styles/_public-api.scss`. Looks like it is because dart-sass and libsass handles newlines in strings a bit differently.

### WHAT is this pull request doing?

dart-sass doesn't like multi-line strings (which I kinda agree with - css doesn't like unescaped multiline strings either). Escaping the newlines (`\n`)
results in libsass not displaying them properly. Result: remove
linebreaks.

Also change a block-style comment to be inline so it doesn't get output.

### How to 🎩

- Confirm the public api can be compiled with no output using node-sass: `npx node-sass src/styles/_public-api.scss`
Confirm the public api can be compiled with no output (and no errors!) using dart-sass : `npx sass@latest src/styles/_public-api.scss`

For bonus points, add a usage of these mixins and see that they the error message looks decent in both of the above cases. 

```css
.x {
  content: color(JUNK);
  content: ms-high-contrast-color(JUNK);
  content: shadow(JUNK);
}
```
