### PR TITLE
[Collapsible]Add expandOnPrint prop to support showing content in print

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Update `EmptySearchResult` illustration ([#3185](https://github.com/Shopify/polaris-react/pull/3185)).
 - Update `ActionList` to allow the items to have a suffix ([#3216](https://github.com/Shopify/polaris-react/pull/3216)).
 - Added support for the `inputMode` attribute on the `TextField` component ([#3222](https://github.com/Shopify/polaris-react/pull/3222)).
+- Added `expandOnPrint` prop to `Collapsible` for print support ([#3231](https://github.com/Shopify/polaris-react/pull/3231))
 
 ### Bug fixes
 

--- a/src/components/Collapsible/Collapsible.scss
+++ b/src/components/Collapsible/Collapsible.scss
@@ -22,3 +22,11 @@
 .fullyOpen {
   overflow: visible;
 }
+
+.expandOnPrint {
+  @include when-printing {
+    opacity: 1;
+    max-height: none !important;
+    overflow: visible;
+  }
+}

--- a/src/components/Collapsible/Collapsible.scss
+++ b/src/components/Collapsible/Collapsible.scss
@@ -26,6 +26,7 @@
 .expandOnPrint {
   @include when-printing {
     opacity: 1;
+    // stylelint-disable-next-line declaration-no-important
     max-height: none !important;
     overflow: visible;
   }

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -20,6 +20,8 @@ interface Transition {
 export interface CollapsibleProps {
   /** Assign a unique ID to the collapsible. For accessibility, pass this ID as the value of the triggering component’s aria-controls prop. */
   id: string;
+  /** Option to show collapsible content when printing */
+  expandOnPrint?: boolean;
   /** Toggle whether the collapsible is expanded or not. */
   open: boolean;
   /** Assign transition properties to the collapsible */
@@ -114,7 +116,7 @@ class CollapsibleInner extends Component<CollapsibleProps, State> {
   }
 
   render() {
-    const {id, open, children, transition} = this.props;
+    const {id, expandOnPrint, open, children, transition} = this.props;
     const {animationState, height} = this.state;
     const parentCollapsibleExpanding = this.context;
 
@@ -125,11 +127,12 @@ class CollapsibleInner extends Component<CollapsibleProps, State> {
       open && styles.open,
       animating && styles.animating,
       !animating && open && styles.fullyOpen,
+      expandOnPrint && styles.expandOnPrint,
     );
 
     const displayHeight = collapsibleHeight(open, animationState, height);
 
-    const content = animating || open ? children : null;
+    const content = animating || open || expandOnPrint ? children : null;
 
     const transitionProperties = transition
       ? {

--- a/src/components/Collapsible/tests/Collapsible.test.tsx
+++ b/src/components/Collapsible/tests/Collapsible.test.tsx
@@ -47,6 +47,26 @@ describe('<Collapsible />', () => {
     expect(collapsible.contains('content')).toBe(true);
   });
 
+  it('renders its children when expandOnPrint is true and open is false', () => {
+    const collapsible = mountWithAppProvider(
+      <Collapsible id="test-collapsible" open={false} expandOnPrint>
+        content
+      </Collapsible>,
+    );
+
+    expect(collapsible.contains('content')).toBe(true);
+  });
+
+  it('renders its children when expandOnPrint is true and open is true', () => {
+    const collapsible = mountWithAppProvider(
+      <Collapsible id="test-collapsible" open expandOnPrint>
+        content
+      </Collapsible>,
+    );
+
+    expect(collapsible.contains('content')).toBe(true);
+  });
+
   describe('Transition', () => {
     it('passes a duration property', () => {
       const duration = Tokens.duration150;


### PR DESCRIPTION


### WHY are these changes introduced?
This `expandOnPrint` prop will allow a consumer the option to setup their collapsible such that when it is printed, the content in the collapsible is always shown regardless of its `open` state on the page. This makes it easier for users to see collapsed details without having to click and open the collapsibles on the page before printing. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Allows a consumer to  show the collapsible content in a print preview even when collapsible is closed
<details>
   <summary>Behaviour with expandOnPrint true - print preview shows content even when collapsible is closed</summary>
    <img src="https://user-images.githubusercontent.com/313318/92800416-aa7f7800-f382-11ea-8d3a-d498d45f1e35.gif" alt="Showing behaviour with expandOnPrint true">
</details>

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->
Using the playground code below, run `yarn dev` and then use the right click menu to print the page with the collapsible close or open. Either way the print preview should show the collapsible as open. 

<details>
<summary>Copy-paste this code in `playground/Playground.tsx`:</summary>

```jsx

import React, {useState, useCallback} from 'react';

import {Page, Card, Stack, Button, Collapsible, TextContainer} from '../src';

export function Playground() {
  const [active, setActive] = useState(false);

  const handleToggle = useCallback(() => setActive((active) => !active), []);

  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
      <Card sectioned>
        <Stack vertical>
          <Button
            onClick={handleToggle}
            ariaExpanded={active}
            ariaControls="basic-collapsible"
          >
            Toggle
          </Button>
          <Collapsible
            open={active}
            id="basic-collapsible"
            transition={{duration: '150ms', timingFunction: 'ease'}}
            expandOnPrint
          >
            <TextContainer>
              Your mailing list lets you contact customers or visitors who have
              shown an interest in your store. Reach out to them with exclusive
              offers or updates about your products.
            </TextContainer>
          </Collapsible>
        </Stack>
      </Card>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
