### PR TITLE
ResourceItem fix alignment of checkbox when no media

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@
 - Added `flex: 1 1 auto` to `Banner` `.ContentWrapper` CSS selector ([#3062](https://github.com/Shopify/polaris-react/pull/3062))
 - Fixed mis-alignment on `Page` action rollup ([#3064](https://github.com/Shopify/polaris-react/pull/3064))
 - Ensured Sass mixins can compile in Dart Sass ([#3064](https://github.com/Shopify/polaris-react/pull/3063))
+- Fixed alignment of `ResourceItem` when there is no media ([#3080](https://github.com/Shopify/polaris-react/pull/3080))
 
 ### Documentation
 

--- a/src/components/ResourceItem/ResourceItem.scss
+++ b/src/components/ResourceItem/ResourceItem.scss
@@ -205,6 +205,10 @@ $resource-list-item-variables: (
   display: flex;
 }
 
+.OwnedNoMedia {
+  padding-top: spacing(extra-tight);
+}
+
 // Item handle
 .Handle {
   width: resource-list-item(handle-width);

--- a/src/components/ResourceItem/ResourceItem.tsx
+++ b/src/components/ResourceItem/ResourceItem.tsx
@@ -190,7 +190,12 @@ class BaseResourceItem extends React.Component<CombinedProps, State> {
 
     if (media || selectable) {
       ownedMarkup = (
-        <div className={styles.Owned}>
+        <div
+          className={classNames(
+            styles.Owned,
+            !mediaMarkup && styles.OwnedNoMedia,
+          )}
+        >
           {handleMarkup}
           {mediaMarkup}
         </div>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/deliveries/issues/837

### WHAT is this pull request doing?

Fixing alignment of resource items when there is no media.

Currently the text is below the checkbox:
![Screen Shot 2020-06-25 at 8 17 46 AM](https://user-images.githubusercontent.com/19199063/85718558-a1a0d380-b6bc-11ea-985b-f9360da36d5c.png)

Now the text is inline with the checkbox:
![Screen Shot 2020-06-25 at 8 17 54 AM](https://user-images.githubusercontent.com/19199063/85718622-b1201c80-b6bc-11ea-9006-ef9436e864aa.png)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Open the simple resource list item example in storybook and compare the spacing in multiple browsers.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit