### PR TITLE
Added disclosure text to tabs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,7 +9,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Remove `button-base` mixin from `Frame` SkipAnchor ([#3303](https://github.com/Shopify/polaris-react/pull/3303))
-- Updated `Toast` to use `currentColor` for the close icon ([#3324](https://github.com/Shopify/polaris-react/pull/3324)).
+- Updated `Toast` to use `currentColor` for the close icon ([#3324](https://github.com/Shopify/polaris-react/pull/3324))
+- Added `disclosureText` to `Tabs` ([#3331](https://github.com/Shopify/polaris-react/pull/3331))
 
 ### Bug fixes
 

--- a/src/components/Tabs/README.md
+++ b/src/components/Tabs/README.md
@@ -230,3 +230,57 @@ function TabsWithBadgeExample() {
   );
 }
 ```
+
+### Tabs with custom disclosure
+
+Use to provide information about the popover contents
+
+```jsx
+function TabsWithCustomDisclosureExample() {
+  const [selected, setSelected] = useState(0);
+
+  const handleTabChange = useCallback(
+    (selectedTabIndex) => setSelected(selectedTabIndex),
+    [],
+  );
+
+  const tabs = [
+    {
+      id: 'all-customers',
+      content: 'All',
+      accessibilityLabel: 'All customers',
+      panelID: 'all-customers-content',
+    },
+    {
+      id: 'accepts-marketing',
+      content: 'Accepts marketing',
+      panelID: 'accepts-marketing-content',
+    },
+    {
+      id: 'repeat-customers',
+      content: 'Repeat customers',
+      panelID: 'repeat-customers-content',
+    },
+    {
+      id: 'prospects',
+      content: 'Prospects',
+      panelID: 'prospects-content',
+    },
+  ];
+
+  return (
+    <Card>
+      <Tabs
+        tabs={tabs}
+        selected={selected}
+        onSelect={handleTabChange}
+        disclosureText="More views"
+      >
+        <Card.Section title={tabs[selected].content}>
+          <p>Tab {selected} selected</p>
+        </Card.Section>
+      </Tabs>
+    </Card>
+  );
+}
+```

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -134,6 +134,10 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
   min-width: $item-min-width;
 }
 
+.titleWithIcon {
+  display: flex;
+}
+
 .Panel {
   display: block;
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -21,6 +21,8 @@ export interface TabsProps {
   tabs: TabDescriptor[];
   /** Fit tabs to container */
   fitted?: boolean;
+  /** Text to replace disclosures horizontal dots */
+  disclosureText?: string;
   /** Callback when tab is selected */
   onSelect?(selectedTabIndex: number): void;
 }
@@ -69,7 +71,15 @@ class TabsInner extends PureComponent<CombinedProps, State> {
   };
 
   render() {
-    const {tabs, selected, fitted, children, i18n, features} = this.props;
+    const {
+      tabs,
+      selected,
+      fitted,
+      children,
+      i18n,
+      features,
+      disclosureText,
+    } = this.props;
     const {tabToFocus, visibleTabs, hiddenTabs, showDisclosure} = this.state;
     const disclosureTabs = hiddenTabs.map((tabIndex) => tabs[tabIndex]);
     const {newDesignLanguage} = features;
@@ -118,17 +128,33 @@ class TabsInner extends PureComponent<CombinedProps, State> {
       disclosureActivatorVisible && styles['DisclosureTab-visible'],
     );
 
-    const activator = (
+    const disclosureActivatorClassName = classNames(
+      styles.TabContainer,
+      newDesignLanguage && styles.newDesignLanguage,
+    );
+
+    const disclosureButtonClassName = classNames(
+      styles.DisclosureActivator,
+      disclosureText && styles.Tab,
+    );
+
+    const disclosureButton = (
       <button
         type="button"
-        className={styles.DisclosureActivator}
+        className={disclosureButtonClassName}
         onClick={this.handleDisclosureActivatorClick}
         aria-label={i18n.translate('Polaris.Tabs.toggleTabsLabel')}
       >
         <span className={styles.Title}>
-          <Icon source={HorizontalDotsMinor} />
+          {disclosureText || <Icon source={HorizontalDotsMinor} />}
         </span>
       </button>
+    );
+
+    const activator = disclosureText ? (
+      <div className={disclosureActivatorClassName}>{disclosureButton}</div>
+    ) : (
+      disclosureButton
     );
 
     return (

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import React, {PureComponent} from 'react';
-import {HorizontalDotsMinor} from '@shopify/polaris-icons';
+import {HorizontalDotsMinor, CaretDownMinor} from '@shopify/polaris-icons';
 
 import {classNames} from '../../utilities/css';
 import {Icon} from '../Icon';
@@ -110,6 +110,7 @@ class TabsInner extends PureComponent<CombinedProps, State> {
       .map((tabIndex) => this.renderTabMarkup(tabs[tabIndex], tabIndex));
 
     const disclosureActivatorVisible = visibleTabs.length < tabs.length;
+    const hasCustomDisclosure = Boolean(disclosureText);
 
     const classname = classNames(
       styles.Tabs,
@@ -135,7 +136,21 @@ class TabsInner extends PureComponent<CombinedProps, State> {
 
     const disclosureButtonClassName = classNames(
       styles.DisclosureActivator,
-      disclosureText && styles.Tab,
+      hasCustomDisclosure && styles.Tab,
+    );
+
+    const disclosureButtonContentWrapperClassName = classNames(
+      styles.Title,
+      hasCustomDisclosure && styles.titleWithIcon,
+    );
+
+    const disclosureButtonContent = hasCustomDisclosure ? (
+      <>
+        {disclosureText}
+        <Icon source={CaretDownMinor} color="inkLighter" />
+      </>
+    ) : (
+      <Icon source={HorizontalDotsMinor} />
     );
 
     const disclosureButton = (
@@ -145,8 +160,8 @@ class TabsInner extends PureComponent<CombinedProps, State> {
         onClick={this.handleDisclosureActivatorClick}
         aria-label={i18n.translate('Polaris.Tabs.toggleTabsLabel')}
       >
-        <span className={styles.Title}>
-          {disclosureText || <Icon source={HorizontalDotsMinor} />}
+        <span className={disclosureButtonContentWrapperClassName}>
+          {disclosureButtonContent}
         </span>
       </button>
     );

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -458,6 +458,15 @@ describe('<Tabs />', () => {
   });
 
   describe('<Popover />', () => {
+    it('renders disclosureText when provided', () => {
+      const disclosureText = 'More views';
+      const wrapper = mountWithApp(
+        <Tabs {...mockProps} disclosureText={disclosureText} />,
+      );
+
+      expect(wrapper).toContainReactText(disclosureText);
+    });
+
     it('passes preferredPosition below to the Popover', () => {
       const tabs = mountWithAppProvider(<Tabs {...mockProps} />);
       const tabMeasurer = tabs.find(TabMeasurer);


### PR DESCRIPTION
### WHY are these changes introduced?

Order's uses a custom disclosure so let's systemize that!

### With current DL

![Screen Recording 2020-09-28 at 05 05 29 PM](https://user-images.githubusercontent.com/24610840/94488389-87412f00-01b0-11eb-844a-cb643ffd503a.gif)


### WIth new DL

![Screen Recording 2020-09-28 at 05 11 13 PM](https://user-images.githubusercontent.com/24610840/94488383-84463e80-01b0-11eb-9a1d-a9a1175acd1f.gif)


### WHAT is this pull request doing?

Allowing the disclosure in tabs to be replaced by text provided by the consumer

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
