### PR TITLE
[Page] action rollup consistent padding and alignment

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 - Added `flex: 1 1 auto` to `Banner` `.ContentWrapper` CSS selector ([#3062](https://github.com/Shopify/polaris-react/pull/3062))
+- Fixed mis-alignment on `Page` action rollup ([#3064](https://github.com/Shopify/polaris-react/pull/3064))
 
 ### Documentation
 

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -1,7 +1,7 @@
 @import '../../../../styles/common';
 
 $individual-action-padding-x: (1.5 * spacing(tight));
-$action-menu-rollup-computed-width: icon-size();
+$action-menu-rollup-computed-width: rem(40px);
 
 .Header {
   @include page-header-layout;
@@ -104,7 +104,7 @@ $action-menu-rollup-computed-width: icon-size();
   .mobileView & {
     position: absolute;
     top: spacing(loose) + (control-height() / 4);
-    right: 0;
+    right: spacing(loose);
     margin-top: 0;
 
     @include page-content-when-not-fully-condensed {


### PR DESCRIPTION
Co-Authored-By: Dan Ross <hypd@users.noreply.github.com>

### WHY are these changes introduced?

Fixes https://github.com/Shopify/deliveries/issues/1102 and fixes https://github.com/Shopify/polaris-react/issues/2739

### WHAT is this pull request doing?

The ellipsis in the page actions currently does not use the same spacing as the header on the left hand side. This makes the padding around the Page component appear consistent.

Example of issue:
<img width="494" alt="Screen Shot 2020-06-18 at 10 29 46@2x" src="https://user-images.githubusercontent.com/970304/85033305-ccd07380-b14e-11ea-8d7f-cbc98733111d.png">

This PR does:
![ellipsis](https://user-images.githubusercontent.com/19199063/85064214-39606800-b179-11ea-945d-9d75189ceaba.gif)


### How to 🎩

Open up the Page component in StoryBook and test the ellipsis and action locations on desktop and mobile.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
