### PR TITLE
Disable SB docs as it drastically slows down iframe load

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -11,7 +11,7 @@ const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
 module.exports = {
   stories: ['../playground/stories.tsx', '../src/components/**/*/README.md'],
   addons: [
-    '@storybook/addon-essentials',
+    {name: '@storybook/addon-essentials', options: {docs: false}},
     '@storybook/addon-a11y',
     '@storybook/addon-contexts',
     '@storybook/addon-knobs',


### PR DESCRIPTION
### WHY are these changes introduced?

Our a11y tests are now very slow, taking 45mins to complete. That's not acceptable if we want speedy dev feedback cycles. https://github.com/Shopify/polaris-react/pull/3284 is a testbed for a bunch of changes that can be added incrementally. I'll be splitting them out over a few PRs. Here's the first one

The Storybook iframe load time goes from ~800ms to ~3200ms if you enable
docs.

This has a massive knock-on effect to our a11y tests - we we load the
iframe for each story (606 times) this means our test end up quite a bit
longer than before SB 6.

Losing Docs is a shame, but we've not really used them to their fullest extent and we can look reenabling them once other speed improvements get applied, but this is a good first bandaid for now even if it isn't ideal long-term.

### WHAT is this pull request doing?

Disables storybook docs, so that the docs js DLL isn't loaded in the preview iframe, which reduces load time considerably.

### How to 🎩

Run a11y tests, see that they take less time than before (45mins)
