### PR TITLE
[v5] Date picker type juggling, take 2

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,14 +15,16 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Reversed the precedence of the language dictionaries passed into the `AppProvider`’s `i18n` prop. When passing an array of dictionaries the first dictionary should be your prefered language, followed by any fallback languages. ([#2572](https://github.com/Shopify/polaris-react/pull/2572))
 - Removed `centeredLayout` prop in `EmptyState`. All layouts within the new design language context will be center aligned ([#3111](https://github.com/Shopify/polaris-react/pull/3111))
 - Updated types of `DatePicker` component - `month`,`year` `weekStartsOn` are now typed as plain `number` - functionality remains identical as the former types effectivly ended up being aliases of `number` anyway ([#3113](https://github.com/Shopify/polaris-react/pull/3113))
-- Removed `Year` type export (used by the DatePicker's props). Replace its usage with `number`. ([#3113](https://github.com/Shopify/polaris-react/pull/3113))
-- Removed the `Month` enum export (used by the DatePicker's props). Replace its usage with a number from 0 to 11, representing the number of the month in question - `Month.January` becomes `0`, `Month.December` becomes `11` etc. ([#3113](https://github.com/Shopify/polaris-react/pull/3113))
+- Removed `Year` type export (used by the DatePicker's props). Replace its usage with `number`. ([#3121](https://github.com/Shopify/polaris-react/pull/3121))
+- Removed the `Month` enum export (used by the DatePicker's props). Replace its usage with a number from 0 to 11, representing the number of the month in question - `Month.January` becomes `0`, `Month.December` becomes `11` etc. ([#3121](https://github.com/Shopify/polaris-react/pull/3121))
 
 ### Enhancements
 
 - Added an activator prop to `Modal` so that focus can be returned to it when the `Modal` is closed ([#2206](https://github.com/Shopify/polaris-react/pull/2206))
 
 ### Bug fixes
+
+- Fixed case where `DatePicker` did not translate the month name in an aria label ([#3121](https://github.com/Shopify/polaris-react/pull/3121))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,9 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Moved styles from `global.scss` to `AppProvider`. This change only affects applications using the `esnext` build (applications importing `@shopify/polaris/styles.css` aren’t affected), who no longer need to import the `@shopify/polaris/esnext/global.scss` file. An empty `global.scss` was kept in, to ensure applications using sewing-kit \<v0.113.0 still build ([#2392](https://github.com/Shopify/polaris-react/pull/2392))
 - Reversed the precedence of the language dictionaries passed into the `AppProvider`’s `i18n` prop. When passing an array of dictionaries the first dictionary should be your prefered language, followed by any fallback languages. ([#2572](https://github.com/Shopify/polaris-react/pull/2572))
 - Removed `centeredLayout` prop in `EmptyState`. All layouts within the new design language context will be center aligned ([#3111](https://github.com/Shopify/polaris-react/pull/3111))
+- Updated types of `DatePicker` component - `month`,`year` `weekStartsOn` are now typed as plain `number` - functionality remains identical as the former types effectivly ended up being aliases of `number` anyway ([#3113](https://github.com/Shopify/polaris-react/pull/3113))
+- Removed `Year` type export (used by the DatePicker's props). Replace its usage with `number`. ([#3113](https://github.com/Shopify/polaris-react/pull/3113))
+- Removed the `Month` enum export (used by the DatePicker's props). Replace its usage with a number from 0 to 11, representing the number of the month in question - `Month.January` becomes `0`, `Month.December` becomes `11` etc. ([#3113](https://github.com/Shopify/polaris-react/pull/3113))
 
 ### Enhancements
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -64,15 +64,6 @@
         "november": "November",
         "december": "December"
       },
-      "days": {
-        "monday": "Monday",
-        "tuesday": "Tuesday",
-        "wednesday": "Wednesday",
-        "thursday": "Thursday",
-        "friday": "Friday",
-        "saturday": "Saturday",
-        "sunday": "Sunday"
-      },
       "daysAbbreviated": {
         "monday": "Mo",
         "tuesday": "Tu",

--- a/locales/en.json
+++ b/locales/en.json
@@ -64,6 +64,15 @@
         "november": "November",
         "december": "December"
       },
+      "days": {
+        "monday": "Monday",
+        "tuesday": "Tuesday",
+        "wednesday": "Wednesday",
+        "thursday": "Thursday",
+        "friday": "Friday",
+        "saturday": "Saturday",
+        "sunday": "Sunday"
+      },
       "daysAbbreviated": {
         "monday": "Mo",
         "tuesday": "Tu",

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -38,7 +38,8 @@ export interface DatePickerProps {
   disableDatesAfter?: Date;
   /** The selection can span multiple months */
   multiMonth?: boolean;
-  /** First day of week, from 0 to 6. 0 is Sunday, 1 is Monday ... 6 is Saturday
+  /**
+   * First day of week, from 0 to 6. 0 is Sunday, 1 is Monday ... 6 is Saturday
    * @default 0
    */
   weekStartsOn?: number;

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -4,8 +4,6 @@ import {ArrowLeftMinor, ArrowRightMinor} from '@shopify/polaris-icons';
 import {Button} from '../Button';
 import {classNames} from '../../utilities/css';
 import {
-  Month as Months,
-  Weekday,
   isDateAfter,
   isDateBefore,
   getNextDisplayYear,
@@ -13,7 +11,7 @@ import {
   getPreviousDisplayYear,
   getPreviousDisplayMonth,
 } from '../../utilities/dates';
-import type {Range, Year} from '../../utilities/dates';
+import type {Range} from '../../utilities/dates';
 import {useI18n} from '../../utilities/i18n';
 import {useFeatures} from '../../utilities/features';
 
@@ -21,19 +19,17 @@ import {monthName} from './utilities';
 import {Month} from './components';
 import styles from './DatePicker.scss';
 
-// Export as Months for public facing backwards compat
-export {Months};
-export type {Range, Year};
+export type {Range};
 
 export interface DatePickerProps {
   /** ID for the element */
   id?: string;
   /** The selected date or range of dates */
   selected?: Date | Range;
-  /** The month to show */
-  month: Months;
+  /** The month to show, from 0 to 11. 0 is January, 1 is February ... 11 is December */
+  month: number;
   /** The year to show */
-  year: Year;
+  year: number;
   /** Allow a range of dates to be selected */
   allowRange?: boolean;
   /** Disable selecting dates before this. */
@@ -42,12 +38,14 @@ export interface DatePickerProps {
   disableDatesAfter?: Date;
   /** The selection can span multiple months */
   multiMonth?: boolean;
-  /** First day of week. Sunday by default */
-  weekStartsOn?: Weekday;
+  /** First day of week, from 0 to 6. 0 is Sunday, 1 is Monday ... 6 is Saturday
+   * @default 0
+   */
+  weekStartsOn?: number;
   /** Callback when date is selected. */
   onChange?(date: Range): void;
   /** Callback when month is changed. */
-  onMonthChange?(month: Months, year: Year): void;
+  onMonthChange?(month: number, year: number): void;
 }
 
 export function DatePicker({
@@ -59,7 +57,7 @@ export function DatePicker({
   multiMonth,
   disableDatesBefore,
   disableDatesAfter,
-  weekStartsOn = Weekday.Sunday,
+  weekStartsOn = 0,
   onMonthChange,
   onChange = noop,
 }: DatePickerProps) {
@@ -99,7 +97,7 @@ export function DatePicker({
   );
 
   const handleMonthChangeClick = useCallback(
-    (month: Months, year: Year) => {
+    (month: number, year: number) => {
       if (!onMonthChange) {
         return;
       }

--- a/src/components/DatePicker/components/Day/Day.tsx
+++ b/src/components/DatePicker/components/Day/Day.tsx
@@ -1,8 +1,9 @@
 import React, {useRef, useEffect, memo} from 'react';
 
 import {classNames} from '../../../../utilities/css';
-import {Month, isSameDay} from '../../../../utilities/dates';
+import {isSameDay} from '../../../../utilities/dates';
 import {useI18n} from '../../../../utilities/i18n';
+import {monthName} from '../../utilities';
 import styles from '../../DatePicker.scss';
 
 export interface DayProps {
@@ -74,7 +75,9 @@ export const Day = memo(function Day({
     (focused || selected || today || date === 1) && !disabled ? 0 : -1;
   const ariaLabel = [
     `${today ? i18n.translate('Polaris.DatePicker.today') : ''}`,
-    `${Month[day.getMonth()]} `,
+    `${i18n.translate(
+      `Polaris.DatePicker.months.${monthName(day.getMonth())}`,
+    )} `,
     `${date} `,
     `${day.getFullYear()}`,
   ].join('');

--- a/src/components/DatePicker/components/Month/Month.tsx
+++ b/src/components/DatePicker/components/Month/Month.tsx
@@ -68,7 +68,7 @@ export function Month({
       title={i18n.translate(
         `Polaris.DatePicker.daysAbbreviated.${weekdayName(weekday)}`,
       )}
-      label={i18n.translate(`Polaris.DatePicker.days.${weekdayName(weekday)}`)}
+      label={WeekdayEnum[weekday]}
       current={current && new Date().getDay() === weekday}
     />
   ));
@@ -182,4 +182,16 @@ function isDateStart(day: Date | null, range: Range) {
   const {start} = range;
 
   return Boolean(start && isSameDay(start, day));
+}
+
+// This is a hack based on previous behaviour as time constraints means we can't
+// wait for translations. This should be converted to use translation keys.
+enum WeekdayEnum {
+  Sunday = 0,
+  Monday = 1,
+  Tuesday = 2,
+  Wednesday = 3,
+  Thursday = 4,
+  Friday = 5,
+  Saturday = 6,
 }

--- a/src/components/DatePicker/components/Month/Month.tsx
+++ b/src/components/DatePicker/components/Month/Month.tsx
@@ -2,8 +2,6 @@ import React, {useCallback, useMemo} from 'react';
 
 import {classNames} from '../../../../utilities/css';
 import {
-  Weekday as WeekdayEnum,
-  Month as MonthEnum,
   isDateBefore,
   isDateAfter,
   isSameDay,
@@ -14,7 +12,7 @@ import {
   getNewRange,
   getOrderedWeekdays,
 } from '../../../../utilities/dates';
-import type {Range, Year} from '../../../../utilities/dates';
+import type {Range} from '../../../../utilities/dates';
 import {useI18n} from '../../../../utilities/i18n';
 import styles from '../../DatePicker.scss';
 import {Day} from '../Day';
@@ -25,12 +23,12 @@ export interface MonthProps {
   focusedDate?: Date;
   selected?: Range;
   hoverDate?: Date;
-  month: MonthEnum;
-  year: Year;
+  month: number;
+  year: number;
   disableDatesBefore?: Date;
   disableDatesAfter?: Date;
   allowRange?: boolean;
-  weekStartsOn: WeekdayEnum;
+  weekStartsOn: number;
   onChange?(date: Range): void;
   onHover?(hoverEnd: Date): void;
   onFocus?(date: Date): void;
@@ -70,8 +68,8 @@ export function Month({
       title={i18n.translate(
         `Polaris.DatePicker.daysAbbreviated.${weekdayName(weekday)}`,
       )}
+      label={i18n.translate(`Polaris.DatePicker.days.${weekdayName(weekday)}`)}
       current={current && new Date().getDay() === weekday}
-      label={weekday}
     />
   ));
 

--- a/src/components/DatePicker/components/Month/tests/Month.test.tsx
+++ b/src/components/DatePicker/components/Month/tests/Month.test.tsx
@@ -8,20 +8,12 @@ import {Month} from '../Month';
 
 describe('<Month />', () => {
   describe('title', () => {
-    it('passes the abbreviated value to the title prop of Weekday', () => {
+    it('passes the label and abbreviated value to Weekday', () => {
       const month = mountWithAppProvider(
         <Month month={0} year={2018} weekStartsOn={1} />,
       );
       expect(month.find(Weekday).first().prop('title')).toBe('Mo');
-    });
-  });
-
-  describe('label', () => {
-    it('passes the numeric value to the label prop of Weekday', () => {
-      const month = mountWithAppProvider(
-        <Month month={0} year={2018} weekStartsOn={1} />,
-      );
-      expect(month.find(Weekday).first().prop('label')).toBe(1);
+      expect(month.find(Weekday).first().prop('label')).toBe('Monday');
     });
   });
 

--- a/src/components/DatePicker/components/Weekday/Weekday.tsx
+++ b/src/components/DatePicker/components/Weekday/Weekday.tsx
@@ -1,11 +1,10 @@
 import React, {memo} from 'react';
 
 import {classNames} from '../../../../utilities/css';
-import {Weekday as WeekdayEnum} from '../../../../utilities/dates';
 import styles from '../../DatePicker.scss';
 
 export interface WeekdayProps {
-  label: WeekdayEnum;
+  label: string;
   title: string;
   current: boolean;
 }
@@ -21,7 +20,7 @@ export const Weekday = memo(function Weekday({
   );
 
   return (
-    <div aria-label={WeekdayEnum[label]} className={className}>
+    <div aria-label={label} className={className}>
       {title}
     </div>
   );

--- a/src/components/DatePicker/components/Weekday/tests/Weekday.test.tsx
+++ b/src/components/DatePicker/components/Weekday/tests/Weekday.test.tsx
@@ -5,19 +5,11 @@ import {mountWithAppProvider} from 'test-utilities/legacy';
 import {Weekday} from '../Weekday';
 
 describe('<Weekday />', () => {
-  const mockProps = {
-    title: 'Su',
-    current: false,
-    label: 0,
-  };
-
-  it('uses the title as content', () => {
-    const weekday = mountWithAppProvider(<Weekday {...mockProps} title="Su" />);
+  it('sets the text and label', () => {
+    const weekday = mountWithAppProvider(
+      <Weekday title="Su" current={false} label="Sunday" />,
+    );
     expect(weekday.text()).toBe('Su');
-  });
-
-  it('uses the label to create the aria-label', () => {
-    const weekday = mountWithAppProvider(<Weekday {...mockProps} />);
     expect(weekday.find('div').prop('aria-label')).toBe('Sunday');
   });
 });

--- a/src/components/DatePicker/utilities.tsx
+++ b/src/components/DatePicker/utilities.tsx
@@ -1,6 +1,4 @@
-import type {Month, Weekday} from '../../utilities/dates';
-
-export function monthName(month: Month) {
+export function monthName(month: number) {
   switch (month) {
     case 0:
       return 'january';
@@ -29,7 +27,7 @@ export function monthName(month: Month) {
   }
 }
 
-export function weekdayName(weekday: Weekday) {
+export function weekdayName(weekday: number) {
   switch (weekday) {
     case 0:
       return 'sunday';

--- a/src/components/ResourceList/components/FilterControl/components/DateSelector/DateSelector.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/DateSelector/DateSelector.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useCallback, useRef, memo} from 'react';
 import {CalendarMinor} from '@shopify/polaris-icons';
 
-import {DatePicker, Months, Year, Range} from '../../../../../DatePicker';
+import {DatePicker, Range} from '../../../../../DatePicker';
 import {Select} from '../../../../../Select';
 import {TextField} from '../../../../../TextField';
 import {Icon} from '../../../../../Icon';
@@ -171,7 +171,7 @@ export const DateSelector = memo(function DateSelector({
   );
 
   const handleDatePickerMonthChange = useCallback(
-    (month: Months, year: Year) => {
+    (month: number, year: number) => {
       setDatePickerMonth(month);
       setDatePickerYear(year);
     },

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -74,8 +74,8 @@ export type {
   ColumnContentType,
 } from './DataTable';
 
-export {DatePicker, Months} from './DatePicker';
-export type {DatePickerProps, Range, Year} from './DatePicker';
+export {DatePicker} from './DatePicker';
+export type {DatePickerProps, Range} from './DatePicker';
 
 export {DescriptionList} from './DescriptionList';
 export type {DescriptionListProps} from './DescriptionList';

--- a/src/utilities/dates.ts
+++ b/src/utilities/dates.ts
@@ -1,43 +1,16 @@
-export enum Weekday {
-  Sunday = 0,
-  Monday = 1,
-  Tuesday = 2,
-  Wednesday = 3,
-  Thursday = 4,
-  Friday = 5,
-  Saturday = 6,
-}
-
-export enum Month {
-  January = 0,
-  February = 1,
-  March = 2,
-  April = 3,
-  May = 4,
-  June = 5,
-  July = 6,
-  August = 7,
-  September = 8,
-  October = 9,
-  November = 10,
-  December = 11,
-}
-
 export interface Range {
   start: Date;
   end: Date;
 }
-
-export type Year = number;
 
 export type Week = (Date | null)[];
 
 const WEEK_LENGTH = 7;
 
 export function getWeeksForMonth(
-  month: Month,
-  year: Year,
-  weekStartsOn: Weekday = Weekday.Sunday,
+  month: number,
+  year: number,
+  weekStartsOn = 0,
 ): Week[] {
   const firstOfMonth = new Date(year, month, 1);
   const firstDayOfWeek = firstOfMonth.getDay();
@@ -125,29 +98,29 @@ export function getNewRange(range: Range | undefined, selected: Date): Range {
   return {start: selected, end: selected};
 }
 
-export function getNextDisplayMonth(month: Month): Month {
-  if (Month[month] === Month[11]) {
+export function getNextDisplayMonth(month: number): number {
+  if (month === 11) {
     return 0;
   }
-  return (month as number) + 1;
+  return month + 1;
 }
 
-export function getNextDisplayYear(month: Month, year: Year): Year {
-  if (Month[month] === Month[11]) {
+export function getNextDisplayYear(month: number, year: number): number {
+  if (month === 11) {
     return year + 1;
   }
   return year;
 }
 
-export function getPreviousDisplayMonth(month: Month): Month {
-  if (Month[month] === Month[0]) {
+export function getPreviousDisplayMonth(month: number): number {
+  if (month === 0) {
     return 11;
   }
-  return (month as number) - 1;
+  return month - 1;
 }
 
-export function getPreviousDisplayYear(month: Month, year: Year): Year {
-  if (Month[month] === Month[0]) {
+export function getPreviousDisplayYear(month: number, year: number): number {
+  if (month === 0) {
     return year - 1;
   }
   return year;
@@ -169,17 +142,9 @@ export function isSameDate(source: Date, target: Date) {
   );
 }
 
-const WEEKDAYS = [
-  Weekday.Sunday,
-  Weekday.Monday,
-  Weekday.Tuesday,
-  Weekday.Wednesday,
-  Weekday.Thursday,
-  Weekday.Friday,
-  Weekday.Saturday,
-];
+const WEEKDAYS: number[] = [0, 1, 2, 3, 4, 5, 6];
 
-export function getOrderedWeekdays(weekStartsOn: Weekday): Weekday[] {
+export function getOrderedWeekdays(weekStartsOn: number): number[] {
   const weekDays = [...WEEKDAYS];
   const restOfDays = weekDays.splice(weekStartsOn);
   return [...restOfDays, ...weekDays];


### PR DESCRIPTION
This PR is the same as #3113, except without requiring translations, as we're time constrained and want to test these breaking changes without waiting for the translations.

---

### WHY are these changes introduced?

Follow up to #3108, where I discovered that the API of DatePicker is clunky without adding much type safety, so we could strip it back a little.

### WHAT is this pull request doing?

Remove usage of enums and replace them with plain numbers as it results
in a smaller API surface area without having a negative affect on type
strictness.

- BREAKING: Removed export of `Year` type and `Months` enum
- DatePickerProps['month'] was an enum `Months` (representing the numbers
  0 to 11), it is now a plain `number` instead
- DatePickerProps['weekStartsOn'] was an enum `Weekdays` (representing
the numbers 0 to 6), it is now a plain `number` instead
- DatePickerProps['year'] was type `Year`, it is now `number`
  (Year was a type alias of number anyway)


Taking a look at web it seems like most people passed numbers into DatePicker instead of using the enums anyway so I'm looking at this as "removing a corner case that was rarely used" instead of a deep change of functionality.

This always worked and still does:

```jsx
import {DatePicker} from '@shopify/polaris';

<DatePicker year={2019} month={0} weekStartsOn={0} />
```

The following no longer works and will need to be changed to the above:

```jsx
import {Weekdays} from '@shopify/javascript-utilities';
import {DatePicker, Months} from '@shopify/polaris';

<DatePicker year={2019} month={Months.January} weekStartsOn={Weekdays.Sunday} />
```