### PR TITLE
Remove dependency on @shopify/javascript-utilities

### DIFF
--- a/UNRELEASED-v5.md
+++ b/UNRELEASED-v5.md
@@ -35,6 +35,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed `withAppProvider` higher-order component. ([#3098](https://github.com/Shopify/polaris-react/pull/3098))
 - Removed several dependencies on the deprecated `@shopify/javascript-utilities` library ([#3102](https://github.com/Shopify/polaris-react/pull/3102))
 - Removed dependency on `@shopify/useful-types`
-- Remove dependency on `@shopify/javascript-utilities` ([#3108](https://github.com/Shopify/polaris-react/pull/3108))
+- Removed dependency on `@shopify/javascript-utilities` ([#3108](https://github.com/Shopify/polaris-react/pull/3108))
 
 ### Deprecations

--- a/UNRELEASED-v5.md
+++ b/UNRELEASED-v5.md
@@ -35,5 +35,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed `withAppProvider` higher-order component. ([#3098](https://github.com/Shopify/polaris-react/pull/3098))
 - Removed several dependencies on the deprecated `@shopify/javascript-utilities` library ([#3102](https://github.com/Shopify/polaris-react/pull/3102))
 - Removed dependency on `@shopify/useful-types`
+- Remove dependency on `@shopify/javascript-utilities` ([#3108](https://github.com/Shopify/polaris-react/pull/3108))
 
 ### Deprecations

--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
       ]
     }
   },
-  "browserslist": ["extends @shopify/browserslist-config"],
+  "browserslist": [
+    "extends @shopify/browserslist-config"
+  ],
   "devDependencies": {
     "@babel/core": "^7.6.0",
     "@babel/node": "^7.6.1",
@@ -176,7 +178,6 @@
     "!*.tsbuildinfo"
   ],
   "dependencies": {
-    "@shopify/javascript-utilities": "^2.4.1",
     "@shopify/polaris-icons": "^3.10.0",
     "@shopify/polaris-tokens": "^2.12.3",
     "@types/react": "^16.9.12",

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,20 +1,19 @@
 import React, {useState, useEffect, useCallback, useMemo} from 'react';
 import {ArrowLeftMinor, ArrowRightMinor} from '@shopify/polaris-icons';
+
+import {Button} from '../Button';
+import {classNames} from '../../utilities/css';
 import {
-  Range,
-  Months,
-  Year,
+  Month as Months,
+  Weekday,
   isDateAfter,
   isDateBefore,
   getNextDisplayYear,
   getNextDisplayMonth,
   getPreviousDisplayYear,
   getPreviousDisplayMonth,
-  Weekdays,
-} from '@shopify/javascript-utilities/dates';
-
-import {Button} from '../Button';
-import {classNames} from '../../utilities/css';
+} from '../../utilities/dates';
+import type {Range, Year} from '../../utilities/dates';
 import {useI18n} from '../../utilities/i18n';
 import {useFeatures} from '../../utilities/features';
 
@@ -22,6 +21,7 @@ import {monthName} from './utilities';
 import {Month} from './components';
 import styles from './DatePicker.scss';
 
+// Export as Months for public facing backwards compat
 export {Months};
 export type {Range, Year};
 
@@ -43,7 +43,7 @@ export interface DatePickerProps {
   /** The selection can span multiple months */
   multiMonth?: boolean;
   /** First day of week. Sunday by default */
-  weekStartsOn?: Weekdays;
+  weekStartsOn?: Weekday;
   /** Callback when date is selected. */
   onChange?(date: Range): void;
   /** Callback when month is changed. */
@@ -59,7 +59,7 @@ export function DatePicker({
   multiMonth,
   disableDatesBefore,
   disableDatesAfter,
-  weekStartsOn = Weekdays.Sunday,
+  weekStartsOn = Weekday.Sunday,
   onMonthChange,
   onChange = noop,
 }: DatePickerProps) {

--- a/src/components/DatePicker/components/Day/Day.tsx
+++ b/src/components/DatePicker/components/Day/Day.tsx
@@ -1,7 +1,7 @@
 import React, {useRef, useEffect, memo} from 'react';
-import {Months, isSameDay} from '@shopify/javascript-utilities/dates';
 
 import {classNames} from '../../../../utilities/css';
+import {Month, isSameDay} from '../../../../utilities/dates';
 import {useI18n} from '../../../../utilities/i18n';
 import styles from '../../DatePicker.scss';
 
@@ -74,7 +74,7 @@ export const Day = memo(function Day({
     (focused || selected || today || date === 1) && !disabled ? 0 : -1;
   const ariaLabel = [
     `${today ? i18n.translate('Polaris.DatePicker.today') : ''}`,
-    `${Months[day.getMonth()]} `,
+    `${Month[day.getMonth()]} `,
     `${date} `,
     `${day.getFullYear()}`,
   ].join('');

--- a/src/components/DatePicker/components/Month/Month.tsx
+++ b/src/components/DatePicker/components/Month/Month.tsx
@@ -1,9 +1,9 @@
 import React, {useCallback, useMemo} from 'react';
+
+import {classNames} from '../../../../utilities/css';
 import {
-  Range,
-  Weekdays,
-  Months,
-  Year,
+  Weekday as WeekdayEnum,
+  Month as MonthEnum,
   isDateBefore,
   isDateAfter,
   isSameDay,
@@ -12,9 +12,9 @@ import {
   dateIsInRange,
   dateIsSelected,
   getNewRange,
-} from '@shopify/javascript-utilities/dates';
-
-import {classNames} from '../../../../utilities/css';
+  getOrderedWeekdays,
+} from '../../../../utilities/dates';
+import type {Range, Year} from '../../../../utilities/dates';
 import {useI18n} from '../../../../utilities/i18n';
 import styles from '../../DatePicker.scss';
 import {Day} from '../Day';
@@ -25,29 +25,16 @@ export interface MonthProps {
   focusedDate?: Date;
   selected?: Range;
   hoverDate?: Date;
-  month: Months;
+  month: MonthEnum;
   year: Year;
   disableDatesBefore?: Date;
   disableDatesAfter?: Date;
   allowRange?: boolean;
-  weekStartsOn: Weekdays;
-  newDesignLanguage?: boolean;
+  weekStartsOn: WeekdayEnum;
   onChange?(date: Range): void;
   onHover?(hoverEnd: Date): void;
   onFocus?(date: Date): void;
-  monthName?(month: Months): string;
-  weekdayName?(weekday: Weekdays): string;
 }
-
-const WEEKDAYS = [
-  Weekdays.Sunday,
-  Weekdays.Monday,
-  Weekdays.Tuesday,
-  Weekdays.Wednesday,
-  Weekdays.Thursday,
-  Weekdays.Friday,
-  Weekdays.Saturday,
-];
 
 export function Month({
   focusedDate,
@@ -77,7 +64,7 @@ export function Month({
     weekStartsOn,
     year,
   ]);
-  const weekdays = getWeekdaysOrdered(weekStartsOn).map((weekday) => (
+  const weekdays = getOrderedWeekdays(weekStartsOn).map((weekday) => (
     <Weekday
       key={weekday}
       title={i18n.translate(
@@ -183,12 +170,6 @@ function hoveringDateIsInRange(
   }
   const {start, end} = range;
   return Boolean(isSameDay(start, end) && day > start && day <= hoverEndDate);
-}
-
-function getWeekdaysOrdered(weekStartsOn: Weekdays): Weekdays[] {
-  const weekDays = [...WEEKDAYS];
-  const restOfDays = weekDays.splice(weekStartsOn);
-  return [...restOfDays, ...weekDays];
 }
 
 function isDateEnd(day: Date | null, range: Range) {

--- a/src/components/DatePicker/components/Month/tests/Month.test.tsx
+++ b/src/components/DatePicker/components/Month/tests/Month.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Weekdays} from '@shopify/javascript-utilities/dates';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 
@@ -11,7 +10,7 @@ describe('<Month />', () => {
   describe('title', () => {
     it('passes the abbreviated value to the title prop of Weekday', () => {
       const month = mountWithAppProvider(
-        <Month month={0} year={2018} weekStartsOn={Weekdays.Monday} />,
+        <Month month={0} year={2018} weekStartsOn={1} />,
       );
       expect(month.find(Weekday).first().prop('title')).toBe('Mo');
     });
@@ -20,7 +19,7 @@ describe('<Month />', () => {
   describe('label', () => {
     it('passes the numeric value to the label prop of Weekday', () => {
       const month = mountWithAppProvider(
-        <Month month={0} year={2018} weekStartsOn={Weekdays.Monday} />,
+        <Month month={0} year={2018} weekStartsOn={1} />,
       );
       expect(month.find(Weekday).first().prop('label')).toBe(1);
     });
@@ -44,7 +43,7 @@ describe('<Month />', () => {
 
     it('passes false to Weekday if month year and weekStartsOn are not today', () => {
       const month = mountWithAppProvider(
-        <Month month={1} year={2016} weekStartsOn={Weekdays.Monday} />,
+        <Month month={1} year={2016} weekStartsOn={1} />,
       );
       expect(month.find(Weekday).first().prop('current')).toBe(false);
     });
@@ -57,7 +56,7 @@ describe('<Month />', () => {
         <Month
           month={0}
           year={2018}
-          weekStartsOn={Weekdays.Monday}
+          weekStartsOn={1}
           allowRange
           hoverDate={hoverDate}
           selected={{

--- a/src/components/DatePicker/components/Weekday/Weekday.tsx
+++ b/src/components/DatePicker/components/Weekday/Weekday.tsx
@@ -1,11 +1,11 @@
 import React, {memo} from 'react';
-import {Weekdays} from '@shopify/javascript-utilities/dates';
 
 import {classNames} from '../../../../utilities/css';
+import {Weekday as WeekdayEnum} from '../../../../utilities/dates';
 import styles from '../../DatePicker.scss';
 
 export interface WeekdayProps {
-  label: Weekdays;
+  label: WeekdayEnum;
   title: string;
   current: boolean;
 }
@@ -21,7 +21,7 @@ export const Weekday = memo(function Weekday({
   );
 
   return (
-    <div aria-label={Weekdays[label]} className={className}>
+    <div aria-label={WeekdayEnum[label]} className={className}>
       {title}
     </div>
   );

--- a/src/components/DatePicker/components/Weekday/tests/Weekday.test.tsx
+++ b/src/components/DatePicker/components/Weekday/tests/Weekday.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Weekdays} from '@shopify/javascript-utilities/dates';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 
@@ -9,7 +8,7 @@ describe('<Weekday />', () => {
   const mockProps = {
     title: 'Su',
     current: false,
-    label: Weekdays.Sunday,
+    label: 0,
   };
 
   it('uses the title as content', () => {

--- a/src/components/DatePicker/tests/DatePicker.test.tsx
+++ b/src/components/DatePicker/tests/DatePicker.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Weekdays} from '@shopify/javascript-utilities/dates';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
@@ -28,7 +27,7 @@ describe('<DatePicker />', () => {
   describe('when weekStartsOn is passed', () => {
     it('renders Monday as first day of the week', () => {
       const datePicker = mountWithAppProvider(
-        <DatePicker month={0} year={2018} weekStartsOn={Weekdays.Monday} />,
+        <DatePicker month={0} year={2018} weekStartsOn={1} />,
       );
 
       const weekday = datePicker.find(Weekday);
@@ -37,7 +36,7 @@ describe('<DatePicker />', () => {
 
     it('renders Saturday as first day of the week', () => {
       const datePicker = mountWithAppProvider(
-        <DatePicker month={0} year={2018} weekStartsOn={Weekdays.Saturday} />,
+        <DatePicker month={0} year={2018} weekStartsOn={6} />,
       );
 
       const weekday = datePicker.find(Weekday);
@@ -94,7 +93,7 @@ describe('<DatePicker />', () => {
           month={month}
           year={year}
           onChange={spy}
-          weekStartsOn={Weekdays.Sunday}
+          weekStartsOn={0}
         />,
       );
       const day = datePicker.find(Day);

--- a/src/components/DatePicker/utilities.tsx
+++ b/src/components/DatePicker/utilities.tsx
@@ -1,6 +1,6 @@
-import type {Months, Weekdays} from '@shopify/javascript-utilities/dates';
+import type {Month, Weekday} from '../../utilities/dates';
 
-export function monthName(month: Months) {
+export function monthName(month: Month) {
   switch (month) {
     case 0:
       return 'january';
@@ -29,7 +29,7 @@ export function monthName(month: Months) {
   }
 }
 
-export function weekdayName(weekday: Weekdays) {
+export function weekdayName(weekday: Weekday) {
   switch (weekday) {
     case 0:
       return 'sunday';

--- a/src/utilities/dates.ts
+++ b/src/utilities/dates.ts
@@ -1,0 +1,186 @@
+export enum Weekday {
+  Sunday = 0,
+  Monday = 1,
+  Tuesday = 2,
+  Wednesday = 3,
+  Thursday = 4,
+  Friday = 5,
+  Saturday = 6,
+}
+
+export enum Month {
+  January = 0,
+  February = 1,
+  March = 2,
+  April = 3,
+  May = 4,
+  June = 5,
+  July = 6,
+  August = 7,
+  September = 8,
+  October = 9,
+  November = 10,
+  December = 11,
+}
+
+export interface Range {
+  start: Date;
+  end: Date;
+}
+
+export type Year = number;
+
+export type Week = (Date | null)[];
+
+const WEEK_LENGTH = 7;
+
+export function getWeeksForMonth(
+  month: Month,
+  year: Year,
+  weekStartsOn: Weekday = Weekday.Sunday,
+): Week[] {
+  const firstOfMonth = new Date(year, month, 1);
+  const firstDayOfWeek = firstOfMonth.getDay();
+  const weeks: Week[] = [[]];
+
+  let currentWeek = weeks[0];
+  let currentDate = firstOfMonth;
+
+  const orderedWeekday = getOrderedWeekdays(weekStartsOn);
+  for (let i = 0; i < orderedWeekday.indexOf(firstDayOfWeek); i++) {
+    currentWeek.push(null);
+  }
+
+  while (currentDate.getMonth() === month) {
+    if (currentWeek.length === WEEK_LENGTH) {
+      currentWeek = [];
+      weeks.push(currentWeek);
+    }
+
+    currentWeek.push(currentDate);
+    currentDate = new Date(year, month, currentDate.getDate() + 1);
+  }
+
+  while (currentWeek.length < 7) {
+    currentWeek.push(null);
+  }
+
+  return weeks;
+}
+
+export function dateIsInRange(day: Date | null, range: Range) {
+  if (day == null) {
+    return false;
+  }
+
+  const {start, end} = range;
+
+  return Boolean(start && day > start && end && day < end);
+}
+
+export function dateIsSelected(day: Date | null, range: Range) {
+  if (day == null) {
+    return false;
+  }
+  const {start, end} = range;
+
+  return Boolean(
+    (start && isSameDay(start, day)) || (end && isSameDay(end, day)),
+  );
+}
+
+export function isSameDay(day1: Date, day2: Date) {
+  return (
+    day1.getDate() === day2.getDate() &&
+    day1.getMonth() === day2.getMonth() &&
+    day1.getFullYear() === day2.getFullYear()
+  );
+}
+
+export function getNewRange(range: Range | undefined, selected: Date): Range {
+  if (range == null) {
+    return {start: selected, end: selected};
+  }
+
+  const {start, end} = range;
+
+  if (end && (isDateAfter(start, end) || isDateBefore(start, end))) {
+    return {start: selected, end: selected};
+  }
+
+  if (start) {
+    if (isDateBefore(selected, start)) {
+      return {start: selected, end: selected};
+    }
+    return {start, end: selected};
+  }
+
+  if (end) {
+    if (isDateBefore(selected, end)) {
+      return {start: selected, end};
+    }
+    return {start: start || end, end: selected};
+  }
+
+  return {start: selected, end: selected};
+}
+
+export function getNextDisplayMonth(month: Month): Month {
+  if (Month[month] === Month[11]) {
+    return 0;
+  }
+  return (month as number) + 1;
+}
+
+export function getNextDisplayYear(month: Month, year: Year): Year {
+  if (Month[month] === Month[11]) {
+    return year + 1;
+  }
+  return year;
+}
+
+export function getPreviousDisplayMonth(month: Month): Month {
+  if (Month[month] === Month[0]) {
+    return 11;
+  }
+  return (month as number) - 1;
+}
+
+export function getPreviousDisplayYear(month: Month, year: Year): Year {
+  if (Month[month] === Month[0]) {
+    return year - 1;
+  }
+  return year;
+}
+
+export function isDateAfter(date: Date, dateToCompare: Date) {
+  return date.getTime() > dateToCompare.getTime();
+}
+
+export function isDateBefore(date: Date, dateToCompare: Date) {
+  return date.getTime() < dateToCompare.getTime();
+}
+
+export function isSameDate(source: Date, target: Date) {
+  return (
+    source.getFullYear() === target.getFullYear() &&
+    source.getMonth() === target.getMonth() &&
+    source.getDate() === target.getDate()
+  );
+}
+
+const WEEKDAYS = [
+  Weekday.Sunday,
+  Weekday.Monday,
+  Weekday.Tuesday,
+  Weekday.Wednesday,
+  Weekday.Thursday,
+  Weekday.Friday,
+  Weekday.Saturday,
+];
+
+export function getOrderedWeekdays(weekStartsOn: Weekday): Weekday[] {
+  const weekDays = [...WEEKDAYS];
+  const restOfDays = weekDays.splice(weekStartsOn);
+  return [...restOfDays, ...weekDays];
+}

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -76,7 +76,6 @@ export function focusNextFocusableNode(node: HTMLElement, filter?: Filter) {
   return false;
 }
 
-// https://github.com/Shopify/javascript-utilities/blob/1e705564643d6fe7ffea5ebfbbf3e6b759a66c9b/src/focus.ts
 export function findFirstKeyboardFocusableNode(
   element: HTMLElement,
   onlyDescendants = true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1858,7 +1858,7 @@
   resolved "https://registry.yarnpkg.com/@shopify/integrity-sha-utils/-/integrity-sha-utils-1.0.5.tgz#26e32b104950aad49f9531378684782aaec8dc58"
   integrity sha512-w10TkoJgCVTIiLbkCuzb5259PWXpvIwBJAifr4mc6aHEXeJLE+yZ3dW/5wTV7OuMMn/Xa1AsBo3nmgLQVe3ZIQ==
 
-"@shopify/javascript-utilities@^2.1.0", "@shopify/javascript-utilities@^2.4.0", "@shopify/javascript-utilities@^2.4.1":
+"@shopify/javascript-utilities@^2.1.0", "@shopify/javascript-utilities@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@shopify/javascript-utilities/-/javascript-utilities-2.4.1.tgz#99e1994381fc33a2609f7792b6812feee32362fa"
   integrity sha512-CDp4nWHjVXTr+rYV5RMBs8aJ5PbXUdbz47jnKisBWa9GFwJktZFj2PxefXqfLd51KpIuQpFnA/NMvq4M5tdTlw==


### PR DESCRIPTION
### WHY are these changes introduced?

Removes dependency on deprecated package

### WHAT is this pull request doing?

Date functions have been moved into utilities/dates, though they are
only used within the DatePicker component.

This goes to highlight the terrible ergonomics of the Weekday/Month enums. People already use DatePicker by passing in numbers to `month` and `weekStartsOn` number,  which is what our example does e.g. `<DatePicker year={2019} month={0} weekStartsOn={0} />` instead of an enum value e.g. `<DatePicker year={2019} month={Months.January} weekStartsOn={Weekdays.Sunday} />` (note that they would have had to import `Weekdays` from the javascript-utilities package as we never exposed it). Because of that I'm highly tempted to convert these enums into just `number` to avoid needing to export additional enums that are just nice-to-haves (I tried using a union type `0|1|2|3...` but that means consumers have do do annoying casting which doesn't feel worth it - they never had to befor and didn't have problems).

General rule - no enums in props - use union types instead (note that this the case for most other places e.g. Button size, DatePicker and PopoverCloseSource are the two exceptions.

### How to 🎩

 Check functionality of DatePicker