### PR TITLE
[Navigation] reduce left and right padding by 0.4rem

### DIFF
--- a/playground/DetailsPage.scss
+++ b/playground/DetailsPage.scss
@@ -4,7 +4,7 @@ $top-bar-height: 56px;
 .ContextControl {
   display: flex;
   align-items: center;
-  padding: 0 16px;
+  padding: 0 12px;
   height: $top-bar-height;
 }
 

--- a/src/components/Navigation/Navigation.scss
+++ b/src/components/Navigation/Navigation.scss
@@ -314,7 +314,7 @@ $secondary-item-font-size: rem(15px);
     .Navigation-newDesignLanguage & {
       @include focus-ring;
       font-weight: 500;
-      padding-left: nav(icon-size) + spacing(extra-loose);
+      padding-left: nav(icon-size) + spacing(extra-loose) - spacing(extra-tight);
 
       @include breakpoint-after(nav-min-window-corrected()) {
         font-size: $item-font-size-small;

--- a/src/components/Navigation/_variables.scss
+++ b/src/components/Navigation/_variables.scss
@@ -45,7 +45,8 @@ $nav-animation-variables: (
   .Navigation-newDesignLanguage & {
     font-weight: 600;
     line-height: $item-line-height-large;
-    padding-left: spacing();
+    padding-left: spacing() - spacing(extra-tight);
+    padding-right: spacing(extra-tight);
   }
 
   &:hover {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/442

### WHAT is this pull request doing?

This gives nav item labels more room within the nav. Necessary for languages that are generally longer than english. More context in the issue above

Before | After
---|---
<img width="640" src="https://screenshot.click/Storybook_2020-09-11_14-38-14.png"> | <img width="640" src="https://screenshot.click/Storybook_2020-09-11_14-37-58.png">

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
