### PR TITLE
[Breadcrumbs] Render content as a visually hidden label if new design language is enabled

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -7,6 +7,7 @@ import type {CallbackAction, LinkAction} from '../../types';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 import {FeaturesContext} from '../../utilities/features';
 import {classNames} from '../../utilities/css';
+import {VisuallyHidden} from '../VisuallyHidden';
 
 import styles from './Breadcrumbs.scss';
 
@@ -36,7 +37,9 @@ export class Breadcrumbs extends PureComponent<BreadcrumbsProps, never> {
             source={newDesignLanguage ? ArrowLeftMinor : ChevronLeftMinor}
           />
         </span>
-        {newDesignLanguage ? null : (
+        {newDesignLanguage ? (
+          <VisuallyHidden>{content}</VisuallyHidden>
+        ) : (
           <span className={styles.Content}>{content}</span>
         )}
       </span>

--- a/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
@@ -5,6 +5,7 @@ import {mountWithAppProvider} from 'test-utilities/legacy';
 import {UnstyledLink} from '../../UnstyledLink';
 import type {CallbackAction, LinkAction} from '../../../types';
 import {Breadcrumbs} from '../Breadcrumbs';
+import {VisuallyHidden} from '../../VisuallyHidden';
 
 describe('<Breadcrumbs />', () => {
   describe('url', () => {
@@ -126,6 +127,29 @@ describe('<Breadcrumbs />', () => {
       expect(wrapper.find(UnstyledLink).prop('className')).toStrictEqual(
         'Breadcrumb',
       );
+    });
+
+    it('renders breadcrumb content as a visually hidden label when the new design language is enabled', () => {
+      const wrapper = mountWithAppProvider(
+        <Breadcrumbs breadcrumbs={linkBreadcrumbs} />,
+        {
+          features: {newDesignLanguage: true},
+        },
+      );
+
+      expect(wrapper.find(VisuallyHidden).text()).toStrictEqual('Products');
+    });
+
+    it('does not render breadcrumb content as a visually hidden label when the new design language is enabled', () => {
+      const wrapper = mountWithAppProvider(
+        <Breadcrumbs breadcrumbs={linkBreadcrumbs} />,
+        {
+          features: {newDesignLanguage: false},
+        },
+      );
+
+      expect(wrapper.find(VisuallyHidden)).toHaveLength(0);
+      expect(wrapper.find('.Content').text()).toStrictEqual('Products');
     });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3271

While auditing the new design language, we noticed that the Page breadcrumb is missing an accessible text label even when a `content` prop is defined:

|Markup|Output
|---|---
|`<Page title="Playground" breadcrumbs={[{content: 'Visually hidden breadcrumb content', url: 'https://shopify.com'},]}>`|![image](https://user-images.githubusercontent.com/8534230/93615958-1163e900-f9a2-11ea-8023-dba3fecbb0f2.png)

This fails to meet web accessibility guidelines that requires either visible or visually hidden text labels for all links and controls.

This is a regression from the previous design language, which rendered a visible text label for the breadcrumb component. 

It is also divergent from the Polaris Rails breadcrumb component, which does render a visually hidden label when the new design language is enabled.

![image](https://user-images.githubusercontent.com/8534230/93616311-93eca880-f9a2-11ea-82b2-d10baf09d748.png)

### WHAT is this pull request doing?
This pull request updates the following ternary, which currently sets the breadcrumb content to `null` if the new design language is enabled:

```jsx
        // Render a visually hidden label instead of null when newDesignLanguage is true
        {newDesignLanguage ? null : (
          <span className={styles.Content}>{content}</span>
        )}
```

Instead of setting the breadcrumb content to `null` when `newDesignLanguage` is true, this PR renders the content as a `VisuallyHidden` component:

```jsx
        {newDesignLanguage ? (
          <VisuallyHidden>{content}</VisuallyHidden>
        ) : (
          <span className={styles.Content}>{content}</span>
        )}
```

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page
      title="Playground"
      breadcrumbs={[
        {
          content: 'Visually hidden breadcrumb content',
          url: 'https://shopify.com',
        },
      ]}
    >
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
