### PR TITLE
[Banner] Fix focus ring border radius on in-content banners

### DIFF
--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -27,8 +27,10 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
       inset shadow(transparent),
       shadow()
     );
+    @include focus-ring('wide');
   } @else {
     border-radius: var(--p-border-radius-base, border-radius());
+    @include focus-ring('base');
   }
 
   @if $tint {
@@ -36,8 +38,6 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
   } @else {
     background-color: var(--p-banner-background, $background);
   }
-
-  @include focus-ring('wide');
 
   &:focus {
     outline: none;
@@ -123,7 +123,6 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 }
 
 .withinContentContainer {
-  border-radius: var(--p-border-radius-wide, border-radius());
   padding: spacing(tight) $intermediate-spacing;
 
   &.newDesignLanguage {


### PR DESCRIPTION
### WHY are these changes introduced?

Focus ring border radius wasn't being applied properly on focusable banners:

before:
<img width="621" alt="Screen Shot 2020-09-18 at 2 45 47 PM" src="https://user-images.githubusercontent.com/1229901/93633979-d40d5480-f9bd-11ea-8e60-0cead9aa78be.png">
after:

<img width="628" alt="Screen Shot 2020-09-18 at 2 44 21 PM" src="https://user-images.githubusercontent.com/1229901/93633986-d66fae80-f9bd-11ea-8087-ee787f4445b3.png">
### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

In storybook ensure that with and without the design language enable, both the regular Banner and the Banner inside modal get the proper border-radius when focuses.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
