### PR TITLE
Only show underline on hover/active/focus for plain button and link

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Remove `button-base` mixin from `Frame` SkipAnchor ([#3303](https://github.com/Shopify/polaris-react/pull/3303))
 - Updated `Toast` to use `currentColor` for the close icon ([#3324](https://github.com/Shopify/polaris-react/pull/3324))
 - Added `disclosureText` to `Tabs` ([#3331](https://github.com/Shopify/polaris-react/pull/3331))
+- Added underline to links on focus and active ([#3335](https://github.com/Shopify/polaris-react/pull/3335))
 
 ### Bug fixes
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -458,14 +458,12 @@ $stacking-order: (
     &:hover {
       @include recolor-icon(var(--p-interactive-hovered));
       color: var(--p-interactive-hovered);
-      text-decoration: underline;
     }
 
     &:focus {
       @include recolor-icon(var(--p-interactive));
       color: var(--p-interactive);
       @include no-focus-ring;
-      text-decoration: underline;
     }
 
     &:active {

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -12,10 +12,6 @@
   text-decoration: none;
   cursor: pointer;
 
-  &.newDesignLanguage {
-    text-decoration: underline;
-  }
-
   &:hover {
     color: var(--p-interactive-hovered, color('blue', 'dark'));
     text-decoration: underline;
@@ -24,6 +20,7 @@
   &:focus {
     $chrome-default-outline: rgba(0, 103, 244, 0.247) auto rem(4.5px);
     outline: var(--p-override-none, $chrome-default-outline);
+    text-decoration: underline;
   }
 
   @include focus-ring;
@@ -34,6 +31,9 @@
 
   &:active {
     position: relative;
+    color: var(--p-interactive-pressed, color('blue', 'dark'));
+    text-decoration: underline;
+
     &::before {
       content: var(--p-non-null-content, none);
       position: absolute;
@@ -47,8 +47,6 @@
 
       border-radius: border-radius();
     }
-    color: var(--p-interactive-pressed, color('blue', 'dark'));
-    text-decoration: underline;
   }
 }
 

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -152,7 +152,6 @@
     );
     border-color: $border-color;
     color: color('white');
-    text-decoration: none;
   }
 
   &:focus {


### PR DESCRIPTION
# [View the changes 🤘👀🤞](https://5d559397bae39100201eedc1-fcxrwfezlo.chromatic.com)

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3239

### WHAT is this pull request doing?

Reverts link changes, look at Percy. Should match https://polaris.shopify.com

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
