### PR TITLE
Add ref type to modal activator

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added `RefOject` as a possible type for the `activator` prop on `Modal` ([#3395](https://github.com/Shopify/polaris-react/pull/3395))
+
 ### Bug fixes
 
 - Fixed `Button` from flashing an icon and changing its width when loading ([#3370](https://github.com/Shopify/polaris-react/pull/3370))

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -55,8 +55,8 @@ export interface ModalProps extends FooterProps {
   onTransitionEnd?(): void;
   /** Callback when the bottom of the modal content is reached */
   onScrolledToBottom?(): void;
-  /** The element to activate the Modal */
-  activator?: React.ReactElement;
+  /** The element or the RefObject that activates the Modal */
+  activator?: React.RefObject<HTMLElement> | React.ReactElement;
 }
 
 export const Modal: React.FunctionComponent<ModalProps> & {
@@ -101,11 +101,14 @@ export const Modal: React.FunctionComponent<ModalProps> & {
   const handleExited = useCallback(() => {
     setIframeHeight(IFRAME_LOADING_HEIGHT);
 
-    const activatorElement = activatorRef.current;
+    const activatorElement =
+      activator && isRef(activator)
+        ? activator && activator.current
+        : activatorRef.current;
     if (activatorElement) {
       requestAnimationFrame(() => focusFirstFocusableNode(activatorElement));
     }
-  }, []);
+  }, [activator]);
 
   const handleIFrameLoad = useCallback(
     (evt: React.SyntheticEvent<HTMLIFrameElement>) => {
@@ -198,9 +201,14 @@ export const Modal: React.FunctionComponent<ModalProps> & {
 
   const animated = !instant;
 
+  const activatorMarkup =
+    activator && !isRef(activator) ? (
+      <div ref={activatorRef}>{activator}</div>
+    ) : null;
+
   return (
     <WithinContentContext.Provider value>
-      {activator && <div ref={activatorRef}>{activator}</div>}
+      {activatorMarkup}
       <Portal idPrefix="modal">
         <TransitionGroup appear={animated} enter={animated} exit={animated}>
           {dialog}
@@ -210,5 +218,11 @@ export const Modal: React.FunctionComponent<ModalProps> & {
     </WithinContentContext.Provider>
   );
 };
+
+function isRef(
+  ref: React.RefObject<HTMLElement> | React.ReactElement,
+): ref is React.RefObject<HTMLElement> {
+  return Object.prototype.hasOwnProperty.call(ref, 'current');
+}
 
 Modal.Section = Section;

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -704,7 +704,7 @@ function ModalExample() {
 
 <!-- example-for: web -->
 
-Use an external activator when technical limitations prevent you from passing the activator as element or a ref. Make sure to focus the activator on close when choosing this approach.
+Use an external activator when technical limitations prevent you from passing the activator as an element or a ref. Make sure to focus the activator on close when choosing this approach.
 See the [accessibility features of a modal](https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html) for more information regarding focus.
 
 ```jsx

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -641,11 +641,70 @@ function ModalWithScrollListenerExample() {
 }
 ```
 
-### External activator
+### Modal with activator ref
 
 <!-- example-for: web -->
 
-Use an external activator when technical limitations prevent you from passing it as a prop. Make sure to focus the activator on close when choosing this approach.
+Provide an activator ref when it’s more convenient than providing an element. This ensures proper focus management when closing the modal.
+See the [accessibility features of a modal](https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html) for more information regarding focus.
+
+```jsx
+function ModalExample() {
+  const [active, setActive] = useState(true);
+
+  const buttonRef = useRef(null);
+
+  const handleOpen = useCallback(() => setActive(true), []);
+
+  const handleClose = useCallback(() => {
+    setActive(false);
+  }, []);
+
+  const activator = (
+    <div ref={buttonRef}>
+      <Button onClick={handleOpen}>Open</Button>
+    </div>
+  );
+
+  return (
+    <div style={{height: '500px'}}>
+      {activator}
+      <Modal
+        activator={buttonRef}
+        open={active}
+        onClose={handleClose}
+        title="Reach more shoppers with Instagram product tags"
+        primaryAction={{
+          content: 'Add Instagram',
+          onAction: handleClose,
+        }}
+        secondaryActions={[
+          {
+            content: 'Learn more',
+            onAction: handleClose,
+          },
+        ]}
+      >
+        <Modal.Section>
+          <TextContainer>
+            <p>
+              Use Instagram posts to share your products with millions of
+              people. Let shoppers buy from your store without leaving
+              Instagram.
+            </p>
+          </TextContainer>
+        </Modal.Section>
+      </Modal>
+    </div>
+  );
+}
+```
+
+### Modal without an activator prop
+
+<!-- example-for: web -->
+
+Use an external activator when technical limitations prevent you from passing the activator as element or a ref. Make sure to focus the activator on close when choosing this approach.
 See the [accessibility features of a modal](https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html) for more information regarding focus.
 
 ```jsx


### PR DESCRIPTION
### WHY are these changes introduced?

In order to improve accessibility on our Modal, this adds the ability to include a ref as the activator type on Modal.

We recently added the activator prop in order to return focus to it once the modal closes. However, it's not always possible to pass in the element and consumers are left to manage their own focus, which is in most cases overlooked. By adding a ref as a possible type, the Modal can still be responsible for focusing the correct node when closing.

### WHAT is this pull request doing?

- Adds React.RefObject as a possible prop type for the activator
- updates test
- updates documentation

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Storybook contains all the examples. Ensure they all work as expected.

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
