### PR TITLE
Add action list item prefix and fix content which should take as much as possible

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added `spacing` prop to `ButtonGroup` ([#3308](https://github.com/Shopify/polaris-react/pull/3308))
 - Added `contextControl` prop to `ContextualSaveBar` ([#3357](https://github.com/Shopify/polaris-react/pull/3357))
 - Added `spacing` prop to `DescriptionList` ([#3359](https://github.com/Shopify/polaris-react/pull/3359))
+- Added `prefix` prop to `ActionList` items ([#3313](https://github.com/Shopify/polaris-react/pull/3313))
 
 ### Bug fixes
 

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -311,7 +311,7 @@ $active-indicator-width: rem(3px);
   align-items: center;
 }
 
-.Image {
+.Prefix {
   @include recolor-icon(color('ink', 'light'), color('white'));
   display: flex;
   flex: 0 0 auto;

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -180,7 +180,7 @@ $active-indicator-width: rem(3px);
     pointer-events: none;
 
     // stylelint-disable-next-line selector-max-class
-    .Image,
+    .Prefix,
     .Suffix {
       @include recolor-icon(color('ink', 'lightest'), color('white'));
     }
@@ -296,7 +296,7 @@ $active-indicator-width: rem(3px);
     &.disabled {
       background-image: none;
       color: var(--p-text-disabled);
-      .Image,
+      .Prefix,
       .Suffix {
         @include recolor-icon(var(--p-icon-disabled));
       }

--- a/src/components/ActionList/README.md
+++ b/src/components/ActionList/README.md
@@ -312,6 +312,39 @@ function ActionListWithHelpTextExample() {
 }
 ```
 
+### Action list with a prefix and a suffix
+
+Use help text when the normal Verb noun syntax for the actions does not provide sufficient context for the merchant.
+
+```jsx
+function ActionListWithPrefixSuffixExample() {
+  return (
+    <div style={{height: '250px', maxWidth: '350px'}}>
+      <ActionList
+        items={[
+          {
+            content: 'Go here',
+            prefix: (
+              <Thumbnail
+                source="https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg"
+                size="small"
+                alt="Black leather pet collar"
+              />
+            ),
+            suffix: <Icon source={ChevronRightMinor} />,
+          },
+          {
+            content: 'Or there',
+            prefix: <Avatar customer name="Farrah" size="small" />,
+            suffix: <Icon source={ChevronRightMinor} />,
+          },
+        ]}
+      />
+    </div>
+  );
+}
+```
+
 ---
 
 ## Related components

--- a/src/components/ActionList/components/Item/Item.tsx
+++ b/src/components/ActionList/components/Item/Item.tsx
@@ -22,6 +22,7 @@ export function Item({
   onAction,
   icon,
   image,
+  prefix,
   suffix,
   disabled,
   external,
@@ -39,19 +40,21 @@ export function Item({
     newDesignLanguage && styles.newDesignLanguage,
   );
 
-  let imageElement: React.ReactNode | null = null;
+  let prefixMarkup: React.ReactNode | null = null;
 
-  if (icon) {
-    imageElement = (
-      <div className={styles.Image}>
+  if (prefix) {
+    prefixMarkup = <div className={styles.Prefix}>{prefix}</div>;
+  } else if (icon) {
+    prefixMarkup = (
+      <div className={styles.Prefix}>
         <Icon source={icon} />
       </div>
     );
   } else if (image) {
-    imageElement = (
+    prefixMarkup = (
       <div
         role="presentation"
-        className={styles.Image}
+        className={styles.Prefix}
         style={{backgroundImage: `url(${image}`}}
       />
     );
@@ -78,15 +81,11 @@ export function Item({
     <span className={styles.Suffix}>{suffix}</span>
   );
 
-  const textMarkup = imageElement ? (
-    <div className={styles.Text}>{contentMarkup}</div>
-  ) : (
-    contentMarkup
-  );
+  const textMarkup = <div className={styles.Text}>{contentMarkup}</div>;
 
   const contentElement = (
     <div className={styles.Content}>
-      {imageElement}
+      {prefixMarkup}
       {textMarkup}
       {badgeMarkup}
       {suffixMarkup}

--- a/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -42,6 +42,12 @@ describe('<Item />', () => {
     expect(item).toContainReactComponent(Suffix);
   });
 
+  it('renders a prefix when the prefix prop is defined', () => {
+    const Prefix = () => <div>Prefix</div>;
+    const item = mountWithApp(<Item prefix={<Prefix />} />);
+    expect(item).toContainReactComponent(Prefix);
+  });
+
   it('does not render a label when content is undefined and ellipsis is true', () => {
     const item = mountWithAppProvider(<Item ellipsis />);
     expect(item.text()).toBe('');

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,6 +170,8 @@ export interface ActionListItemDescriptor
   helpText?: string;
   /** Image source */
   image?: string;
+  /** Prefix source */
+  prefix?: React.ReactNode;
   /** Suffix source */
   suffix?: React.ReactNode;
   /**  Add an ellipsis suffix to action content */


### PR DESCRIPTION
### WHY are these changes introduced?

This PR does 2 things:
- Makes the "content" takes all the space, so the suffix/badge will always go right aligned. This is because it is already the behavior when the item has an icon/image. So this makes it be consistent with or without icons/images.
- Adds a `prefix` prop, in the same way `suffix` works, allowing any React nodes. This PR doesn't remove any other prop such as icon or image, but they could also be removed in favor of `prefix`. Ideally, we would remove all these extra props in a major release (v6?) and keeps the component flexible with these 2 props: prefix/suffix.

Does it make sense? Anything missing?

![image](https://user-images.githubusercontent.com/1972567/94184894-981d3800-fe72-11ea-9148-6f05f4fb829b.png)