### PR TITLE
Toast highcontrast

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Updated `Toast` to use `currentColor` for the close icon ([#3324](https://github.com/Shopify/polaris-react/pull/3324)).
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Frame/components/Toast/Toast.scss
+++ b/src/components/Frame/components/Toast/Toast.scss
@@ -51,11 +51,14 @@ $Backdrop-opacity: 0.88;
   border: none;
   appearance: none;
   background: transparent;
-  color: currentColor;
-  @include recolor-icon(currentColor);
+  fill: var(--p-icon, color('white'));
   cursor: pointer;
 
   &:focus {
     outline: none;
+  }
+
+  @media (-ms-high-contrast: active) {
+    fill: ms-high-contrast-color('text');
   }
 }

--- a/src/components/Frame/components/Toast/Toast.scss
+++ b/src/components/Frame/components/Toast/Toast.scss
@@ -51,14 +51,11 @@ $Backdrop-opacity: 0.88;
   border: none;
   appearance: none;
   background: transparent;
-  fill: var(--p-icon, color('white'));
+  color: currentColor;
+  @include recolor-icon(currentColor);
   cursor: pointer;
 
   &:focus {
     outline: none;
-  }
-
-  @media (-ms-high-contrast: active) {
-    fill: ms-high-contrast-color('text');
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/398

### WHAT is this pull request doing?

Use `currentColor` on the SVG fill to make sure it follows the text color when in high contrast mode. See https://sarahmhigley.com/writing/whcm-quick-tips/ for more information.

![toast](https://user-images.githubusercontent.com/19199063/94372137-589c5900-00c9-11eb-9925-c108fd139066.PNG)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Open the [toast](https://5d559397bae39100201eedc1-wydjwmvuxu.chromatic.com/?path=/story/all-components-toast--all-examples) up in windows high contrast mode.

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit