### PR TITLE
[Labelled] Add `text-breakword` to styling

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Added optional `videoProgress` and `showVideoProgress` props to `VideoThumbnail` for video progress indicator ([#3057](https://github.com/Shopify/polaris-react/pull/3057))
 - Enabled much easier tree-shaking in consuming apps by having a multi-file build instead of a single-file build ([#3137](https://github.com/Shopify/polaris-react/pull/3137))
+- Labelled component now breaks on long lines of text, regardless of presence of naturally breaking characters (hyphens, whitespace, etc.) ([#3156](https://github.com/Shopify/polaris-react/pull/3156))
 
 ### Bug fixes
 

--- a/src/components/Labelled/Labelled.scss
+++ b/src/components/Labelled/Labelled.scss
@@ -16,6 +16,7 @@
 .HelpText {
   @include text-style-body;
   @include text-emphasis-subdued;
+  @include text-breakword;
   margin-top: spacing(extra-tight);
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

When using the TextField component and passing helpText, we noticed it did not wrap properly if there were no spaces or dashes to break up the text. 


### WHAT is this pull request doing?

Before: 
**HelpText does not wrap properly when there are no spaces or dashes to break up the words**
<img width="705" alt="Screen Shot 2020-08-06 at 10 56 07 AM" alt="HelpText does not wrap properly when there are no spaces or dashes to break up the words" src="https://user-images.githubusercontent.com/8573756/89540800-e8add880-d7d3-11ea-99b0-279e1d9286cb.png">

After:
**HelpText wraps even though there are no spaces in the text**
<img width="709" alt="Screen Shot 2020-08-06 at 10 56 21 AM" alt="HelpText wraps even though there are no spaces in the text" src="https://user-images.githubusercontent.com/8573756/89541031-332f5500-d7d4-11ea-98fc-feb177a254b1.png">


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <TextField
      label="Account email"
      type="email"
      value={textFieldValue}
      onChange={handleTextFieldChange}
      helpText="jdaklsdfjslkdfjalsdjfklsdjfjdaklsdfjslkdfjalsdjfklsdjfjdaklsdfjslkdfjalsdjfklsdjfjdaklsdfjslkdfjalsdjfklsdjfjdaklsdfjslkdfjalsdjfklsdjfjdaklsdfjslkdfjalsdjfklsdjfjdaklsdfjslkdfjalsdjfklsdjfjdaklsdfjslkdfjalsdjfklsdjfjdaklsdfjslkdfjalsdjfklsdjfjdaklsdfjslkdfjalsdjfklsdjf"
    />
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [not necessary?] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [no necessary] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
