### PR TITLE
Fix ButtonGroup with connectedTop=false

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fix `Button` css in a `connectedTop` or `fullWidth` `ButtonGroup` ([#3215](https://github.com/Shopify/polaris-react/pull/3215)).
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -109,7 +109,7 @@ $stacking-order: (
   }
 }
 
-[data-buttongroup-connected-top] {
+[data-buttongroup-connected-top='true'] {
   > :first-child .Button,
   > :first-child .Button::after {
     border-top-left-radius: 0;
@@ -121,7 +121,7 @@ $stacking-order: (
   }
 }
 
-[data-buttongroup-full-width] {
+[data-buttongroup-full-width='true'] {
   .Button {
     @include button-full-width;
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Having `connectedTop={false}` on the `ButtonGroup` was still applying the css because the css doesn't check the value.
I made the same fix for fullWidth.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit