### PR TITLE
[TextField][Select] Tweak colors

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,8 +8,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-- Tweaked colors in `TextField` and `Select` components ([#3378](https://github.com/Shopify/polaris-react/pull/3378))
-
 ### Bug fixes
 
 - Fixed `Button` from flashing an icon and changing its width when loading ([#3370](https://github.com/Shopify/polaris-react/pull/3370))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Tweaked colors in `TextField` and `Select` components ([#3378](https://github.com/Shopify/polaris-react/pull/3378))
+
 ### Bug fixes
 
 - Fixed `Button` from flashing an icon and changing its width when loading ([#3370](https://github.com/Shopify/polaris-react/pull/3370))

--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -155,7 +155,7 @@ $stacking-order: (
     right: 0;
     bottom: 0;
     left: 0;
-    border: border-width() solid var(--p-border-neutral-subdued);
+    border: border-width() solid var(--p-border-subdued);
     border-bottom-color: var(--p-border-shadow-subdued);
     border-radius: var(--p-border-radius-base);
     background-color: var(--p-surface);

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -394,8 +394,8 @@ $stacking-order: (
     @include focus-ring($border-width: border-width());
     background-color: var(--p-surface);
     position: absolute;
-    border: 1px solid var(--p-border-neutral-subdued);
-    border-top: border(dark);
+    border: 1px solid var(--p-border-subdued);
+    border-top-color: var(--p-border-shadow);
     box-shadow: none;
 
     &::after {


### PR DESCRIPTION
Tweaks the border colors of TextField and Select per @jessebc request (#3364).

These design decisions are based on upcoming color tweaks in polaris-tokens, so they won't look right until a new release of polaris-token is out.