### PR TITLE
[Button] Fix width so that it stays the same when loading

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed `Button` from flashing an icon and changing its width when loading ([#3370](https://github.com/Shopify/polaris-react/pull/3370))
+- Fixed `Button` from resizing its width when loading ([#3392](https://github.com/Shopify/polaris-react/pull/3392))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,7 +11,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed `Button` from flashing an icon and changing its width when loading ([#3370](https://github.com/Shopify/polaris-react/pull/3370))
-- Fixed `Button` from resizing its width when loading ([#3392](https://github.com/Shopify/polaris-react/pull/3392))
 
 ### Documentation
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -119,11 +119,9 @@ $stacking-order: (
 .Icon {
   transition: color duration() easing();
 
-  &:first-child {
-    // This compensates for the typical icon used in buttons being
-    // inset within its bounding box.
-    margin-left: -(spacing(extra-tight));
-  }
+  // This compensates for the typical icon used in buttons being
+  // inset within its bounding box.
+  margin-left: -(spacing(extra-tight));
 
   &:last-child {
     // This compensates for the disclosure icon, which is substantially

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -170,6 +170,7 @@ export function Button({
         className={classNames(
           styles.DisclosureIcon,
           disclosure === 'up' && styles.DisclosureIconFacingUp,
+          loading && styles.Hidden
         )}
       >
         {disclosureIcon}
@@ -208,9 +209,7 @@ export function Button({
         )}
       />
     </span>
-  ) : (
-    <span />
-  );
+  ) : null;
 
   const content =
     iconMarkup || disclosureIconMarkup ? (

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -170,7 +170,7 @@ export function Button({
         className={classNames(
           styles.DisclosureIcon,
           disclosure === 'up' && styles.DisclosureIconFacingUp,
-          loading && styles.Hidden
+          loading && styles.Hidden,
         )}
       >
         {disclosureIcon}


### PR DESCRIPTION
### WHY are these changes introduced?

Follow up from https://github.com/Shopify/polaris-react/pull/3370 which caused buttons with only icons (like pagination) to have extra spacing to the left of the icon.

### WHAT is this pull request doing?

This PR ensures that all buttons keep the same width when they are loading or not. The loading state renders a spinner which is an icon, this was removing the `margin-left` property from the initial icon since it is longer the first child (spinner becomes the first child instead).

The only button variation I found that still resizes its width is a button that uses the `iconOnly` style (since this sets the margin property to 0) and still has another element (see the 3rd example in the below gif of a button with only an icon and a connected disclosure). Though I believe this variation would never exist in the wild.

![Buttons](https://user-images.githubusercontent.com/22782157/95254072-559e1880-07ed-11eb-80c7-53e5c63ffc4b.gif)

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>The following snippet was pasted into README.md for the Button:</summary>

```jsx
function button() {
  const [loading, isLoading] = useState(false);

  return (
    <div>
      <Button loading={loading}>Add product</Button>
      <br />
      <br />
      <Button loading={loading} icon={ChevronLeftMinor} />
      <br />
      <br />
      <Button loading={loading} icon={ChevronLeftMinor} disclosure={'up'} />
      <br />
      <br />
      <Button
        loading={loading}
        icon={ChevronLeftMinor}
        connectedDisclosure={{
          accessibilityLabel: 'Other save actions',
          actions: [{content: 'Save as draft'}],
        }}
      />
      <br />
      <Button outline icon={ChevronLeftMinor} loading={loading}>
        Add product
      </Button>
      <br />
      <br />
      <Button loading={loading} disclosure={'up'}>
        Add product
      </Button>
      <br />
      <br />
      <Button icon={ChevronLeftMinor} loading={loading} disclosure={'down'}>
        Add product
      </Button>
      <br />
      <br />
      <Button onClick={() => isLoading(!loading)}>Toggle</Button>
    </div>
  );
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
