### PR TITLE
[Badge] Colors to use updated values in design language

### DIFF
--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -18,7 +18,7 @@ $pip-spacing: ($height - $pip-size) / 2;
   display: inline-flex;
   align-items: center;
   padding: 0 $horizontal-padding;
-  background-color: var(--p-action-secondary-disabled, color('sky'));
+  background-color: var(--p-surface-neutral, color('sky'));
   border: border-width(thick) solid var(--p-surface, color('white'));
   border-radius: $height;
   font-size: rem(13px);

--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -35,23 +35,13 @@ $pip-spacing: ($height - $pip-size) / 2;
 .statusSuccess {
   @include pip-color(var(--p-icon-success, color('green', 'dark')));
   background-color: var(--p-surface-success, color('green', 'light'));
-  color: color('green', 'text');
-
-  .Content {
-    color: var(--p-text);
-    mix-blend-mode: var(--p-badge-mix-blend-mode);
-  }
+  color: var(--p-text, color('green', 'text'));
 }
 
 .statusInfo {
   @include pip-color(var(--p-icon-highlight, color('blue', 'dark')));
   background-color: var(--p-surface-highlight, color('blue', 'light'));
-  color: color('blue', 'text');
-
-  .Content {
-    color: var(--p-text);
-    mix-blend-mode: var(--p-badge-mix-blend-mode);
-  }
+  color: var(--p-text, color('blue', 'text'));
 }
 
 .statusAttention {
@@ -63,23 +53,13 @@ $pip-spacing: ($height - $pip-size) / 2;
 .statusWarning {
   @include pip-color(var(--p-icon-warning, color('orange', 'dark')));
   background-color: var(--p-surface-warning, color('orange', 'light'));
-  color: color('orange', 'text');
-
-  .Content {
-    color: var(--p-text);
-    mix-blend-mode: var(--p-badge-mix-blend-mode);
-  }
+  color: var(--p-text, color('orange', 'text'));
 }
 
 .statusCritical {
   @include pip-color(var(--p-icon-critical, color('red', 'dark')));
   background-color: var(--p-surface-critical, color('red', 'light'));
-  color: color('red', 'text');
-
-  .Content {
-    color: var(--p-text);
-    mix-blend-mode: var(--p-badge-mix-blend-mode);
-  }
+  color: var(--p-text, color('red', 'text'));
 }
 
 .statusNew {

--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -63,8 +63,8 @@ $pip-spacing: ($height - $pip-size) / 2;
 }
 
 .statusNew {
-  background-color: color('sky');
-  color: color('ink');
+  background-color: var(--p-surface-neutral, color('sky'));
+  color: var(--p-text, color('ink'));
   font-weight: 500;
   border: none;
 }

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -109,7 +109,7 @@ export function Badge({
     <span className={className}>
       {statusLabelMarkup}
       {pipMarkup}
-      <span className={styles.Content}>{children}</span>
+      {children}
     </span>
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

When implementing the badge in rails I noticed that the colors were using `mix-blend-mode`. Looking at the Figma documentation, the colors were changed to use text-default color.

Documentation here: https://www.figma.com/file/4dAAt5iFPSaxUKiYVKrkYj/DL%E2%80%93Polaris-(Web)%3A-Components?node-id=367%3A343
<img width="423" alt="Screen Shot 2020-07-21 at 7 40 54 PM" src="https://user-images.githubusercontent.com/19199063/88118102-c9d00500-cb8a-11ea-89ac-3384b9c195dc.png">

### WHAT is this pull request doing?

Removing parent div and `mix-blend-mode`.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
