### PR TITLE
Hide popover menu (rollup or non rollup) for action menus on print

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Hide `ActionMenu`, `Actions`, `RollupActions` menu popover overlays when printing ([#3277](https://github.com/Shopify/polaris-react/pull/3277))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
+++ b/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
@@ -68,6 +68,7 @@ export function MenuGroup({
       activator={popoverActivator}
       preferredAlignment="left"
       onClose={handleClose}
+      hideOnPrint
     >
       <ActionList items={actions} onActionAnyItem={handleClose} />
       {details && <div className={styles.Details}>{details}</div>}

--- a/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
+++ b/src/components/ActionMenu/components/RollupActions/RollupActions.tsx
@@ -50,6 +50,7 @@ export function RollupActions({items = [], sections = []}: RollupActionsProps) {
       activator={activatorMarkup}
       preferredAlignment="right"
       onClose={toggleRollupOpen}
+      hideOnPrint
     >
       <ActionList
         items={items}

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -61,7 +61,7 @@ export interface PopoverProps {
   fixed?: boolean;
   /** Used to illustrate the type of popover element */
   ariaHaspopup?: AriaAttributes['aria-haspopup'];
-  /** Allow the popover overaly to be hidden when printing */
+  /** Allow the popover overlay to be hidden when printing */
   hideOnPrint?: boolean;
   /** Callback when popover is closed */
   onClose(source: PopoverCloseSource): void;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
The header actions for the `Page` component are hidden by default when printing. However any popover menus that were opened by these actions are currently not. These changes attempt to fix that and hide any menu popovers. 
After some discussion, the changes have been made to hide `ActionMenu` popovers by default without adding any new props.

Stems from 'hide when printing' requirements https://github.com/Shopify/store/issues/8609
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<details>
  <summary>Hide page action popovers on print</summary>
  <img src="https://user-images.githubusercontent.com/313318/93647780-3f175500-f9d7-11ea-9b6c-3b6cabfe6f93.gif" alt="hide page action popover on print">
</details>


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>. Click on the <code>Print</code> action, under the <code>Promote</code> action group, to launch the print window and see that there is no popover shown. Try this on a smaller size window as well to use the Rollup action menu:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {Button, Page, Collapsible, Card, TextStyle, Stack} from '../src';

export function Playground() {
  return (
    <div style={{height: '250px'}}>
      <Page
        breadcrumbs={[{content: 'Products', url: '/products'}]}
        title="3/4 inch Leather pet collar"
        subtitle="Perfect for any pet"
        primaryAction={{content: 'Save', disabled: true}}
        secondaryActions={[
          {
            content: 'Duplicate',
            accessibilityLabel: 'Secondary action label',
            onAction: () => alert('Duplicate action'),
          },
          {
            content: 'View on your store',
            onAction: () => alert('View on your store action'),
          },
        ]}
        actionGroups={[
          {
            title: 'Promote',
            accessibilityLabel: 'Action group label',
            actions: [
              {
                content: 'Print',
                accessibilityLabel: 'Individual action label',
                onAction: window.print,
              },
            ],
          },
        ]}
        pagination={{
          hasPrevious: true,
          hasNext: true,
        }}
      >
        <p>
          <TextStyle variation="subdued">myLabel</TextStyle>
         </p>    
      </Page>
    </div>
  );
}


```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
