### PR TITLE
Update translations: default

### DIFF
--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -65,13 +65,13 @@
         "december": "十二月"
       },
       "daysAbbreviated": {
-        "monday": "星期一",
-        "tuesday": "星期二",
-        "wednesday": "星期三",
-        "thursday": "星期四",
-        "friday": "周五",
-        "saturday": "星期六",
-        "sunday": "星期日"
+        "monday": "一",
+        "tuesday": "二",
+        "wednesday": "三",
+        "thursday": "四",
+        "friday": "五",
+        "saturday": "六",
+        "sunday": "日"
       },
       "days": {
         "monday": "星期一",


### PR DESCRIPTION
### WHY are these changes introduced?

The Chinese datepicker translations are inconsistent and take up quite a lot of space (3 characters), most Chinese sites just go with 一, 二, 三 (1, 2, 3) for the header labels.

### WHAT is this pull request doing?
Updates the datepicker header labels (abbreviated day names).

_Before (in Storybook test)_
<img width="606" alt="Screen Shot 2020-09-24 at 10 55 57 PM" src="https://user-images.githubusercontent.com/1108361/94162624-7e531380-feb9-11ea-9c69-f8075411ea86.png">

_After (in Storybook test)_
<img width="606" alt="Screen Shot 2020-09-24 at 10 54 41 PM" src="https://user-images.githubusercontent.com/1108361/94162627-7e531380-feb9-11ea-9fbf-3e3d05a48bee.png">

## Before you deploy
- [x] Check translations for malicious HTML.
- [x] This PR is [safe to rollback](https://development.shopify.io/guides/shipping/safe_to_merge#Signs_your_PR_is_safe_to_rollback).

## Questions?
- Visit [#help-i18n-and-translation](https://shopify.slack.com/messages/C7TJQLVC7) for questions about the this pull request.

@Shopify/polaris-team
