### PR TITLE
Update docs links to App Bridge React

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,13 @@ ReactDOM.render(
 );
 ```
 
-### Building an embedded app
+### Building an embedded app (deprecated)
 
 We provide React wrappers around the Shopify App Bridge (formerly known as the EASDK). You don’t need to go through the initialization of the Shopify App Bridge as described in the docs. Instead, [configure the connection to the Shopify admin through the app provider component](https://github.com/Shopify/polaris-react/blob/master/documentation/Embedded%20apps.md).
 
 If you need help using Shopify App Bridge, the Embedded App SDK, or the POS App SDK, please visit our [API & SDK forum](https://community.shopify.com/c/Shopify-APIs-SDKs/bd-p/shopify-apis-and-technology). It is the best place to discuss the libraries, get support, notify us about bugs, or request features.
+
+As of v3.17.0, using Shopify App Bridge through Polaris is deprecated and will be removed in v5.0. Use [`@shopify/app-bridge-react`](https://shopify.dev/tools/app-bridge/react-components#using-app-bridge-react-with-polaris) instead; it provides the same functionality.
 
 ## Using the CSS components
 

--- a/documentation/Embedded apps.md
+++ b/documentation/Embedded apps.md
@@ -4,6 +4,8 @@ In addition to the [visual components](https://polaris.shopify.com/components/ge
 
 When using Polaris, you don’t need to go through the initialization of the Shopify App Bridge as described [in the docs](https://help.shopify.com/en/api/embedded-apps/app-bridge#set-up-your-app). Instead, configure the connection to the Shopify admin through the [app provider component](https://polaris.shopify.com/components/structure/app-provider#initializing-the-shopify-app-bridge), which must wrap all components in an embedded app. This component initializes the Shopify App Bridge using the `apiKey` you provide. **The `apiKey` attribute is required** and can be found in the [Shopify Partner Dashboard](https://partners.shopify.com).
 
+As of v3.17.0, using Shopify App Bridge through Polaris is deprecated and will be removed in v5.0. Use [`@shopify/app-bridge-react`](https://shopify.dev/tools/app-bridge/react-components#using-app-bridge-react-with-polaris) instead; it provides the same functionality.
+
 ## Components which wrap Shopify App Bridge
 
 - [`<Toast />`](https://polaris.shopify.com/components/feedback-indicators/toast)

--- a/src/components/AppProvider/README.md
+++ b/src/components/AppProvider/README.md
@@ -587,13 +587,13 @@ ReactDOM.render(
 
 #### Deprecation rationale
 
-As of v3.17.0, using `apiKey` and `shopOrigin` on `AppProvider` to initialize the Shopify App Bridge is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. Learn more about the [deprecation rationale](https://github.com/Shopify/polaris-react/issues/814). Use [`Provider`](https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components/provider) from [`@shopify/app-bridge-react`](https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components) instead.
+As of v3.17.0, using `apiKey` and `shopOrigin` on `AppProvider` to initialize the Shopify App Bridge is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. Learn more about the [deprecation rationale](https://github.com/Shopify/polaris-react/issues/814). Use [`@shopify/app-bridge-react`](https://shopify.dev/tools/app-bridge/react-components#using-app-bridge-react-with-polaris) instead; it provides the same functionality.
 
 ---
 
 ## Access to the Shopify App Bridge instance (deprecated)
 
-To provide access to your initialized Shopify App Bridge instance, we make it available through [React’s `context`](https://facebook.github.io/react/docs/context.html). The example below demonstrates how to access the `appBridge` object from React’s `context`, in order to use the [`Redirect` action](https://help.shopify.com/en/api/embedded-apps/app-bridge/actions/navigation/redirect) to navigate:
+To provide access to your initialized Shopify App Bridge instance, we make it available through [React’s `context`](https://reactjs.org/docs/context.html). The example below demonstrates how to access the `appBridge` object from React’s `context`, in order to use the [`Redirect` action](https://shopify.dev/tools/app-bridge/actions/navigation/redirect) to navigate:
 
 ```js
 import React from 'react';
@@ -630,7 +630,7 @@ render(
 
 #### Deprecation rationale
 
-As of v3.17.0, using the Shopify App Bridge instance in context is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. More information can be found [here](https://github.com/Shopify/polaris-react/issues/814). Use the [Shopify App Bridge](https://help.shopify.com/en/api/embedded-apps/app-bridge) directly instead.
+As of v3.17.0, using the Shopify App Bridge instance in context is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. More information can be found [here](https://github.com/Shopify/polaris-react/issues/814). Use [`@shopify/app-bridge-react`](https://shopify.dev/tools/app-bridge/react-components) instead. Learn [how to access the Shopify App Bridge instance](https://shopify.dev/tools/app-bridge/react-components#using-app-bridge-react-with-polaris) through React’s `context` API in App Bridge React.
 
 ---
 

--- a/src/components/Loading/README.md
+++ b/src/components/Loading/README.md
@@ -56,7 +56,7 @@ function EmbeddedAppLoadingExample() {
 
 #### Deprecation rationale
 
-As of v3.17.0, using `Loading` in an embedded app is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. Learn more about the [deprecation rationale](https://github.com/Shopify/polaris-react/issues/814). Use [`Loading`](https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components/loading) from [`@shopify/app-bridge-react`](https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components) instead.
+As of v3.17.0, using `Loading` in an embedded app is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. Learn more about the [deprecation rationale](https://github.com/Shopify/polaris-react/issues/814). Use [`Loading`](https://shopify.dev/tools/app-bridge/react-components/loading) from [`@shopify/app-bridge-react`](https://shopify.dev/tools/app-bridge/react-components) instead.
 
 ---
 

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -42,7 +42,7 @@ Modals are overlays that prevent merchants from interacting with the rest of the
 
 ## Use in an embedded application (deprecated)
 
-Passing an API key to the [app provider component](https://polaris.shopify.com/components/structure/app-provider#section-initializing-the-shopify-app-bridge) causes the modal component to delegate to the [Shopify App Bridge](https://help.shopify.com/en/api/embedded-apps/app-bridge) instead of rendering as it would in a stand-alone application.
+Passing an API key to the [app provider component](https://polaris.shopify.com/components/structure/app-provider#section-initializing-the-shopify-app-bridge) causes the modal component to delegate to the [Shopify App Bridge](https://shopify.dev/tools/app-bridge) instead of rendering as it would in a stand-alone application.
 
 In an embedded application context, not all documented properties are available. Some properties are only available in stand-alone applications.
 
@@ -81,7 +81,7 @@ function EmbeddedAppModalExample() {
 
 #### Deprecation rationale
 
-As of v3.17.0, using `Modal` in an embedded app is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. Learn more about the [deprecation rationale](https://github.com/Shopify/polaris-react/issues/814). Use [`Modal`](https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components/modal) from [`@shopify/app-bridge-react`](https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components) instead.
+As of v3.17.0, using `Modal` in an embedded app is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. Learn more about the [deprecation rationale](https://github.com/Shopify/polaris-react/issues/814). Use [`Modal`](https://shopify.dev/tools/app-bridge/react-components/modal) from [`@shopify/app-bridge-react`](https://shopify.dev/tools/app-bridge/react-components) instead.
 
 ---
 

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -38,7 +38,7 @@ Use to build the outer wrapper of a page, including the page title and associate
 
 ## Use in an embedded application (deprecated)
 
-Passing an API key to the [app provider component](https://polaris.shopify.com/components/structure/app-provider#section-initializing-the-shopify-app-bridge) causes the page component to delegate to the [Shopify App Bridge](https://help.shopify.com/en/api/embedded-apps/app-bridge) instead of rendering as it would in a stand-alone application.
+Passing an API key to the [app provider component](https://polaris.shopify.com/components/structure/app-provider#section-initializing-the-shopify-app-bridge) causes the page component to delegate to the [Shopify App Bridge](https://shopify.dev/tools/app-bridge) instead of rendering as it would in a stand-alone application.
 
 Note in the props table that a number of properties are only available in stand-alone applications, and won’t work in an embedded context. Configure your application’s icon and navigation in the [Shopify Partner Dashboard](https://partners.shopify.com) app setup section. To help visualize the page component in an embedded application, we’ve provided the following screenshot.
 
@@ -79,7 +79,7 @@ ReactDOM.render(
 
 #### Deprecation rationale
 
-As of v3.17.0, using `Page` to render an embedded app title bar is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. Learn more about the [deprecation rationale](https://github.com/Shopify/polaris-react/issues/814). Use [`TitleBar`](https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components/titlebar) from [`@shopify/app-bridge-react`](https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components) combined with `Page` instead.
+As of v3.17.0, using `Page` to render an embedded app title bar is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. Learn more about the [deprecation rationale](https://github.com/Shopify/polaris-react/issues/814). Use [`TitleBar`](https://shopify.dev/tools/app-bridge/react-components/titlebar) from [`@shopify/app-bridge-react`](https://shopify.dev/tools/app-bridge/react-components) combined with `Page` instead.
 
 ---
 

--- a/src/components/ResourcePicker/README.md
+++ b/src/components/ResourcePicker/README.md
@@ -29,7 +29,7 @@ keywords:
 
 ## Use in an embedded application (deprecated)
 
-Enable the resource picker component to delegate to the [Shopify App Bridge](https://help.shopify.com/en/api/embedded-apps/app-bridge) by passing an API key to the [app provider component](https://polaris.shopify.com/components/structure/app-provider#section-initializing-the-shopify-app-bridge).
+Enable the resource picker component to delegate to the [Shopify App Bridge](https://shopify.dev/tools/app-bridge) by passing an API key to the [app provider component](https://polaris.shopify.com/components/structure/app-provider#section-initializing-the-shopify-app-bridge).
 
 Use of the resource picker component is only supported in an embedded application—it will not render in a stand-alone application. To help visualize the resource picker component in an embedded application, we've provided the following screenshot.
 
@@ -37,7 +37,7 @@ Use of the resource picker component is only supported in an embedded applicatio
 
 ### Deprecation rationale
 
-As of v3.17.0, `ResourcePicker` is deprecated. It will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. Learn more about the [deprecation rationale](https://github.com/Shopify/polaris-react/issues/814). Use [`ResourcePicker`](https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components/resourcepicker) from [`@shopify/app-bridge-react`](https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components) instead.
+As of v3.17.0, `ResourcePicker` is deprecated. It will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. Learn more about the [deprecation rationale](https://github.com/Shopify/polaris-react/issues/814). Use [`ResourcePicker`](https://shopify.dev/tools/app-bridge/react-components/resourcepicker) from [`@shopify/app-bridge-react`](https://shopify.dev/tools/app-bridge/react-components) instead.
 
 ---
 

--- a/src/components/Toast/README.md
+++ b/src/components/Toast/README.md
@@ -39,7 +39,7 @@ The toast component must be wrapped in the [frame](https://polaris.shopify.com/c
 
 ## Use in an embedded application (deprecated)
 
-Passing an API key to the [app provider component](https://polaris.shopify.com/components/structure/app-provider#section-initializing-the-shopify-app-bridge) causes the toast component to delegate to the [Shopify App Bridge](https://help.shopify.com/en/api/embedded-apps/app-bridge) instead of rendering as it would in a stand-alone application.
+Passing an API key to the [app provider component](https://polaris.shopify.com/components/structure/app-provider#section-initializing-the-shopify-app-bridge) causes the toast component to delegate to the [Shopify App Bridge](https://shopify.dev/tools/app-bridge) instead of rendering as it would in a stand-alone application.
 
 Note that when used in an embedded application, the toast component does not support multiple, simultaneous toast messages.
 
@@ -63,7 +63,7 @@ function EmbeddedAppToastExample() {
 
 #### Deprecation rationale
 
-As of v3.17.0, using `Toast` in an embedded app is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. Learn more about the [deprecation rationale](https://github.com/Shopify/polaris-react/issues/814). Use [`Toast`](https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components/toast) from [`@shopify/app-bridge-react`](https://help.shopify.com/en/api/embedded-apps/app-bridge/react-components) instead.
+As of v3.17.0, using `Toast` in an embedded app is deprecated. Support for this will be removed in v5.0 as the underlying Shopify App Bridge library will be removed from Polaris React. Learn more about the [deprecation rationale](https://github.com/Shopify/polaris-react/issues/814). Use [`Toast`](https://shopify.dev/tools/app-bridge/react-components/toast) from [`@shopify/app-bridge-react`](https://shopify.dev/tools/app-bridge/react-components) instead.
 
 ---
 


### PR DESCRIPTION
Updated links to App Bridge React from help -> dev, and added some specificity  pointing to the section on migrating from Polaris: https://shopify.dev/tools/app-bridge/react-components#using-app-bridge-react-with-polaris).
