### PR TITLE
[Filters] Fix spacing issues with filters button group

### DIFF
--- a/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
+++ b/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
@@ -57,8 +57,8 @@ $stacking-order: (
 }
 
 .newDesignLanguage {
-  .CenterContainer + .RightContainer {
-    margin-left: spacing(extra-tight);
+  .CenterContainer {
+    margin-right: spacing(extra-tight);
   }
 }
 

--- a/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
+++ b/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
@@ -58,7 +58,7 @@ $stacking-order: (
 
 .newDesignLanguage {
   .CenterContainer {
-    margin-right: spacing(extra-tight);
+    margin-right: spacing(tight);
   }
 }
 

--- a/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
+++ b/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
@@ -57,8 +57,9 @@ $stacking-order: (
 }
 
 .newDesignLanguage {
-  .CenterContainer {
-    margin-right: spacing(tight);
+  .CenterContainer + .RightContainer,
+  .CenterContainer + .MoreFiltersButtonContainer {
+    margin-left: spacing(extra-tight) / 2;
   }
 }
 


### PR DESCRIPTION
# WHY are these changes introduced?

Fixes #3163  [https://github.com/Shopify/polaris-react/issues/3163]

### WHAT is this pull request doing?
Fixes the issue of the filter customers textfield and more filters button when the screen is small. 

Before
<img width="311" alt="Screen Shot 2020-09-11 at 11 46 29 AM" src="https://user-images.githubusercontent.com/54586463/92946321-7e1c3800-f424-11ea-90b5-7a45f1c86723.png">

After
<img width="535" alt="Screen Shot 2020-09-14 at 2 21 59 PM" src="https://user-images.githubusercontent.com/54586463/93123229-c5f5c600-f695-11ea-9f25-c52c1c729944.png">

<img width="318" alt="Screen Shot 2020-09-14 at 2 22 12 PM" src="https://user-images.githubusercontent.com/54586463/93123270-d0b05b00-f695-11ea-891f-d40e2c185a78.png">


### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
