### PR TITLE
Update the “Testing in a consuming project” section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ To test the changes on a mobile or virtual machine, you will need to open the so
 
 ### Testing in a consuming project
 
-1. In your terminal, run `yarn run build-consumer PROJECT_DIRECTORY` from the polaris-react repo
+1. Run `yarn run build` from the `polaris-react` repo to build polaris with your changes.
+
+2. Run `yarn run build-consumer PROJECT_DIRECTORY` from the `polaris-react` repo
 
 `PROJECT_DIRECTORY` is where the build will be copied, which must be a sibling of the `polaris-react` directory.
 
@@ -119,7 +121,7 @@ To test the changes on a mobile or virtual machine, you will need to open the so
 yarn run build-consumer polaris-styleguide
 ```
 
-2. In your terminal, open a second tab and run `yarn run dev` from the `polaris-styleguide` repository
+3. In your terminal, open a second tab and run `yarn run dev` from the `polaris-styleguide` repository
 
 In the example above, the build is copied to `polaris-styleguide/node_modules/@shopify/polaris`. And in this case, a rebuild of `polaris-styleguide` is required after copying the `polaris-react` build, but may not be the case for all consuming projects.
 


### PR DESCRIPTION
With a first step to build the repo before running the `build-consumer` script. Got confused for a bit while testing https://github.com/Shopify/polaris-react/pull/3199. Let me know if I did something wrong tho 😄 

Should I add this to UNRELEASED.md? Which section? 🤔 