### PR TITLE
Reorder package.json and simplify some linting config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "arrowParens": "always",
-  "singleQuote": true,
-  "trailingComma": "all",
-  "bracketSpacing": false
-}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,12 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "dist",
+    "esnext",
+    "locales",
+    "!*.tsbuildinfo"
+  ],
   "sideEffects": [
     "**/*.css",
     "**/*.scss",
@@ -73,25 +79,19 @@
     "colordocs": "node ./scripts/color-system-docs",
     "postcolordocs": "yarn run format"
   },
-  "stylelint": {
-    "extends": [
-      "@shopify/stylelint-plugin/prettier"
-    ],
-    "rules": {
-      "selector-class-pattern": "^[a-zA-Z][a-zA-Z0-9-]+$",
-      "selector-pseudo-class-no-unknown": [
-        true,
-        {
-          "ignorePseudoClasses": [
-            "global"
-          ]
-        }
-      ]
-    }
+  "dependencies": {
+    "@shopify/polaris-icons": "^3.10.0",
+    "@shopify/polaris-tokens": "^2.12.3",
+    "@types/react": "^16.9.12",
+    "@types/react-dom": "^16.9.4",
+    "@types/react-transition-group": "^4.4.0",
+    "lodash": "^4.17.4",
+    "react-transition-group": "^4.4.1"
   },
-  "browserslist": [
-    "extends @shopify/browserslist-config"
-  ],
+  "peerDependencies": {
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.6.0",
     "@babel/node": "^7.6.1",
@@ -167,23 +167,13 @@
     "svgo": "^1.3.0",
     "typescript": "~3.9.2"
   },
-  "peerDependencies": {
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
-  },
-  "files": [
-    "dist",
-    "esnext",
-    "locales",
-    "!*.tsbuildinfo"
+  "browserslist": [
+    "extends @shopify/browserslist-config"
   ],
-  "dependencies": {
-    "@shopify/polaris-icons": "^3.10.0",
-    "@shopify/polaris-tokens": "^2.12.3",
-    "@types/react": "^16.9.12",
-    "@types/react-dom": "^16.9.4",
-    "@types/react-transition-group": "^4.4.0",
-    "lodash": "^4.17.4",
-    "react-transition-group": "^4.4.1"
+  "prettier": "@shopify/prettier-config",
+  "stylelint": {
+    "extends": [
+      "@shopify/stylelint-plugin/prettier"
+    ]
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The ordering of fields in our package.json is silly.

### WHAT is this pull request doing?

Reorders package.json keys: dependencies, then peerDependencies, then devDependencies, then
linting configs

Remove stylelint configs that we not longer need to diverge from - `selector-class-pattern` matches the rule provided by `@shopify/stylelint-plugin/prettier`, and we no longer use `:global` in css modules so no need to allow its usage with `selector-pseudo-class-no-unknown`.

Extend from our shared prettier config package

### How to 🎩

See linting and tests pass