### PR TITLE
[Button] Add -1 layer shadow for pressed state

### DIFF
--- a/documentation/Color system.md
+++ b/documentation/Color system.md
@@ -246,6 +246,7 @@ Used to decorate elements where color does convey a specific meaning in componen
 | `--p-top-bar-shadow`                      | `0 2px 2px -1px var(--p-shadow-from-direct-light)`                                                           |
 | `--p-button-drop-shadow`                  | `0 1px 0 rgba(0, 0, 0, 0.05)`                                                                                |
 | `--p-button-inner-shadow`                 | `inset 0 -1px 0 rgba(0, 0, 0, 0.2)`                                                                          |
+| `--p-button-pressed-inner-shadow`         | `inset 0 2px 0 rgba(0, 0, 0, 0.05)`                                                                          |
 | `--p-override-none`                       | `none`                                                                                                       |
 | `--p-override-transparent`                | `transparent`                                                                                                |
 | `--p-override-one`                        | `1`                                                                                                          |

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -100,7 +100,7 @@
 
     &.pressed {
       background: var(--p-action-secondary-depressed);
-      box-shadow: var(--p-button-inner-shadow);
+      box-shadow: var(--p-button-pressed-inner-shadow);
       color: var(--p-text);
     }
 
@@ -180,24 +180,26 @@
 
     &:focus {
       border-color: transparent;
+      box-shadow: var(--p-button-drop-shadow), var(--p-button-inner-shadow);
     }
 
     &:active {
       background: var(--p-button-color-active);
       border-color: transparent;
-      box-shadow: none;
+      box-shadow: var(--p-button-drop-shadow), var(--p-button-inner-shadow);
     }
 
     &.pressed {
+      color: var(--p-button-text);
       background: var(--p-button-color-depressed);
       border-color: transparent;
-      box-shadow: var(--p-button-inner-shadow);
+      box-shadow: var(--p-button-drop-shadow), var(--p-button-inner-shadow);
 
       &:hover,
       &:focus {
         background: var(--p-button-color-depressed);
         border-color: transparent;
-        box-shadow: var(--p-button-inner-shadow);
+        box-shadow: var(--p-button-drop-shadow), var(--p-button-inner-shadow);
       }
     }
   }

--- a/src/utilities/theme/tokens.ts
+++ b/src/utilities/theme/tokens.ts
@@ -13,6 +13,7 @@ export const Tokens = {
   topBarShadow: '0 2px 2px -1px var(--p-shadow-from-direct-light)',
   buttonDropShadow: '0 1px 0 rgba(0, 0, 0, 0.05)',
   buttonInnerShadow: 'inset 0 -1px 0 rgba(0, 0, 0, 0.2)',
+  buttonPressedInnerShadow: 'inset 0 2px 0 rgba(0, 0, 0, 0.05)',
 
   // Overrides
   overrideNone: 'none',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/436

[Figma](https://www.figma.com/file/O3sxnpfbMTuV2e4Yb3HOsh/Tokens%3A-Shadows-Light-Mode-(WIP)?node-id=0%3A1)

![image](https://screenshot.click/Storybook_2020-09-09_15-05-59.png)

Primary / destructive are less noticeable but the shadow is still there. I also had to update the text color because that was reverting to --p-text and not visible at all

![image](https://screenshot.click/Storybook_2020-09-09_15-17-45.png)

### WHAT is this pull request doing?

Fixes pressed button states for default and primary / destructive buttons

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

Paste this into playground to test primary and destructive buttons

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, ButtonGroup, Button} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
    <ButtonGroup segmented>
      <Button pressed={isFirstButtonActive} primary onClick={handleFirstButtonClick}>
        First button
      </Button>
      <Button pressed={!isFirstButtonActive} destructive onClick={handleSecondButtonClick}>
        Second button
      </Button>
    </ButtonGroup>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
