### PR TITLE
Multi-file ESM build

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added optional `videoProgress` and `showVideoProgress` props to `VideoThumbnail` for video progress indicator ([#3057](https://github.com/Shopify/polaris-react/pull/3057))
+- Enabled much easier tree-shaking in consuming apps by having a multi-file build instead of a single-file build ([#3137](https://github.com/Shopify/polaris-react/pull/3137))
 
 ### Bug fixes
 

--- a/config/rollup/plugin-styles.js
+++ b/config/rollup/plugin-styles.js
@@ -76,9 +76,10 @@ export function styles({
 
   function generateBundleStandalone(rollup, generateOptions, bundle) {
     // generateBundle gets called once per call to bundle.write(). We call
-    // that twice - one for the cjs build (index.js), one for the esm build
-    // (index.es.js). We only want to do perform this logic once though
-    if (!generateOptions.file.endsWith('/index.js')) {
+    // that twice - once for the commonjs build (the index.js file), once for
+    // the esm build (the esm folder). We only want to do perform this logic
+    // once in the commonjs build
+    if (!(generateOptions.file && generateOptions.format === 'cjs')) {
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "component library"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.es.js",
+  "module": "dist/esm/index.js",
   "sewing-kit:esnext": "dist/esnext/index.ts.esnext",
   "types": "dist/types/latest/src/index.d.ts",
   "typesVersions": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,7 +53,7 @@ export default [
     input: `${root}/src/index.ts`,
     output: [
       {format: 'cjs', file: `${root}/dist/index.js`},
-      {format: 'esm', file: `${root}/dist/index.es.js`},
+      {format: 'esm', dir: `${root}/dist/esm`, preserveModules: true},
     ],
     plugins: plugins({
       // Not specifying a browserslist config here to use the default as

--- a/scripts/build-validate.js
+++ b/scripts/build-validate.js
@@ -17,16 +17,17 @@ validateVersionReplacement();
 function validateStandardBuild() {
   // Standard build
   assert.ok(fs.existsSync('./dist/index.js'));
-  assert.ok(fs.existsSync('./dist/index.es.js'));
+  assert.ok(fs.existsSync('./dist/esm/index.js'));
   assert.ok(fs.existsSync('./dist/styles.css'));
 
   // Assert it uses named exports rather than properties from the React default
   // export to help tree-shaking.
   // React.createElement and React.Fragment are the allowed exceptions
-  const esModuleContent = fs.readFileSync('./dist/index.es.js', 'utf-8');
+  const esModuleContent = fs.readFileSync('./dist/index.js', 'utf-8');
   const unwantedReactUsageMatches =
-    esModuleContent.match(/React\.(?!createElement|Fragment)[A-Za-z0-9]+/g) ||
-    [];
+    esModuleContent.match(
+      /React__default\.(?!createElement|Fragment)[A-Za-z0-9]+/g,
+    ) || [];
 
   assert.deepStrictEqual(unwantedReactUsageMatches, []);
 
@@ -116,9 +117,9 @@ function validateVersionReplacement() {
   assert.strictEqual(fileBuckets.includesTemplateString.length, 0);
 
   assert.deepStrictEqual(fileBuckets.includesVersion, [
+    './dist/esm/configure.js',
     './dist/esnext/components/AppProvider/AppProvider.css',
     './dist/esnext/configure.ts.esnext',
-    './dist/index.es.js',
     './dist/index.js',
     './dist/styles.css',
   ]);


### PR DESCRIPTION
### WHY are these changes introduced?

Getting tree-shaking working. 

#3133 did a really good job of highlighting dead code elimination and got us to a point where that is close to ideal for a single file when using rollup. but I never addressed the lowest-hanging fruit - and the most obvious one that webpack seems to care about - splitting the build into multiple files so consumers can shake out unused imports (which is a lot easier than doing general-purpose dead code elimination).

Earlier this week I was a little wary of doing this as I wasn't sure how I could do it in a way that was both a non-breaking change, and wouldn't require oddness in our build steps. Today I had my moment of inspiration - doing a multi-file commonjs build isn't important, we only need it for the es-modules build. So we can leave index.js and styles.css where they are, and make a subfolder just for the esm standalone build (in the same way we make a folder for the esnext build).

### WHAT is this pull request doing?

This PR changes our build and entrypoint config:

- Add a dist/esm folder to the build that contains a multi-file esm
  build using `preserveModules` - replacing the single dist/index.es.js build
- Update our package.json to point at dist/esm/index.js as our module
  entrypoint


### How to 🎩

Let's use our examples/create-react-app app as a testbed to prove this.

- Set up a baseline build using the latest polaris version - 5.1.0: `cd examples/create-react-app &&  yarn add @shopify/polaris && yarn install && yarn build` to generate a baseline build. Make a note of the generated bundle size (it's around 120kb).
- In the root folder `yarn clean && yarn build-consumer polaris-react/examples/create-react-app` to do a fresh build and push it into the CRA example's node_modules folder
- Back in the CRA example folder,  run a new build `yarn build` CRA will tell you the size difference between this and the last build. Locally I get the following (these sizes are post-gzip):

```
File sizes after gzip:

  81.59 KB (-43.94 KB)  build/static/js/2.dbd0b3bd.chunk.js
  37.63 KB (-23 B)      build/static/css/2.6b5bcce3.chunk.css
  1.23 KB (+59 B)       build/static/js/main.bbf4e3ba.chunk.js
  792 B                 build/static/js/runtime-main.dc6be76f.js
```


As a bonus you can now use source-map-explorer to identify what component files are taking up the most space with in the CRA output with `npx source-map-explorer 'build/static/js/*.js'`
