### PR TITLE
[UnstyledButton] Add component and use in banners

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added `UnstyledButton` component and refactored `Banner` to use it ([#32326](https://github.com/Shopify/polaris-react/pull/32326))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -4,9 +4,6 @@ $accent-height: 3px;
 $heading-offset: rem(2px);
 $intermediate-spacing: spacing(base-tight);
 $ribbon-flex-basis: rem(32px);
-$action-min-height: control-height();
-$action-vertical-padding: ($action-min-height - line-height(body) - rem(2px)) /
-  2;
 $secondary-action-vertical-padding: 0.5 * (control-height() - line-height(body));
 $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 
@@ -281,9 +278,12 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 .Button {
   @include button-base;
   @include text-style-button;
-  border: border();
-  border-radius: var(--p-border-radius-base, border-radius());
-  padding: $action-vertical-padding spacing(tight);
+  @include focus-ring($border-width: rem(2px));
+  color: var(--p-text);
+
+  &:focus {
+    @include focus-ring($style: 'focused');
+  }
 }
 
 .newDesignLanguage {

--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -4,6 +4,9 @@ $accent-height: 3px;
 $heading-offset: rem(2px);
 $intermediate-spacing: spacing(base-tight);
 $ribbon-flex-basis: rem(32px);
+$action-min-height: control-height();
+$action-vertical-padding: ($action-min-height - line-height(body) - rem(2px)) /
+  2;
 $secondary-action-vertical-padding: 0.5 * (control-height() - line-height(body));
 $secondary-action-horizontal-padding: 1.5 * spacing(tight);
 
@@ -275,9 +278,17 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
   transition: box-shadow duration() easing();
 }
 
+.Button {
+  @include button-base;
+  @include text-style-button;
+  border: border();
+  border-radius: var(--p-border-radius-base, border-radius());
+  padding: $action-vertical-padding spacing(tight);
+}
+
 .newDesignLanguage {
   // stylelint-disable selector-max-class, selector-max-combinators
-  &.statusCritical .PrimaryAction > button {
+  &.statusCritical .PrimaryAction .Button {
     border-color: var(--p-border-critical-subdued);
     background: var(--p-surface-critical-subdued);
 
@@ -297,7 +308,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
     }
   }
 
-  &.statusWarning .PrimaryAction > button {
+  &.statusWarning .PrimaryAction .Button {
     border-color: var(--p-border-warning-subdued);
     background: var(--p-surface-warning-subdued);
 
@@ -317,7 +328,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
     }
   }
 
-  &.statusInfo .PrimaryAction > button {
+  &.statusInfo .PrimaryAction .Button {
     border-color: var(--p-border-highlight-subdued);
     background: var(--p-surface-highlight-subdued);
 
@@ -337,7 +348,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
     }
   }
 
-  &.statusSuccess .PrimaryAction > button {
+  &.statusSuccess .PrimaryAction .Button {
     border-color: var(--p-border-success-subdued);
     background: var(--p-surface-success-subdued);
 

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -27,6 +27,7 @@ import type {
 import {Button, buttonFrom} from '../Button';
 import {Heading} from '../Heading';
 import {ButtonGroup} from '../ButtonGroup';
+import {UnstyledButton, unstyledButtonFrom} from '../UnstyledButton';
 import {UnstyledLink} from '../UnstyledLink';
 import {Icon} from '../Icon';
 import {WithinContentContext} from '../../utilities/within-content-context';
@@ -104,17 +105,40 @@ export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
     );
   }
 
-  const actionMarkup = action && (
-    <div className={styles.Actions}>
-      <ButtonGroup>
-        <div className={styles.PrimaryAction}>
-          {buttonFrom(action, {outline: true, size: buttonSizeValue})}
-        </div>
+  let actionMarkup;
+  if (action) {
+    if (newDesignLanguage) {
+      actionMarkup = (
+        <div className={styles.Actions}>
+          <ButtonGroup>
+            <div className={styles.PrimaryAction}>
+              {unstyledButtonFrom(action, {
+                className: styles.Button,
+              })}
+            </div>
 
-        {secondaryAction && <SecondaryActionFrom action={secondaryAction} />}
-      </ButtonGroup>
-    </div>
-  );
+            {secondaryAction && (
+              <SecondaryActionFrom action={secondaryAction} />
+            )}
+          </ButtonGroup>
+        </div>
+      );
+    } else {
+      actionMarkup = (
+        <div className={styles.Actions}>
+          <ButtonGroup>
+            <div className={styles.PrimaryAction}>
+              {buttonFrom(action, {outline: true, size: buttonSizeValue})}
+            </div>
+
+            {secondaryAction && (
+              <SecondaryActionFrom action={secondaryAction} />
+            )}
+          </ButtonGroup>
+        </div>
+      );
+    }
+  }
 
   let contentMarkup: React.ReactNode = null;
   let contentID: string | undefined;
@@ -188,9 +212,12 @@ function SecondaryActionFrom({action}: {action: Action}) {
   }
 
   return (
-    <button className={styles.SecondaryAction} onClick={action.onAction}>
+    <UnstyledButton
+      className={styles.SecondaryAction}
+      onClick={action.onAction}
+    >
       <span className={styles.Text}>{action.content}</span>
-    </button>
+    </UnstyledButton>
   );
 }
 

--- a/src/components/Banner/README.md
+++ b/src/components/Banner/README.md
@@ -261,7 +261,8 @@ Use when you want merchants to take an action after reading the banner.
 <Banner
   title="Some of your product variants are missing weights"
   status="warning"
-  action={{content: 'Edit variant weights'}}
+  action={{content: 'Edit variant weights', url: '#'}}
+  secondary={{content: 'Learn more', url: '#'}}
   onDismiss={() => {}}
 >
   <p>
@@ -290,7 +291,8 @@ Use to update merchants about a change or give them advice.
 ```jsx
 <Banner
   title="USPS has updated their rates"
-  action={{content: 'Learn more'}}
+  action={{content: 'Update rates', url: '#some-link'}}
+  secondaryAction={{content: 'Learn more'}}
   status="info"
   onDismiss={() => {}}
 >

--- a/src/components/Banner/README.md
+++ b/src/components/Banner/README.md
@@ -261,8 +261,8 @@ Use when you want merchants to take an action after reading the banner.
 <Banner
   title="Some of your product variants are missing weights"
   status="warning"
-  action={{content: 'Edit variant weights', url: '#'}}
-  secondary={{content: 'Learn more', url: '#'}}
+  action={{content: 'Edit variant weights', url: ''}}
+  secondary={{content: 'Learn more', url: ''}}
   onDismiss={() => {}}
 >
   <p>
@@ -291,7 +291,7 @@ Use to update merchants about a change or give them advice.
 ```jsx
 <Banner
   title="USPS has updated their rates"
-  action={{content: 'Update rates', url: '#some-link'}}
+  action={{content: 'Update rates', url: ''}}
   secondaryAction={{content: 'Learn more'}}
   status="info"
   onDismiss={() => {}}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -5,12 +5,12 @@ import {classNames, variationName} from '../../utilities/css';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 import {useFeatures} from '../../utilities/features';
 import {useI18n} from '../../utilities/i18n';
-import {UnstyledLink} from '../UnstyledLink';
 import {Icon} from '../Icon';
 import type {IconProps, ConnectedDisclosure} from '../../types';
 import {Spinner} from '../Spinner';
 import {Popover} from '../Popover';
 import {ActionList} from '../ActionList';
+import {UnstyledButton} from '../UnstyledButton';
 
 import styles from './Button.scss';
 
@@ -300,7 +300,7 @@ export function Button({
         {content}
       </a>
     ) : (
-      <UnstyledLink
+      <UnstyledButton
         id={id}
         url={url}
         external={external}
@@ -315,11 +315,11 @@ export function Button({
         aria-label={accessibilityLabel}
       >
         {content}
-      </UnstyledLink>
+      </UnstyledButton>
     );
   } else {
     buttonMarkup = (
-      <button
+      <UnstyledButton
         id={id}
         type={type}
         onClick={onClick}
@@ -341,7 +341,7 @@ export function Button({
         aria-busy={loading ? true : undefined}
       >
         {content}
-      </button>
+      </UnstyledButton>
     );
   }
 

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -412,7 +412,7 @@ describe('<Modal>', () => {
 
       modal.find(Dialog)!.trigger('onExited');
 
-      expect(document.activeElement).toBe(modal.find(Button)!.domNode);
+      expect(document.activeElement).toBe(modal.find('button')!.domNode);
       expect(focusSpy).toHaveBeenCalledTimes(3);
     });
 
@@ -441,7 +441,7 @@ describe('<Modal>', () => {
 
       expect(document.activeElement).toBe(
         testHarness.findWhere(
-          (wrap) => wrap.is(Button) && wrap.prop('id') === buttonId,
+          (wrap) => wrap.is('button') && wrap.prop('id') === buttonId,
         )!.domNode,
       );
     });

--- a/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
+++ b/src/components/ResourceList/components/FilterControl/components/FilterCreator/tests/FilterCreator.test.tsx
@@ -78,16 +78,19 @@ describe('<FilterCreator />', () => {
       .trigger('onChange', mockDefaultProps.filters[0].key);
 
     const activator = filterCreator.find(Button, {children: 'Filter'})!;
+    const activatorButton = activator.find('button')!;
 
     // This any cast is needed as the activator's onFocus actually uses the
     // event argument that gets passed into the onFocus handler, though we type
     // onFocus as accepting no arguments
-    (activator as any).trigger('onFocus', {target: activator!.domNode});
+    (activator as any).trigger('onFocus', {
+      target: activatorButton.domNode,
+    });
     filterCreator.find(FilterValueSelector)!.trigger('onChange', 'x');
 
     filterCreator.find(Button, {children: 'Add filter'})!.trigger('onClick');
 
-    expect(document.activeElement).toBe(activator!.domNode);
+    expect(document.activeElement).toBe(activatorButton.domNode);
   });
 
   it('does not focus the activator after adding a filter if focus was never originally received by the by activator', () => {

--- a/src/components/UnstyledButton/UnstyledButton.scss
+++ b/src/components/UnstyledButton/UnstyledButton.scss
@@ -1,0 +1,5 @@
+@import '../../styles/common';
+
+.UnstyledButton {
+  @include unstyled-button;
+}

--- a/src/components/UnstyledButton/UnstyledButton.scss
+++ b/src/components/UnstyledButton/UnstyledButton.scss
@@ -1,5 +1,5 @@
 @import '../../styles/common';
 
-.UnstyledButton {
+[data-polaris-unstyled-button] {
   @include unstyled-button;
 }

--- a/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/UnstyledButton/UnstyledButton.tsx
@@ -1,0 +1,157 @@
+import React, {useRef} from 'react';
+
+import {classNames} from '../../utilities/css';
+import {handleMouseUpByBlurring} from '../../utilities/focus';
+import {UnstyledLink} from '../UnstyledLink';
+
+import styles from './UnstyledButton.scss';
+
+export interface UnstyledButtonProps {
+  /** The content to display inside the button */
+  children?: React.ReactNode;
+  /** A destination to link to, rendered in the href attribute of a link */
+  url?: string;
+  /** A unique identifier for the button */
+  id?: string;
+  /** A custom class name to apply styles to button */
+  className?: string;
+  /** Disables the button, disallowing merchant interaction */
+  disabled?: boolean;
+  /** Allows the button to submit a form */
+  submit?: boolean;
+  /** Forces url to open in a new tab */
+  external?: boolean;
+  /** Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value */
+  download?: string | boolean;
+  /** Sets the button in a pressed state */
+  pressed?: boolean;
+  /** Visually hidden text for screen readers */
+  accessibilityLabel?: string;
+  /** Id of the element the button controls */
+  ariaControls?: string;
+  /** Tells screen reader the controlled element is expanded */
+  ariaExpanded?: boolean;
+  /**
+   * @deprecated As of release 4.7.0, replaced by {@link https://polaris.shopify.com/components/structure/page#props-pressed}
+   * Tells screen reader the element is pressed
+   */
+  ariaPressed?: boolean;
+  /** Callback when clicked */
+  onClick?(): void;
+  /** Callback when button becomes focussed */
+  onFocus?(): void;
+  /** Callback when focus leaves button */
+  onBlur?(): void;
+  /** Callback when a keypress event is registered on the button */
+  onKeyPress?(event: React.KeyboardEvent<HTMLButtonElement>): void;
+  /** Callback when a keyup event is registered on the button */
+  onKeyUp?(event: React.KeyboardEvent<HTMLButtonElement>): void;
+  /** Callback when a keydown event is registered on the button */
+  onKeyDown?(event: React.KeyboardEvent<HTMLButtonElement>): void;
+  /** Callback when mouse enter */
+  onMouseEnter?(): void;
+  /** Callback when element is touched */
+  onTouchStart?(): void;
+  [key: string]: any;
+}
+
+export function UnstyledButton({
+  id,
+  url,
+  disabled,
+  children,
+  className,
+  pressed,
+  accessibilityLabel,
+  ariaControls,
+  ariaExpanded,
+  ariaPressed,
+  onClick,
+  onFocus,
+  onBlur,
+  onKeyDown,
+  onKeyPress,
+  onKeyUp,
+  onMouseEnter,
+  onTouchStart,
+  external,
+  download,
+  submit,
+  ...rest
+}: UnstyledButtonProps) {
+  const hasGivenDeprecationWarning = useRef(false);
+
+  if (ariaPressed && !hasGivenDeprecationWarning.current) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Deprecation: The ariaPressed prop has been replaced with pressed',
+    );
+    hasGivenDeprecationWarning.current = true;
+  }
+
+  const buttonClassName = classNames(
+    styles.UnstyledButton,
+    className && className,
+  );
+
+  const type = submit ? 'submit' : 'button';
+  const ariaPressedStatus = pressed !== undefined ? pressed : ariaPressed;
+
+  let buttonMarkup;
+
+  if (url) {
+    buttonMarkup = disabled ? (
+      // Render an `<a>` so toggling disabled/enabled state changes only the
+      // `href` attribute instead of replacing the whole element.
+      // eslint-disable-next-line jsx-a11y/anchor-is-valid
+      <a id={id} className={buttonClassName} aria-label={accessibilityLabel}>
+        {children}
+      </a>
+    ) : (
+      <UnstyledLink
+        id={id}
+        url={url}
+        external={external}
+        download={download}
+        onClick={onClick}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onMouseUp={handleMouseUpByBlurring}
+        onMouseEnter={onMouseEnter}
+        onTouchStart={onTouchStart}
+        className={buttonClassName}
+        aria-label={accessibilityLabel}
+        {...rest}
+      >
+        {children}
+      </UnstyledLink>
+    );
+  } else {
+    buttonMarkup = (
+      <button
+        id={id}
+        type={type}
+        onClick={onClick}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onKeyDown={onKeyDown}
+        onKeyUp={onKeyUp}
+        onKeyPress={onKeyPress}
+        onMouseUp={handleMouseUpByBlurring}
+        onMouseEnter={onMouseEnter}
+        onTouchStart={onTouchStart}
+        className={buttonClassName}
+        disabled={disabled}
+        aria-label={accessibilityLabel}
+        aria-controls={ariaControls}
+        aria-expanded={ariaExpanded}
+        aria-pressed={ariaPressedStatus}
+        {...rest}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  return buttonMarkup;
+}

--- a/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/UnstyledButton/UnstyledButton.tsx
@@ -1,10 +1,9 @@
 import React, {useRef} from 'react';
 
-import {classNames} from '../../utilities/css';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 import {UnstyledLink} from '../UnstyledLink';
 
-import styles from './UnstyledButton.scss';
+import './UnstyledButton.scss';
 
 export interface UnstyledButtonProps {
   /** The content to display inside the button */
@@ -89,11 +88,6 @@ export function UnstyledButton({
     hasGivenDeprecationWarning.current = true;
   }
 
-  const buttonClassName = classNames(
-    styles.UnstyledButton,
-    className && className,
-  );
-
   const type = submit ? 'submit' : 'button';
   const ariaPressedStatus = pressed !== undefined ? pressed : ariaPressed;
 
@@ -104,7 +98,12 @@ export function UnstyledButton({
       // Render an `<a>` so toggling disabled/enabled state changes only the
       // `href` attribute instead of replacing the whole element.
       // eslint-disable-next-line jsx-a11y/anchor-is-valid
-      <a id={id} className={buttonClassName} aria-label={accessibilityLabel}>
+      <a
+        id={id}
+        className={className}
+        aria-label={accessibilityLabel}
+        data-polaris-unstyled-button
+      >
         {children}
       </a>
     ) : (
@@ -119,8 +118,9 @@ export function UnstyledButton({
         onMouseUp={handleMouseUpByBlurring}
         onMouseEnter={onMouseEnter}
         onTouchStart={onTouchStart}
-        className={buttonClassName}
+        className={className}
         aria-label={accessibilityLabel}
+        data-polaris-unstyled-button
         {...rest}
       >
         {children}
@@ -140,12 +140,13 @@ export function UnstyledButton({
         onMouseUp={handleMouseUpByBlurring}
         onMouseEnter={onMouseEnter}
         onTouchStart={onTouchStart}
-        className={buttonClassName}
+        className={className}
         disabled={disabled}
         aria-label={accessibilityLabel}
         aria-controls={ariaControls}
         aria-expanded={ariaExpanded}
         aria-pressed={ariaPressedStatus}
+        data-polaris-unstyled-button
         {...rest}
       >
         {children}

--- a/src/components/UnstyledButton/index.ts
+++ b/src/components/UnstyledButton/index.ts
@@ -1,0 +1,2 @@
+export * from './utils';
+export * from './UnstyledButton';

--- a/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
+++ b/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
@@ -1,0 +1,328 @@
+import React from 'react';
+
+// eslint-disable-next-line no-restricted-imports
+import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
+import {UnstyledLink} from 'components';
+
+import {UnstyledButton} from '../UnstyledButton';
+
+describe('<Button />', () => {
+  describe('url', () => {
+    const mockUrl = 'http://google.com';
+
+    it('renders a link when present', () => {
+      const button = mountWithAppProvider(<UnstyledButton url={mockUrl} />);
+      expect(button.find(UnstyledLink).exists()).toBeTruthy();
+    });
+
+    it('gets passed into the link', () => {
+      const button = mountWithAppProvider(<UnstyledButton url={mockUrl} />);
+      expect(button.find(UnstyledLink).prop('url')).toBe(mockUrl);
+    });
+
+    it('renders a button when not present', () => {
+      const button = mountWithAppProvider(<UnstyledButton />);
+      expect(button.find('button').exists()).toBeTruthy();
+    });
+  });
+
+  describe('children', () => {
+    it('renders the given children into the button', () => {
+      const label = 'Click me!';
+      const button = mountWithAppProvider(
+        <UnstyledButton>{label}</UnstyledButton>,
+      );
+      expect(button.text()).toContain(label);
+    });
+
+    it('renders the given children into the link', () => {
+      const label = 'Click me!';
+      const button = mountWithAppProvider(
+        <UnstyledButton url="http://google.com">{label}</UnstyledButton>,
+      );
+      expect(button.text()).toContain(label);
+    });
+  });
+
+  describe('id', () => {
+    it('is passed into the button', () => {
+      const id = 'MyID';
+      const button = mountWithAppProvider(<UnstyledButton id={id} />);
+      expect(button.find('button').prop('id')).toBe(id);
+    });
+
+    it('is passed into the link', () => {
+      const id = 'MyID';
+      const button = mountWithAppProvider(
+        <UnstyledButton url="https://shopify.com" id={id} />,
+      );
+      expect(button.find(UnstyledLink).prop('id')).toBe(id);
+    });
+  });
+
+  describe('disabled', () => {
+    it('disable without a url renders <button disabled>', () => {
+      const button = mountWithAppProvider(<UnstyledButton disabled />);
+      expect(button.find('button').prop('disabled')).toBeTruthy();
+    });
+
+    it('disable with a url renders <a> without an href (as <a disabled> is invalid HTML)>', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton disabled url="http://google.com" />,
+      );
+      expect(button.find('a').prop('href')).toBeFalsy();
+    });
+  });
+
+  describe('submit', () => {
+    it('sets a submit type on the button when present', () => {
+      const button = mountWithAppProvider(<UnstyledButton submit />);
+      expect(button.find('button').prop('type')).toBe('submit');
+    });
+
+    it('sets a button type on the button when not present', () => {
+      const button = mountWithAppProvider(<UnstyledButton />);
+      expect(button.find('button').prop('type')).toBe('button');
+    });
+  });
+
+  describe('external', () => {
+    it('gets passed into the link', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton url="http://google.com" external />,
+      );
+      expect(button.find(UnstyledLink).prop('external')).toBeTruthy();
+    });
+
+    it('is false when not set', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton url="http://google.com" />,
+      );
+      expect(button.find(UnstyledLink).prop('external')).toBeFalsy();
+    });
+  });
+
+  describe('download', () => {
+    it('gets passed into the link as a boolean', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton url="/foo" download />,
+      );
+      expect(button.find(UnstyledLink).prop('download')).toBe(true);
+    });
+
+    it('gets passed into the link as a string', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton url="/foo" download="file.txt" />,
+      );
+      expect(button.find(UnstyledLink).prop('download')).toBe('file.txt');
+    });
+
+    it('is false when not set', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton url="http://google.com" />,
+      );
+      expect(button.find(UnstyledLink).prop('download')).toBeFalsy();
+    });
+  });
+
+  describe('accessibilityLabel', () => {
+    it('sets an aria-label on the button', () => {
+      const label = 'This deletes a thing';
+      const button = mountWithAppProvider(
+        <UnstyledButton accessibilityLabel={label} />,
+      );
+      expect(button.find('button').prop('aria-label')).toBe(label);
+    });
+
+    it('sets an aria-label on the link', () => {
+      const label = 'This deletes a thing';
+      const button = mountWithAppProvider(
+        <UnstyledButton accessibilityLabel={label} url="http://google.com" />,
+      );
+      expect(button.find(UnstyledLink).prop('aria-label')).toBe(label);
+    });
+  });
+
+  describe('ariaControls', () => {
+    it('sets an aria-controls on the button', () => {
+      const id = 'panel1';
+      const button = mountWithAppProvider(<UnstyledButton ariaControls={id} />);
+      expect(button.find('button').prop('aria-controls')).toBe(id);
+    });
+  });
+
+  describe('ariaExpanded', () => {
+    it('sets an aria-expended on the button', () => {
+      const button = mountWithAppProvider(<UnstyledButton ariaExpanded />);
+      expect(button.find('button').prop('aria-expanded')).toBeTruthy();
+    });
+  });
+
+  describe('ariaPressed', () => {
+    it('sets an aria-pressed on the button', () => {
+      const warningSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      const button = mountWithAppProvider(<UnstyledButton ariaPressed />);
+      expect(button.find('button').prop('aria-pressed')).toBeTruthy();
+
+      warningSpy.mockRestore();
+    });
+  });
+
+  describe('onClick()', () => {
+    it('is called when the button is clicked', () => {
+      const onClickSpy = jest.fn();
+      const button = mountWithAppProvider(
+        <UnstyledButton onClick={onClickSpy} />,
+      );
+      trigger(button.find('button'), 'onClick');
+      expect(onClickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called when the link is clicked', () => {
+      const onClickSpy = jest.fn();
+      const button = mountWithAppProvider(
+        <UnstyledButton onClick={onClickSpy} url="http://google.com" />,
+      );
+      trigger(button.find(UnstyledLink), 'onClick');
+      expect(onClickSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onMouseEnter()', () => {
+    it('is called when the mouse enters button', () => {
+      const onMouseEnterSpy = jest.fn();
+      const button = mountWithAppProvider(
+        <UnstyledButton onMouseEnter={onMouseEnterSpy} />,
+      );
+      trigger(button.find('button'), 'onMouseEnter');
+      expect(onMouseEnterSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called when the mouse enters link', () => {
+      const onMouseEnterSpy = jest.fn();
+      const button = mountWithAppProvider(
+        <UnstyledButton
+          onMouseEnter={onMouseEnterSpy}
+          url="http://google.com"
+        />,
+      );
+      trigger(button.find(UnstyledLink), 'onMouseEnter');
+      expect(onMouseEnterSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onTouchEnter()', () => {
+    it('is called when button is pressed', () => {
+      const onTouchStartSpy = jest.fn();
+      const button = mountWithAppProvider(
+        <UnstyledButton onTouchStart={onTouchStartSpy} />,
+      );
+      trigger(button.find('button'), 'onTouchStart');
+      expect(onTouchStartSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called when link is pressed', () => {
+      const onTouchStartSpy = jest.fn();
+      const button = mountWithAppProvider(
+        <UnstyledButton
+          onTouchStart={onTouchStartSpy}
+          url="http://google.com"
+        />,
+      );
+      trigger(button.find(UnstyledLink), 'onTouchStart');
+      expect(onTouchStartSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onFocus()', () => {
+    it('is called when the button is focussed', () => {
+      const onFocusSpy = jest.fn();
+      const button = mountWithAppProvider(
+        <UnstyledButton onFocus={onFocusSpy} />,
+      );
+      trigger(button.find('button'), 'onFocus');
+      expect(onFocusSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called when the link is focussed', () => {
+      const onFocusSpy = jest.fn();
+      const button = mountWithAppProvider(
+        <UnstyledButton onFocus={onFocusSpy} url="http://google.com" />,
+      );
+      trigger(button.find(UnstyledLink), 'onFocus');
+      expect(onFocusSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onBlur()', () => {
+    it('is called when the button is blurred', () => {
+      const onBlurSpy = jest.fn();
+      const button = mountWithAppProvider(
+        <UnstyledButton onBlur={onBlurSpy} />,
+      );
+      trigger(button.find('button'), 'onBlur');
+      expect(onBlurSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('is called when the link is blurred', () => {
+      const onBlurSpy = jest.fn();
+      const button = mountWithAppProvider(
+        <UnstyledButton onBlur={onBlurSpy} url="http://google.com" />,
+      );
+      trigger(button.find(UnstyledLink), 'onBlur');
+      expect(onBlurSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onKeyPress()', () => {
+    it('is called when a keypress event is registered on the button', () => {
+      const spy = jest.fn();
+      const button = mountWithAppProvider(
+        <UnstyledButton onKeyPress={spy}>Test</UnstyledButton>,
+      ).find('button');
+      trigger(button, 'onKeyPress');
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('onKeyUp()', () => {
+    it('is called when a keyup event is registered on the button', () => {
+      const spy = jest.fn();
+      const button = mountWithAppProvider(
+        <UnstyledButton onKeyUp={spy}>Test</UnstyledButton>,
+      ).find('button');
+      trigger(button, 'onKeyUp');
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('onKeyDown()', () => {
+    it('is called when a keydown event is registered on the button', () => {
+      const spy = jest.fn();
+      const button = mountWithAppProvider(
+        <UnstyledButton onKeyDown={spy}>Test</UnstyledButton>,
+      ).find('button');
+      trigger(button, 'onKeyDown');
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('deprecations', () => {
+    it('warns the ariaPressed prop has been replaced', () => {
+      const warningSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+      mountWithApp(<UnstyledButton ariaPressed />);
+
+      expect(warningSpy).toHaveBeenCalledWith(
+        'Deprecation: The ariaPressed prop has been replaced with pressed',
+      );
+      warningSpy.mockRestore();
+    });
+  });
+});

--- a/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
+++ b/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';

--- a/src/components/UnstyledButton/utils.tsx
+++ b/src/components/UnstyledButton/utils.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import type {ComplexAction} from '../../types';
+
+import {UnstyledButton, UnstyledButtonProps} from './UnstyledButton';
+
+export function unstyledButtonFrom(
+  {content, onAction, ...action}: ComplexAction,
+  overrides?: Partial<UnstyledButtonProps>,
+  key?: any,
+) {
+  return (
+    <UnstyledButton key={key} onClick={onAction} {...action} {...overrides}>
+      {content}
+    </UnstyledButton>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -304,6 +304,9 @@ export type {TrapFocusProps} from './TrapFocus';
 export {Truncate} from './Truncate';
 export type {TruncateProps} from './Truncate';
 
+export {UnstyledButton, unstyledButtonFrom} from './UnstyledButton';
+export type {UnstyledButtonProps} from './UnstyledButton';
+
 export {UnstyledLink} from './UnstyledLink';
 export type {UnstyledLinkProps} from './UnstyledLink';
 


### PR DESCRIPTION
### WHY are these changes introduced?

There are often times where we need a button with custom styles, but we don't want to have to do the same reset and implement functionality built into our existing `Button` component. For changes like the styling the actions in banners with the new design language we were forced 

### WHAT is this pull request doing?

This adds a new `UnstyledButton` component that will accept a `className` and updates the banner to use it and add its custom styling through that.

### How to 🎩
Go through the different banner and button examples and make sure everything is still working as expected.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
