### PR TITLE
[TextField] Support `inputMode` attribute

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Update `EmptySearchResult` illustration ([#3185](https://github.com/Shopify/polaris-react/pull/3185)).
 - Update `ActionList` to allow the items to have a suffix ([#3216](https://github.com/Shopify/polaris-react/pull/3216)).
+- Added support for the `inputMode` attribute on the `TextField` component ([#3222](https://github.com/Shopify/polaris-react/pull/3222)).
 
 ### Bug fixes
 

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -872,6 +872,7 @@ Text fields have standard keyboard support.
 - If the `type` is set to `number`, then merchants can use the up and down arrow keys to adjust the value typed into the field
 - Using the `disabled` prop will prevent the text field from receive keyboard focus or inputs
 - The `readOnly` prop allows focus on the text field but prevents input or editing
+- The `inputMode` prop can be used to bring up a relevant keyboard for merchants on mobile; it’s passed down to the input as an [`inputmode` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode)
 
 #### Automatically focusing
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -38,6 +38,16 @@ type Type =
 
 type Alignment = 'left' | 'center' | 'right';
 
+type InputMode =
+  | 'none'
+  | 'text'
+  | 'decimal'
+  | 'numeric'
+  | 'tel'
+  | 'search'
+  | 'email'
+  | 'url';
+
 interface NonMutuallyExclusiveProps {
   /** Text to display before value */
   prefix?: React.ReactNode;
@@ -95,6 +105,8 @@ interface NonMutuallyExclusiveProps {
   minLength?: number;
   /** A regular expression to check the value against */
   pattern?: string;
+  /** Choose the keyboard that should be used on mobile devices */
+  inputMode?: InputMode;
   /** Indicate whether value should have spelling checked */
   spellCheck?: boolean;
   /** Indicates the id of a component owned by the input */
@@ -155,6 +167,7 @@ export function TextField({
   min,
   minLength,
   pattern,
+  inputMode,
   spellCheck,
   ariaOwns,
   ariaControls,
@@ -405,6 +418,7 @@ export function TextField({
     maxLength,
     spellCheck,
     pattern,
+    inputMode,
     type: inputType,
     'aria-describedby': describedBy.length ? describedBy.join(' ') : undefined,
     'aria-labelledby': labelledBy.join(' '),

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -10,6 +10,7 @@ import {TextField} from '../TextField';
 describe('<TextField />', () => {
   it('allows specific props to pass through properties on the input', () => {
     const pattern = '\\d\\d';
+    const inputMode = 'numeric';
     const input = mountWithAppProvider(
       <TextField
         label="TextField"
@@ -26,6 +27,7 @@ describe('<TextField />', () => {
         maxLength={2}
         spellCheck={false}
         pattern={pattern}
+        inputMode={inputMode}
         align="left"
       />,
     ).find('input');
@@ -42,6 +44,7 @@ describe('<TextField />', () => {
     expect(input.prop('maxLength')).toBe(2);
     expect(input.prop('spellCheck')).toBe(false);
     expect(input.prop('pattern')).toBe(pattern);
+    expect(input.prop('inputMode')).toBe(inputMode);
   });
 
   it('blocks props not listed as component props to pass on the input', () => {


### PR DESCRIPTION
# WHY are these changes introduced?

I have noticed the `TextField` doesn’t support [the `inputMode` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode). Thought I’d add support for it as I discussed this attribute twice in PRs this week. Here‘s [a good article](https://css-tricks.com/finger-friendly-numerical-inputs-with-inputmode/) about it.

### WHAT is this pull request doing?

Passing down the `inputMode` prop to the `TextField`’s `input`.

TextField without an `inputMode` attribute:
![Screenshot 2020-09-08 at 10 46 11](https://user-images.githubusercontent.com/9154236/92454249-968c1880-f1c0-11ea-913c-4352234be05c.png)


TextField with `inputMode="numeric"`
![Screenshot 2020-09-08 at 10 45 29](https://user-images.githubusercontent.com/9154236/92454214-8ecc7400-f1c0-11ea-99a2-3920b432925a.png)

☝️ This doesn’t work on `master`, the prop is swallowed.


### 🎩 checklist

* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide