### PR TITLE
Bugfix: Bump up Polaris to 5.1.0 in Examples to Fix Broken Builds

### DIFF
--- a/examples/create-react-app-ts-react-testing/package.json
+++ b/examples/create-react-app-ts-react-testing/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@shopify/polaris": "^5.0.0",
+    "@shopify/polaris": "^5.1.0",
     "@types/jest": "24.0.19",
     "@types/node": "13.7.0",
     "@types/react": "16.9.19",

--- a/examples/create-react-app-ts-react-testing/yarn.lock
+++ b/examples/create-react-app-ts-react-testing/yarn.lock
@@ -1343,21 +1343,21 @@
   resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-3.12.0.tgz#8c8c396f37b53f2f1be1c05f327cf9a1c72ae307"
   integrity sha512-2mFVSasVkZ6N7J5jOfnl4F83Ws6Q3xLef/k1pz3iV2osw0vUyJN0U4+E1H/8MFpY0hpBshTZYa1nHLwx9ORlPQ==
 
-"@shopify/polaris-tokens@^2.12.3":
-  version "2.12.3"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.12.3.tgz#f34991fd70d90dce569072964b9482df22950053"
-  integrity sha512-3xBJxJqdMOE61SWjNFHaRGegoYSc4SOlAkwQ/VnZgSn/2AoG72m7OFQ+vA/tWR87Z9L3QKggymBxQR9aqBJ7FA==
+"@shopify/polaris-tokens@^2.12.9":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.14.0.tgz#f2e469bf820e60744cea3f0fefba4d81ccbe6fa7"
+  integrity sha512-AuqBYXxy/YAOnuQBLAKD0OqoYIp94x+HN0mYgqVHK2afMEpmm/OecwHPh9+j95QMMB7tRYZKDH4xygSYpWDGmg==
   dependencies:
     hsluv "^0.1.0"
     tslib "^1.10.0"
 
-"@shopify/polaris@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-5.0.0.tgz#d5c7bbcd5014d6ebac379fadc1b4e9f42dbce730"
-  integrity sha512-sUK6amxFLiJ77QnGbKz8oyODCVBL+SUtYMpHQoICuSH9T0IVW9SjyZ4pmv9efG1mwV5gWhweMWDR+PSW+DrDmQ==
+"@shopify/polaris@^5.1.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-5.4.0.tgz#6b0398fae0011cda10fa021784e28adceeecaa89"
+  integrity sha512-bgWxBNocPd/n/sRr2IHGb/QNeMRoN0iMpQdRwJBQA+chDIjr3wNXEFUpP298W95Epm03H2Vn6SA8PSGuLlR3/Q==
   dependencies:
     "@shopify/polaris-icons" "^3.10.0"
-    "@shopify/polaris-tokens" "^2.12.3"
+    "@shopify/polaris-tokens" "^2.12.9"
     "@types/react" "^16.9.12"
     "@types/react-dom" "^16.9.4"
     "@types/react-transition-group" "^4.4.0"

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -11,7 +11,7 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@shopify/polaris": "^5.0.0",
+    "@shopify/polaris": "^5.1.0",
     "@shopify/polaris-icons": "^3.12.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/examples/create-react-app/yarn.lock
+++ b/examples/create-react-app/yarn.lock
@@ -1323,21 +1323,21 @@
   resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-3.12.0.tgz#8c8c396f37b53f2f1be1c05f327cf9a1c72ae307"
   integrity sha512-2mFVSasVkZ6N7J5jOfnl4F83Ws6Q3xLef/k1pz3iV2osw0vUyJN0U4+E1H/8MFpY0hpBshTZYa1nHLwx9ORlPQ==
 
-"@shopify/polaris-tokens@^2.12.3":
-  version "2.12.3"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.12.3.tgz#f34991fd70d90dce569072964b9482df22950053"
-  integrity sha512-3xBJxJqdMOE61SWjNFHaRGegoYSc4SOlAkwQ/VnZgSn/2AoG72m7OFQ+vA/tWR87Z9L3QKggymBxQR9aqBJ7FA==
+"@shopify/polaris-tokens@^2.12.9":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.14.0.tgz#f2e469bf820e60744cea3f0fefba4d81ccbe6fa7"
+  integrity sha512-AuqBYXxy/YAOnuQBLAKD0OqoYIp94x+HN0mYgqVHK2afMEpmm/OecwHPh9+j95QMMB7tRYZKDH4xygSYpWDGmg==
   dependencies:
     hsluv "^0.1.0"
     tslib "^1.10.0"
 
-"@shopify/polaris@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-5.0.0.tgz#d5c7bbcd5014d6ebac379fadc1b4e9f42dbce730"
-  integrity sha512-sUK6amxFLiJ77QnGbKz8oyODCVBL+SUtYMpHQoICuSH9T0IVW9SjyZ4pmv9efG1mwV5gWhweMWDR+PSW+DrDmQ==
+"@shopify/polaris@^5.1.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-5.4.0.tgz#6b0398fae0011cda10fa021784e28adceeecaa89"
+  integrity sha512-bgWxBNocPd/n/sRr2IHGb/QNeMRoN0iMpQdRwJBQA+chDIjr3wNXEFUpP298W95Epm03H2Vn6SA8PSGuLlR3/Q==
   dependencies:
     "@shopify/polaris-icons" "^3.10.0"
-    "@shopify/polaris-tokens" "^2.12.3"
+    "@shopify/polaris-tokens" "^2.12.9"
     "@types/react" "^16.9.12"
     "@types/react-dom" "^16.9.4"
     "@types/react-transition-group" "^4.4.0"

