### PR TITLE
[Empty state] Adjust padding and replace example image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [these versioning and changelog guidelines](https://git.i
 
 ---
 
+## 4.26.2 - 2020-06-24
+
+### Enhancements
+
+- Removed padding from the details container in `EmptyState` to account for new illustration size ([#3069](https://github.com/Shopify/polaris-react/pull/3069))
+
 ## 4.26.1 - 2020-06-16
 
 ### Code quality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,6 @@ The format is based on [these versioning and changelog guidelines](https://git.i
 
 ---
 
-## 4.26.2 - 2020-06-24
-
-### Enhancements
-
-- Removed padding from the details container in `EmptyState` to account for new illustration size ([#3069](https://github.com/Shopify/polaris-react/pull/3069))
-
 ## 4.26.1 - 2020-06-16
 
 ### Code quality

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@
 
 ### Enhancements
 
+- Removed padding from the details container in `EmptyState` to account for new illustration size ([#3069](https://github.com/Shopify/polaris-react/pull/3069))
+
 ### Bug fixes
 
 - Added `flex: 1 1 auto` to `Banner` `.ContentWrapper` CSS selector ([#3062](https://github.com/Shopify/polaris-react/pull/3062))

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -77,7 +77,7 @@ $centered-illustration-width: rem(226px);
   }
 
   .DetailsContainer {
-    padding-top: spacing();
+    padding-top: 0;
   }
 
   .Details {

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -76,10 +76,6 @@ $centered-illustration-width: rem(226px);
     justify-content: center;
   }
 
-  .DetailsContainer {
-    padding-top: 0;
-  }
-
   .Details {
     display: flex;
     text-align: center;

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -210,7 +210,7 @@ Use to provide additional but non-critical context for a new product or feature.
     <EmptyState
       heading="Upload a file to get started"
       action={{content: 'Upload files'}}
-      image="https://cdn.shopify.com/s/files/1/2376/3301/products/emptystate-files.png"
+      image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
     >
       <p>
         You can use the Files section to upload images, videos, and other
@@ -232,7 +232,7 @@ Stacked image over centered content and actions
   centeredLayout
   heading="Upload a file to get started"
   action={{content: 'Upload files'}}
-  image="https://cdn.shopify.com/s/files/1/2376/3301/products/emptystate-files.png"
+  image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
 >
   <p>
     You can use the Files section to upload images, videos, and other documents
@@ -250,7 +250,7 @@ Stacked image over centered content and actions
     <EmptyState
       heading="Upload a file to get started"
       action={{content: 'Upload files'}}
-      image="https://cdn.shopify.com/s/files/1/2376/3301/products/emptystate-files.png"
+      image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
       fullWidth
     >
       <p>


### PR DESCRIPTION

### WHY are these changes introduced?

These changes are a part of the [new illustration style rollout project](https://vault.shopify.io/projects/13698). Empty states are changing and to align with the new style we need to remove the padding from the top of the details container. 

Before:

![alt](https://screenshot.click/22-41-cfp5n-c8y3s.png)

After: 

![alt](https://screenshot.click/22-42-ib5xy-3rod7.png)

To make sure that we show the right layout in the style guide examples, I updated the example image to the dimensions (226 x 226 px) that Creative Direction uses for the new empty state illustrations. This applies to all the examples with centered content. 

### WHAT is this pull request doing?

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
