### PR TITLE
Bug fix: updates ProgressBar's background colour

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixes `Badge` when it becomes 2 lines due to small viewport ([#3315](https://github.com/Shopify/polaris-react/pull/3315))
 - Update `DatePicker` layout so that `Popover` can calculate the width correctly ([#3330](https://github.com/Shopify/polaris-react/pull/3330))
+- Changes `ProgressBar` background to neutral ([#3341](https://github.com/Shopify/polaris-react/pull/3341))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,7 +19,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixes `Badge` when it becomes 2 lines due to small viewport ([#3315](https://github.com/Shopify/polaris-react/pull/3315))
 - Update `DatePicker` layout so that `Popover` can calculate the width correctly ([#3330](https://github.com/Shopify/polaris-react/pull/3330))
-- Changes `ProgressBar` background to neutral ([#3341](https://github.com/Shopify/polaris-react/pull/3341))
 
 ### Documentation
 

--- a/src/components/ProgressBar/ProgressBar.scss
+++ b/src/components/ProgressBar/ProgressBar.scss
@@ -20,7 +20,7 @@
 .ProgressBar {
   overflow: hidden;
   width: 100%;
-  background-color: var(--p-action-secondary, color('sky'));
+  background-color: var(--p-surface-neutral, color('sky'));
   border-radius: var(--p-border-radius-base, border-radius());
 
   @media screen and (-ms-high-contrast: active) {


### PR DESCRIPTION
<img width="996" alt="Screen Shot 2020-09-30 at 1 14 48 PM" src="https://user-images.githubusercontent.com/3760543/94718143-4f0c2e80-031f-11eb-9dba-e405bd4c62de.png">

Closes https://github.com/Shopify/polaris-react/issues/3340

As per https://www.figma.com/file/4dAAt5iFPSaxUKiYVKrkYj/Admin-Design-Language-(Web)%3A-Components?node-id=5540%3A55