### PR TITLE
Use React.Children.toArray to remove child component key warning logs

### DIFF
--- a/src/components/ResourceItem/ResourceItem.tsx
+++ b/src/components/ResourceItem/ResourceItem.tsx
@@ -137,7 +137,6 @@ class BaseResourceItem extends Component<CombinedProps, State> {
 
   render() {
     const {
-      id,
       children,
       url,
       external,
@@ -328,7 +327,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
     );
 
     return (
-      <li key={id} className={listItemClassName}>
+      <li className={listItemClassName}>
         <div className={styles.ItemWrapper}>
           <div
             ref={this.setNode}

--- a/src/components/ResourceList/ResourceList.tsx
+++ b/src/components/ResourceList/ResourceList.tsx
@@ -706,7 +706,7 @@ export const ResourceList: ResourceListType = function ResourceList<ItemType>({
       aria-busy={loading}
     >
       {loadingOverlay}
-      {items.map(renderItemWithId)}
+      {React.Children.toArray(items.map(renderItemWithId))}
     </ul>
   ) : null;
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes warning logs seen on this page http://polaris-react.herokuapp.com/?path=/story/all-components-resource-list--all-examples

### WHAT is this pull request doing?

Generating the key with `React.Children.toArray`

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
