### PR TITLE
[Empty State] Remove centered layout prop and add new design language class

### DIFF
--- a/UNRELEASED-v5.md
+++ b/UNRELEASED-v5.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Dropped support for iOS 9 ([#2195](https://github.com/Shopify/polaris-react/pull/2195))
 - Moved styles from `global.scss` to `AppProvider`. This change only affects applications using the `esnext` build (applications importing `@shopify/polaris/styles.css` aren’t affected), who no longer need to import the `@shopify/polaris/esnext/global.scss` file. An empty `global.scss` was kept in, to ensure applications using sewing-kit \<v0.113.0 still build ([#2392](https://github.com/Shopify/polaris-react/pull/2392))
 - Reversed the precedence of the language dictionaries passed into the `AppProvider`’s `i18n` prop. When passing an array of dictionaries the first dictionary should be your prefered language, followed by any fallback languages. ([#2572](https://github.com/Shopify/polaris-react/pull/2572))
+- Removed `centeredLayout` prop in `EmptyState`. All layouts within the new design language context will be center aligned ([#3111](https://github.com/Shopify/polaris-react/pull/3111))
 
 ### Enhancements
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -32,5 +32,3 @@
 - Migrated tests using document.activeElement to use react-testing ([#3070](https://github.com/Shopify/polaris-react/pull/3070))
 
 ### Deprecations
-
-- Removed `centeredLayout` prop in `EmptyState`. All layouts within the new design language context will be center aligned ([#3111](https://github.com/Shopify/polaris-react/pull/3111))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -32,3 +32,5 @@
 - Migrated tests using document.activeElement to use react-testing ([#3070](https://github.com/Shopify/polaris-react/pull/3070))
 
 ### Deprecations
+
+- Removed `centeredLayout` prop in `EmptyState`. All layouts within the new design language context will be center aligned [#]()

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -33,4 +33,4 @@
 
 ### Deprecations
 
-- Removed `centeredLayout` prop in `EmptyState`. All layouts within the new design language context will be center aligned [#]()
+- Removed `centeredLayout` prop in `EmptyState`. All layouts within the new design language context will be center aligned ([#3111](https://github.com/Shopify/polaris-react/pull/3111))

--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -64,6 +64,7 @@ $centered-illustration-width: rem(226px);
   }
 }
 
+.newDesignLanguage,
 .withinContentContainer {
   margin: 0 auto;
   padding-top: spacing(loose);
@@ -137,31 +138,6 @@ $centered-illustration-width: rem(226px);
       position: initial;
       width: 100%;
     }
-  }
-}
-
-.centeredLayout {
-  .Section {
-    left: 0;
-    flex-direction: column-reverse;
-    justify-content: center;
-    align-items: center;
-  }
-
-  .ImageContainer,
-  .DetailsContainer {
-    flex: 0;
-  }
-
-  .Image {
-    margin: unset;
-    width: $centered-illustration-width;
-    max-width: 100%;
-  }
-
-  .Details {
-    text-align: center;
-    width: 100%;
   }
 }
 

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -26,8 +26,6 @@ export interface EmptyStateProps {
   imageContained?: boolean;
   /** Whether or not the content should span the full width of its container  */
   fullWidth?: boolean;
-  /** Whether or not the layout is stacked and centered vs justified apart */
-  centeredLayout?: boolean;
   /** Elements to display inside empty state */
   children?: React.ReactNode;
   /** Primary action for empty state */
@@ -44,7 +42,6 @@ export function EmptyState({
   image,
   largeImage,
   imageContained,
-  centeredLayout = false,
   fullWidth = false,
   action,
   secondaryAction,
@@ -52,11 +49,10 @@ export function EmptyState({
 }: EmptyStateProps) {
   const withinContentContainer = useContext(WithinContentContext);
   const {newDesignLanguage = false} = useFeatures();
-  const newLayout = centeredLayout || newDesignLanguage;
   const className = classNames(
     styles.EmptyState,
     fullWidth && styles.fullWidth,
-    newLayout && styles.centeredLayout,
+    newDesignLanguage && styles.newDesignLanguage,
     imageContained && styles.imageContained,
     withinContentContainer ? styles.withinContentContainer : styles.withinPage,
   );
@@ -78,7 +74,7 @@ export function EmptyState({
   );
 
   const secondaryActionMarkup = secondaryAction
-    ? buttonFrom(secondaryAction, newLayout ? {} : {plain: true})
+    ? buttonFrom(secondaryAction, newDesignLanguage ? {} : {plain: true})
     : null;
 
   const footerContentMarkup = footerContent ? (
@@ -89,7 +85,7 @@ export function EmptyState({
 
   const headingSize = withinContentContainer ? 'small' : 'medium';
   const primaryActionSize =
-    withinContentContainer || newLayout ? 'medium' : 'large';
+    withinContentContainer || newDesignLanguage ? 'medium' : 'large';
 
   const primaryActionMarkup = action
     ? buttonFrom(action, {primary: true, size: primaryActionSize})
@@ -105,7 +101,7 @@ export function EmptyState({
 
   const textContentMarkup =
     headingMarkup || children ? (
-      <TextContainer spacing={newLayout ? 'tight' : undefined}>
+      <TextContainer>
         {headingMarkup}
         {childrenMarkup}
       </TextContainer>
@@ -116,8 +112,8 @@ export function EmptyState({
       <div className={styles.Actions}>
         <Stack
           alignment="center"
-          distribution={newLayout ? 'center' : undefined}
-          spacing={newLayout ? 'tight' : undefined}
+          distribution={newDesignLanguage ? 'center' : undefined}
+          spacing={newDesignLanguage ? 'tight' : undefined}
         >
           {primaryActionMarkup}
           {secondaryActionMarkup}

--- a/src/components/EmptyState/README.md
+++ b/src/components/EmptyState/README.md
@@ -221,25 +221,6 @@ Use to provide additional but non-critical context for a new product or feature.
 </Card>
 ```
 
-### Empty state with centered layout
-
-<!-- example-for: web -->
-
-Stacked image over centered content and actions
-
-```jsx
-<EmptyState
-  centeredLayout
-  heading="Upload a file to get started"
-  action={{content: 'Upload files'}}
-  image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
->
-  <p>
-    You can use the Files section to upload images, videos, and other documents
-  </p>
-</EmptyState>
-```
-
 ### Empty state with full width layout in a content context
 
 <!-- example-for: web -->

--- a/src/components/EmptyState/tests/EmptyState.test.tsx
+++ b/src/components/EmptyState/tests/EmptyState.test.tsx
@@ -177,26 +177,26 @@ describe('<EmptyState />', () => {
     });
   });
 
-  describe('centeredLayout', () => {
+  describe('newDesignLanguage', () => {
     it('adds a classname to the root component', () => {
-      const emptyState = mountWithApp(
-        <EmptyState centeredLayout image={imgSrc} />,
-      );
+      const emptyState = mountWithApp(<EmptyState image={imgSrc} />, {
+        features: {newDesignLanguage: true},
+      });
       expect(emptyState).toContainReactComponent('div', {
-        className: 'EmptyState centeredLayout withinPage',
+        className: 'EmptyState newDesignLanguage withinPage',
       });
     });
 
     it('does not render a plain link as a secondaryAction', () => {
       const emptyState = mountWithApp(
         <EmptyState
-          centeredLayout
           image={imgSrc}
           secondaryAction={{
             content: 'Learn more',
             url: 'https://help.shopify.com',
           }}
         />,
+        {features: {newDesignLanguage: true}},
       );
 
       expect(emptyState).toContainReactComponent(UnstyledLink, {
@@ -206,11 +206,8 @@ describe('<EmptyState />', () => {
 
     it('renders a medium size primary button', () => {
       const emptyState = mountWithApp(
-        <EmptyState
-          centeredLayout
-          image={imgSrc}
-          action={{content: 'Add transfer'}}
-        />,
+        <EmptyState image={imgSrc} action={{content: 'Add transfer'}} />,
+        {features: {newDesignLanguage: true}},
       );
 
       expect(emptyState).toContainReactComponent(Button, {
@@ -219,41 +216,15 @@ describe('<EmptyState />', () => {
       });
     });
 
-    it('changes the spacing to "tight" on TextContainer', () => {
-      const emptyState = mountWithApp(
-        <EmptyState centeredLayout image={imgSrc}>
-          Children
-        </EmptyState>,
-      );
-
-      expect(emptyState).toContainReactComponent(TextContainer, {
-        spacing: 'tight',
-      });
-    });
-
     it('adds center distribution and tight spacing to Stack', () => {
       const emptyState = mountWithApp(
-        <EmptyState
-          centeredLayout
-          image={imgSrc}
-          action={{content: 'Add transfer'}}
-        />,
+        <EmptyState image={imgSrc} action={{content: 'Add transfer'}} />,
+        {features: {newDesignLanguage: true}},
       );
 
       expect(emptyState).toContainReactComponent(Stack, {
         spacing: 'tight',
         distribution: 'center',
-      });
-    });
-  });
-
-  describe('newDesignLanguage', () => {
-    it('adds a centeredLayout classname to the root component', () => {
-      const emptyState = mountWithApp(<EmptyState image={imgSrc} />, {
-        features: {newDesignLanguage: true},
-      });
-      expect(emptyState).toContainReactComponent('div', {
-        className: 'EmptyState centeredLayout withinPage',
       });
     });
   });


### PR DESCRIPTION
### WHY are these changes introduced?

⚠️ This PR targets the v5 branch since it includes a breaking change

The `centeredLayout` prop was added before empty states were included in a card context so it's no longer necessary. This removes that prop, its styles, and adds a `newDesignLanguage` class that piggy backs on the `withinContentContainer` styles

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

http://localhost:6006/iframe.html?id=all-components-empty-state--all-examples&contexts=New%20Design%20Language=Enabled%20-%20Light%20Mode

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
