### PR TITLE
Being able to target element position inside the Frame content

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added `position: relative` to content container within Frame ([#3178](https://github.com/Shopify/polaris-react/pull/3178))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Frame/Frame.scss
+++ b/src/components/Frame/Frame.scss
@@ -218,6 +218,7 @@ $skip-vertical-offset: rem(10px);
 }
 
 .Content {
+  position: relative;
   padding-bottom: var(--global-ribbon-height, 0);
   flex: 1;
   @include layout-flex-fix;


### PR DESCRIPTION
### WHY are these changes introduced?
We have an issue with Safari 10. `height: 100%` doesn't work as expected because all the parent element doesn't set `height: 100%`. To fix that, we can use a `position: absolute` trick. To be able to use this trick, we need to set `position: relative` on the Frame content.

This is a screenshot of the AppBridge Frame on safari 10.
![image](https://user-images.githubusercontent.com/4728325/90188751-fe9a3b00-dd89-11ea-837d-b83a5c11c47a.png)


### WHAT is this pull request doing?
Setting `position: relative` on the Frame content so we can use `position: absolute` inside a children.
```
position: absolute;
top: 0;
left: 0;
right: 0;
bottom: 0;
```

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
