### PR TITLE
Only disable Storybook docs when running a11y tests

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,10 +8,16 @@ const postcssShopify = require('@shopify/postcss-plugin');
 // eslint-disable-next-line node/no-extraneous-require, import/no-extraneous-dependencies
 const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
 
+// Enabling docs means the preview panel takes an extra 2ish seconds to load
+// This usually isn't a big deal, except when we're running all of our stories
+// through our a11y tests, and a 2s delay over several hundred stories adds up.
+// This is an escape hatch to disable docs only wheile we're running a11y tests
+const enableDocs = !parseInt(process.env.STORYBOOK_DISABLE_DOCS || '0', 10);
+
 module.exports = {
   stories: ['../playground/stories.tsx', '../src/components/**/*/README.md'],
   addons: [
-    {name: '@storybook/addon-essentials', options: {docs: false}},
+    {name: '@storybook/addon-essentials', options: {docs: enableDocs}},
     '@storybook/addon-a11y',
     '@storybook/addon-contexts',
     '@storybook/addon-knobs',

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: 'Accessibility Tests'
       script:
-        - yarn run storybook:build --quiet
+        - STORYBOOK_DISABLE_DOCS=1 yarn run storybook:build --quiet
         - node ./scripts/pa11y.js
 
     # Travis builds on commit and for PR builds (where Travis merges your last


### PR DESCRIPTION
### WHY are these changes introduced?

@amrocha had good idea: (paraphrasing) "Docs are still useful, what if we only disable them during the a11y test?"

I keep fogetting that SB has decent support for environment variables.

### WHAT is this pull request doing?

Only disable docs when running a11y tests


### How to 🎩

- See that a11y test speed does not regress back down to ~45mins
- See that opening storybook normally / in chromatic you still have access to the docs panel