### PR TITLE
[Actions] Remove disable exhaustive deps lint

### DIFF
--- a/src/components/ActionMenu/components/Actions/Actions.tsx
+++ b/src/components/ActionMenu/components/Actions/Actions.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useCallback, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import debounce from 'lodash/debounce';
 
 import {sortAndOverrideActionOrder} from '../../utilities';
@@ -57,17 +57,17 @@ export function Actions({actions = [], groups = []}: Props) {
     [],
   );
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleResize = useCallback(
-    debounce(
-      () => {
-        if (!newDesignLanguage || !actionsLayoutRef.current) return;
-        setAvailableWidth(actionsLayoutRef.current.offsetWidth);
-      },
-      20,
-      {leading: false, trailing: true, maxWait: 40},
-    ),
-    [actionsLayoutRef],
+  const handleResize = useMemo(
+    () =>
+      debounce(
+        () => {
+          if (!newDesignLanguage || !actionsLayoutRef.current) return;
+          setAvailableWidth(actionsLayoutRef.current.offsetWidth);
+        },
+        20,
+        {leading: false, trailing: true, maxWait: 40},
+      ),
+    [newDesignLanguage],
   );
 
   useEffect(() => {


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses: https://github.com/Shopify/polaris-react/pull/3308#discussion_r498211820

Thanks for the suggestion @tleunen this seems to work well

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
