### PR TITLE
export PositionedOverlay for use in custom popover

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Enabled much easier tree-shaking in consuming apps by having a multi-file build instead of a single-file build ([#3137](https://github.com/Shopify/polaris-react/pull/3137))
 - Labelled component now breaks on long lines of text, regardless of presence of naturally breaking characters (hyphens, whitespace, etc.) ([#3156](https://github.com/Shopify/polaris-react/pull/3156))
 - Added optional `isFiltered` prop to `ResourceList` to conditionally render more informative select all button label ([#3153](https://github.com/Shopify/polaris-react/pull/3153))
+- Exported `PositionedOverlay` component for use in consuming applications ([#3161](https://github.com/Shopify/polaris-react/pull/3161))
 
 ### Bug fixes
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -198,6 +198,9 @@ export type {PopoverProps} from './Popover';
 export {Portal} from './Portal';
 export type {PortalProps} from './Portal';
 
+export {PositionedOverlay} from './PositionedOverlay';
+export type {PositionedOverlayProps} from './PositionedOverlay';
+
 export {ProgressBar} from './ProgressBar';
 export type {ProgressBarProps} from './ProgressBar';
 


### PR DESCRIPTION
The `Popover` component makes a number of choices related to focus management and accessibility attributes which are incompatible with building an accessible combobox (autocomplete) implementation. In particular, the `Popover` makes itself focusable, taking focus away from the `TextField` which should maintain focus even while suggestions are navigated through. That said, its positioning logic is useful for implementing a custom `Popover`. This PR exposes that component so it can be consumed directly.