### PR TITLE
Connected fields stop child border radius

### DIFF
--- a/src/components/Connected/Connected.scss
+++ b/src/components/Connected/Connected.scss
@@ -26,16 +26,16 @@ $stacking-order: (
 // TextField.scss has a dependency due to this override.
 // stylelint-disable declaration-no-important
 
-.Item-primary {
+.Connected:not(.newDesignLanguage) .Item-primary {
   z-index: z-index(primary, $stacking-order);
   flex: 1 1 auto;
 
-  .Connected:not(.newDesignLanguage) &:not(:first-child) * {
+  &:not(:first-child) * {
     border-top-left-radius: 0 !important;
     border-bottom-left-radius: 0 !important;
   }
 
-  .Connected:not(.newDesignLanguage) &:not(:last-child) * {
+  &:not(:last-child) * {
     border-top-right-radius: 0 !important;
     border-bottom-right-radius: 0 !important;
   }

--- a/src/components/Connected/Connected.scss
+++ b/src/components/Connected/Connected.scss
@@ -26,38 +26,42 @@ $stacking-order: (
 // TextField.scss has a dependency due to this override.
 // stylelint-disable declaration-no-important
 
-// stylelint-disable-next-line selector-max-combinators, selector-max-specificity
 .Connected:not(.newDesignLanguage) .Item-primary {
   z-index: z-index(primary, $stacking-order);
   flex: 1 1 auto;
 
+  // stylelint-disable-next-line selector-max-combinators, selector-max-specificity
   &:not(:first-child) * {
     border-top-left-radius: 0 !important;
     border-bottom-left-radius: 0 !important;
   }
 
+  // stylelint-disable-next-line selector-max-combinators, selector-max-specificity
   &:not(:last-child) * {
     border-top-right-radius: 0 !important;
     border-bottom-right-radius: 0 !important;
   }
 }
 
-// stylelint-disable-next-line selector-max-combinators, selector-max-specificity
 .Connected:not(.newDesignLanguage) .Item-connection {
+  // stylelint-disable-next-line selector-max-combinators, selector-max-specificity
   &:first-child * {
     border-top-right-radius: 0 !important;
     border-bottom-right-radius: 0 !important;
 
+    // stylelint-disable-next-line selector-max-combinators, selector-max-specificity
     &::after {
       border-top-right-radius: 0 !important;
       border-bottom-right-radius: 0 !important;
     }
   }
 
+  // stylelint-disable-next-line selector-max-combinators, selector-max-specificity
   &:last-child * {
     border-top-left-radius: 0 !important;
     border-bottom-left-radius: 0 !important;
 
+    // stylelint-disable-next-line selector-max-combinators, selector-max-specificity
     &::after {
       border-top-left-radius: 0 !important;
       border-bottom-left-radius: 0 !important;

--- a/src/components/Connected/Connected.scss
+++ b/src/components/Connected/Connected.scss
@@ -30,35 +30,35 @@ $stacking-order: (
   z-index: z-index(primary, $stacking-order);
   flex: 1 1 auto;
 
-  &:not(:first-child) * {
-    border-top-left-radius: var(--p-border-radius-base, 0) !important;
-    border-bottom-left-radius: var(--p-border-radius-base, 0) !important;
+  .Connected:not(.newDesignLanguage) &:not(:first-child) * {
+    border-top-left-radius: 0 !important;
+    border-bottom-left-radius: 0 !important;
   }
 
-  &:not(:last-child) * {
-    border-top-right-radius: var(--p-border-radius-base, 0) !important;
-    border-bottom-right-radius: var(--p-border-radius-base, 0) !important;
+  .Connected:not(.newDesignLanguage) &:not(:last-child) * {
+    border-top-right-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
   }
 }
 
-.Item-connection {
+.Connected:not(.newDesignLanguage) .Item-connection {
   &:first-child * {
-    border-top-right-radius: var(--p-border-radius-base, 0) !important;
-    border-bottom-right-radius: var(--p-border-radius-base, 0) !important;
+    border-top-right-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
 
     &::after {
-      border-top-right-radius: var(--p-border-radius-base, 0) !important;
-      border-bottom-right-radius: var(--p-border-radius-base, 0) !important;
+      border-top-right-radius: 0 !important;
+      border-bottom-right-radius: 0 !important;
     }
   }
 
   &:last-child * {
-    border-top-left-radius: var(--p-border-radius-base, 0) !important;
-    border-bottom-left-radius: var(--p-border-radius-base, 0) !important;
+    border-top-left-radius: 0 !important;
+    border-bottom-left-radius: 0 !important;
 
     &::after {
-      border-top-left-radius: var(--p-border-radius-base, 0) !important;
-      border-bottom-left-radius: var(--p-border-radius-base, 0) !important;
+      border-top-left-radius: 0 !important;
+      border-bottom-left-radius: 0 !important;
     }
   }
 }

--- a/src/components/Connected/Connected.scss
+++ b/src/components/Connected/Connected.scss
@@ -26,6 +26,7 @@ $stacking-order: (
 // TextField.scss has a dependency due to this override.
 // stylelint-disable declaration-no-important
 
+// stylelint-disable-next-line selector-max-combinators, selector-max-specificity
 .Connected:not(.newDesignLanguage) .Item-primary {
   z-index: z-index(primary, $stacking-order);
   flex: 1 1 auto;
@@ -41,6 +42,7 @@ $stacking-order: (
   }
 }
 
+// stylelint-disable-next-line selector-max-combinators, selector-max-specificity
 .Connected:not(.newDesignLanguage) .Item-connection {
   &:first-child * {
     border-top-right-radius: 0 !important;

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -545,22 +545,40 @@ function ConnectedFieldsExample() {
   const handleSelectChange = useCallback((value) => setSelectValue(value), []);
 
   return (
-    <TextField
-      label="Weight"
-      type="number"
-      value={textFieldValue}
-      onChange={handleTextFieldChange}
-      connectedLeft={
-        <Select
-          value={selectValue}
-          label="Weight unit"
-          onChange={handleSelectChange}
-          labelHidden
-          options={['kg', 'lb']}
-        />
-      }
-      connectedRight={<Button>Submit</Button>}
-    />
+    <>
+      <TextField
+        label="Weight"
+        type="number"
+        value={textFieldValue}
+        onChange={handleTextFieldChange}
+        connectedLeft={
+          <Select
+            value={selectValue}
+            label="Weight unit"
+            onChange={handleSelectChange}
+            labelHidden
+            options={['kg', 'lb']}
+          />
+        }
+        connectedRight={<Button>Submit</Button>}
+      />
+      <TextField
+        label="Weight"
+        type="number"
+        value={textFieldValue}
+        onChange={handleTextFieldChange}
+        connectedLeft={
+          <Select
+            value={selectValue}
+            label="Weight unit"
+            onChange={handleSelectChange}
+            labelHidden
+            options={['kg', 'lb']}
+          />
+        }
+        connectedRight={<Button icon={PlusMinor}>Submit</Button>}
+      />
+    </>
   );
 }
 ```

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -545,40 +545,22 @@ function ConnectedFieldsExample() {
   const handleSelectChange = useCallback((value) => setSelectValue(value), []);
 
   return (
-    <>
-      <TextField
-        label="Weight"
-        type="number"
-        value={textFieldValue}
-        onChange={handleTextFieldChange}
-        connectedLeft={
-          <Select
-            value={selectValue}
-            label="Weight unit"
-            onChange={handleSelectChange}
-            labelHidden
-            options={['kg', 'lb']}
-          />
-        }
-        connectedRight={<Button>Submit</Button>}
-      />
-      <TextField
-        label="Weight"
-        type="number"
-        value={textFieldValue}
-        onChange={handleTextFieldChange}
-        connectedLeft={
-          <Select
-            value={selectValue}
-            label="Weight unit"
-            onChange={handleSelectChange}
-            labelHidden
-            options={['kg', 'lb']}
-          />
-        }
-        connectedRight={<Button icon={PlusMinor}>Submit</Button>}
-      />
-    </>
+    <TextField
+      label="Weight"
+      type="number"
+      value={textFieldValue}
+      onChange={handleTextFieldChange}
+      connectedLeft={
+        <Select
+          value={selectValue}
+          label="Weight unit"
+          onChange={handleSelectChange}
+          labelHidden
+          options={['kg', 'lb']}
+        />
+      }
+      connectedRight={<Button>Submit</Button>}
+    />
   );
 }
 ```


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/445

![Screen Shot 2020-10-08 at 2 12 17 PM](https://user-images.githubusercontent.com/19199063/95497515-7347bb00-0970-11eb-8f9b-d9cc07c1fba1.png)

### WHAT is this pull request doing?

Makes sure the border radius removal of connected fields happens when the newDesignLanguage is not on.

![Screen Shot 2020-10-08 at 2 12 38 PM](https://user-images.githubusercontent.com/19199063/95497535-793d9c00-0970-11eb-8edf-8ba55147f227.png)
![Screen Shot 2020-10-08 at 2 11 14 PM](https://user-images.githubusercontent.com/19199063/95497538-79d63280-0970-11eb-90eb-ff55c5bec43e.png)

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
