### PR TITLE
[Nav] Fix alignment on small screens

### DIFF
--- a/src/components/Navigation/_variables.scss
+++ b/src/components/Navigation/_variables.scss
@@ -155,6 +155,7 @@ $nav-animation-variables: (
   .Navigation-newDesignLanguage & {
     margin-top: spacing(tight);
     margin-bottom: spacing(tight);
+    margin-right: spacing();
   }
   .Item-selected &,
   .Item-selected:hover &,


### PR DESCRIPTION
### WHY are these changes introduced?

Before:
![image](https://screenshot.click/Storybook_2020-08-11_16-00-16.png)

After:
![image](https://screenshot.click/Storybook_2020-08-11_15-59-50.png)

Fixes an alignment issue where the icon in the previous DL was pushing the item labels a little farther right than on desktop. 


## <!-- ℹ️ Delete the following for small / trivial changes -->

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
