### PR TITLE
[Tabs] Loosen content type

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added optional `isFiltered` prop to `ResourceList` to conditionally render more informative select all button label ([#3153](https://github.com/Shopify/polaris-react/pull/3153))
 - Exported `PositionedOverlay` component for use in consuming applications ([#3161](https://github.com/Shopify/polaris-react/pull/3161))
 - Update package.json to use `esnext` as a custom mainField instead of `sewing-kit:esnext` to match updated sewing-kit behavior ([#3169](https://github.com/Shopify/polaris-react/pull/3169))
+- Updated type restrictions for `Tabs` to allow its `content` prop to accept `React.ReactNode` instead of `string` ([#2972](https://github.com/Shopify/polaris-react/pull/3171))
 
 ### Bug fixes
 

--- a/src/components/Tabs/README.md
+++ b/src/components/Tabs/README.md
@@ -183,3 +183,50 @@ Also known as [Segmented controls](https://developer.apple.com/design/human-inte
 ![Fixed tabs on iOS](/public_images/components/Tabs/ios/fixed@2x.png)
 
 <!-- /content-for -->
+
+### Tabs with badge content
+
+Use to inform a piece of information about the tabs.
+
+```jsx
+function TabsWithBadgeExample() {
+  const [selected, setSelected] = useState(0);
+
+  const handleTabChange = useCallback(
+    (selectedTabIndex) => setSelected(selectedTabIndex),
+    [],
+  );
+
+  const tabs = [
+    {
+      id: 'all-customers-fitted',
+      content: (
+        <span>
+          All <Badge status="new">10+</Badge>
+        </span>
+      ),
+      accessibilityLabel: 'All customers',
+      panelID: 'all-customers-fitted-content',
+    },
+    {
+      id: 'accepts-marketing-fitted',
+      content: (
+        <span>
+          Accepts marketing <Badge status="new">4</Badge>
+        </span>
+      ),
+      panelID: 'accepts-marketing-fitted-Ccontent',
+    },
+  ];
+
+  return (
+    <Card>
+      <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange} fitted>
+        <Card.Section title={tabs[selected].content}>
+          <p>Tab {selected} selected</p>
+        </Card.Section>
+      </Tabs>
+    </Card>
+  );
+}
+```

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -191,6 +191,29 @@ describe('<Tabs />', () => {
         );
       });
     });
+
+    it('sets the content correctly if given React nodes', () => {
+      const tabsWithContent = [
+        {content: <span>Tab 1</span>, id: 'tab-1'},
+        {
+          content: (
+            <span>
+              Tab <b>2</b>
+            </span>
+          ),
+          id: 'tab-2',
+        },
+      ];
+      const wrapper = mountWithAppProvider(
+        <Tabs {...mockProps} tabs={tabsWithContent} />,
+      );
+
+      tabsWithContent.forEach((tab, index) => {
+        expect(wrapper.find(Tab).at(index).prop('children')).toStrictEqual(
+          tab.content,
+        );
+      });
+    });
   });
 
   describe('selected', () => {

--- a/src/components/Tabs/types.ts
+++ b/src/components/Tabs/types.ts
@@ -4,7 +4,7 @@ export interface TabDescriptor {
   /** A destination to link to */
   url?: string;
   /** Content for the tab */
-  content: string;
+  content: React.ReactNode;
   /** A unique identifier for the panel */
   panelID?: string;
   /** Visually hidden text for screen readers */


### PR DESCRIPTION
### WHY are these changes introduced?

We want to add badges to the Tabs content. In our use-case, our tab opens up a list and we would like a badge to show the # of items in that list.

Fixes https://github.com/Shopify/polaris-react/issues/3162

### WHAT is this pull request doing?

* Loosen the type of Tabs content to allow for React.ReactNode instead of only strings
* Add Tabs example with Badge in content

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

See that the below code type checks.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {Page, Card, Tabs, Badge} from '../src';

export function Playground() {
  const [selected, setSelected] = useState(0);

  const handleTabChange = useCallback(
    (selectedTabIndex) => setSelected(selectedTabIndex),
    [],
  );

  const tabs = [
    {
      id: 'all-customers',
      content: (
        <span>
          All <Badge status="info">New</Badge>
        </span>
      ),
      accessibilityLabel: 'All customers',
      panelID: 'all-customers-content',
    },
    {
      id: 'accepts-marketing',
      content: (
        <span>
          Accepts marketing <Badge status="new">2</Badge>
        </span>
      ),
      panelID: 'accepts-marketing-content',
    },
  ];

  return (
    <Page title="Playground">
      <Card>
        <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
          <Card.Section title={tabs[selected].content}>
            <p>Tab {selected} selected</p>
          </Card.Section>
        </Tabs>
      </Card>
    </Page>
  );
}
```

</details>
