### PR TITLE
Tweaks to DatePicker to test Popover width calc fix

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Update `DatePicker` layout so that `Popover` can calculate the width correctly ([#3326](https://github.com/Shopify/polaris-react/pull/3326))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -7,6 +7,7 @@ $font-size: rem(12px);
 $in-range-border-color: #9ca6de;
 
 $range-end-border-radius: rem(30px);
+$month-width: rem(240px);
 
 .DatePicker {
   position: relative;
@@ -14,21 +15,22 @@ $range-end-border-radius: rem(30px);
 
 .MonthContainer {
   display: flex;
-  flex-wrap: wrap;
   margin-top: -1 * spacing();
-  margin-left: -1 * spacing();
 }
 
 .Month {
-  flex: 1 1 rem(230px);
+  flex: 1 1 $month-width;
   margin-top: spacing();
-  margin-left: spacing();
   max-width: calc(100% - #{spacing()});
-  min-width: rem(230px);
+  min-width: $month-width;
   table-layout: fixed;
   border-collapse: collapse;
   border: none;
   border-spacing: 0;
+}
+
+.Month + .Month {
+  margin-left: spacing();
 }
 
 .Month-current {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3325 and unblocks https://github.com/Shopify/web/pull/32054

![Screen Shot 2020-09-27 at 3 33 05 PM](https://user-images.githubusercontent.com/19199063/94373934-c00cd580-00d6-11eb-9e65-835e79f3ca23.png)

### WHAT is this pull request doing?

Removing `flex: wrap` and cleaning up some small layout tweaks.

![Screen Shot 2020-09-27 at 3 33 31 PM](https://user-images.githubusercontent.com/19199063/94373942-cf8c1e80-00d6-11eb-9e49-dddaf0879c09.png)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {Page, Button, Popover, DatePicker, Select, Stack} from '../src';
import {CalendarMinor} from '@shopify/polaris-icons';

export function Playground() {
  const [popoverActive, setPopoverActive] = useState(true);

  const togglePopoverActive = useCallback(
    () => setPopoverActive((popoverActive) => !popoverActive),
    [],
  );

  const activator = (
    <Button icon={CalendarMinor} onClick={togglePopoverActive} disclosure>
      Today
    </Button>
  );

  const [{month, year}, setDate] = useState({month: 1, year: 2018});
  const [selectedDates, setSelectedDates] = useState({
    start: new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
    end: new Date('Mon Mar 12 2018 00:00:00 GMT-0500 (EST)'),
  });

  const handleMonthChange = useCallback(
    (month, year) => setDate({month, year}),
    [],
  );

  return (
    <Page title="Playground">
      <Popover
        active={popoverActive}
        activator={activator}
        onClose={togglePopoverActive}
        fluidContent
      >
        <Popover.Pane fixed>
          <Popover.Section>
            <Stack vertical>
              <Select label="Date range" />
              <DatePicker
                month={month}
                year={year}
                onChange={setSelectedDates}
                onMonthChange={handleMonthChange}
                selected={selectedDates}
                multiMonth
                allowRange
              />
            </Stack>
          </Popover.Section>
        </Popover.Pane>
      </Popover>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit