### PR TITLE
Add a `suffix` to an Action List Item

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Update `EmptySearchResult` illustration ([#3185](https://github.com/Shopify/polaris-react/pull/3185)).
+- Update `ActionList` to allow the items to have a suffix ([#3216](https://github.com/Shopify/polaris-react/pull/3216)).
 
 ### Bug fixes
 

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -174,7 +174,8 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
     pointer-events: none;
 
     // stylelint-disable-next-line selector-max-class
-    .Image {
+    .Image,
+    .Suffix {
       @include recolor-icon(color('ink', 'lightest'), color('white'));
     }
   }
@@ -272,7 +273,8 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
     &.disabled {
       background-image: none;
       color: var(--p-text-disabled);
-      .Image {
+      .Image,
+      .Suffix {
         @include recolor-icon(var(--p-icon-disabled));
       }
     }
@@ -303,11 +305,12 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   background-position: center center;
 }
 
+.Suffix {
+  @include recolor-icon(color('ink', 'light'), color('white'));
+  margin-left: spacing();
+}
+
 .Text {
   @include layout-flex-fix;
   flex: 1 1 auto;
-}
-
-.BadgeWrapper {
-  margin-left: spacing();
 }

--- a/src/components/ActionList/ActionList.tsx
+++ b/src/components/ActionList/ActionList.tsx
@@ -39,9 +39,7 @@ export function ActionList({
   );
 
   const hasMultipleSections = finalSections.length > 1;
-  // Type asserting to any is required for TS3.2 but can be removed when we update to 3.3
-  // see https://github.com/Microsoft/TypeScript/issues/28768
-  const Element: any = hasMultipleSections ? 'ul' : 'div';
+  const Element = hasMultipleSections ? 'ul' : 'div';
   const sectionMarkup = finalSections.map((section, index) => {
     return section.items.length > 0 ? (
       <Section

--- a/src/components/ActionList/README.md
+++ b/src/components/ActionList/README.md
@@ -158,6 +158,42 @@ function ActionListWithMediaExample() {
 }
 ```
 
+### Action list with an icon and a suffix
+
+Use when the items benefit from an associated action or image, such as a list of products.
+
+```jsx
+function ActionListWithSuffixExample() {
+  const [active, setActive] = useState(true);
+
+  const toggleActive = useCallback(() => setActive((active) => !active), []);
+
+  const activator = (
+    <Button onClick={toggleActive} disclosure>
+      More actions
+    </Button>
+  );
+
+  return (
+    <div style={{height: '200px'}}>
+      <Popover active={active} activator={activator} onClose={toggleActive}>
+        <ActionList
+          items={[
+            {
+              content: 'Import file',
+              icon: ImportMinor,
+              suffix: <Icon source={TickSmallMinor} />,
+              active: true,
+            },
+            {content: 'Export file', icon: ExportMinor},
+          ]}
+        />
+      </Popover>
+    </div>
+  );
+}
+```
+
 ### Sectioned action list
 
 Use when the items benefit from sections to help differentiate actions.

--- a/src/components/ActionList/components/Item/Item.tsx
+++ b/src/components/ActionList/components/Item/Item.tsx
@@ -22,6 +22,7 @@ export function Item({
   onAction,
   icon,
   image,
+  suffix,
   disabled,
   external,
   destructive,
@@ -38,7 +39,7 @@ export function Item({
     newDesignLanguage && styles.newDesignLanguage,
   );
 
-  let imageElement = null;
+  let imageElement: React.ReactNode | null = null;
 
   if (icon) {
     imageElement = (
@@ -68,9 +69,13 @@ export function Item({
   );
 
   const badgeMarkup = badge && (
-    <span className={styles.BadgeWrapper}>
+    <span className={styles.Suffix}>
       <Badge status={badge.status}>{badge.content}</Badge>
     </span>
+  );
+
+  const suffixMarkup = suffix && (
+    <span className={styles.Suffix}>{suffix}</span>
   );
 
   const textMarkup = imageElement ? (
@@ -84,6 +89,7 @@ export function Item({
       {imageElement}
       {textMarkup}
       {badgeMarkup}
+      {suffixMarkup}
     </div>
   );
 

--- a/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -36,6 +36,12 @@ describe('<Item />', () => {
     expect(item.text()).toBe('Test…');
   });
 
+  it('renders a suffix when the suffix prop is defined', () => {
+    const Suffix = () => <div>Suffix</div>;
+    const item = mountWithApp(<Item suffix={<Suffix />} />);
+    expect(item).toContainReactComponent(Suffix);
+  });
+
   it('does not render a label when content is undefined and ellipsis is true', () => {
     const item = mountWithAppProvider(<Item ellipsis />);
     expect(item.text()).toBe('');

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,8 @@ export interface ActionListItemDescriptor
   helpText?: string;
   /** Image source */
   image?: string;
+  /** Suffix source */
+  suffix?: React.ReactNode;
   /**  Add an ellipsis suffix to action content */
   ellipsis?: boolean;
   /** Whether the action is active or not */


### PR DESCRIPTION
### WHY are these changes introduced?

Some consumers would like to have a way to provide a "suffix" to an item and this PR adds this functionality.

![Screen Shot 2020-09-04 at 9 47 36 AM](https://user-images.githubusercontent.com/1972567/92249054-852cce80-ee97-11ea-8858-6b36a1ecbd96.jpg)


### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
