### PR TITLE
[ButtonGroup] Fix Segmented Button Gap Fix

### DIFF
--- a/documentation/Color system.md
+++ b/documentation/Color system.md
@@ -271,7 +271,7 @@ Used to decorate elements where color does convey a specific meaning in componen
 | `--p-text-field-spinner-offset`           | `0.2rem`                                                                                                     |
 | `--p-text-field-focus-ring-offset`        | `-0.4rem`                                                                                                    |
 | `--p-text-field-focus-ring-border-radius` | `0.7rem`                                                                                                     |
-| `--p-button-group-item-spacing`           | `0.2rem`                                                                                                     |
+| `--p-button-group-item-spacing`           | `-0.1rem`                                                                                                    |
 | `--p-contextual-save-bar-height`          | `64px`                                                                                                       |
 | `--p-duration-1-0-0`                      | `100ms`                                                                                                      |
 | `--p-duration-1-5-0`                      | `150ms`                                                                                                      |

--- a/src/components/ButtonGroup/ButtonGroup.scss
+++ b/src/components/ButtonGroup/ButtonGroup.scss
@@ -44,7 +44,7 @@ $item-spacing: spacing(tight);
     margin-left: 0;
 
     &:not(:first-child) {
-      margin-left: var(--p-button-group-item-spacing, -1 * border-width());
+      margin-left: -1 * border-width();
     }
   }
 

--- a/src/utilities/theme/tokens.ts
+++ b/src/utilities/theme/tokens.ts
@@ -38,7 +38,7 @@ export const Tokens = {
   textFieldSpinnerOffset: rem('2px'),
   textFieldFocusRingOffset: rem('-4px'),
   textFieldFocusRingBorderRadius: rem('7px'),
-  buttonGroupItemSpacing: rem('2px'),
+  buttonGroupItemSpacing: rem('-1px'),
   contextualSaveBarHeight: '64px',
   duration100: '100ms',
   duration150: '150ms',


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes https://github.com/Shopify/polaris-react/issues/3243

### WHAT is this pull request doing?
This PR is fixing the gap between segmented buttons.

After 

Button group with segmented buttons
<img width="247" alt="Screen Shot 2020-09-16 at 3 10 27 PM" src="https://user-images.githubusercontent.com/54586463/93381516-c7a6c180-f82e-11ea-874a-382610698341.png">

Filters (Some filters disabled)
<img width="1456" alt="Screen Shot 2020-09-16 at 3 11 16 PM" src="https://user-images.githubusercontent.com/54586463/93381619-ef962500-f82e-11ea-9e56-68aad14901e4.png">


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
