### PR TITLE
[Popover] Add prop to allow hiding popover overlay when printing.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Update `ActionList` to allow the items to have a suffix ([#3216](https://github.com/Shopify/polaris-react/pull/3216)).
 - Added support for the `inputMode` attribute on the `TextField` component ([#3222](https://github.com/Shopify/polaris-react/pull/3222)).
 - Added `expandOnPrint` prop to `Collapsible` for print support ([#3231](https://github.com/Shopify/polaris-react/pull/3231))
+- Added `hideOnPrint` prop to `Popover` to allow hiding the overlay when printing ([#3242](https://github.com/Shopify/polaris-react/pull/3242))
 
 ### Bug fixes
 

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -108,3 +108,7 @@ $content-max-width: rem(400px);
 .FocusTracker {
   @include visually-hidden;
 }
+
+.PopoverOverlay-hideOnPrint {
+  @include hidden-when-printing;
+}

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -61,6 +61,8 @@ export interface PopoverProps {
   fixed?: boolean;
   /** Used to illustrate the type of popover element */
   ariaHaspopup?: AriaAttributes['aria-haspopup'];
+  /** Allow the popover overaly to be hidden when printing */
+  hideOnPrint?: boolean;
   /** Callback when popover is closed */
   onClose(source: PopoverCloseSource): void;
 }

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -45,6 +45,7 @@ export interface PopoverOverlayProps {
   preventAutofocus?: boolean;
   sectioned?: boolean;
   fixed?: boolean;
+  hideOnPrint?: boolean;
   onClose(source: PopoverCloseSource): void;
 }
 
@@ -185,6 +186,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
       fullWidth,
       fullHeight,
       fluidContent,
+      hideOnPrint,
     } = this.props;
 
     const className = classNames(
@@ -192,6 +194,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
       positioning === 'above' && styles.positionedAbove,
       fullWidth && styles.fullWidth,
       measuring && styles.measuring,
+      hideOnPrint && styles.hideOnPrint,
     );
 
     const contentStyles = measuring ? undefined : {height: desiredHeight};


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

If there is a print action in a popover, the Popover overlay is still shown when printing the page which can cause obstruction of data on the page. Added `hideOnPrint` prop to `Popover` to allow a consumer to hide the overlay when printing.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Adding a new prop to allow hiding the popover overlay when printing. 

 <details>
      <summary>Gif of hiding the popover when printing</summary>
      <img src="https://user-images.githubusercontent.com/313318/93030682-dacd4d80-f5f2-11ea-82ec-ea2c5b7a907b.gif" alt="Showing gif of hiding the popover when printing">
</details>



## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {Button, ActionList, Popover} from '../src';

export function Playground() {
  const [popoverActive, setPopoverActive] = useState(false);

  const togglePopoverActive = useCallback(
    () => setPopoverActive((popoverActive) => !popoverActive),
    [],
  );

  const activator = (
    <Button onClick={togglePopoverActive} disclosure>
      More actions
    </Button>
  );

  return (
    <div style={{height: '250px'}}>
      <Popover
        active={popoverActive}
        activator={activator}
        onClose={togglePopoverActive}
        hideOnPrint
      >
        <ActionList
          items={[
            {content: 'Import', onAction: window.print},
            {content: 'Export'},
          ]}
        />
      </Popover>
    </div>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
