### PR TITLE
Use React.Fragment in README examples

### DIFF
--- a/src/components/Autocomplete/README.md
+++ b/src/components/Autocomplete/README.md
@@ -454,12 +454,12 @@ function AutocompleteExample() {
   );
 
   const emptyState = (
-    <>
+    <React.Fragment>
       <Icon source={SearchMinor} />
       <div style={{textAlign: 'center'}}>
         <TextContainer>Could not find any results</TextContainer>
       </div>
-    </>
+    </React.Fragment>
   );
 
   return (


### PR DESCRIPTION
### WHY are these changes introduced?

The styleguide is still transpiling examples with babel v6 so doesn't
understand the shorthand fragment syntax.

Long-term fix would be updating the styleguide to transpile examples with babel 7 but that's a bit more effort than this band-aid.

Note that we're still good to use the shorthand syntax in our code, just not the README examples.

Fixes #3149

### WHAT is this pull request doing?

 Use longhand fragment syntax.


### How to 🎩

- `yarn run build-consumer polaris-styleguide`
- Run your local styleguide, Visit https://polaris.myshopify.io/components/forms/autocomplete and see that the "Autocomplete with empty state" example renders correctly.