### PR TITLE
Seperate connected fields with new design language

### DIFF
--- a/src/components/Connected/Connected.scss
+++ b/src/components/Connected/Connected.scss
@@ -31,34 +31,34 @@ $stacking-order: (
   flex: 1 1 auto;
 
   &:not(:first-child) * {
-    border-top-left-radius: 0 !important;
-    border-bottom-left-radius: 0 !important;
+    border-top-left-radius: var(--p-border-radius-base, 0) !important;
+    border-bottom-left-radius: var(--p-border-radius-base, 0) !important;
   }
 
   &:not(:last-child) * {
-    border-top-right-radius: 0 !important;
-    border-bottom-right-radius: 0 !important;
+    border-top-right-radius: var(--p-border-radius-base, 0) !important;
+    border-bottom-right-radius: var(--p-border-radius-base, 0) !important;
   }
 }
 
 .Item-connection {
   &:first-child * {
-    border-top-right-radius: 0 !important;
-    border-bottom-right-radius: 0 !important;
+    border-top-right-radius: var(--p-border-radius-base, 0) !important;
+    border-bottom-right-radius: var(--p-border-radius-base, 0) !important;
 
     &::after {
-      border-top-right-radius: 0 !important;
-      border-bottom-right-radius: 0 !important;
+      border-top-right-radius: var(--p-border-radius-base, 0) !important;
+      border-bottom-right-radius: var(--p-border-radius-base, 0) !important;
     }
   }
 
   &:last-child * {
-    border-top-left-radius: 0 !important;
-    border-bottom-left-radius: 0 !important;
+    border-top-left-radius: var(--p-border-radius-base, 0) !important;
+    border-bottom-left-radius: var(--p-border-radius-base, 0) !important;
 
     &::after {
-      border-top-left-radius: 0 !important;
-      border-bottom-left-radius: 0 !important;
+      border-top-left-radius: var(--p-border-radius-base, 0) !important;
+      border-bottom-left-radius: var(--p-border-radius-base, 0) !important;
     }
   }
 }
@@ -67,4 +67,10 @@ $stacking-order: (
 
 .Item-focused {
   z-index: z-index(focused, $stacking-order);
+}
+
+.newDesignLanguage .Item {
+  &:not(:first-child) {
+    margin-left: spacing(extra-tight);
+  }
 }

--- a/src/components/Connected/Connected.tsx
+++ b/src/components/Connected/Connected.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 import {classNames} from '../../utilities/css';
+import {useFeatures} from '../../utilities/features';
+
 import {Item} from './components';
 import styles from './Connected.scss';
-import {useFeatures} from '../../utilities/features';
 
 export interface ConnectedProps {
   /** Content to display on the left */

--- a/src/components/Connected/Connected.tsx
+++ b/src/components/Connected/Connected.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
+import {classNames} from '../../utilities/css';
 import {Item} from './components';
 import styles from './Connected.scss';
+import {useFeatures} from '../../utilities/features';
 
 export interface ConnectedProps {
   /** Content to display on the left */
@@ -13,6 +15,12 @@ export interface ConnectedProps {
 }
 
 export function Connected({children, left, right}: ConnectedProps) {
+  const {newDesignLanguage} = useFeatures();
+  const className = classNames(
+    styles.Connected,
+    newDesignLanguage && styles.newDesignLanguage,
+  );
+
   const leftConnectionMarkup = left ? (
     <Item position="left">{left}</Item>
   ) : null;
@@ -22,7 +30,7 @@ export function Connected({children, left, right}: ConnectedProps) {
   ) : null;
 
   return (
-    <div className={styles.Connected}>
+    <div className={className}>
       {leftConnectionMarkup}
       <Item position="primary">{children}</Item>
       {rightConnectionMarkup}

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -550,7 +550,7 @@ function ConnectedFieldsExample() {
       type="number"
       value={textFieldValue}
       onChange={handleTextFieldChange}
-      connectedRight={
+      connectedLeft={
         <Select
           value={selectValue}
           label="Weight unit"
@@ -559,6 +559,7 @@ function ConnectedFieldsExample() {
           options={['kg', 'lb']}
         />
       }
+      connectedRight={<Button>Submit</Button>}
     />
   );
 }


### PR DESCRIPTION
Co-Authored-By: Kyle Durand <kyledurand@users.noreply.github.com>

### WHY are these changes introduced?

Fixes connected fields layout when the new design language is used.

### WHAT is this pull request doing?

Adds a margin gap for the new design language.

Before:
![Screen Shot 2020-08-06 at 2 36 55 PM](https://user-images.githubusercontent.com/19199063/89569192-59fc8400-d7f2-11ea-9c71-6777fb361ffa.png)

After:
![Screen Shot 2020-08-06 at 2 37 07 PM](https://user-images.githubusercontent.com/19199063/89569174-5537d000-d7f2-11ea-8cf4-8dedc897df10.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Open up the connected field example.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
