### PR TITLE
[TextField] Updated number field spinner bg

### DIFF
--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -415,16 +415,16 @@ $stacking-order: (
     --p-text-field-spinner-border-radius: calc(
       var(--p-border-radius-base) - var(--p-text-field-spinner-offset)
     );
-    background: var(--p-action-secondary);
+    background: var(--p-surface-neutral);
     border-radius: var(--p-text-field-spinner-border-radius);
     border-left: var(--p-override-none);
 
     &:hover {
-      background: var(--p-action-secondary-hovered);
+      background: var(--p-surface-neutral-hovered);
     }
 
     &:active {
-      background: var(--p-action-secondary-pressed);
+      background: var(--p-surface-neutral-pressed);
       box-shadow: none;
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3403

### WHAT is this pull request doing?

This updates the background color of the stepper buttons on number fields.

<img width="186" alt="Screen Shot 2020-10-09 at 9 51 52 AM" src="https://user-images.githubusercontent.com/478990/95591460-531e0780-0a15-11eb-92a0-ad3a6b71ca67.png">

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

