### PR TITLE
Use explicit browserslist instead of config

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed case where `DatePicker` did not translate the weekday name in an aria label ([#3113](https://github.com/Shopify/polaris-react/pull/3113))
+- Updated browserslist config to be an explicit list instead of extending an existing config, so that consuming apps don't need to depend upon `@shopify/browserslist-config` ([#3132](https://github.com/Shopify/polaris-react/pull/3132))
 
 ### Documentation
 

--- a/package.json
+++ b/package.json
@@ -168,7 +168,13 @@
     "typescript": "~3.9.2"
   },
   "browserslist": [
-    "extends @shopify/browserslist-config"
+    "last 3 chrome versions",
+    "last 3 chromeandroid versions",
+    "last 3 firefox versions",
+    "last 3 opera versions",
+    "last 2 edge versions",
+    "safari >= 10",
+    "ios >= 10"
   ],
   "prettier": "@shopify/prettier-config",
   "stylelint": {


### PR DESCRIPTION
### WHY are these changes introduced?

Consuming apps may end up reading this config and we don't want them to
need `@shopify/browserslist-config` installed to work.

Fixes #3130
Reverts #3101

### WHAT is this pull request doing?

Use explicit browserslist instead of extending from a shared config

