### PR TITLE
Update search input and results to new design language

### DIFF
--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -186,14 +186,9 @@ export function DetailsPage() {
   );
 
   const searchResultsMarkup = (
-    <Card>
-      <ActionList
-        items={[
-          {content: 'Shopify help center'},
-          {content: 'Community forums'},
-        ]}
-      />
-    </Card>
+    <ActionList
+      items={[{content: 'Shopify help center'}, {content: 'Community forums'}]}
+    />
   );
 
   const searchFieldMarkup = (

--- a/src/components/Frame/README.md
+++ b/src/components/Frame/README.md
@@ -166,14 +166,9 @@ function FrameExample() {
   );
 
   const searchResultsMarkup = (
-    <Card>
-      <ActionList
-        items={[
-          {content: 'Shopify help center'},
-          {content: 'Community forums'},
-        ]}
-      />
-    </Card>
+    <ActionList
+      items={[{content: 'Shopify help center'}, {content: 'Community forums'}]}
+    />
   );
 
   const searchFieldMarkup = (
@@ -509,14 +504,9 @@ function FrameExample() {
   );
 
   const searchResultsMarkup = (
-    <Card>
-      <ActionList
-        items={[
-          {content: 'Shopify help center'},
-          {content: 'Community forums'},
-        ]}
-      />
-    </Card>
+    <ActionList
+      items={[{content: 'Shopify help center'}, {content: 'Community forums'}]}
+    />
   );
 
   const searchFieldMarkup = (

--- a/src/components/TopBar/README.md
+++ b/src/components/TopBar/README.md
@@ -211,14 +211,9 @@ function TopBarExample() {
   );
 
   const searchResultsMarkup = (
-    <Card>
-      <ActionList
-        items={[
-          {content: 'Shopify help center'},
-          {content: 'Community forums'},
-        ]}
-      />
-    </Card>
+    <ActionList
+      items={[{content: 'Shopify help center'}, {content: 'Community forums'}]}
+    />
   );
 
   const searchFieldMarkup = (
@@ -357,14 +352,9 @@ function TopBarExample() {
   );
 
   const searchResultsMarkup = (
-    <Card>
-      <ActionList
-        items={[
-          {content: 'Shopify help center'},
-          {content: 'Community forums'},
-        ]}
-      />
-    </Card>
+    <ActionList
+      items={[{content: 'Shopify help center'}, {content: 'Community forums'}]}
+    />
   );
 
   const searchFieldMarkup = (
@@ -500,14 +490,9 @@ function TopBarExample() {
   );
 
   const searchResultsMarkup = (
-    <Card>
-      <ActionList
-        items={[
-          {content: 'Shopify help center'},
-          {content: 'Community forums'},
-        ]}
-      />
-    </Card>
+    <ActionList
+      items={[{content: 'Shopify help center'}, {content: 'Community forums'}]}
+    />
   );
 
   const searchFieldMarkup = (

--- a/src/components/TopBar/_variables.scss
+++ b/src/components/TopBar/_variables.scss
@@ -4,6 +4,7 @@ $stacking-order: (
 );
 
 $search-max-width: rem(694px);
+$new-search-max-width: rem(580px);
 
 // TODO: Replace `$large-width` breakpoints with
 // `page-content-when-not-partially-condensed`

--- a/src/components/TopBar/components/Search/Search.scss
+++ b/src/components/TopBar/components/Search/Search.scss
@@ -8,17 +8,28 @@
   top: top-bar-height();
   left: 0;
   right: 0;
+  box-shadow: var(--p-modal-shadow, shadow());
+  overflow: hidden;
 
   @include page-content-when-not-fully-condensed {
     position: absolute;
     top: 100%;
     max-width: $search-max-width;
     margin: spacing(extra-tight) spacing(loose) 0;
+    border-radius: var(--p-border-radius-wide, border-radius());
+
+    &.newDesignLanguage {
+      max-width: $new-search-max-width;
+    }
   }
 
   @include page-content-when-not-partially-condensed {
     margin: spacing(extra-tight) spacing(extra-loose) 0;
   }
+}
+
+.SearchContent {
+  background-color: var(--p-surface, color('white'));
 }
 
 .visible {

--- a/src/components/TopBar/components/Search/Search.tsx
+++ b/src/components/TopBar/components/Search/Search.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
+import {ThemeProvider} from '../../../ThemeProvider';
 import {classNames} from '../../../../utilities/css';
 import {SearchDismissOverlay} from '../SearchDismissOverlay';
+import {useFeatures} from '../../../../utilities/features';
 
 import styles from './Search.scss';
 
@@ -22,6 +24,8 @@ export function Search({
   onDismiss,
   overlayVisible = false,
 }: SearchProps) {
+  const {newDesignLanguage} = useFeatures();
+
   if (children == null) {
     return null;
   }
@@ -31,9 +35,24 @@ export function Search({
   ) : null;
 
   return (
-    <div className={classNames(styles.Search, visible && styles.visible)}>
-      {overlayMarkup}
-      <div className={styles.Results}>{children}</div>
+    <div
+      className={classNames(
+        styles.Search,
+        visible && styles.visible,
+        newDesignLanguage && styles.newDesignLanguage,
+      )}
+    >
+      <ThemeProvider theme={{colorScheme: 'dark'}}>
+        <div
+          className={classNames(
+            styles.SearchContent,
+            newDesignLanguage && styles.newDesignLanguage,
+          )}
+        >
+          {overlayMarkup}
+          <div className={styles.Results}>{children}</div>
+        </div>
+      </ThemeProvider>
     </div>
   );
 }

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
@@ -11,6 +11,11 @@ $backdrop-color: rgba(color('ink'), 0.4);
   right: 0;
   z-index: z-index(nav-backdrop, $fixed-element-stacking-order);
   height: calc(100vh - #{top-bar-height()});
+
+  &.newDesignLanguage {
+    top: 0;
+    height: 100%;
+  }
 }
 
 .visible {

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.tsx
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useRef} from 'react';
 
 import {ScrollLock} from '../../../ScrollLock';
 import {classNames} from '../../../../utilities/css';
+import {useFeatures} from '../../../../utilities/features';
 
 import styles from './SearchDismissOverlay.scss';
 
@@ -14,6 +15,7 @@ interface Props {
 
 export function SearchDismissOverlay({onDismiss, visible}: Props) {
   const node = useRef<HTMLDivElement>(null);
+  const {newDesignLanguage} = useFeatures();
 
   const handleDismiss = useCallback(
     ({target}: React.MouseEvent<HTMLDivElement>) => {
@@ -32,6 +34,7 @@ export function SearchDismissOverlay({onDismiss, visible}: Props) {
         className={classNames(
           styles.SearchDismissOverlay,
           visible && styles.visible,
+          newDesignLanguage && styles.newDesignLanguage,
         )}
         onClick={handleDismiss}
       />

--- a/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/src/components/TopBar/components/SearchField/SearchField.scss
@@ -5,7 +5,6 @@ $icon-size: rem(20px);
 $input-height: rem(34px);
 $new-input-height: rem(36px);
 $clear-button-width: $icon-size + spacing();
-$new-search-max-width: rem(580px);
 
 $stacking-order: (
   backdrop: 1,
@@ -25,6 +24,7 @@ $stacking-order: (
 }
 
 .SearchField-newDesignLanguage {
+  z-index: z-index(modal, $fixed-element-stacking-order);
   max-width: $new-search-max-width;
 
   .Backdrop {


### PR DESCRIPTION
### WHAT is this pull request doing?
- Adjusts width of search results so that they match the search field
- Makes the backdrop cover 100% of the screen (behind the text input + results)
- Adds a background to the search results. We currently recommend that users pass in a Card as a background, but this change adds a "forced" background to the results. This is because the NDL requires 1) a light mode shadow around the component and 2) dark mode contents of the component. This is quite tricky to achieve so it makes sense for the Polaris component to take care of that logic.

![search-ndl](https://user-images.githubusercontent.com/875708/95484786-e9432680-095e-11eb-8dad-f8920bc9fe0e.gif)

### How to 🎩

View the changes locally in Storybook and go to the Details page.

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit