### PR TITLE
Build: Avoid repeating babel config in rollup config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,9 +5,16 @@ module.exports = function (api) {
     return ['babel-loader', '@rollup/plugin-babel'].includes(caller.name);
   });
 
+  // Our esnext rollup build will want to override the browserslist we pass in
+  // instead of using the default as defined in our package.json
+  const browsers = api.caller((caller = {}) => caller.browserslistOverride);
+
   const runtimePreset = isWeb
-    ? ['@shopify/babel-preset/web', {modules: false, typescript: true}]
-    : ['@shopify/babel-preset/node', {modules: 'commonjs', typescript: true}];
+    ? [
+        '@shopify/babel-preset/web',
+        {modules: 'auto', typescript: true, browsers},
+      ]
+    : ['@shopify/babel-preset/node', {modules: 'auto', typescript: true}];
 
   return {
     presets: [runtimePreset, ['@shopify/babel-preset/react']],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,12 +21,6 @@ function external(id) {
 }
 
 function plugins({browserslist, stylesConfig}) {
-  const babelWebPresetOptions = {
-    modules: 'auto',
-    typescript: true,
-    browsers: browserslist,
-  };
-
   return [
     replace({
       '{{POLARIS_VERSION}}': packageJSON.version,
@@ -38,18 +32,12 @@ function plugins({browserslist, stylesConfig}) {
     commonjs(),
     babel({
       extensions: ['.js', '.jsx', '.ts', '.tsx'],
-      // We need to specify an environment name as leaving it blank defaults
-      // to "development", which ends up including a bunch of debug helpers.
       envName: 'production',
       exclude: 'node_modules/**',
       babelHelpers: 'bundled',
-      // Don't use config from babel.config.js as we want to customise the
-      // browserslist per compile target.
-      configFile: false,
-      presets: [
-        ['@shopify/babel-preset/web', babelWebPresetOptions],
-        ['@shopify/babel-preset/react'],
-      ],
+      caller: {
+        browserslistOverride: browserslist,
+      },
     }),
     styles({
       ...stylesConfig,


### PR DESCRIPTION


### WHY are these changes introduced?
 Not repeating myself

### WHAT is this pull request doing?

Rollup will now use the config in babel.config.js as a base and augment
when needed