### PR TITLE
[Banner] Refactor to a functional component and fix its `id` server/client mismatch

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fix `Button` css in a `connectedTop` or `fullWidth` `ButtonGroup` ([#3215](https://github.com/Shopify/polaris-react/pull/3215)).
+- Fixed `Banner`’s `id` being mismatched on server VS client ([#3199](https://github.com/Shopify/polaris-react/pull/3199)).
 
 ### Documentation
 

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -18,9 +18,10 @@ import {
   CircleDisabledMajorFilled,
 } from '@shopify/polaris-icons';
 
-import {BannerContext} from '../../utilities/banner-context';
 import {classNames, variationName} from '../../utilities/css';
+import {BannerContext} from '../../utilities/banner-context';
 import {useFeatures} from '../../utilities/features';
+import {useUniqueId} from '../../utilities/unique-id';
 import type {
   Action,
   DisableableAction,
@@ -73,7 +74,7 @@ export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
   const {newDesignLanguage} = useFeatures();
   const withinContentContainer = useContext(WithinContentContext);
   const buttonSizeValue = withinContentContainer ? 'slim' : undefined;
-  const id = uniqueID();
+  const id = useUniqueId('Banner');
   const {
     wrapperRef,
     handleKeyUp,
@@ -176,12 +177,6 @@ export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
     </BannerContext.Provider>
   );
 });
-
-let index = 1;
-
-function uniqueID() {
-  return `Banner${index++}`;
-}
 
 function SecondaryActionFrom({action}: {action: Action}) {
   if (action.url) {

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,4 +1,10 @@
-import React, {PureComponent, createRef} from 'react';
+import React, {
+  forwardRef,
+  useRef,
+  useState,
+  useContext,
+  useImperativeHandle,
+} from 'react';
 import {
   CancelSmallMinor,
   CircleTickMajorTwotone,
@@ -12,9 +18,9 @@ import {
   CircleDisabledMajorFilled,
 } from '@shopify/polaris-icons';
 
-import {FeaturesContext} from '../../utilities/features';
 import {BannerContext} from '../../utilities/banner-context';
 import {classNames, variationName} from '../../utilities/css';
+import {useFeatures} from '../../utilities/features';
 import type {
   Action,
   DisableableAction,
@@ -31,10 +37,6 @@ import {WithinContentContext} from '../../utilities/within-content-context';
 import styles from './Banner.scss';
 
 export type BannerStatus = 'success' | 'info' | 'warning' | 'critical';
-
-interface State {
-  showFocus: boolean;
-}
 
 export interface BannerProps {
   /** Title content for the banner. */
@@ -55,202 +57,133 @@ export interface BannerProps {
   stopAnnouncements?: boolean;
 }
 
-export class Banner extends PureComponent<BannerProps, State> {
-  static contextType = FeaturesContext;
-  context!: React.ContextType<typeof FeaturesContext>;
+export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
+  {
+    icon,
+    action,
+    secondaryAction,
+    title,
+    children,
+    status,
+    onDismiss,
+    stopAnnouncements,
+  }: BannerProps,
+  bannerRef,
+) {
+  const {newDesignLanguage} = useFeatures();
+  const withinContentContainer = useContext(WithinContentContext);
+  const buttonSizeValue = withinContentContainer ? 'slim' : undefined;
+  const id = uniqueID();
+  const {
+    wrapperRef,
+    handleKeyUp,
+    handleBlur,
+    handleMouseUp,
+    shouldShowFocus,
+  } = useBannerFocus(bannerRef);
+  const {defaultIcon, iconColor, ariaRoleType} = useBannerAttributes(
+    status,
+    newDesignLanguage,
+  );
+  const iconName = icon || defaultIcon;
+  const className = classNames(
+    styles.Banner,
+    status && styles[variationName('status', status)],
+    onDismiss && styles.hasDismiss,
+    shouldShowFocus && styles.keyFocused,
+    withinContentContainer ? styles.withinContentContainer : styles.withinPage,
+    newDesignLanguage && styles.newDesignLanguage,
+  );
 
-  state: State = {
-    showFocus: false,
-  };
+  let headingMarkup: React.ReactNode = null;
+  let headingID: string | undefined;
 
-  private wrapper = createRef<HTMLDivElement>();
-
-  public focus() {
-    this.wrapper.current && this.wrapper.current.focus();
-    this.setState({showFocus: true});
-  }
-
-  render() {
-    const {newDesignLanguage} = this.context || {};
-    const {showFocus} = this.state;
-
-    const handleKeyUp = (evt: React.KeyboardEvent<HTMLDivElement>) => {
-      if (evt.target === this.wrapper.current) {
-        this.setState({showFocus: true});
-      }
-    };
-
-    const handleBlur = () => {
-      this.setState({showFocus: false});
-    };
-
-    const handleMouseUp = ({
-      currentTarget,
-    }: React.MouseEvent<HTMLDivElement>) => {
-      const {showFocus} = this.state;
-      currentTarget.blur();
-      showFocus && this.setState({showFocus: false});
-    };
-
-    return (
-      <BannerContext.Provider value>
-        <WithinContentContext.Consumer>
-          {(withinContentContainer) => {
-            const {
-              icon,
-              action,
-              secondaryAction,
-              title,
-              children,
-              status,
-              onDismiss,
-              stopAnnouncements,
-            } = this.props;
-            let color: IconProps['color'];
-            let defaultIcon: IconProps['source'];
-            let ariaRoleType = 'status';
-
-            switch (status) {
-              case 'success':
-                color = newDesignLanguage ? 'success' : 'greenDark';
-                defaultIcon = newDesignLanguage
-                  ? CircleTickMajorFilled
-                  : CircleTickMajorTwotone;
-                break;
-              case 'info':
-                color = newDesignLanguage ? 'highlight' : 'tealDark';
-                defaultIcon = newDesignLanguage
-                  ? CircleInformationMajorFilled
-                  : CircleInformationMajorTwotone;
-                break;
-              case 'warning':
-                color = newDesignLanguage ? 'warning' : 'yellowDark';
-                defaultIcon = newDesignLanguage
-                  ? CircleAlertMajorFilled
-                  : CircleAlertMajorTwotone;
-                ariaRoleType = 'alert';
-                break;
-              case 'critical':
-                color = newDesignLanguage ? 'critical' : 'redDark';
-                defaultIcon = newDesignLanguage
-                  ? CircleDisabledMajorFilled
-                  : CircleDisabledMajorTwotone;
-                ariaRoleType = 'alert';
-                break;
-              default:
-                color = newDesignLanguage ? 'base' : 'inkLighter';
-                defaultIcon = newDesignLanguage
-                  ? CircleInformationMajorFilled
-                  : FlagMajorTwotone;
-            }
-            const className = classNames(
-              styles.Banner,
-              status && styles[variationName('status', status)],
-              onDismiss && styles.hasDismiss,
-              showFocus && styles.keyFocused,
-              withinContentContainer
-                ? styles.withinContentContainer
-                : styles.withinPage,
-              newDesignLanguage && styles.newDesignLanguage,
-            );
-
-            const id = uniqueID();
-            const iconName = icon || defaultIcon;
-
-            let headingMarkup: React.ReactNode = null;
-            let headingID: string | undefined;
-
-            if (title) {
-              headingID = `${id}Heading`;
-              headingMarkup = (
-                <div className={styles.Heading} id={headingID}>
-                  <Heading element="p">{title}</Heading>
-                </div>
-              );
-            }
-
-            const buttonSizeValue = withinContentContainer ? 'slim' : undefined;
-
-            const secondaryActionMarkup = secondaryAction
-              ? secondaryActionFrom(secondaryAction)
-              : null;
-
-            const actionMarkup = action ? (
-              <div className={styles.Actions}>
-                <ButtonGroup>
-                  <div className={styles.PrimaryAction}>
-                    {buttonFrom(action, {outline: true, size: buttonSizeValue})}
-                  </div>
-                  {secondaryActionMarkup}
-                </ButtonGroup>
-              </div>
-            ) : null;
-
-            let contentMarkup = null;
-            let contentID: string | undefined;
-
-            if (children || actionMarkup) {
-              contentID = `${id}Content`;
-              contentMarkup = (
-                <div className={styles.Content} id={contentID}>
-                  {children}
-                  {actionMarkup}
-                </div>
-              );
-            }
-
-            const dismissButton = onDismiss ? (
-              <div className={styles.Dismiss}>
-                <Button
-                  plain
-                  icon={CancelSmallMinor}
-                  onClick={onDismiss}
-                  accessibilityLabel="Dismiss notification"
-                />
-              </div>
-            ) : null;
-
-            return (
-              <div
-                className={className}
-                // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-                tabIndex={0}
-                ref={this.wrapper}
-                role={ariaRoleType}
-                aria-live={stopAnnouncements ? 'off' : 'polite'}
-                onMouseUp={handleMouseUp}
-                onKeyUp={handleKeyUp}
-                onBlur={handleBlur}
-                aria-labelledby={headingID}
-                aria-describedby={contentID}
-              >
-                {dismissButton}
-                <div className={styles.Ribbon}>
-                  <Icon
-                    source={iconName}
-                    color={color}
-                    backdrop={!newDesignLanguage}
-                  />
-                </div>
-                <div className={styles.ContentWrapper}>
-                  {headingMarkup}
-                  {contentMarkup}
-                </div>
-              </div>
-            );
-          }}
-        </WithinContentContext.Consumer>
-      </BannerContext.Provider>
+  if (title) {
+    headingID = `${id}Heading`;
+    headingMarkup = (
+      <div className={styles.Heading} id={headingID}>
+        <Heading element="p">{title}</Heading>
+      </div>
     );
   }
-}
+
+  const actionMarkup = action && (
+    <div className={styles.Actions}>
+      <ButtonGroup>
+        <div className={styles.PrimaryAction}>
+          {buttonFrom(action, {outline: true, size: buttonSizeValue})}
+        </div>
+
+        {secondaryAction && <SecondaryActionFrom action={secondaryAction} />}
+      </ButtonGroup>
+    </div>
+  );
+
+  let contentMarkup: React.ReactNode = null;
+  let contentID: string | undefined;
+
+  if (children || actionMarkup) {
+    contentID = `${id}Content`;
+    contentMarkup = (
+      <div className={styles.Content} id={contentID}>
+        {children}
+        {actionMarkup}
+      </div>
+    );
+  }
+
+  const dismissButton = onDismiss && (
+    <div className={styles.Dismiss}>
+      <Button
+        plain
+        icon={CancelSmallMinor}
+        onClick={onDismiss}
+        accessibilityLabel="Dismiss notification"
+      />
+    </div>
+  );
+
+  return (
+    <BannerContext.Provider value>
+      <div
+        className={className}
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+        tabIndex={0}
+        ref={wrapperRef}
+        role={ariaRoleType}
+        aria-live={stopAnnouncements ? 'off' : 'polite'}
+        onMouseUp={handleMouseUp}
+        onKeyUp={handleKeyUp}
+        onBlur={handleBlur}
+        aria-labelledby={headingID}
+        aria-describedby={contentID}
+      >
+        {dismissButton}
+
+        <div className={styles.Ribbon}>
+          <Icon
+            source={iconName}
+            color={iconColor}
+            backdrop={!newDesignLanguage}
+          />
+        </div>
+
+        <div className={styles.ContentWrapper}>
+          {headingMarkup}
+          {contentMarkup}
+        </div>
+      </div>
+    </BannerContext.Provider>
+  );
+});
 
 let index = 1;
+
 function uniqueID() {
   return `Banner${index++}`;
 }
 
-function secondaryActionFrom(action: Action) {
+function SecondaryActionFrom({action}: {action: Action}) {
   if (action.url) {
     return (
       <UnstyledLink
@@ -268,4 +201,98 @@ function secondaryActionFrom(action: Action) {
       <span className={styles.Text}>{action.content}</span>
     </button>
   );
+}
+
+interface BannerAttributes {
+  iconColor: IconProps['color'];
+  defaultIcon: IconProps['source'];
+  ariaRoleType: 'status' | 'alert';
+}
+
+function useBannerAttributes(
+  status: BannerProps['status'],
+  newDesignLanguage: boolean,
+): BannerAttributes {
+  switch (status) {
+    case 'success':
+      return {
+        defaultIcon: newDesignLanguage
+          ? CircleTickMajorFilled
+          : CircleTickMajorTwotone,
+        iconColor: newDesignLanguage ? 'success' : 'greenDark',
+        ariaRoleType: 'status',
+      };
+
+    case 'info':
+      return {
+        defaultIcon: newDesignLanguage
+          ? CircleInformationMajorFilled
+          : CircleInformationMajorTwotone,
+        iconColor: newDesignLanguage ? 'highlight' : 'tealDark',
+        ariaRoleType: 'status',
+      };
+
+    case 'warning':
+      return {
+        defaultIcon: newDesignLanguage
+          ? CircleAlertMajorFilled
+          : CircleAlertMajorTwotone,
+        iconColor: newDesignLanguage ? 'warning' : 'yellowDark',
+        ariaRoleType: 'alert',
+      };
+
+    case 'critical':
+      return {
+        defaultIcon: newDesignLanguage
+          ? CircleDisabledMajorFilled
+          : CircleDisabledMajorTwotone,
+        iconColor: newDesignLanguage ? 'critical' : 'redDark',
+        ariaRoleType: 'alert',
+      };
+
+    default:
+      return {
+        defaultIcon: newDesignLanguage
+          ? CircleInformationMajorFilled
+          : FlagMajorTwotone,
+        iconColor: newDesignLanguage ? 'base' : 'inkLighter',
+        ariaRoleType: 'status',
+      };
+  }
+}
+
+export interface BannerHandles {
+  focus(): void;
+}
+
+function useBannerFocus(bannerRef: React.Ref<BannerHandles>) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [shouldShowFocus, setShouldShowFocus] = useState(false);
+
+  useImperativeHandle(bannerRef, () => ({
+    focus: () => {
+      wrapperRef.current?.focus();
+      setShouldShowFocus(true);
+    },
+  }));
+
+  const handleKeyUp = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.target === wrapperRef.current) {
+      setShouldShowFocus(true);
+    }
+  };
+
+  const handleBlur = () => setShouldShowFocus(false);
+  const handleMouseUp = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.currentTarget.blur();
+    setShouldShowFocus(false);
+  };
+
+  return {
+    wrapperRef,
+    handleKeyUp,
+    handleBlur,
+    handleMouseUp,
+    shouldShowFocus,
+  };
 }

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -36,24 +36,41 @@ describe('<Banner />', () => {
     expect(banner.find(Icon).prop('source')).toBe(CirclePlusMinor);
   });
 
-  it('uses a greenDark circleCheckMark if status is success', () => {
+  it('uses a greenDark circleCheckMark if status is success and sets a status aria role', () => {
     const banner = mountWithAppProvider(<Banner status="success" />);
     expect(banner.find(Icon).prop('source')).toBe(CircleTickMajorTwotone);
     expect(banner.find(Icon).prop('color')).toBe('greenDark');
+    expect(banner.find('div').first().prop('role')).toBe('status');
   });
 
-  it('uses a tealDark circleInformation if status is info', () => {
+  it('uses a tealDark circleInformation if status is info and sets a status aria role', () => {
     const banner = mountWithAppProvider(<Banner status="info" />);
     expect(banner.find(Icon).prop('source')).toBe(
       CircleInformationMajorTwotone,
     );
     expect(banner.find(Icon).prop('color')).toBe('tealDark');
+    expect(banner.find('div').first().prop('role')).toBe('status');
   });
 
-  it('uses a yellowDark circleAlert if status is warning', () => {
+  it('uses a yellowDark circleAlert if status is warning and sets an alert aria role', () => {
     const banner = mountWithAppProvider(<Banner status="warning" />);
     expect(banner.find(Icon).prop('source')).toBe(CircleAlertMajorTwotone);
     expect(banner.find(Icon).prop('color')).toBe('yellowDark');
+    expect(banner.find('div').first().prop('role')).toBe('alert');
+  });
+
+  it('uses a redDark circleBarred if status is critical and sets an alert aria role', () => {
+    const banner = mountWithAppProvider(<Banner status="critical" />);
+    expect(banner.find(Icon).prop('source')).toBe(CircleDisabledMajorTwotone);
+    expect(banner.find(Icon).prop('color')).toBe('redDark');
+    expect(banner.find('div').first().prop('role')).toBe('alert');
+  });
+
+  it('uses a default icon and aria role', () => {
+    const banner = mountWithAppProvider(<Banner />);
+    expect(banner.find(Icon).prop('source')).toBe(FlagMajorTwotone);
+    expect(banner.find(Icon).prop('color')).toBe('inkLighter');
+    expect(banner.find('div').first().prop('role')).toBe('status');
   });
 
   it('disables aria-live when stopAnnouncements is enabled', () => {
@@ -66,18 +83,6 @@ describe('<Banner />', () => {
       .find('div')
       .filterWhere((element) => element.prop('aria-live') === 'off');
     expect(quietBanner).toBeTruthy();
-  });
-
-  it('uses a redDark circleBarred if status is critical', () => {
-    const banner = mountWithAppProvider(<Banner status="critical" />);
-    expect(banner.find(Icon).prop('source')).toBe(CircleDisabledMajorTwotone);
-    expect(banner.find(Icon).prop('color')).toBe('redDark');
-  });
-
-  it('uses a default icon', () => {
-    const banner = mountWithAppProvider(<Banner />);
-    expect(banner.find(Icon).prop('source')).toBe(FlagMajorTwotone);
-    expect(banner.find(Icon).prop('color')).toBe('inkLighter');
   });
 
   describe('onDismiss()', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

We’re getting server/client `id` mismatches on the Admin dashboard on pages that use `Banner`s. This is because the current way of generating unique `id`s is not foolproof.

### WHAT is this pull request doing?

The first commit is refactoring `Banner` to a functional component since we can’t use hooks in class components.
The second commit fixes the `id` server/client mismatch by using the `useUniqueId` hook instead of the `Banner`’s custom `uniqueID()` util.

### How to 🎩

We can’t 🎩  the bug fix on the Playground since it’s not server-side rendered.

Here‘s how I tested it:
- Go to a page on your local `web` that renders a `Banner`; I used `/admin/settings/payments`. Notice how there’s a warning in the console that looks like this one:
<img width="780" alt="Screenshot 2020-08-26 at 15 53 03" src="https://user-images.githubusercontent.com/9154236/91312194-3fe01100-e7b4-11ea-9b0f-cc66cfb3b9aa.png">

- Checkout the `fix-mismatch-banner-ids` branch on `polaris-react`
- Run `yarn build` then `yarn build-consumer web`
- Restart your `web` server then refresh the page on `/admin/settings/payments`, notice how there’s no more warning in the console

I think relying on automated testing for the rest is OK here as I’m not really changing any behaviour/styles, just implementation details: the unit tests & visual regression tests are passing.
Let me know if you still want me to go through the regular 🎩 checklist.