### PR TITLE
[Tooltip] Added optional boolean dismissOnMouseOut prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added a `dismissOnMouseOut` prop to `Tooltip` to dismiss Tooltip once pointer is no longer over children ([#3086](https://github.com/Shopify/polaris-react/pull/3086))
+
 ### Bug fixes
 
 - Fixed case where `DatePicker` did not translate the weekday name in an aria label ([#3113](https://github.com/Shopify/polaris-react/pull/3113))

--- a/src/components/PositionedOverlay/PositionedOverlay.scss
+++ b/src/components/PositionedOverlay/PositionedOverlay.scss
@@ -12,3 +12,7 @@
 .calculating {
   visibility: hidden;
 }
+
+.preventInteraction {
+  pointer-events: none;
+}

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -36,6 +36,7 @@ export interface PositionedOverlayProps {
   preferredAlignment?: PreferredAlignment;
   fullWidth?: boolean;
   fixed?: boolean;
+  preventInteraction?: boolean;
   classNames?: string;
   render(overlayDetails: OverlayDetails): React.ReactNode;
   onScrollOut?(): void;
@@ -121,7 +122,12 @@ export class PositionedOverlay extends React.PureComponent<
 
   render() {
     const {left, right, top, zIndex, width} = this.state;
-    const {render, fixed, classNames: propClassNames} = this.props;
+    const {
+      render,
+      fixed,
+      preventInteraction,
+      classNames: propClassNames,
+    } = this.props;
 
     const style = {
       top: top == null || isNaN(top) ? undefined : top,
@@ -134,6 +140,7 @@ export class PositionedOverlay extends React.PureComponent<
     const className = classNames(
       styles.PositionedOverlay,
       fixed && styles.fixed,
+      preventInteraction && styles.preventInteraction,
       propClassNames,
     );
 

--- a/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -6,6 +6,7 @@ import {EventListener} from '../../EventListener';
 import {PositionedOverlay} from '../PositionedOverlay';
 import * as mathModule from '../utilities/math';
 import * as geometry from '../../../utilities/geometry';
+import styles from '../PositionedOverlay.scss';
 
 describe('<PositionedOverlay />', () => {
   const mockProps = {
@@ -96,6 +97,26 @@ describe('<PositionedOverlay />', () => {
 
       expect((positionedOverlay.find('div').prop('style') as any).width).toBe(
         0,
+      );
+    });
+  });
+
+  describe('preventInteraction', () => {
+    it('passes preventInteraction to PositionedOverlay when preventInteraction is true', () => {
+      const positionedOverlay = mountWithAppProvider(
+        <PositionedOverlay {...mockProps} preventInteraction />,
+      );
+      expect(positionedOverlay.find('div').prop('className')).toContain(
+        styles.preventInteraction,
+      );
+    });
+
+    it('does not pass preventInteraction to PositionedOverlay by default', () => {
+      const positionedOverlay = mountWithAppProvider(
+        <PositionedOverlay {...mockProps} />,
+      );
+      expect(positionedOverlay.find('div').prop('className')).not.toContain(
+        styles.preventInteraction,
       );
     });
   });

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -86,6 +86,30 @@ A light tooltip draws less attention than the default tooltip. Use only when nec
 </div>
 ```
 
+### Tooltip visible only with child interaction
+
+Use when the tooltip overlays interactive elements when active, for example a form input. The `dismissOnMouseOut` prop prevents the tooltip from remaining active when mouse hover or focus leaves its `children` and enters the tooltip's content.
+
+```jsx
+<div style={{width: '200px'}}>
+  <ButtonGroup segmented fullWidth>
+    <Tooltip content="Bold" dismissOnMouseOut>
+      <Button>B</Button>
+    </Tooltip>
+    <Tooltip content="Italic" dismissOnMouseOut>
+      <Button>I</Button>
+    </Tooltip>
+    <Tooltip content="Underline" dismissOnMouseOut>
+      <Button>U</Button>
+    </Tooltip>
+    <Tooltip content="Strikethrough" dismissOnMouseOut>
+      <Button>S</Button>
+    </Tooltip>
+  </ButtonGroup>
+  <TextField label="Product title" labelHidden multiline />
+</div>
+```
+
 ---
 
 ## Related components

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -17,6 +17,8 @@ export interface TooltipProps {
   light?: boolean;
   /** Toggle whether the tooltip is visible */
   active?: boolean;
+  /** Dismiss tooltip when not interacting with its children */
+  dismissOnMouseOut?: TooltipOverlayProps['preventInteraction'];
   /**
    * The direction the tooltip tries to display
    * @default 'below'
@@ -33,6 +35,7 @@ export function Tooltip({
   children,
   content,
   light,
+  dismissOnMouseOut,
   active: originalActive,
   preferredPosition = 'below',
   activatorWrapper = 'span',
@@ -68,6 +71,7 @@ export function Tooltip({
         active={active}
         onClose={noop}
         light={light}
+        preventInteraction={dismissOnMouseOut}
       >
         <div className={styles.Label} testID="TooltipOverlayLabel">
           {content}

--- a/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -12,6 +12,7 @@ export interface TooltipOverlayProps {
   id: string;
   active: boolean;
   light?: boolean;
+  preventInteraction?: PositionedOverlayProps['preventInteraction'];
   preferredPosition?: PositionedOverlayProps['preferredPosition'];
   children?: React.ReactNode;
   activator: HTMLElement;
@@ -30,13 +31,19 @@ export class TooltipOverlay extends React.PureComponent<
 
   // eslint-disable-next-line @shopify/react-no-multiple-render-methods
   private renderOverlay = () => {
-    const {active, activator, preferredPosition = 'below'} = this.props;
+    const {
+      active,
+      activator,
+      preferredPosition = 'below',
+      preventInteraction,
+    } = this.props;
 
     return (
       <PositionedOverlay
         active={active}
         activator={activator}
         preferredPosition={preferredPosition}
+        preventInteraction={preventInteraction}
         render={this.renderTooltip}
       />
     );

--- a/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -4,6 +4,7 @@ import {findByTestID, mountWithAppProvider} from 'test-utilities/legacy';
 import {Link} from 'components';
 
 import {Tooltip} from '../Tooltip';
+import {TooltipOverlay} from '../components';
 
 describe('<Tooltip />', () => {
   const tooltip = mountWithAppProvider(
@@ -31,6 +32,17 @@ describe('<Tooltip />', () => {
     expect(findByTestID(tooltipActive, 'TooltipOverlayLabel').exists()).toBe(
       true,
     );
+  });
+
+  it('passes preventInteraction to TooltipOverlay when dismissOnMouseOut is true', () => {
+    const tooltipPreventInteraction = mountWithAppProvider(
+      <Tooltip content="Inner content" active dismissOnMouseOut>
+        <Link>link content</Link>
+      </Tooltip>,
+    );
+    expect(
+      tooltipPreventInteraction.find(TooltipOverlay).prop('preventInteraction'),
+    ).toBe(true);
   });
 
   it('renders on mouseOver', () => {


### PR DESCRIPTION
## Why are these changes needed?

Fixes Shopify/online-store-ui/issues/1598

Currently, when a `Tooltip` is activated, the tooltip remains visible when the mouse leaves the activator and hovers the overlay, which gets in the way of interacting and clicking on interactive content beneath the overlay. This is a problem in the Online Store Editor, where the tooltips rendered on hovering buttons in the RTE toolbar prevent interaction with the textarea which can have very limited height.

![Kapture 2020-04-07 at 16 16 06](https://user-images.githubusercontent.com/1416436/78715237-1dc02200-78eb-11ea-9e78-60b8cdbf41d6.gif)


## What is this PR doing?

This PR adds a new optional boolean prop which sets `pointer-events: none` on the `PositionedOverlay` so that as soon as the cursor leaves the activator (children), the `Tooltip` disappears.

## How to tophat 🎩 

- `git checkout tooltip && yarn dev` (`git remote prune origin` first if you run into ref errors)
- Copy/paste the playground code below into `playground/Playground.tsx`
- Hover over one of the buttons to activate its tooltip
  - You'll see that if you move your mouse away from the button and onto the tooltip it remains visible
- Click the "Prevent overlay interaction" action to toggle the `preventInteraction` prop to true
- Now when you hover over the button to active the tooltip, moving away from the button over to the tooltip will cause it to hide, preventing the text field below from being blocked.

<details>
<summary>Click to view collapsed playground code</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {
  Page,
  ButtonGroup,
  Button,
  Tooltip,
  Card,
  TextField,
  Layout,
} from '../src';

export function Playground() {
  const [value, setValue] = useState('3/4 inch Leather pet collar');
  const [preventInteraction, setPreventInteraction] = useState(false);

  const handleChange = useCallback((newValue) => setValue(newValue), []);
  const togglePreventInteraction = useCallback(() => {
    setPreventInteraction((preventInteraction) => !preventInteraction);
  }, []);

  return (
    <Page
      title="Playground"
      secondaryActions={[
        {
          content: `${
            preventInteraction ? 'Allow' : 'Prevent'
          } overlay interaction`,
          onAction: togglePreventInteraction,
        },
      ]}
    >
      <Layout>
        <Layout.Section>
          <Card sectioned>
            <div style={{width: '200px'}}>
              <ButtonGroup segmented fullWidth>
                <Tooltip content="Bold" preventInteraction={preventInteraction}>
                  <Button>B</Button>
                </Tooltip>
                <Tooltip
                  content="Italic"
                  preventInteraction={preventInteraction}
                >
                  <Button>I</Button>
                </Tooltip>
                <Tooltip
                  content="Underline"
                  preventInteraction={preventInteraction}
                >
                  <Button>U</Button>
                </Tooltip>
                <Tooltip
                  content="Strikethrough"
                  preventInteraction={preventInteraction}
                >
                  <Button>S</Button>
                </Tooltip>
              </ButtonGroup>
              <TextField
                label="Product title"
                labelHidden
                value={value}
                onChange={handleChange}
                multiline
              />
            </div>
          </Card>
        </Layout.Section>
      </Layout>
    </Page>
  );
}
```

</details>