### PR TITLE
Use contrasting colors in theming examples

### DIFF
--- a/src/components/AppProvider/README.md
+++ b/src/components/AppProvider/README.md
@@ -220,7 +220,7 @@ function AppProviderThemeExample() {
   const theme = {
     colors: {
       topBar: {
-        background: '#357997',
+        background: '#225062',
       },
     },
     logo: {
@@ -330,9 +330,11 @@ function AppProviderWithAllThemeKeysExample() {
   const theme = {
     colors: {
       topBar: {
-        background: '#357997',
-        backgroundLighter: '#6192a9',
-        color: '#FFFFFF',
+        background: '#fff',
+        backgroundLighter: '#F4F6F8',
+        backgroundDarker: '#DFE3E8',
+        border: '#C4CDD5',
+        color: '#212B36',
       },
     },
     logo: {

--- a/src/components/Frame/README.md
+++ b/src/components/Frame/README.md
@@ -312,7 +312,7 @@ function FrameExample() {
   const theme = {
     colors: {
       topBar: {
-        background: '#357997',
+        background: '#225062',
       },
     },
     logo: {
@@ -655,7 +655,7 @@ function FrameExample() {
   const theme = {
     colors: {
       topBar: {
-        background: '#357997',
+        background: '#225062',
       },
     },
     frameOffset: 60,

--- a/src/components/TopBar/README.md
+++ b/src/components/TopBar/README.md
@@ -180,7 +180,7 @@ function TopBarExample() {
   const theme = {
     colors: {
       topBar: {
-        background: '#357997',
+        background: '#225062',
       },
     },
     logo: {


### PR DESCRIPTION
### WHY are these changes introduced?

If we only pass in a "background" to the legacy theme then we adjust its
lightness to generate the "backgroundLighter" color, however changing 
lightness does not guarantee in a large enough contrast.

This problem goes away with new theming so no need to think too hard
about it. Ideally we could push people towards having to specify their own
accessible backgroundLighter color but as i say it won't be a problem for much longer.

Our theming examples use colors that don't produce a shade with high enough contrast so they cause a11y failures in storybook - as surfaced in #3284 where I investigate moving to use axe for our a11y tests so CI matches what storybook addons report. Let's fix the examples to use colors that generate accessible color schemes.

### WHAT is this pull request doing?

Updates examples:

- Examples that only specify a background color now use `#225062`
- Examples that specify a full set of colors consistently use a light color scheme - The AppProvider example matches what is done in Frame for "all theme keys" examples.

### How to 🎩

Open the relevant examples in storybook and see that the Accessibility addon tab no longer reports errors