### PR TITLE
[DatePicker] Fix multimonth layout in Firefox

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixes `Badge` when it becomes 2 lines due to small viewport ([#3315](https://github.com/Shopify/polaris-react/pull/3315))
+- Update `DatePicker` layout so that `Popover` can calculate the width correctly ([#3330](https://github.com/Shopify/polaris-react/pull/3330))
 
 ### Documentation
 

--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -12,19 +12,23 @@ $range-end-border-radius: rem(30px);
   position: relative;
 }
 
-.MonthContainer {
+.MonthLayout {
   display: flex;
   flex-wrap: wrap;
   margin-top: -1 * spacing();
   margin-left: -1 * spacing();
 }
 
-.Month {
+.MonthContainer {
   flex: 1 1 rem(230px);
   margin-top: spacing();
   margin-left: spacing();
   max-width: calc(100% - #{spacing()});
   min-width: rem(230px);
+}
+
+.Month {
+  width: 100%;
   table-layout: fixed;
   border-collapse: collapse;
   border: none;

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -245,7 +245,7 @@ export function DatePicker({
           onClick={() => handleMonthChangeClick(showNextMonth, showNextYear)}
         />
       </div>
-      <div className={styles.MonthContainer}>
+      <div className={styles.MonthLayout}>
         <Month
           onFocus={handleFocus}
           focusedDate={focusDate}

--- a/src/components/DatePicker/components/Month/Month.tsx
+++ b/src/components/DatePicker/components/Month/Month.tsx
@@ -142,15 +142,17 @@ export function Month({
   ));
 
   return (
-    <table role="grid" className={styles.Month}>
-      <caption className={className}>
-        {i18n.translate(`Polaris.DatePicker.months.${monthName(month)}`)} {year}
-      </caption>
-      <thead>
-        <tr className={styles.WeekHeadings}>{weekdays}</tr>
-      </thead>
-      <tbody>{weeksMarkup}</tbody>
-    </table>
+    <div className={styles.MonthContainer}>
+      <table role="grid" className={styles.Month}>
+        <caption className={className}>
+          {i18n.translate(`Polaris.DatePicker.months.${monthName(month)}`)} {year}
+        </caption>
+        <thead>
+          <tr className={styles.WeekHeadings}>{weekdays}</tr>
+        </thead>
+        <tbody>{weeksMarkup}</tbody>
+      </table>
+    </div>
   );
 }
 

--- a/src/components/DatePicker/components/Month/Month.tsx
+++ b/src/components/DatePicker/components/Month/Month.tsx
@@ -145,7 +145,8 @@ export function Month({
     <div className={styles.MonthContainer}>
       <table role="grid" className={styles.Month}>
         <caption className={className}>
-          {i18n.translate(`Polaris.DatePicker.months.${monthName(month)}`)} {year}
+          {i18n.translate(`Polaris.DatePicker.months.${monthName(month)}`)}{' '}
+          {year}
         </caption>
         <thead>
           <tr className={styles.WeekHeadings}>{weekdays}</tr>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3325 and unblocks https://github.com/Shopify/web/pull/32054

![Screen Shot 2020-09-27 at 3 33 05 PM](https://user-images.githubusercontent.com/19199063/94373934-c00cd580-00d6-11eb-9e65-835e79f3ca23.png)

### WHAT is this pull request doing?

It adds a wrapping div around each month table so that the flex layout gets correctly calculated before showing the popover.

This is what it looks like now:

<img width="641" alt="Screen Shot 2020-09-28 at 10 29 51 AM" src="https://user-images.githubusercontent.com/478990/94445589-9e166000-0175-11eb-889b-cf0abc28673d.png">
<img width="296" alt="Screen Shot 2020-09-28 at 10 29 41 AM" src="https://user-images.githubusercontent.com/478990/94445591-9eaef680-0175-11eb-92c0-c92e6d9fae75.png">


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {Page, Button, Popover, DatePicker, Select, Stack} from '../src';
import {CalendarMinor} from '@shopify/polaris-icons';

export function Playground() {
  const [popoverActive, setPopoverActive] = useState(true);

  const togglePopoverActive = useCallback(
    () => setPopoverActive((popoverActive) => !popoverActive),
    [],
  );

  const activator = (
    <Button icon={CalendarMinor} onClick={togglePopoverActive} disclosure>
      Today
    </Button>
  );

  const [{month, year}, setDate] = useState({month: 1, year: 2018});
  const [selectedDates, setSelectedDates] = useState({
    start: new Date('Wed Feb 07 2018 00:00:00 GMT-0500 (EST)'),
    end: new Date('Mon Mar 12 2018 00:00:00 GMT-0500 (EST)'),
  });

  const handleMonthChange = useCallback(
    (month, year) => setDate({month, year}),
    [],
  );

  return (
    <Page title="Playground">
      <Popover
        active={popoverActive}
        activator={activator}
        onClose={togglePopoverActive}
        fluidContent
      >
        <Popover.Pane fixed>
          <Popover.Section>
            <Stack vertical>
              <Select label="Date range" />
              <DatePicker
                month={month}
                year={year}
                onChange={setSelectedDates}
                onMonthChange={handleMonthChange}
                selected={selectedDates}
                multiMonth
                allowRange
              />
            </Stack>
          </Popover.Section>
        </Popover.Pane>
      </Popover>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit