### PR TITLE
[new DL] Tweak topbar search input colors

### DIFF
--- a/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/src/components/TopBar/components/SearchField/SearchField.scss
@@ -56,7 +56,7 @@ $stacking-order: (
 
 .Input:focus {
   ~ .Backdrop {
-    background-color: var(--p-surface-neutral, color('white'));
+    background-color: var(--p-on-surface-background, color('white'));
   }
 
   ~ .BackdropShowFocusBorder {
@@ -64,13 +64,13 @@ $stacking-order: (
   }
 
   ~ .Icon {
-    @include recolor-icon(var(--p-icon-subdued, color('ink', 'lightest')));
+    @include recolor-icon(var(--p-icon, color('ink', 'lightest')));
   }
 }
 
 .focused {
   .Backdrop {
-    background-color: var(--p-surface-neutral, color('white'));
+    background-color: var(--p-on-surface-background, color('white'));
   }
 
   .BackdropShowFocusBorder {
@@ -78,7 +78,7 @@ $stacking-order: (
   }
 
   .Icon {
-    @include recolor-icon(var(--p-icon-subdued, color('ink', 'lightest')));
+    @include recolor-icon(var(--p-icon color('ink', 'lightest')));
   }
 }
 
@@ -165,7 +165,10 @@ $stacking-order: (
   right: 0;
   bottom: 0;
   left: 0;
-  background-color: var(--p-surface-neutral, var(--top-bar-background-lighter));
+  background-color: var(
+    --p-on-surface-background,
+    var(--top-bar-background-lighter)
+  );
   will-change: background-color;
   transition: background-color duration() easing();
   border-radius: var(--p-border-radius-base, border-radius());

--- a/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/src/components/TopBar/components/SearchField/SearchField.scss
@@ -56,7 +56,7 @@ $stacking-order: (
 
 .Input:focus {
   ~ .Backdrop {
-    background-color: var(--p-action-secondary, color('white'));
+    background-color: var(--p-surface-neutral, color('white'));
   }
 
   ~ .BackdropShowFocusBorder {
@@ -70,7 +70,7 @@ $stacking-order: (
 
 .focused {
   .Backdrop {
-    background-color: var(--p-action-secondary, color('white'));
+    background-color: var(--p-surface-neutral, color('white'));
   }
 
   .BackdropShowFocusBorder {
@@ -165,10 +165,7 @@ $stacking-order: (
   right: 0;
   bottom: 0;
   left: 0;
-  background-color: var(
-    --p-on-surface-background,
-    var(--top-bar-background-lighter)
-  );
+  background-color: var(--p-surface-neutral, var(--top-bar-background-lighter));
   will-change: background-color;
   transition: background-color duration() easing();
   border-radius: var(--p-border-radius-base, border-radius());
@@ -178,7 +175,7 @@ $stacking-order: (
 @keyframes toLightBackground {
   to {
     background-color: var(
-      --p-action-secondary,
+      --p-surface-neutral,
       var(--top-bar-background-lighter)
     );
   }

--- a/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/src/components/TopBar/components/SearchField/SearchField.scss
@@ -78,7 +78,7 @@ $stacking-order: (
   }
 
   .Icon {
-    @include recolor-icon(var(--p-icon color('ink', 'lightest')));
+    @include recolor-icon(var(--p-icon, color('ink', 'lightest')));
   }
 }
 


### PR DESCRIPTION
Adjust the colors of the top bar search. Based on [this Figma file](https://www.figma.com/file/4dAAt5iFPSaxUKiYVKrkYj/Admin-Design-Language-(Web)%3A-Components?node-id=22369%3A1350).

The search background is now `--p-surface-neutral`.

## Before

Default:
<img width="671" alt="Screen Shot 2020-10-08 at 4 39 52 PM" src="https://user-images.githubusercontent.com/875708/95511101-fb37c000-0984-11eb-8acb-7d0511f54f81.png">

Focused:
<img width="752" alt="Screen Shot 2020-10-08 at 4 26 45 PM" src="https://user-images.githubusercontent.com/875708/95511108-fbd05680-0984-11eb-8327-67329c5ac1c0.png">

## After
Default:
<img width="677" alt="Screen Shot 2020-10-08 at 4 42 37 PM" src="https://user-images.githubusercontent.com/875708/95511381-62557480-0985-11eb-888a-4ee292c34933.png">

Focused:
<img width="681" alt="Screen Shot 2020-10-08 at 4 42 42 PM" src="https://user-images.githubusercontent.com/875708/95511385-62ee0b00-0985-11eb-8809-57cc0e3b8b14.png">
