### PR TITLE
[Button / Slim] Fix an issue where icons would vertically stretch the button

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -540,9 +540,12 @@ $stacking-order: (
   padding: $slim-vertical-padding spacing(base-tight);
 
   &.newDesignLanguage {
-    // Local override for slim button height.
+    // Local override for slim button height and padding
     $slim-min-height: rem(28px);
+    $slim-vertical-padding: ($slim-min-height - line-height(body) - rem(2px)) /
+      2;
     min-height: $slim-min-height;
+    padding: $slim-vertical-padding spacing(base-tight);
   }
 }
 


### PR DESCRIPTION

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes this issue:

![Screen_Shot_2020-10-05_at_10_02_53_AM](https://user-images.githubusercontent.com/85783/95134745-400aef00-0718-11eb-8b8d-14aa5cbe2fd9.png)


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Trickles the `$slim-min-height` local override down to the slim button's padding too.