### PR TITLE
[Badge] Show border and fill in pips when printing

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fix `Button` css in a `connectedTop` or `fullWidth` `ButtonGroup` ([#3215](https://github.com/Shopify/polaris-react/pull/3215)).
 - Fixed `Banner`’s `id` being mismatched on server VS client ([#3199](https://github.com/Shopify/polaris-react/pull/3199)).
+- Fixed the border and pip fill colors on the `Badge` to show when printing ([#3226](https://github.com/Shopify/polaris-react/pull/3226)).
 
 ### Documentation
 

--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -25,6 +25,11 @@ $pip-spacing: ($height - $pip-size) / 2;
   line-height: $height;
   color: var(--p-text, color('ink', 'light'));
   font-weight: var(--p-badge-font-weight, 400);
+
+  @media print {
+    border: solid rem(0.1px) var(--p-border, color('ink', 'light'));
+    border-radius: $height;
+  }
 }
 
 .sizeSmall {
@@ -92,6 +97,20 @@ $pip-spacing: ($height - $pip-size) / 2;
       transparent 50%,
       transparent
     );
+
+    @media print {
+      position: relative;
+      overflow: hidden;
+
+      &::before {
+        content: '';
+        position: absolute;
+        width: 100%;
+        height: 50%;
+        transform: translateY(100%);
+        box-shadow: 0 0 0 $pip-size currentColor inset;
+      }
+    }
   }
 }
 
@@ -103,5 +122,9 @@ $pip-spacing: ($height - $pip-size) / 2;
       currentColor 50%,
       currentColor 50%
     );
+
+    @media print {
+      box-shadow: 0 0 0 $pip-size currentColor inset;
+    }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

When printing a Badge, both the border and the pip fill colors were not showing.

<kbd>![image](https://user-images.githubusercontent.com/22782157/92636596-a16ca900-f2a5-11ea-8b5b-3489bc46d67e.png)</kbd>

<kbd>![image](https://user-images.githubusercontent.com/22782157/92636561-8e59d900-f2a5-11ea-9c8a-8febb0198822.png)</kbd>

### WHAT is this pull request doing?

Instead of going with a fill or background color approach, I went with `box-shadow` since some browsers may have the print with color setting turned off.

![image](https://user-images.githubusercontent.com/22782157/92636651-b8ab9680-f2a5-11ea-9afe-8be720b3c635.png)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### Noticeable issue with this approach:

The `box-shadow` just barely touches the pip's border,

![image](https://user-images.githubusercontent.com/22782157/92636978-3a9bbf80-f2a6-11ea-8aad-1df7b0d929b1.png)

This is barely noticeable until you zoom in quite far, but on Safari its a little more obvious,

![image](https://user-images.githubusercontent.com/22782157/92637038-530bda00-f2a6-11ea-9b51-5496b8c84c62.png)

We could leave this as is since it's not very noticeable at 100% but a better solution is always welcome.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers) (Chrome, Firefox, Safari, and Edge on a Macbook)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
