### PR TITLE
[ AppProvider] Update AppProvider Testing Components section for version 4

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,8 @@
 
 ### Documentation
 
+- Updated AppProvider test component information
+
 ### Development workflow
 
 - Updated sewing-kit to v0.132.2 and storybook to v5.3.19 ((#3072)[https://github.com/Shopify/polaris-react/pull/3072])

--- a/src/components/AppProvider/README.md
+++ b/src/components/AppProvider/README.md
@@ -640,6 +640,5 @@ You must include Polaris context in your tests when you use Polaris components.
 
 To make this easier for you, we’ve provided:
 
-- a `createPolarisContext()` function to create the Polaris context for you
-- a `polarisContextTypes` variable that contains all the necessary context types
+- a PolarisTestProvider component to provide the Polaris contexts for you
 - a fully-working [example app with Jest and Enzyme](https://github.com/Shopify/polaris-react/tree/master/examples/create-react-app) you can reference


### PR DESCRIPTION
### WHY are these changes introduced?

The sample test app is updated to use PolarisTestProvider but this documentation snippet still refers to the old 3.x functions.

### WHAT is this pull request doing?

Changing the AppProvider docs

### 🎩 checklist

* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
