### PR TITLE
[Banner] Adjusting spacing

### DIFF
--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -125,7 +125,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 .withinContentContainer {
   padding: spacing(tight) $intermediate-spacing;
 
-  // stylelint-disable selector-max-specificity
+  // stylelint-disable selector-max-class
   &.newDesignLanguage {
     $newDesignLanguageSpacing: rem(14px);
     $newDesignLanguageOffset: $newDesignLanguageSpacing - spacing();
@@ -147,7 +147,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
       padding-right: spacing();
     }
   }
-  // stylelint-enable selector-max-specificity
+  // stylelint-enable selector-max-class
 
   @include banner-variants;
 

--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -125,16 +125,29 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 .withinContentContainer {
   padding: spacing(tight) $intermediate-spacing;
 
+  // stylelint-disable selector-max-specificity
   &.newDesignLanguage {
     $newDesignLanguageSpacing: rem(14px);
     $newDesignLanguageOffset: $newDesignLanguageSpacing - spacing();
     padding: spacing() spacing() $newDesignLanguageSpacing;
 
-    // stylelint-disable-next-line selector-max-class
+    &.hasDismiss {
+      padding-right: calc(#{2 * spacing()} + var(--p-icon-size));
+    }
+
     .ContentWrapper {
       margin-top: $newDesignLanguageOffset;
     }
+
+    .Dismiss {
+      top: spacing();
+    }
+
+    .Ribbon {
+      padding-right: spacing();
+    }
   }
+  // stylelint-enable selector-max-specificity
 
   @include banner-variants;
 


### PR DESCRIPTION
In the new design language, Banners that are in content (card or modal) had 3 issues:

1. The dismissable icon wasn't vertical aligned properly
2. The ribbon right spacing wasn't being applied
3. The dismiss icon was overlapping text is some cases.

before:
<img width="721" alt="Screen Shot 2020-10-01 at 12 54 06 PM" src="https://user-images.githubusercontent.com/1229901/94839936-ac6ab300-03e5-11eb-909b-5d835e744c1c.png">
after:
<img width="757" alt="Screen Shot 2020-10-01 at 12 54 59 PM" src="https://user-images.githubusercontent.com/1229901/94839933-abd21c80-03e5-11eb-810b-09c551cf07fe.png">



### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
