### PR TITLE
Move discard modal out of theme provider

### DIFF
--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -143,6 +143,7 @@ export function DetailsPage() {
       }}
       discardAction={{
         onAction: handleDiscard,
+        discardConfirmationModal: true,
       }}
     />
   ) : null;

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -127,7 +127,6 @@ export function ContextualSaveBar({
             </div>
           </div>
         </div>
-
       </ThemeProvider>
       {discardConfirmationModalMarkup}
     </>

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -113,20 +113,23 @@ export function ContextualSaveBar({
   );
 
   return (
-    <ThemeProvider theme={{colorScheme: 'inverse'}}>
-      <div className={contexualSaveBarClassName}>
-        {logoMarkup}
-        <div className={contentsClassName}>
-          <h2 className={styles.Message}>{message}</h2>
-          <div className={styles.ActionContainer}>
-            <Stack spacing="tight" wrap={false}>
-              {discardActionMarkup}
-              {saveActionMarkup}
-            </Stack>
+    <>
+      <ThemeProvider theme={{colorScheme: 'inverse'}}>
+        <div className={contexualSaveBarClassName}>
+          {logoMarkup}
+          <div className={contentsClassName}>
+            <h2 className={styles.Message}>{message}</h2>
+            <div className={styles.ActionContainer}>
+              <Stack spacing="tight" wrap={false}>
+                {discardActionMarkup}
+                {saveActionMarkup}
+              </Stack>
+            </div>
           </div>
         </div>
-      </div>
+
+      </ThemeProvider>
       {discardConfirmationModalMarkup}
-    </ThemeProvider>
+    </>
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This fixes #3219 


### WHAT is this pull request doing?

It moves the discard modal out of the `ContextualSaveBar`'s theme provider so that it doesn't inherit the same dark theme.

This is what it looks like after this change:

<img width="975" alt="Screen Shot 2020-09-17 at 4 23 44 PM" src="https://user-images.githubusercontent.com/478990/93524595-b9c27080-f902-11ea-9373-7151c54ba8e4.png">


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Use the details page view in storybook and make a change to the title and then try to discard with the context bar
