### PR TITLE
Bug fix: adds extra padding to dismissable banner

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixes `Badge` when it becomes 2 lines due to small viewport ([#3315](https://github.com/Shopify/polaris-react/pull/3315))
 - Update `DatePicker` layout so that `Popover` can calculate the width correctly ([#3330](https://github.com/Shopify/polaris-react/pull/3330))
+- Update `Banner` styling to apply `.hasDismissed` on new design language ([#3343](https://github.com/Shopify/polaris-react/pull/3343))
 
 ### Documentation
 

--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -204,6 +204,9 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 }
 
 .hasDismiss {
+  &.newDesignLanguage {
+    padding-right: spacing() + spacing(extra-tight) + control-height();
+  }
   padding-right: spacing() + spacing(extra-tight) + control-height();
 }
 


### PR DESCRIPTION
![Screen Shot 2020-09-30 at 3 09 45 PM](https://user-images.githubusercontent.com/3760543/94728936-fc3a7300-032e-11eb-83a2-5c9992dbce86.png)


`hasDismiss` style wasn't being applied to `.newDesignLanguage` since it had more cascading points for the regular padding. This works but not sure if the implementation is the best

Closes https://github.com/Shopify/store/issues/17695

When fixed, here are the styles that apply
![Screen Shot 2020-09-30 at 3 12 11 PM](https://user-images.githubusercontent.com/3760543/94729218-5e937380-032f-11eb-84fd-68ad93f57304.png)
