### PR TITLE
Add sub navigation example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [these versioning and changelog guidelines](https://git.i
 
 ### Bug fixes
 
-- Add position relative back to FrameContent [#3259](https://github.com/Shopify/polaris-react/pull/3259)
+- Add position relative back to FrameContent ([#3259](https://github.com/Shopify/polaris-react/pull/3259))
 
 ## 5.3.0 - 2020-09-15
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Add subNavigationItems to the Navigation example ([3295](https://github.com/Shopify/polaris-react/pull/3295))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Navigation/README.md
+++ b/src/components/Navigation/README.md
@@ -178,10 +178,24 @@ Use to present a navigation menu in the [frame](https://polaris.shopify.com/comp
         icon: HomeMajorMonotone,
       },
       {
-        url: '/path/to/place',
+        url: '#',
         label: 'Orders',
         icon: OrdersMajorTwotone,
         badge: '15',
+        subNavigationItems: [
+          {
+            url: '#',
+            label: 'Orders',
+          },
+          {
+            url: '/path/to/place',
+            label: 'Drafts',
+          },
+          {
+            url: '/path/to/place',
+            label: 'Abandoned checkouts',
+          },
+        ],
       },
       {
         url: '/path/to/place',


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses point 2 in https://github.com/Shopify/polaris-react/issues/1949

### WHAT is this pull request doing?

Make sure that sub navigation is surfaced on the navigation examples
