### PR TITLE
[SecondaryAction] Pass on Action to onClick handler

### DIFF
--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -468,14 +468,20 @@ export function DetailsPage() {
         {
           content: 'Duplicate',
           icon: DuplicateMinor,
+          // eslint-disable-next-line no-console
+          onAction: () => console.log('duplicate'),
         },
         {
           content: 'View',
           icon: ViewMinor,
+          // eslint-disable-next-line no-console
+          onAction: () => console.log('view'),
         },
         {
           content: 'Print',
           icon: PrintMinor,
+          // eslint-disable-next-line no-console
+          onAction: () => console.log('print'),
         },
       ]}
       actionGroups={[

--- a/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
+++ b/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
@@ -7,11 +7,13 @@ import {useFeatures} from '../../../../utilities/features';
 import styles from './SecondaryAction.scss';
 
 interface SecondaryAction extends ButtonProps {
+  onAction?(): void;
   getOffsetWidth?(width: number): void;
 }
 
 export function SecondaryAction({
   children,
+  onAction,
   getOffsetWidth,
   ...rest
 }: SecondaryAction) {
@@ -27,7 +29,9 @@ export function SecondaryAction({
 
   return (
     <span className={styles.SecondaryAction} ref={secondaryActionsRef}>
-      <Button {...rest}>{children}</Button>
+      <Button onClick={onAction} {...rest}>
+        {children}
+      </Button>
     </span>
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3393

Pages actions don't perfectly line up with button props. Converting onAction to onClick is necessary 


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
