### PR TITLE
Export `colorToHsla` (Shopify#3033)

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed export function `colorToHsla` ([#3179](https://github.com/Shopify/polaris-react/pull/3179))
+
 ### Documentation
 
 ### Development workflow

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export type {
   HSBLAColor,
 } from './utilities/color-types';
 export {
+  colorToHsla,
   rgbToHex,
   rgbToHsb,
   rgbToHsl,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3033 <!-- link to issue if one exists -->

### WHAT is this pull request doing?
Export `colorToHsla` function for use in consuming applications

