### PR TITLE
[ActionMenu] Fix regression with new design language

### DIFF
--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -86,13 +86,18 @@ export class ActionMenu extends React.PureComponent<ActionMenuProps, State> {
         ) : null;
       }
 
-      const {content, ...rest} = action;
+      const {content, onAction, ...rest} = action;
       return newDesignLanguage ? (
-        <Button key={index} {...rest}>
+        <Button key={index} onClick={onAction} {...rest}>
           {content}
         </Button>
       ) : (
-        <MenuAction key={`MenuAction-${index}`} content={content} {...rest} />
+        <MenuAction
+          key={`MenuAction-${index}`}
+          content={content}
+          onAction={onAction}
+          {...rest}
+        />
       );
     });
 

--- a/src/components/ActionMenu/tests/ActionMenu.test.tsx
+++ b/src/components/ActionMenu/tests/ActionMenu.test.tsx
@@ -388,6 +388,21 @@ describe('<ActionMenu />', () => {
       expect(wrapper.find(MenuAction)).toHaveLength(0);
     });
 
+    it('action callbacks are passed through to Button', () => {
+      const spy = jest.fn();
+      const wrapper = mountWithAppProvider(
+        <ActionMenu
+          {...mockProps}
+          actions={[{content: 'mock', onAction: spy}]}
+        />,
+        {features: {newDesignLanguage: true}},
+      );
+
+      trigger(wrapper.find(Button), 'onClick');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
     it('uses MenuAction instead of Button and ButtonGroup as subcomponents when disabled', () => {
       const wrapper = mountWithAppProvider(
         <ActionMenu {...mockProps} actions={mockActions} />,
@@ -397,6 +412,20 @@ describe('<ActionMenu />', () => {
       expect(wrapper.find(MenuAction)).toHaveLength(2);
       expect(wrapper.find(Button)).toHaveLength(0);
       expect(wrapper.find(ButtonGroup)).toHaveLength(0);
+    });
+
+    it('action callbacks are passed through to MenuAction', () => {
+      const spy = jest.fn();
+      const wrapper = mountWithAppProvider(
+        <ActionMenu
+          {...mockProps}
+          actions={[{content: 'mock', onAction: spy}]}
+        />,
+      );
+
+      trigger(wrapper.find(MenuAction), 'onAction');
+
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -199,8 +199,12 @@ Use for detail pages, which should have pagination and breadcrumbs, and also oft
     {
       content: 'Duplicate',
       accessibilityLabel: 'Secondary action label',
+      onAction: () => alert('Duplicate action'),
     },
-    {content: 'View on your store'},
+    {
+      content: 'View on your store',
+      onAction: () => alert('View on your store action'),
+    },
   ]}
   actionGroups={[
     {
@@ -210,7 +214,7 @@ Use for detail pages, which should have pagination and breadcrumbs, and also oft
         {
           content: 'Share on Facebook',
           accessibilityLabel: 'Individual action label',
-          onAction: () => {},
+          onAction: () => alert('Share on Facebook action'),
         },
       ],
     },


### PR DESCRIPTION
### WHY are these changes introduced?

`Page` actions were no longer triggering their callbacks with the new design language because the callback was being passed through to `Button` as `onAction`, not `onClick`. TypeScript should have caught this, I have not looked at why this happened.

### WHAT is this pull request doing?

Destructuring `onAction` from the `rest` props and passing to `onClick` for `Button` or `onAction` for `MenuAction`, depending if the new design language is enabled or not.

Also adds the tests first so you can see the failure then the fix as a separate commit to verify.

- [x] 🎩 

