### PR TITLE
🎨 [Button] Remove the inline style from plain monochrome example

### DIFF
--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -141,7 +141,7 @@ Use for less important or less commonly used actions since they’re less promin
 Use for less important or less commonly used actions where matching the current text color is desired. For example in the InlineError component.
 
 ```jsx
-<div style={{color: '#bf0711'}}>
+<div>
   Could not retrieve data.{' '}
   <Button plain monochrome>
     Try again


### PR DESCRIPTION
Noticed this while reading the documentation:
http://polaris-react.herokuapp.com/?path=/story/all-components-button--plain-monochrome-button

All I have done is remove that inline-style. I'm guessing that got added by accident?

#### Before

<img width="242" alt="before" src="https://user-images.githubusercontent.com/643944/95483244-feb75100-095c-11eb-95f8-31dc30222769.png">

#### After

<img width="256" alt="after" src="https://user-images.githubusercontent.com/643944/95483255-01b24180-095d-11eb-91cd-97618fb957de.png">