--- a/examples/next.js/package.json
+++ b/examples/next.js/package.json
@@ -10,7 +10,7 @@
     "server": "next start"
   },
   "dependencies": {
-    "@shopify/polaris": "^5.0.0",
+    "@shopify/polaris": "^5.1.0",
     "@shopify/polaris-icons": "^3.12.0",
     "next": "^9.4.4",
     "react": "^16.12.0",

--- a/examples/next.js/yarn.lock
+++ b/examples/next.js/yarn.lock
@@ -1024,21 +1024,21 @@
   resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-3.12.0.tgz#8c8c396f37b53f2f1be1c05f327cf9a1c72ae307"
   integrity sha512-2mFVSasVkZ6N7J5jOfnl4F83Ws6Q3xLef/k1pz3iV2osw0vUyJN0U4+E1H/8MFpY0hpBshTZYa1nHLwx9ORlPQ==
 
-"@shopify/polaris-tokens@^2.12.3":
-  version "2.12.3"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.12.3.tgz#f34991fd70d90dce569072964b9482df22950053"
-  integrity sha512-3xBJxJqdMOE61SWjNFHaRGegoYSc4SOlAkwQ/VnZgSn/2AoG72m7OFQ+vA/tWR87Z9L3QKggymBxQR9aqBJ7FA==
+"@shopify/polaris-tokens@^2.12.9":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.14.0.tgz#f2e469bf820e60744cea3f0fefba4d81ccbe6fa7"
+  integrity sha512-AuqBYXxy/YAOnuQBLAKD0OqoYIp94x+HN0mYgqVHK2afMEpmm/OecwHPh9+j95QMMB7tRYZKDH4xygSYpWDGmg==
   dependencies:
     hsluv "^0.1.0"
     tslib "^1.10.0"
 
-"@shopify/polaris@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-5.0.0.tgz#d5c7bbcd5014d6ebac379fadc1b4e9f42dbce730"
-  integrity sha512-sUK6amxFLiJ77QnGbKz8oyODCVBL+SUtYMpHQoICuSH9T0IVW9SjyZ4pmv9efG1mwV5gWhweMWDR+PSW+DrDmQ==
+"@shopify/polaris@^5.1.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-5.4.0.tgz#6b0398fae0011cda10fa021784e28adceeecaa89"
+  integrity sha512-bgWxBNocPd/n/sRr2IHGb/QNeMRoN0iMpQdRwJBQA+chDIjr3wNXEFUpP298W95Epm03H2Vn6SA8PSGuLlR3/Q==
   dependencies:
     "@shopify/polaris-icons" "^3.10.0"
-    "@shopify/polaris-tokens" "^2.12.3"
+    "@shopify/polaris-tokens" "^2.12.9"
     "@types/react" "^16.9.12"
     "@types/react-dom" "^16.9.4"
     "@types/react-transition-group" "^4.4.0"

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -10,7 +10,7 @@
     "build": "webpack"
   },
   "dependencies": {
-    "@shopify/polaris": "^5.0.0",
+    "@shopify/polaris": "^5.1.0",
     "@shopify/polaris-icons": "^3.12.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/examples/webpack/yarn.lock
+++ b/examples/webpack/yarn.lock
@@ -879,21 +879,21 @@
   resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-3.12.0.tgz#8c8c396f37b53f2f1be1c05f327cf9a1c72ae307"
   integrity sha512-2mFVSasVkZ6N7J5jOfnl4F83Ws6Q3xLef/k1pz3iV2osw0vUyJN0U4+E1H/8MFpY0hpBshTZYa1nHLwx9ORlPQ==
 
-"@shopify/polaris-tokens@^2.12.3":
-  version "2.12.3"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.12.3.tgz#f34991fd70d90dce569072964b9482df22950053"
-  integrity sha512-3xBJxJqdMOE61SWjNFHaRGegoYSc4SOlAkwQ/VnZgSn/2AoG72m7OFQ+vA/tWR87Z9L3QKggymBxQR9aqBJ7FA==
+"@shopify/polaris-tokens@^2.12.9":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.14.0.tgz#f2e469bf820e60744cea3f0fefba4d81ccbe6fa7"
+  integrity sha512-AuqBYXxy/YAOnuQBLAKD0OqoYIp94x+HN0mYgqVHK2afMEpmm/OecwHPh9+j95QMMB7tRYZKDH4xygSYpWDGmg==
   dependencies:
     hsluv "^0.1.0"
     tslib "^1.10.0"
 
-"@shopify/polaris@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-5.0.0.tgz#d5c7bbcd5014d6ebac379fadc1b4e9f42dbce730"
-  integrity sha512-sUK6amxFLiJ77QnGbKz8oyODCVBL+SUtYMpHQoICuSH9T0IVW9SjyZ4pmv9efG1mwV5gWhweMWDR+PSW+DrDmQ==
+"@shopify/polaris@^5.1.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-5.4.0.tgz#6b0398fae0011cda10fa021784e28adceeecaa89"
+  integrity sha512-bgWxBNocPd/n/sRr2IHGb/QNeMRoN0iMpQdRwJBQA+chDIjr3wNXEFUpP298W95Epm03H2Vn6SA8PSGuLlR3/Q==
   dependencies:
     "@shopify/polaris-icons" "^3.10.0"
-    "@shopify/polaris-tokens" "^2.12.3"
+    "@shopify/polaris-tokens" "^2.12.9"
     "@types/react" "^16.9.12"
     "@types/react-dom" "^16.9.4"
     "@types/react-transition-group" "^4.4.0"


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #3334 using the dependency version from #3130 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Fresh builds of the create-react-app and create-react-app-ts examples were broken and yielded the following error:

```
Failed to compile.

./node_modules/@shopify/polaris/dist/styles.css (./node_modules/css-loader/dist/cjs.js??ref--6-oneOf-3-1!./node_modules/postcss-loader/src??postcss!./node_modules/@shopify/polaris/dist/styles.css)
Error: Cannot find module '@shopify/browserslist-config'
    at Array.reduce (<anonymous>)
```

Bumping up `@shopify/polaris` from `5.0.0` to `5.1.0` resolves this. At the suggestion of @BPScott, all of the example apps were synced and their yarn.locks were rebuilt. All example builds are working now.

### Summary of the changes committed

- [x] Run yarn in the repository root
- [x] Bump up Polaris to 5.1.0 in `examples/create-react-app`, `/create-react-app-ts-react-testing`, `/next-js`, and `/webpack`.
- [x] Run yarn and rebuild yarn.lock in examples
- [x] Test new builds locally 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
