### PR TITLE
Update activeElement tests to use modern testing utils

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,4 +19,6 @@
 
 ### Code quality
 
+- Migrated tests using document.activeElement to use react-testing ([#3070](https://github.com/Shopify/polaris-react/pull/3070))
+
 ### Deprecations

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -145,11 +145,11 @@ describe('<Banner />', () => {
         return <Banner ref={banner} status="critical" />;
       }
 
-      const div = mountWithAppProvider(<Test />)
-        .find('div')
-        .filterWhere((element) => element.prop('tabIndex') === 0);
+      const testComponent = mountWithApp(<Test />);
 
-      expect(div.getDOMNode()).toBe(document.activeElement);
+      expect(document.activeElement).toBe(
+        testComponent.find('div', {tabIndex: 0})!.domNode,
+      );
     });
 
     describe('Focus className', () => {

--- a/src/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/Checkbox/tests/Checkbox.test.tsx
@@ -4,6 +4,7 @@ import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 
 import {Key} from '../../../types';
+import {Choice} from '../../Choice';
 import {Checkbox} from '../Checkbox';
 
 describe('<Checkbox />', () => {
@@ -73,12 +74,12 @@ describe('<Checkbox />', () => {
     });
 
     it('sets focus on the input when checkbox is toggled off', () => {
-      const checkbox = mountWithAppProvider(
+      const checkbox = mountWithApp(
         <Checkbox checked id="checkboxId" label="Checkbox" onChange={noop} />,
       );
-      (checkbox.find('input') as any).instance().checked = false;
-      checkbox.simulate('click');
-      expect(checkbox.find('input').instance()).toBe(document.activeElement);
+      checkbox.find(Choice)!.trigger('onClick');
+
+      expect(document.activeElement).toBe(checkbox.find('input')!.domNode);
     });
 
     it('is not called from keyboard events when disabled', () => {

--- a/src/components/Focus/tests/Focus.test.tsx
+++ b/src/components/Focus/tests/Focus.test.tsx
@@ -1,68 +1,57 @@
 import React, {useRef, useState, useEffect} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {Focus, FocusProps} from '../Focus';
 
 describe('<Focus />', () => {
-  it('mounts', () => {
-    const focus = mountWithAppProvider(<FocusTestWrapper />);
-
-    expect(focus.exists()).toBe(true);
-  });
-
   it('will not focus any element if none are natively focusable', () => {
-    mountWithAppProvider(
+    mountWithApp(
       <FocusTestWrapper>
         <span />
       </FocusTestWrapper>,
     );
 
-    expect(document.body).toBe(document.activeElement);
+    expect(document.activeElement).toBe(document.body);
   });
 
   it('will focus first focusable node when passing current node', () => {
-    const focus = mountWithAppProvider(
+    const focus = mountWithApp(
       <FocusTestWrapper>
         <input />
       </FocusTestWrapper>,
     );
 
-    const input = focus.find('input').getDOMNode();
-    expect(input).toBe(document.activeElement);
+    expect(document.activeElement).toBe(focus.find('input')!.domNode);
   });
 
   it('will focus first focusable node when passing ref', () => {
-    const focus = mountWithAppProvider(
+    const focus = mountWithApp(
       <FocusTestWrapperRootReference>
         <input />
       </FocusTestWrapperRootReference>,
     );
 
-    const input = focus.find('input').getDOMNode();
-    expect(input).toBe(document.activeElement);
+    expect(document.activeElement).toBe(focus.find('input')!.domNode);
   });
 
   it('will not focus the first focusable node if `disabled` is true', () => {
-    const focus = mountWithAppProvider(
+    const focus = mountWithApp(
       <FocusTestWrapper disabled>
         <input />
       </FocusTestWrapper>,
     );
 
-    const input = focus.find('input').getDOMNode();
-    expect(input).not.toBe(document.activeElement);
+    expect(document.activeElement).not.toBe(focus.find('input')!.domNode);
   });
 
   it('will not focus if there is no node', () => {
-    const focus = mountWithAppProvider(
+    const focus = mountWithApp(
       <FocusTestWrapperNoNode>
         <input />
       </FocusTestWrapperNoNode>,
     );
 
-    const input = focus.find('input').getDOMNode();
-    expect(input).not.toBe(document.activeElement);
+    expect(document.activeElement).not.toBe(focus.find('input')!.domNode);
   });
 });
 

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -3,7 +3,7 @@ import {CSSTransition} from '@material-ui/react-transition-group';
 import {animationFrame} from '@shopify/jest-dom-mocks';
 import {documentHasStyle, mountWithApp} from 'test-utilities';
 // eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
+import {mountWithAppProvider} from 'test-utilities/legacy';
 import {
   ContextualSaveBar as PolarisContextualSavebar,
   Loading as PolarisLoading,
@@ -53,10 +53,12 @@ describe('<Frame />', () => {
     });
 
     it('sets focus to the main content target anchor element when the skip to content link is clicked', () => {
-      const frame = mountWithAppProvider(<Frame />);
-      const mainAnchor = frame.find('main').find('a');
-      trigger(frame.find('a').at(0), 'onClick');
-      expect(mainAnchor.getDOMNode()).toBe(document.activeElement);
+      const frame = mountWithApp(<Frame />);
+
+      frame.find('a', {children: 'Skip to content'})!.trigger('onClick');
+      expect(document.activeElement).toBe(
+        frame.find('a', {id: 'AppFrameMainContent'})!.domNode,
+      );
     });
 
     it('sets focus to target element when the skip to content link is clicked', () => {
@@ -68,19 +70,18 @@ describe('<Frame />', () => {
         <a id={targetId} ref={targetRef} tabIndex={-1} href="" />
       );
 
-      const frame = mountWithAppProvider(
+      const frame = mountWithApp(
         <Frame skipToContentTarget={targetRef}>{skipToContentTarget}</Frame>,
       );
 
-      const triggerAnchor = frame.find('a').at(0);
-      const targetAnchor = frame.find(`#${targetId}`);
-      trigger(triggerAnchor, 'onFocus');
-      trigger(triggerAnchor, 'onClick');
+      const triggerAnchor = frame.findAll('a')[0]!;
 
-      expect(triggerAnchor.getDOMNode().getAttribute('href')).toBe(
-        `#${targetId}`,
+      triggerAnchor.trigger('onFocus');
+      triggerAnchor.trigger('onClick');
+
+      expect(document.activeElement).toBe(
+        frame.find('a', {id: targetId})!.domNode,
       );
-      expect(targetAnchor.getDOMNode()).toBe(document.activeElement);
     });
   });
 

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -58,7 +58,7 @@ describe('<Modal>', () => {
     const modal = mountWithAppProvider(<Modal onClose={jest.fn()} open />);
     const focusedNode = findFirstFocusableNode(modal.find(Dialog).getDOMNode());
 
-    expect(focusedNode).toBe(document.activeElement);
+    expect(document.activeElement).toBe(focusedNode);
   });
 
   describe('src', () => {

--- a/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
@@ -87,7 +87,7 @@ describe('<FilterCreator />', () => {
       'onClick',
     );
 
-    expect(activator.getDOMNode()).toBe(document.activeElement);
+    expect(document.activeElement).toBe(activator.getDOMNode());
   });
 
   it('does not focus the activator after adding a filter if focus was never originally received by the by activator', () => {
@@ -110,7 +110,7 @@ describe('<FilterCreator />', () => {
       'onClick',
     );
 
-    expect(activator.getDOMNode()).not.toBe(document.activeElement);
+    expect(document.activeElement).not.toBe(activator.getDOMNode());
   });
 
   it('renders just a button by default', () => {

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -9,12 +9,12 @@ import {
   Button,
   EmptyState,
 } from 'components';
+import {mountWithApp} from 'test-utilities';
 // eslint-disable-next-line no-restricted-imports
 import {
   findByTestID,
   mountWithAppProvider,
   trigger,
-  ReactWrapper,
 } from 'test-utilities/legacy';
 
 import {BulkActions, CheckableButton} from '../components';
@@ -925,7 +925,7 @@ describe('<ResourceList />', () => {
 
       describe('large screen', () => {
         it('focuses the checkbox in the bulk action when the plain CheckableButton is clicked', () => {
-          const resourceList = mountWithAppProvider(
+          const resourceList = mountWithApp(
             <ResourceList
               items={itemsWithID}
               renderItem={renderItem}
@@ -933,19 +933,20 @@ describe('<ResourceList />', () => {
             />,
           );
 
-          const selectAllCheckableButton = plainCheckableButton(resourceList);
+          resourceList
+            .find(CheckableButton, {plain: true})!
+            .trigger('onToggleAll');
 
-          trigger(selectAllCheckableButton, 'onToggleAll');
+          const deselectAllCheckbox = resourceList
+            .findAll(CheckableButton)
+            .find((ele) => !ele.prop('plain'))!
+            .find('input', {type: 'checkbox'})!;
 
-          const deselectAllCheckbox = bulkActionsCheckableButton(
-            resourceList,
-          ).find('input[type="checkbox"]');
-
-          expect(deselectAllCheckbox.getDOMNode()).toBe(document.activeElement);
+          expect(document.activeElement).toBe(deselectAllCheckbox.domNode);
         });
 
         it('focuses the plain CheckableButton checkbox when items are selected and the deselect Checkable button is clicked', () => {
-          const resourceList = mountWithAppProvider(
+          const resourceList = mountWithApp(
             <ResourceList
               items={itemsWithID}
               renderItem={renderItem}
@@ -954,18 +955,17 @@ describe('<ResourceList />', () => {
             />,
           );
 
-          const deselectAllCheckableButton = bulkActionsCheckableButton(
-            resourceList,
-          );
+          resourceList
+            .findAll(CheckableButton)
+            .find((ele) => !ele.prop('plain'))!
+            .trigger('onToggleAll');
 
-          trigger(deselectAllCheckableButton, 'onToggleAll');
+          const selectAllCheckableCheckbox = resourceList
+            .find(CheckableButton, {plain: true})!
+            .find('input', {type: 'checkbox'})!;
 
-          const selectAllCheckableCheckbox = plainCheckableButton(
-            resourceList,
-          ).find('input[type="checkbox"]');
-
-          expect(selectAllCheckableCheckbox.getDOMNode()).toBe(
-            document.activeElement,
+          expect(document.activeElement).toBe(
+            selectAllCheckableCheckbox.domNode,
           );
         });
       });
@@ -978,7 +978,7 @@ describe('<ResourceList />', () => {
         it('keeps focus on the CheckableButton checkbox when selecting', () => {
           setSmallScreen();
 
-          const resourceList = mountWithAppProvider(
+          const resourceList = mountWithApp(
             <ResourceList
               items={itemsWithID}
               renderItem={renderItem}
@@ -986,25 +986,25 @@ describe('<ResourceList />', () => {
             />,
           );
 
-          trigger(resourceList.find(Button).first(), 'onClick');
+          resourceList.find(Button)!.trigger('onClick');
 
-          const selectAllCheckableButton = bulkActionsCheckableButton(
-            resourceList,
-          );
+          const selectAllCheckableButton = resourceList
+            .findAll(CheckableButton)
+            .find((ele) => !ele.prop('plain'))!;
 
-          trigger(selectAllCheckableButton, 'onToggleAll');
+          selectAllCheckableButton.trigger('onToggleAll');
 
-          const checkBox = selectAllCheckableButton.find(
-            'input[type="checkbox"]',
-          );
+          const checkBox = selectAllCheckableButton.find('input', {
+            type: 'checkbox',
+          })!;
 
-          expect(checkBox.getDOMNode()).toBe(document.activeElement);
+          expect(document.activeElement).toBe(checkBox.domNode);
         });
 
         it('keeps focus on the CheckableButton checkbox when deselecting', () => {
           setSmallScreen();
 
-          const resourceList = mountWithAppProvider(
+          const resourceList = mountWithApp(
             <ResourceList
               items={itemsWithID}
               selectedItems={allSelectedIDs}
@@ -1013,17 +1013,17 @@ describe('<ResourceList />', () => {
             />,
           );
 
-          const deselectAllCheckableButton = bulkActionsCheckableButton(
-            resourceList,
-          );
+          const deselectAllCheckableButton = resourceList
+            .findAll(CheckableButton)
+            .find((ele) => !ele.prop('plain'))!;
 
-          trigger(deselectAllCheckableButton, 'onToggleAll');
+          deselectAllCheckableButton.trigger('onToggleAll');
 
-          const checkBox = deselectAllCheckableButton.find(
-            'input[type="checkbox"]',
-          );
+          const checkBox = deselectAllCheckableButton.find('input', {
+            type: 'checkbox',
+          })!;
 
-          expect(checkBox.getDOMNode()).toBe(document.activeElement);
+          expect(document.activeElement).toBe(checkBox.domNode);
         });
       });
     });
@@ -1223,16 +1223,4 @@ function setDefaultScreen() {
     writable: true,
     value: defaultWindowWidth,
   });
-}
-
-function bulkActionsCheckableButton(wrapper: ReactWrapper) {
-  return wrapper.findWhere(
-    (wrap) => wrap.is(CheckableButton) && !wrap.prop('plain'),
-  );
-}
-
-function plainCheckableButton(wrapper: ReactWrapper) {
-  return wrapper.findWhere(
-    (wrap) => wrap.is(CheckableButton) && wrap.prop('plain'),
-  );
 }

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1,4 +1,4 @@
-import React, {ReactElement} from 'react';
+import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
 import {InlineError, Labelled, Connected, Select} from 'components';
@@ -85,11 +85,11 @@ describe('<TextField />', () => {
   describe('onFocus()', () => {
     it('is called when the input is focused', () => {
       const spy = jest.fn();
-      mountWithAppProvider(
+      mountWithApp(
         <TextField label="TextField" onFocus={spy} onChange={noop} />,
       )
-        .find('input')
-        .simulate('focus');
+        .find('input')!
+        .trigger('onFocus');
       expect(spy).toHaveBeenCalled();
     });
   });
@@ -147,37 +147,31 @@ describe('<TextField />', () => {
 
   describe('focused', () => {
     it('input is in focus state if focused is true', () => {
-      const element = mountWithAppProvider(
+      const element = mountWithApp(
         <TextField label="TextField" onChange={noop} focused />,
       );
 
-      expect(element.getDOMNode().querySelector('input')).toBe(
-        document.activeElement,
-      );
+      expect(document.activeElement).toBe(element.find('input')!.domNode);
     });
 
     it('focuses input if focused is toggled', () => {
-      const element = mountWithAppProvider(
+      const element = mountWithApp(
         <TextField label="TextField" onChange={noop} />,
       );
 
       element.setProps({focused: true});
 
-      expect(element.getDOMNode().querySelector('input')).toBe(
-        document.activeElement,
-      );
+      expect(document.activeElement).toBe(element.find('input')!.domNode);
     });
 
     it('blurs input if focused is toggled', () => {
-      const element = mountWithAppProvider(
+      const element = mountWithApp(
         <TextField label="TextField" onChange={noop} focused />,
       );
 
       element.setProps({focused: false});
 
-      expect(element.getDOMNode().querySelector('input')).not.toBe(
-        document.activeElement,
-      );
+      expect(document.activeElement).not.toBe(element.find('input')!.domNode);
     });
   });
 
@@ -1034,22 +1028,15 @@ describe('<TextField />', () => {
     });
 
     it('sets focus to the <input /> `onClick`', () => {
-      const textField = mountWithAppProvider(
+      const textField = mountWithApp(
         <TextField label="TextField" onChange={noop} />,
       );
-      const connectedChild = textField
-        .find(Connected)
-        .prop('children') as ReactElement;
 
-      expect(textField.getDOMNode().querySelector('input')).not.toBe(
-        document.activeElement,
-      );
+      expect(document.activeElement).not.toBe(textField.find('input')!.domNode);
 
-      connectedChild.props.onClick({});
+      textField.find(Connected)!.triggerKeypath('children.props.onClick', {});
 
-      expect(textField.getDOMNode().querySelector('input')).toBe(
-        document.activeElement,
-      );
+      expect(document.activeElement).toBe(textField.find('input')!.domNode);
     });
   });
 

--- a/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
+++ b/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
@@ -1,20 +1,12 @@
 import React from 'react';
 import {CircleCancelMinor} from '@shopify/polaris-icons';
+import {mountWithApp} from 'test-utilities';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
-import {mountWithApp} from 'test-utilities';
 
 import {SearchField} from '../SearchField';
 
-describe('<TextField />', () => {
-  it('mounts', () => {
-    const textField = mountWithAppProvider(
-      <SearchField value="" onChange={noop} />,
-    );
-
-    expect(textField.exists()).toBe(true);
-  });
-
+describe('<SearchField />', () => {
   it('passes the placeholder prop to input', () => {
     const textField = mountWithAppProvider(
       <SearchField value="" onChange={noop} placeholder="hello polaris" />,
@@ -25,33 +17,31 @@ describe('<TextField />', () => {
 
   describe('focused', () => {
     it('will give input focus when the focused prop is true', () => {
-      const textField = mountWithAppProvider(
+      const textField = mountWithApp(
         <SearchField value="" onChange={noop} focused />,
       );
 
-      expect(findInput(textField).getDOMNode()).toBe(document.activeElement);
+      expect(document.activeElement).toBe(textField.find('input')!.domNode);
     });
 
     it('will give input focus if focus has been toggled', () => {
-      const textField = mountWithAppProvider(
+      const textField = mountWithApp(
         <SearchField value="" onChange={noop} focused={false} />,
       );
-      expect(findInput(textField).getDOMNode()).not.toBe(
-        document.activeElement,
-      );
+
+      expect(document.activeElement).not.toBe(textField.find('input')!.domNode);
+
       textField.setProps({value: '', onChange: noop, focused: true});
-      expect(findInput(textField).getDOMNode()).toBe(document.activeElement);
+      expect(document.activeElement).toBe(textField.find('input')!.domNode);
     });
 
     it('will blur input if focused has been toggled', () => {
-      const textField = mountWithAppProvider(
+      const textField = mountWithApp(
         <SearchField value="" onChange={noop} focused />,
       );
 
       textField.setProps({value: '', onChange: noop, focused: false});
-      expect(findInput(textField).getDOMNode()).not.toBe(
-        document.activeElement,
-      );
+      expect(document.activeElement).not.toBe(textField.find('input')!.domNode);
     });
   });
 

--- a/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -1,10 +1,4 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {
-  mountWithAppProvider,
-  trigger,
-  ReactWrapper,
-} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {
   EventListener,
@@ -54,75 +48,73 @@ describe('<TrapFocus />', () => {
   });
 
   it('mounts', () => {
-    const trapFocus = mountWithAppProvider(
+    const trapFocus = mountWithApp(
       <TrapFocus>
         <TextContainer>Test</TextContainer>
       </TrapFocus>,
     );
 
-    expect(trapFocus.exists()).toBe(true);
-
     // Render children
-    expect(trapFocus.find(TextContainer)).toHaveLength(1);
+    expect(trapFocus).toContainReactComponent(TextContainer);
 
     // Renders Focus
-    expect(trapFocus.find(Focus)).toHaveLength(1);
+    expect(trapFocus).toContainReactComponent(Focus);
 
     // Renders an event listener
-    expect(trapFocus.find(EventListener)).toHaveLength(1);
-    expect(trapFocus.find(EventListener).prop('event')).toBe('focusin');
+    expect(trapFocus).toContainReactComponent(EventListener, {
+      event: 'focusin',
+    });
   });
 
   it('renders a Focus component with a `disabled` prop set to false by default', () => {
-    const focus = mountWithAppProvider(
+    const trapFocus = mountWithApp(
       <TrapFocus>
         <div />
       </TrapFocus>,
-    ).find(Focus);
-    expect(focus.prop('disabled')).toBe(false);
+    );
+    expect(trapFocus).toContainReactComponent(Focus, {disabled: false});
   });
 
   it('renders a Focus component with a `disabled` prop set to true when `trapping` is false', () => {
-    const focus = mountWithAppProvider(
+    const trapFocus = mountWithApp(
       <TrapFocus trapping={false}>
         <div />
       </TrapFocus>,
-    ).find(Focus);
+    );
 
-    expect(focus.prop('disabled')).toBe(true);
+    expect(trapFocus).toContainReactComponent(Focus, {disabled: true});
   });
 
   it('renders a Focus component with a `disabled` prop set to false when `trapping` is true', () => {
-    const focus = mountWithAppProvider(
+    const trapFocus = mountWithApp(
       <TrapFocus trapping>
         <div />
       </TrapFocus>,
-    ).find(Focus);
+    );
 
-    expect(focus.prop('disabled')).toBe(false);
+    expect(trapFocus).toContainReactComponent(Focus, {disabled: false});
   });
 
   it('keeps focus on nodes contained inside trap focus during mount', () => {
-    const trapFocus = mountWithAppProvider(
+    const trapFocus = mountWithApp(
       <TrapFocus>
         <TextField label="" value="" onChange={noop} autoFocus />
       </TrapFocus>,
     );
-    const input = trapFocus.find('input').getDOMNode();
-    expect(document.activeElement).toBe(input);
+
+    expect(document.activeElement).toBe(trapFocus.find('input')!.domNode);
   });
 
   it('focuses the first focused node when nodes contained in trap focus are not in focus', () => {
-    const trapFocus = mountWithAppProvider(
+    const trapFocus = mountWithApp(
       <TrapFocus>
         <a href="/">
           <TextField label="" value="" onChange={noop} />
         </a>
       </TrapFocus>,
     );
-    const focusedElement = trapFocus.find('a').getDOMNode();
 
-    expect(document.activeElement).toBe(focusedElement);
+    expect(document.activeElement).toBe(trapFocus.find('a')!.domNode);
   });
 
   it(`doesn't trade steal focus from another TrapFocus when multiple are rendered`, () => {
@@ -138,13 +130,11 @@ describe('<TrapFocus />', () => {
       </div>,
     );
 
-    expect(trapFocus.find('input', {id})!.domNode).toBe(document.activeElement);
+    expect(document.activeElement).toBe(trapFocus.find('input', {id})!.domNode);
   });
 
   describe('handleBlur', () => {
-    const externalDomNode = mountWithAppProvider(<Button />)
-      .find('button')
-      .getDOMNode();
+    const externalDomNode = mountWithApp(<Button />).find('button')!.domNode;
 
     const event: FocusEvent = new FocusEvent('focusout', {
       relatedTarget: externalDomNode,
@@ -152,7 +142,7 @@ describe('<TrapFocus />', () => {
     Object.assign(event, {preventDefault: jest.fn()});
 
     it('allows default when trapping is false', () => {
-      const trapFocus = mountWithAppProvider(
+      const trapFocus = mountWithApp(
         <TrapFocus trapping={false}>
           <TextField label="" value="" onChange={noop} autoFocus />
         </TrapFocus>,
@@ -163,27 +153,25 @@ describe('<TrapFocus />', () => {
       });
       Object.assign(event, {preventDefault: jest.fn()});
 
-      trigger(trapFocus.find(EventListener), 'handler', event);
-
+      trapFocus.find(EventListener)!.trigger('handler', event);
       expect(event.preventDefault).not.toHaveBeenCalled();
     });
 
     it('allows default when the related target is a child', () => {
-      const trapFocus = mountWithAppProvider(
+      const trapFocus = mountWithApp(
         <TrapFocus>
           <TextField label="" value="" onChange={noop} autoFocus />
         </TrapFocus>,
       );
 
-      const internalDomNode = trapFocus.find('input').getDOMNode();
+      const internalDomNode = trapFocus.find('input')!.domNode;
 
       const event: FocusEvent = new FocusEvent('focusout', {
         relatedTarget: internalDomNode,
       });
       Object.assign(event, {preventDefault: jest.fn()});
 
-      trigger(trapFocus.find(EventListener), 'handler', event);
-
+      trapFocus.find(EventListener)!.trigger('handler', event);
       expect(event.preventDefault).not.toHaveBeenCalled();
     });
 
@@ -235,12 +223,12 @@ describe('<TrapFocus />', () => {
     const listenerMap: HandlerMap = {};
 
     it('does nothing if trapping is false', () => {
-      const trapFocus = mountWithAppProvider(<TrapFocus trapping={false} />);
+      const trapFocus = mountWithApp(<TrapFocus trapping={false} />);
       const activeElement = document.activeElement;
 
       listenerMap.keydown({keyCode: Key.Tab, element: trapFocus});
 
-      expect(activeElement).toBe(document.activeElement);
+      expect(document.activeElement).toBe(activeElement);
       expect(focusUtils.focusFirstKeyboardFocusableNode).not.toHaveBeenCalled();
       expect(focusUtils.focusLastKeyboardFocusableNode).not.toHaveBeenCalled();
     });
@@ -248,7 +236,7 @@ describe('<TrapFocus />', () => {
     it('prevents default if the target is the last element and the shift key is not pressed', () => {
       const preventDefaultSpy = jest.fn();
 
-      const trapFocus = mountWithAppProvider(
+      const trapFocus = mountWithApp(
         <TrapFocus>
           <button />
           <input />
@@ -257,7 +245,7 @@ describe('<TrapFocus />', () => {
 
       listenerMap.keydown({
         keyCode: Key.Tab,
-        target: lastNode(trapFocus),
+        target: trapFocus.find('input')!.domNode,
         preventDefault: preventDefaultSpy,
       });
 
@@ -265,7 +253,7 @@ describe('<TrapFocus />', () => {
     });
 
     it('focuses the first keyboard focusable node', () => {
-      const trapFocus = mountWithAppProvider(
+      const trapFocus = mountWithApp(
         <TrapFocus>
           <button />
           <input />
@@ -274,18 +262,18 @@ describe('<TrapFocus />', () => {
 
       listenerMap.keydown({
         keyCode: Key.Tab,
-        target: lastNode(trapFocus),
+        target: trapFocus.find('input')!.domNode,
         preventDefault: noop,
       });
 
-      expect(document.activeElement).toBe(firstNode(trapFocus));
+      expect(document.activeElement).toBe(trapFocus.find('button')!.domNode);
       expect(focusUtils.focusFirstKeyboardFocusableNode).toHaveBeenCalled();
     });
 
     it('prevents default if the target is the first element and the shift key is pressed', () => {
       const preventDefaultSpy = jest.fn();
 
-      const trapFocus = mountWithAppProvider(
+      const trapFocus = mountWithApp(
         <TrapFocus>
           <button />
           <input />
@@ -295,7 +283,7 @@ describe('<TrapFocus />', () => {
       listenerMap.keydown({
         keyCode: Key.Tab,
         shiftKey: Key.Shift,
-        target: firstNode(trapFocus),
+        target: trapFocus.find('button')!.domNode,
         preventDefault: preventDefaultSpy,
       });
 
@@ -303,7 +291,7 @@ describe('<TrapFocus />', () => {
     });
 
     it('focuses the last keyboard focusable node', () => {
-      const trapFocus = mountWithAppProvider(
+      const trapFocus = mountWithApp(
         <TrapFocus>
           <button />
           <input />
@@ -313,30 +301,14 @@ describe('<TrapFocus />', () => {
       listenerMap.keydown({
         keyCode: Key.Tab,
         shiftKey: Key.Shift,
-        target: firstNode(trapFocus),
+        target: trapFocus.find('button')!.domNode,
         preventDefault: noop,
       });
 
-      expect(document.activeElement).toBe(lastNode(trapFocus));
+      expect(document.activeElement).toBe(trapFocus.find('input')!.domNode);
       expect(focusUtils.focusLastKeyboardFocusableNode).toHaveBeenCalled();
     });
   });
 });
 
 function noop() {}
-
-function firstNode(element: ReactWrapper) {
-  const elementNode = element.getDOMNode();
-
-  if (Array.isArray(elementNode))
-    return focusUtils.findFirstKeyboardFocusableNode(elementNode[0]);
-  return focusUtils.findFirstKeyboardFocusableNode(elementNode as HTMLElement);
-}
-
-function lastNode(element: ReactWrapper) {
-  const elementNode = element.getDOMNode();
-
-  if (Array.isArray(elementNode))
-    return focusUtils.findLastKeyboardFocusableNode(elementNode[0]);
-  return focusUtils.findLastKeyboardFocusableNode(elementNode as HTMLElement);
-}


### PR DESCRIPTION
### WHY are these changes introduced?

An imminent bump to SK and thus Jest exposes a case where enzyme doesn't handle component mounting to jsdom in a way that results in spec compliant focus management, which then results in tests that assert on document.activeElement failing.
Fortunately react-testing doesn't have this problem, so we can just usethat instead.

Gory details: https://github.com/enzymejs/enzyme/issues/2337#issuecomment-608984530

### WHAT is this pull request doing?

Migrates a handful of test cases from enzyme to use react-testing

### How to 🎩

 Run tests and see they still pass