### PR TITLE
[Icon] Add blueDark to icons with backdrops

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@
 ### Enhancements
 
 - Removed padding from the details container in `EmptyState` to account for new illustration size ([#3069](https://github.com/Shopify/polaris-react/pull/3069))
+- Added `blueDark` to the list of possible `color` values for an `Icon` with a backdrop ([#3076](https://github.com/Shopify/polaris-react/pull/3076))
 
 ### Bug fixes
 

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -146,6 +146,10 @@
 .colorBlueDark {
   @include color-icon('blue', 'dark');
 
+  &::before {
+    background-color: var(--p-surface-highlight, color('blue', 'light'));
+  }
+
   &.newDesignLanguage {
     @include recolor-icon(var(--p-icon));
   }

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -8,6 +8,7 @@ import {IconProps, isNewDesignLanguageColor} from '../../types';
 import styles from './Icon.scss';
 
 const COLORS_WITH_BACKDROPS = [
+  'blueDark',
   'teal',
   'tealDark',
   'greenDark',


### PR DESCRIPTION
### WHY are these changes introduced?

There's a couple of places in web where a blue duotone icon is used. This is done to match the "in progress" badge.

This PR adds `blueDark` to the acceptable values of for duotone Icons. (I know this will changed in the new design language)

<img width="469" alt="Screen Shot 2020-06-24 at 2 32 07 PM" src="https://user-images.githubusercontent.com/1229901/85613543-fe05e380-b627-11ea-8052-5ff6724a6580.png">




## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {CircleInformationMajorTwotone} from '@shopify/polaris-icons';

import {Page, Icon} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Icon source={CircleInformationMajorTwotone} color="blueDark" backdrop />
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
