### PR TITLE
[DescriptionList] Add spacing prop to DescriptionList

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added `disclosureText` to `Tabs` ([#3331](https://github.com/Shopify/polaris-react/pull/3331))
 - Added underline to links on focus and active ([#3335](https://github.com/Shopify/polaris-react/pull/3335))
 - Added `spacing` prop to `ButtonGroup` ([#3308](https://github.com/Shopify/polaris-react/pull/3308))
+- Added `spacing` prop to `DescriptionList` ([#3359](https://github.com/Shopify/polaris-react/pull/3359))
 
 ### Bug fixes
 

--- a/src/components/DescriptionList/DescriptionList.scss
+++ b/src/components/DescriptionList/DescriptionList.scss
@@ -18,9 +18,17 @@ $breakpoint: 550px;
   @include text-emphasis-strong;
   padding: spacing() 0 spacing(tight);
 
+  .spacingTight & {
+    padding: spacing(tight) 0 spacing(extra-tight);
+  }
+
   @include page-content-breakpoint-after($breakpoint) {
     flex: 0 1 25%;
     padding: spacing() spacing() spacing() 0;
+
+    .spacingTight & {
+      padding: spacing(tight) spacing(tight) spacing(tight) 0;
+    }
 
     // stylelint-disable-next-line selector-max-class, selector-max-combinators
     .Description + & + .Description {
@@ -33,6 +41,10 @@ $breakpoint: 550px;
   margin-left: 0;
   padding: 0 0 spacing();
 
+  .spacingTight & {
+    padding: 0 0 spacing(tight);
+  }
+
   + .Term {
     border-top: border('divider');
   }
@@ -40,6 +52,10 @@ $breakpoint: 550px;
   @include page-content-breakpoint-after($breakpoint) {
     flex: 1 1 51%;
     padding: spacing() 0;
+
+    .spacingTight & {
+      padding: spacing(tight) 0;
+    }
 
     // stylelint-disable-next-line selector-max-class, selector-max-combinators
     + .Term + .Description {

--- a/src/components/DescriptionList/DescriptionList.tsx
+++ b/src/components/DescriptionList/DescriptionList.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {classNames} from '../../utilities/css';
+
 import styles from './DescriptionList.scss';
 
 interface Item {
@@ -12,9 +14,14 @@ interface Item {
 export interface DescriptionListProps {
   /** Collection of items for list */
   items: Item[];
+  /** Determines the spacing between list items */
+  spacing: 'tight' | 'loose';
 }
 
-export function DescriptionList({items}: DescriptionListProps) {
+export function DescriptionList({
+  items,
+  spacing = 'loose',
+}: DescriptionListProps) {
   // There's no good key to give React so using the index is a last resport.
   // we can't use the term/description value as it may be a react component
   // which can't be stringified
@@ -31,5 +38,10 @@ export function DescriptionList({items}: DescriptionListProps) {
     [],
   );
 
-  return <dl className={styles.DescriptionList}>{terms}</dl>;
+  const className = classNames(
+    styles.DescriptionList,
+    spacing === 'tight' && styles.spacingTight,
+  );
+
+  return <dl className={className}>{terms}</dl>;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The DescriptionList is used for the [Email modal in web](https://github.com/Shopify/shopify/issues/261981) and from rails to react there's a significant difference in the spacing being used. 

### WHAT is this pull request doing?

Adds a prop to allow for tighter spacing in the description list.

Current:

<img width="669" alt="Screen Shot 2020-10-01 at 4 20 52 PM" src="https://user-images.githubusercontent.com/1229901/94860056-83591b00-0403-11eb-9e9c-b1b9ae8ee12b.png">

Spacing: tight
<img width="668" alt="Screen Shot 2020-10-01 at 4 19 50 PM" src="https://user-images.githubusercontent.com/1229901/94860059-848a4800-0403-11eb-81dc-ab3cbf8d9eee.png">


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
