### PR TITLE
Rangeslider focus

### DIFF
--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -140,6 +140,15 @@ $range-thumb-shadow-focus: var(
     );
     box-shadow: $range-thumb-shadow-error;
   }
+
+  &.newDesignLanguage {
+    @include focus-ring($size: 'wide', $border-width: border-width());
+    position: absolute;
+
+    &:focus {
+      @include focus-ring($style: 'focused');
+    }
+  }
 }
 
 $range-output-size: rem(32px);

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -161,11 +161,17 @@ export class DualThumb extends Component<DualThumbProps, State> {
       styles.Thumbs,
       styles.ThumbLower,
       disabled && styles.disabled,
+      this.context &&
+        this.context.newDesignLanguage &&
+        styles.newDesignLanguage,
     );
     const thumbUpperClassName = classNames(
       styles.Thumbs,
       styles.ThumbUpper,
       disabled && styles.disabled,
+      this.context &&
+        this.context.newDesignLanguage &&
+        styles.newDesignLanguage,
     );
 
     const trackWidth = this.state.trackWidth;

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -185,15 +185,14 @@ $range-thumb-shadow-focus: var(
 
   &.newDesignLanguage {
     @include range-thumb-selectors {
-      content: ' ';
       box-shadow: 0 0 0 0 var(--p-focused);
       transition: box-shadow duration(fast) var(--p-ease);
     }
 
     &:focus {
       @include range-thumb-selectors {
-        box-shadow: 0 0 0 rem(2px) var(--p-surface),
-          0 0 0 rem(4px) var(--p-focused);
+        box-shadow: 0 0 0 rem(1px) var(--p-surface),
+          0 0 0 rem(3px) var(--p-focused);
       }
     }
   }

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -182,6 +182,21 @@ $range-thumb-shadow-focus: var(
       background: var(--p-border-disabled, color('white'));
     }
   }
+
+  &.newDesignLanguage {
+    @include range-thumb-selectors {
+      content: ' ';
+      box-shadow: 0 0 0 0 var(--p-focused);
+      transition: box-shadow duration(fast) var(--p-ease);
+    }
+
+    &:focus {
+      @include range-thumb-selectors {
+        box-shadow: 0 0 0 rem(2px) var(--p-surface),
+          0 0 0 rem(4px) var(--p-focused);
+      }
+    }
+  }
 }
 
 ///

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -186,13 +186,14 @@ $range-thumb-shadow-focus: var(
   &.newDesignLanguage {
     @include range-thumb-selectors {
       box-shadow: 0 0 0 0 var(--p-focused);
+      border: 1px solid transparent;
       transition: box-shadow duration(fast) var(--p-ease);
     }
 
     &:focus {
       @include range-thumb-selectors {
-        box-shadow: 0 0 0 rem(1px) var(--p-surface),
-          0 0 0 rem(3px) var(--p-focused);
+        border-color: var(--p-surface);
+        box-shadow: 0 0 0 rem(2px) var(--p-focused);
       }
     }
   }

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import {useFeatures} from '../../../../utilities/features';
 import {classNames} from '../../../../utilities/css';
 import {clamp} from '../../../../utilities/clamp';
 import {Labelled, helpTextID} from '../../../Labelled';
@@ -35,6 +36,7 @@ export function SingleThumb(props: SingleThumbProps) {
     onBlur,
     onFocus,
   } = props;
+  const {newDesignLanguage} = useFeatures();
   const clampedValue = clamp(value, min, max);
   const describedBy: string[] = [];
 
@@ -79,6 +81,11 @@ export function SingleThumb(props: SingleThumbProps) {
     disabled && styles.disabled,
   );
 
+  const inputClassNames = classNames(
+    styles.Input,
+    newDesignLanguage && styles.newDesignLanguage,
+  );
+
   return (
     <Labelled
       id={id}
@@ -93,7 +100,7 @@ export function SingleThumb(props: SingleThumbProps) {
         <div className={styles.InputWrapper}>
           <input
             type="range"
-            className={styles.Input}
+            className={inputClassNames}
             id={id}
             name={id}
             min={min}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3211

### WHAT is this pull request doing?

![dual-slider](https://user-images.githubusercontent.com/19199063/94219228-50b79b80-feb4-11ea-8a45-201ab10ebdf4.gif)
![focus](https://user-images.githubusercontent.com/19199063/94219229-51503200-feb4-11ea-82fd-07366d07617d.gif)


### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit