### PR TITLE
Ignore excluded files when running build-consumer

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Development workflow
 
+- Fix `build-consumer` script to handle excludes in package.json's files array ([#3136](https://github.com/Shopify/polaris-react/pull/3136))
+
 ### Dependency upgrades
 
 ### Code quality

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,7 +14,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Development workflow
 
-- Fix `build-consumer` script to handle excludes in package.json's files array ([#3136](https://github.com/Shopify/polaris-react/pull/3136))
+- Fixed `build-consumer` script to handle excludes in package.json's `files` array ([#3136](https://github.com/Shopify/polaris-react/pull/3136))
 
 ### Dependency upgrades
 

--- a/scripts/build-consumer.js
+++ b/scripts/build-consumer.js
@@ -27,7 +27,9 @@ const files = [
   'README.md',
   'LICENSE.md',
   'CHANGELOG.md',
-  ...packageJSON.files,
+  // Handle exclusions in the files array by ignoring them
+  // This is a little inefficient but not the end of the world
+  ...packageJSON.files.filter((filename) => !filename.startsWith('!')),
 ];
 
 console.log('Cleaning up old build...');


### PR DESCRIPTION
### WHY are these changes introduced?

`build-consumer` currently doesn't work because it doesn't handle excluded files in package.json's files array.

### WHAT is this pull request doing?

Ignores excluded files when running build-consumer
 
This means these excluded files will be copied across when running
build-consumer but this won't have any negative impact other than being
not optimally efficient.

### How to 🎩

Run build-consumer and see it completes (vs throwing an error on master). Assuming you've got the styleguide checked out: `yarn run build-consumer polaris-styleguide`