### PR TITLE
Remove some enums and public types with no value

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Updated types of `DatePicker` component - `month`,`year` `weekStartsOn` are now typed as plain `number` - functionality remains identical as the former types effectivly ended up being aliases of `number` anyway ([#3113](https://github.com/Shopify/polaris-react/pull/3113))
 - Removed `Year` type export (used by the DatePicker's props). Replace its usage with `number`. ([#3121](https://github.com/Shopify/polaris-react/pull/3121))
 - Removed the `Month` enum export (used by the DatePicker's props). Replace its usage with a number from 0 to 11, representing the number of the month in question - `Month.January` becomes `0`, `Month.December` becomes `11` etc. ([#3121](https://github.com/Shopify/polaris-react/pull/3121))
+- Removed the `TypeOf` enum, and `GeneralObject`, `DeepPartial`, `EffectCallback`, `DependencyList` and `Comparator` type exports - these were for internal use, and were never documented for external use. ([#3123](https://github.com/Shopify/polaris-react/pull/3123))
 
 ### Enhancements
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -325,34 +325,6 @@ export enum Key {
   SingleQuote = 222,
 }
 
-export enum TypeOf {
-  Undefined = 'undefined',
-  Object = 'object',
-  Boolean = 'boolean',
-  Number = 'number',
-  String = 'string',
-  Symbol = 'symbol',
-  Function = 'function',
-}
-
-export interface GeneralObject {
-  [key: string]: any;
-}
-
-export type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends (infer U)[]
-    ? DeepPartial<U>[]
-    : T[P] extends ReadonlyArray<infer U>
-    ? ReadonlyArray<DeepPartial<U>>
-    : DeepPartial<T[P]>;
-};
-
-export type EffectCallback = () => void | (() => void | undefined);
-
-export type DependencyList = ReadonlyArray<unknown>;
-
-export type Comparator = (a: DependencyList, b: DependencyList) => boolean;
-
 export interface CheckboxHandles {
   focus(): void;
 }

--- a/src/utilities/color-transformers.ts
+++ b/src/utilities/color-transformers.ts
@@ -213,32 +213,25 @@ export function hexToRgb(color: string) {
   return {red, green, blue};
 }
 
-export enum ColorType {
-  Hex = 'hex',
-  Rgb = 'rgb',
-  Rgba = 'rgba',
-  Hsl = 'hsl',
-  Hsla = 'hsla',
-  Default = 'default',
-}
+type ColorType = 'hex' | 'rgb' | 'rgba' | 'hsl' | 'hsla' | 'default';
 
 function getColorType(color: string): ColorType {
   if (color.includes('#')) {
-    return ColorType.Hex;
+    return 'hex';
   } else if (color.includes('rgb')) {
-    return ColorType.Rgb;
+    return 'rgb';
   } else if (color.includes('rgba')) {
-    return ColorType.Rgba;
+    return 'rgba';
   } else if (color.includes('hsl')) {
-    return ColorType.Hsl;
+    return 'hsl';
   } else if (color.includes('hsla')) {
-    return ColorType.Hsla;
+    return 'hsla';
   } else {
     if (process.env.NODE_ENV === 'development') {
       /* eslint-disable-next-line no-console */
       console.warn('Accepted colors formats are: hex, rgb, rgba, hsl and hsla');
     }
-    return ColorType.Default;
+    return 'default';
   }
 }
 
@@ -297,17 +290,17 @@ function hslToObject(color: string): HSLAColor {
 }
 
 export function colorToHsla(color: string): HSLAColor {
-  const type: ColorType = getColorType(color);
+  const type = getColorType(color);
   switch (type) {
-    case ColorType.Hex:
+    case 'hex':
       return hexToHsla(color);
-    case ColorType.Rgb:
-    case ColorType.Rgba:
+    case 'rgb':
+    case 'rgba':
       return rbgStringToHsla(color);
-    case ColorType.Hsla:
-    case ColorType.Hsl:
+    case 'hsl':
+    case 'hsla':
       return hslToObject(color);
-    case ColorType.Default:
+    case 'default':
     default:
       throw new Error(
         'Accepted color formats are: hex, rgb, rgba, hsl and hsla',

--- a/src/utilities/get.ts
+++ b/src/utilities/get.ts
@@ -1,9 +1,7 @@
-import type {GeneralObject} from '../types';
-
 const OBJECT_NOTATION_MATCHER = /\[(.*?)\]|(\w+)/g;
 
 export function get<T>(
-  obj: GeneralObject | undefined,
+  obj: Record<string, any> | undefined,
   keypath: string | string[],
   defaultValue?: T,
 ): T | any {

--- a/src/utilities/is-object.ts
+++ b/src/utilities/is-object.ts
@@ -1,6 +1,4 @@
-import {TypeOf} from '../types';
-
 export function isObject(value: any) {
   const type = typeof value;
-  return value != null && (type === TypeOf.Object || type === TypeOf.Function);
+  return value != null && (type === 'object' || type === 'function');
 }

--- a/src/utilities/merge.ts
+++ b/src/utilities/merge.ts
@@ -1,5 +1,3 @@
-import type {GeneralObject} from '../types';
-
 // Unfortunately, this is how we have to type this at the moment.
 // There is currently a proposal to support variadic kinds.
 // https://github.com/Microsoft/TypeScript/issues/5453
@@ -37,6 +35,8 @@ export function merge<TSource1, TSource2, TSource3, TSource4, TSource5>(
 
   return final;
 }
+
+type GeneralObject = Record<string, any>;
 
 function mergeRecursively(inputObjA: GeneralObject, objB: GeneralObject) {
   const objA: GeneralObject = Array.isArray(inputObjA)

--- a/src/utilities/pick.ts
+++ b/src/utilities/pick.ts
@@ -1,6 +1,4 @@
-import {GeneralObject, TypeOf} from '../types';
-
-function pickValueAndLength(obj: GeneralObject, key: string) {
+function pickValueAndLength(obj: Record<string, any>, key: string) {
   const keyPaths = key.split('.');
   let value = obj;
   for (const key of keyPaths) {
@@ -15,14 +13,14 @@ function pickValueAndLength(obj: GeneralObject, key: string) {
 }
 
 export function pick(
-  obj: GeneralObject | null,
+  obj: Record<string, any> | null,
   ...keyPaths: (string | string[])[]
 ) {
   const flattenedKeypaths = ([] as string[]).concat(...keyPaths);
   if (obj == null || flattenedKeypaths.length === 0) return {};
   return flattenedKeypaths.reduce((acc, key) => {
     if (
-      typeof key !== TypeOf.String ||
+      typeof key !== 'string' ||
       Object.prototype.hasOwnProperty.call(obj, key)
     ) {
       return {...acc, [key]: obj[key]};

--- a/src/utilities/use-component-did-mount.ts
+++ b/src/utilities/use-component-did-mount.ts
@@ -1,7 +1,5 @@
 import {useRef} from 'react';
 
-import type {EffectCallback} from '../types';
-
 import {useIsAfterInitialMount} from './use-is-after-initial-mount';
 
 /**
@@ -20,7 +18,7 @@ import {useIsAfterInitialMount} from './use-is-after-initial-mount';
  *  return null;
  * }
  */
-export function useComponentDidMount(callback: EffectCallback) {
+export function useComponentDidMount(callback: () => void) {
   const isAfterInitialMount = useIsAfterInitialMount();
   const hasInvokedLifeCycle = useRef(false);
 

--- a/src/utilities/use-deep-callback.tsx
+++ b/src/utilities/use-deep-callback.tsx
@@ -1,7 +1,5 @@
 import {useCallback} from 'react';
 
-import type {EffectCallback, DependencyList, Comparator} from '../types';
-
 import {useDeepCompareRef} from './use-deep-compare-ref';
 
 /**
@@ -34,9 +32,9 @@ import {useDeepCompareRef} from './use-deep-compare-ref';
  * }
  */
 export function useDeepCallback(
-  callback: EffectCallback,
-  dependencies: DependencyList,
-  customCompare?: Comparator,
+  callback: Parameters<typeof useCallback>[0],
+  dependencies: Parameters<typeof useDeepCompareRef>[0],
+  customCompare?: Parameters<typeof useDeepCompareRef>[1],
 ) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   return useCallback(callback, useDeepCompareRef(dependencies, customCompare));

--- a/src/utilities/use-deep-effect.tsx
+++ b/src/utilities/use-deep-effect.tsx
@@ -1,8 +1,10 @@
 import {useEffect} from 'react';
 
-import type {EffectCallback, DependencyList, Comparator} from '../types';
-
 import {useDeepCompareRef} from './use-deep-compare-ref';
+
+type DependencyList = ReadonlyArray<unknown>;
+
+type Comparator = (a: DependencyList, b: DependencyList) => boolean;
 
 /**
  * A replacement for React.useEffect that'll allow for custom and deep
@@ -25,7 +27,7 @@ import {useDeepCompareRef} from './use-deep-compare-ref';
  * }
  */
 export function useDeepEffect(
-  callback: EffectCallback,
+  callback: Parameters<typeof useEffect>[0],
   dependencies: DependencyList,
   customCompare?: Comparator,
 ) {


### PR DESCRIPTION
### WHY are these changes introduced?

Shrinking our API surface area

### WHAT is this pull request doing?

Remove `TypeOf` enum, `GeneralObject`, `DeepPartial`,
`EffectCallback`, `DependencyList` and `Comparator` types from being publicly exported.

These should always have been internal only, but people occasionally forget that everything in `src/types.ts` is publicly exported.

None of these are ever used in web or in our component APIs, and I highly doubt anywhere else is using them as they are never documented, so I'm gonna skip mentioning them in the migration guide.
