### PR TITLE
[Page Header] Fix mobile layout

### DIFF
--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -1,5 +1,6 @@
 @import '../../../../styles/common';
 
+$mobile-layout: 468px;
 $individual-action-padding-x: (1.5 * spacing(tight));
 $action-menu-rollup-computed-width: rem(40px);
 
@@ -21,9 +22,11 @@ $action-menu-rollup-computed-width: rem(40px);
   .newDesignLanguage & {
     margin-top: spacing(extra-tight);
     align-self: center;
+    flex-basis: 100%;
 
-    @include breakpoint-after(468px) {
+    @include breakpoint-after($mobile-layout) {
       margin-top: 0;
+      flex-basis: auto;
     }
   }
 }
@@ -206,7 +209,7 @@ $action-menu-rollup-computed-width: rem(40px);
     align-items: flex-start;
     justify-content: flex-end;
 
-    @include breakpoint-after(468px) {
+    @include breakpoint-after($mobile-layout) {
       position: static;
     }
 
@@ -218,7 +221,7 @@ $action-menu-rollup-computed-width: rem(40px);
 
 .AdditionalMetaData {
   .newDesignLanguage & {
-    @include breakpoint-after(468px) {
+    @include breakpoint-after($mobile-layout) {
       margin-left: spacing(loose) * 2 + spacing(tight) + spacing(extra-tight);
     }
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes a bug in the rc where titles don't wrap where intended

### WHAT is this pull request doing?

Force the title wrapper to take 100% of the spacing when wrapping

## <!-- ℹ️ Delete the following for small / trivial changes -->

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
