### PR TITLE
[TextField] Remove border-radius reset

### DIFF
--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -403,16 +403,6 @@ $stacking-order: (
     }
   }
 
-  .Backdrop-connectedLeft::after {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  }
-
-  .Backdrop-connectedRight::after {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
   .Spinner {
     --p-text-field-spinner-offset-large: calc(
       var(--p-text-field-spinner-offset) + #{border-width()}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/396 and fixes https://github.com/Shopify/polaris-react/issues/3170. This reverts a change in https://github.com/Shopify/polaris-react/commit/f5aec8efcb7137704cd2af0963b4ef3ecf2ce270 that was to make them flat.

### WHAT is this pull request doing?

The focus ring should now be round on connected fields in the new design language. There should be no regressions. 

### How to 🎩

https://5d559397bae39100201eedc1-wxlqoeshyp.chromatic.com/iframe.html?id=all-components-text-field--text-field-with-connected-fields&contexts=New%20Design%20Language%3DEnabled%20-%20Light%20Mode

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit