### PR TITLE
Fix SB Deprecations in preparation for v6

### DIFF
--- a/.storybook/polaris-readme-loader.js
+++ b/.storybook/polaris-readme-loader.js
@@ -245,7 +245,7 @@ import {
   ViewMinor,
 } from '@shopify/polaris-icons';
 
-export default { title: ${JSON.stringify(`All Components|${readme.name}`)} };
+export default { title: ${JSON.stringify(`All Components/${readme.name}`)} };
 
 ${csfExports.join('\n\n')}
 `;

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {addParameters, addDecorator} from '@storybook/react';
-import {setConsoleOptions} from '@storybook/addon-console';
 import {withContexts} from '@storybook/addon-contexts/react';
 import {color, withKnobs} from '@storybook/addon-knobs';
 import DefaultThemeColors from '@shopify/polaris-tokens/dist-modern/theme/base.json';
@@ -10,7 +9,7 @@ import enTranslations from '../locales/en.json';
 
 addParameters({
   options: {
-    // showRoots: true,
+    showRoots: true,
   },
   percy: {
     skip: true,
@@ -29,7 +28,7 @@ addDecorator(function PaddingDecorator(story) {
   return containsFrame ? (
     story()
   ) : (
-    <div style={{padding: '8px'}}>{story()}</div>
+    <div style={{padding: '1rem'}}>{story()}</div>
   );
 });
 

--- a/playground/stories.tsx
+++ b/playground/stories.tsx
@@ -4,7 +4,7 @@ import {DetailsPage} from './DetailsPage';
 
 // eslint-disable-next-line import/no-default-export, import/no-anonymous-default-export
 export default {
-  title: 'Playground|Playground',
+  title: 'Playground/Playground',
   parameters: {
     chromatic: {disable: true},
   },

--- a/scripts/pa11y.js
+++ b/scripts/pa11y.js
@@ -60,7 +60,7 @@ async function runPa11y() {
   const storyQueryStrings = stories.reduce((memo, story) => {
     // There is no need to test the Playground, or the "All Examples" stories
     const isSkippedStory =
-      story.kind === 'Playground|Playground' || story.name === 'All Examples';
+      story.kind === 'Playground/Playground' || story.name === 'All Examples';
 
     if (!isSkippedStory) {
       const idParam = `id=${encodeURIComponent(story.id)}`;


### PR DESCRIPTION
### WHY are these changes introduced?

Storybook v6 is released 🎉 

Lets preemptively fix some deprecation notices that result in a Percy claiming every snapshot has changed, thanks to story renaming.

That means that when the time comes to update to v6, we can see any regressions more clearly instead of EVERYTHING IS RENAMED

### WHAT is this pull request doing?

- Remove usage of | as separator (this has been removed in v6, and changing this means all our snapshots get renamed)
- set showRoots as it is the new default
- use 1rem for story padding as v6 applies a 1rem padding around stories
  by default


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Run storybook, note that the storynames have been changed
Note that percy has renamed all the snapshots, that's expected.