### PR TITLE
Use esnext as custom mainfield for esnext build

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Labelled component now breaks on long lines of text, regardless of presence of naturally breaking characters (hyphens, whitespace, etc.) ([#3156](https://github.com/Shopify/polaris-react/pull/3156))
 - Added optional `isFiltered` prop to `ResourceList` to conditionally render more informative select all button label ([#3153](https://github.com/Shopify/polaris-react/pull/3153))
 - Exported `PositionedOverlay` component for use in consuming applications ([#3161](https://github.com/Shopify/polaris-react/pull/3161))
+- Update to use `esnext` as a custom mainField instead of `sewing-kit:esnext` to match updated sewing-kit behaviour ([#3169](https://github.com/Shopify/polaris-react/pull/3169))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,7 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Labelled component now breaks on long lines of text, regardless of presence of naturally breaking characters (hyphens, whitespace, etc.) ([#3156](https://github.com/Shopify/polaris-react/pull/3156))
 - Added optional `isFiltered` prop to `ResourceList` to conditionally render more informative select all button label ([#3153](https://github.com/Shopify/polaris-react/pull/3153))
 - Exported `PositionedOverlay` component for use in consuming applications ([#3161](https://github.com/Shopify/polaris-react/pull/3161))
-- Update to use `esnext` as a custom mainField instead of `sewing-kit:esnext` to match updated sewing-kit behaviour ([#3169](https://github.com/Shopify/polaris-react/pull/3169))
+- Update package.json to use `esnext` as a custom mainField instead of `sewing-kit:esnext` to match updated sewing-kit behavior ([#3169](https://github.com/Shopify/polaris-react/pull/3169))
 
 ### Bug fixes
 

--- a/esnext/index.js
+++ b/esnext/index.js
@@ -2,6 +2,6 @@
 // However currently sewing-kit expects the esnext's entrypoint to be this file
 // thanks to a hardcoded alias:
 // https://github.com/Shopify/sewing-kit/blob/9911ec817ebd21384f549187a481f6b624cf7182/packages/sewing-kit/src/tools/webpack/config/resolve.ts#L45-L50.
-// Once that alias is removed then sewing-kit will use the `sewing-kit:esnext`
+// Once that alias is removed then sewing-kit will use the `esnext`
 // key in our package.json as the entrypoint and this file can be removed.
 export * from '../dist/esnext/index.ts.esnext';

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
-  "sewing-kit:esnext": "dist/esnext/index.ts.esnext",
+  "esnext": "dist/esnext/index.ts.esnext",
   "types": "dist/types/latest/src/index.d.ts",
   "typesVersions": {
     "<3.8": {


### PR DESCRIPTION
### WHY are these changes introduced?

sewing-kit v0 now uses `esnext` as the custom mainField, to match the
behaviour of sewing-kit v1. Update to match that.

This is not a breaking change as sewing-kit v0 still has an alias that forces
the use of the esnext folder, so this mainField doesn't do anything
currently, it's just for future compatibility, once SK v0 drops support
for Polaris <5.0 - which will now be "dropping support for < 5.2".

See https://github.com/Shopify/sewing-kit/pull/2279

### WHAT is this pull request doing?
 
Renames field in package.json
