### PR TITLE
Update tag background

### DIFF
--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -9,7 +9,7 @@ $icon-size: rem(16px);
   align-items: center;
   min-height: $height;
   padding: 0 spacing(tight);
-  background-color: var(--p-action-secondary, color('sky'));
+  background-color: var(--p-background, color('sky'));
   border-radius: border-radius();
   color: var(--p-text, color('ink'));
 


### PR DESCRIPTION
# [View the changes](https://5d559397bae39100201eedc1-wmvnnciebr.chromatic.com/iframe.html?id=all-components-tag--all-examples&contexts=New%20Design%20Language%3DEnabled%20-%20Light%20Mode&viewMode=story)

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3289

![Screen Shot 2020-09-23 at 11 22 32 AM](https://user-images.githubusercontent.com/19199063/94033626-27e9b600-fd8f-11ea-8188-6a5fb1c17ab1.png)

### WHAT is this pull request doing?

![Screen Shot 2020-09-23 at 11 22 15 AM](https://user-images.githubusercontent.com/19199063/94033643-2b7d3d00-fd8f-11ea-9392-a4299e4a386f.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

The tabs are now the same color as the background, however they should not be used on that color. This makes tophatting a bit weird.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit