### PR TITLE
DescriptionList - make spacing optional prop

### DIFF
--- a/src/components/DescriptionList/DescriptionList.tsx
+++ b/src/components/DescriptionList/DescriptionList.tsx
@@ -15,7 +15,7 @@ export interface DescriptionListProps {
   /** Collection of items for list */
   items: Item[];
   /** Determines the spacing between list items */
-  spacing: 'tight' | 'loose';
+  spacing?: 'tight' | 'loose';
 }
 
 export function DescriptionList({


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes issues in current release candidate

### WHAT is this pull request doing?

Making the spacing prop optional on DescriptionList

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
