### PR TITLE
Adding orangeDark as a color

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export type Color =
   | 'yellow'
   | 'yellowDark'
   | 'orange'
+  | 'orangeDark'
   | 'redLighter'
   | 'red'
   | 'redDark'


### PR DESCRIPTION
## WHY are these changes introduced?

As part of visually distinguishing various status messages to the user, we are introducing the use of the orangeDark color.

Relates to Shopify/marketing-integrations#914

### WHAT is this pull request doing?

See the (i) icon for a use of the orangeDark color.

<img width="366" alt="Screen Shot 2020-07-20 at 15 03 55" src="https://user-images.githubusercontent.com/1128934/87975920-433bfa80-ca9a-11ea-9e30-44ec05dfd7ea.png">

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
