### PR TITLE
Bug fix: content and dismiss overlap for banner

### DIFF
--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -131,10 +131,6 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
     $newDesignLanguageOffset: $newDesignLanguageSpacing - spacing();
     padding: spacing() spacing() $newDesignLanguageSpacing;
 
-    &.hasDismiss {
-      padding-right: calc(#{2 * spacing()} + var(--p-icon-size));
-    }
-
     .ContentWrapper {
       margin-top: $newDesignLanguageOffset;
     }
@@ -157,11 +153,6 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 
   .Ribbon {
     padding-right: $intermediate-spacing;
-
-    // stylelint-disable-next-line selector-max-combinators, selector-max-class
-    .newDesignLanguage & {
-      padding-right: spacing();
-    }
   }
 
   .Actions {
@@ -218,6 +209,10 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 
 .hasDismiss {
   padding-right: spacing() + spacing(extra-tight) + control-height();
+
+  &.newDesignLanguage {
+    padding-right: calc(#{2 * spacing()} + var(--p-icon-size));
+  }
 }
 
 .Heading {


### PR DESCRIPTION
### Before

<img width="589" alt="Screen Shot 2020-10-06 at 8 17 52 PM" src="https://user-images.githubusercontent.com/3760543/95273480-35805080-0811-11eb-8eaa-053ab30e79ad.png">

### After

<img width="605" alt="Screen Shot 2020-10-06 at 8 18 42 PM" src="https://user-images.githubusercontent.com/3760543/95273484-3618e700-0811-11eb-9eea-e9d4c96ead50.png">
