### PR TITLE
[TextField] Multiline change example to use number instead of boolean

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@
 
 ### Documentation
 
+- Updated TextField example to use a number instead of a boolean [#3114](https://github.com/Shopify/polaris-react/pull/3114)
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -284,7 +284,7 @@ function MultilineFieldExample() {
       label="Shipping address"
       value={value}
       onChange={handleChange}
-      multiline
+      multiline={4}
     />
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The multiline example shows new lines being created by `\n` when the multiline prop takes a number. The number example is much more useful as people may want an empty text field to show the user it is multiple lines.

### WHAT is this pull request doing?

Change the textfield multiline example to use a number.
