### PR TITLE
[Tabs] Bold in new design language

### DIFF
--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -303,6 +303,7 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 .newDesignLanguage {
   .Title {
     padding: spacing(tight) spacing();
+    font-weight: var(--p-button-font-weight);
 
     &::before {
       content: '';
@@ -318,6 +319,14 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 
   .Tab {
     padding: spacing(tight) spacing(extra-tight);
+
+    &:hover,
+    &:active,
+    &:focus {
+      .Title {
+        font-weight: var(--p-button-font-weight);
+      }
+    }
   }
 
   .DisclosureActivator {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/410. Font weight is supposed to be 500

<img width="615" alt="Screen Shot 2020-08-18 at 12 32 43 PM" src="https://user-images.githubusercontent.com/344839/90557258-0b82aa00-e14f-11ea-8712-9b380662d1ee.png">
