### PR TITLE
Adjust connected filter control spacing

### DIFF
--- a/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
+++ b/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
@@ -59,7 +59,7 @@ $stacking-order: (
 .newDesignLanguage {
   .CenterContainer + .RightContainer,
   .CenterContainer + .MoreFiltersButtonContainer {
-    margin-left: spacing(extra-tight) / 2;
+    margin-left: spacing(tight);
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

During a design review for the orders list with @patrickkidney & @AdamWhitcroft we discussed increasing the spacing between the connected filter to make the difference between grouped buttons & separated ones clearer.

#### Screenies

![Screen Shot 2020-09-30 at 12 26 40 PM](https://user-images.githubusercontent.com/24610840/94713992-8081fb80-0319-11eb-9136-d414c5c8e225.png)
![Screen Shot 2020-09-30 at 12 26 52 PM](https://user-images.githubusercontent.com/24610840/94713994-811a9200-0319-11eb-9a23-4f5e4f1d2ae3.png)
![Screen Shot 2020-09-30 at 12 27 08 PM](https://user-images.githubusercontent.com/24610840/94713998-824bbf00-0319-11eb-8e1f-31291ed6cd54.png)

