### PR TITLE
[Button] Fix icon from flashing and width from changing when transitioning to a loading state

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,10 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed `Badge` when it becomes 2 lines due to small viewport ([#3315](https://github.com/Shopify/polaris-react/pull/3315))
+- Update `DatePicker` layout so that `Popover` can calculate the width correctly ([#3330](https://github.com/Shopify/polaris-react/pull/3330))
+- Fixed `Button` from flashing an icon and changing its width when loading ([#3370](https://github.com/Shopify/polaris-react/pull/3370))
+
 ### Documentation
 
 ### Development workflow

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,8 +10,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
-- Fixed `Badge` when it becomes 2 lines due to small viewport ([#3315](https://github.com/Shopify/polaris-react/pull/3315))
-- Update `DatePicker` layout so that `Popover` can calculate the width correctly ([#3330](https://github.com/Shopify/polaris-react/pull/3330))
 - Fixed `Button` from flashing an icon and changing its width when loading ([#3370](https://github.com/Shopify/polaris-react/pull/3370))
 
 ### Documentation

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -138,6 +138,10 @@ $stacking-order: (
   }
 }
 
+.Hidden {
+  visibility: hidden;
+}
+
 .Spinner {
   position: absolute;
   top: 50%;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -185,7 +185,11 @@ export function Button({
     ) : (
       icon
     );
-    iconMarkup = <span className={styles.Icon}>{iconInner}</span>;
+    iconMarkup = (
+      <span className={classNames(styles.Icon, loading && styles.Hidden)}>
+        {iconInner}
+      </span>
+    );
   }
 
   const childMarkup = children ? (
@@ -204,7 +208,9 @@ export function Button({
         )}
       />
     </span>
-  ) : null;
+  ) : (
+    <span />
+  );
 
   const content =
     iconMarkup || disclosureIconMarkup ? (

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -170,7 +170,7 @@ describe('<Button />', () => {
 
     it('does not render the markup for the icon if none is provided', () => {
       const button = mountWithAppProvider(<Button />);
-      expect(button.find('svg').exists()).toBe(false);
+      expect(button.find(Icon).exists()).toBe(false);
     });
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/31389

- The icon flashes a black square right before the loading spinner is shown
- The width of the button changes when the loading spinner is rendered

|Before|After|
|-|-|
|![Before](https://user-images.githubusercontent.com/22782157/94958299-4b161300-04bd-11eb-9d9b-90fde5868b1a.gif) |![After](https://user-images.githubusercontent.com/22782157/94958406-77319400-04bd-11eb-9fb6-2fc54051a484.gif)|

### WHAT is this pull request doing?

- Visually hide the icon when `loading` is true since we only care to see the spinner in this state
- The spinner is always rendered but `visually: hidden` is added and removed based on the state of `loading`

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

This problem can be replicated with,

```jsx
import React, { useState } from "react";
import { Button } from "@shopify/polaris";

export default function App() {
  const [loading, isLoading] = useState(false);

  return (
    <div>
      <Button icon="bank" loading={loading} onClick={() => isLoading(!loading)}>Add product</Button>
      <Button onClick={() => isLoading(false)}>Stop loading</Button>
    </div>
  );
}

```

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
