### PR TITLE
[new DL] Update user menu to accept a colorScheme prop

### DIFF
--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -182,6 +182,7 @@ export function DetailsPage() {
       initials="D"
       open={userMenuActive}
       onToggle={toggleUserMenuActive}
+      colorScheme="dark"
     />
   );
 

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -7,6 +7,7 @@ import React, {
   AriaAttributes,
 } from 'react';
 
+import {InversableColorScheme, ThemeProvider} from '../ThemeProvider';
 import {
   findFirstFocusableNodeIncludingDisabled,
   focusNextFocusableNode,
@@ -65,6 +66,8 @@ export interface PopoverProps {
   hideOnPrint?: boolean;
   /** Callback when popover is closed */
   onClose(source: PopoverCloseSource): void;
+  /** Accepts a color scheme for the contents of the popover */
+  colorScheme?: InversableColorScheme;
 }
 
 // TypeScript can't generate types that correctly infer the typing of
@@ -84,6 +87,7 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
   fixed,
   ariaHaspopup,
   preferInputActivator = true,
+  colorScheme,
   ...rest
 }: PopoverProps) {
   const [activatorNode, setActivatorNode] = useState<HTMLElement>();
@@ -181,7 +185,7 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
   return (
     <WrapperComponent ref={activatorContainer}>
       {Children.only(activator)}
-      {portal}
+      <ThemeProvider theme={{colorScheme}}>{portal}</ThemeProvider>
     </WrapperComponent>
   );
 };

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -7,7 +7,7 @@ import React, {
   AriaAttributes,
 } from 'react';
 
-import {InversableColorScheme, ThemeProvider} from '../ThemeProvider';
+import type {InversableColorScheme} from '../ThemeProvider';
 import {
   findFirstFocusableNodeIncludingDisabled,
   focusNextFocusableNode,
@@ -175,6 +175,7 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
         onClose={handleClose}
         active={active}
         fixed={fixed}
+        colorScheme={colorScheme}
         {...rest}
       >
         {children}
@@ -185,7 +186,7 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
   return (
     <WrapperComponent ref={activatorContainer}>
       {Children.only(activator)}
-      <ThemeProvider theme={{colorScheme}}>{portal}</ThemeProvider>
+      {portal}
     </WrapperComponent>
   );
 };

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -1,6 +1,7 @@
 import React, {PureComponent, Children, createRef} from 'react';
 import {durationBase} from '@shopify/polaris-tokens';
 
+import {InversableColorScheme, ThemeProvider} from '../../../ThemeProvider';
 import {classNames} from '../../../../utilities/css';
 import {
   isElementOfType,
@@ -47,6 +48,7 @@ export interface PopoverOverlayProps {
   fixed?: boolean;
   hideOnPrint?: boolean;
   onClose(source: PopoverCloseSource): void;
+  colorScheme?: InversableColorScheme;
 }
 
 interface State {
@@ -187,6 +189,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
       fullHeight,
       fluidContent,
       hideOnPrint,
+      colorScheme,
     } = this.props;
 
     const className = classNames(
@@ -228,7 +231,9 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
           tabIndex={0}
           onFocus={this.handleFocusFirstItem}
         />
-        <div className={styles.Wrapper}>{content}</div>
+        <ThemeProvider theme={{colorScheme}}>
+          <div className={styles.Wrapper}>{content}</div>
+        </ThemeProvider>
         <div
           className={styles.FocusTracker}
           // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -12,7 +12,7 @@ import {useFeatures} from '../../utilities/features';
 
 type OriginalColorScheme = Required<ThemeConfig['colorScheme']>;
 type Inverse = 'inverse';
-type InversableColorScheme = OriginalColorScheme | Inverse;
+export type InversableColorScheme = OriginalColorScheme | Inverse;
 
 // TS 3.5+ includes the built-in Omit type which does the same thing. But if we
 // use that then we break consumers on older versions of TS. Consider removing

--- a/src/components/TopBar/components/Menu/Menu.tsx
+++ b/src/components/TopBar/components/Menu/Menu.tsx
@@ -1,3 +1,4 @@
+import type {InversableColorScheme} from 'components/ThemeProvider';
 import React from 'react';
 
 import {ActionList, ActionListProps} from '../../../ActionList';
@@ -19,10 +20,22 @@ export interface MenuProps {
   onOpen(): void;
   /** A callback function to handle closing the menu popover */
   onClose(): void;
+  /** A callback function to handle closing the menu popover */
+  onClose(): void;
+  /** Accepts a color scheme for the contents of the menu */
+  colorScheme?: InversableColorScheme;
 }
 
 export function Menu(props: MenuProps) {
-  const {actions, onOpen, onClose, open, activatorContent, message} = props;
+  const {
+    actions,
+    onOpen,
+    onClose,
+    open,
+    activatorContent,
+    message,
+    colorScheme,
+  } = props;
 
   const badgeProps = message &&
     message.badge && {
@@ -58,6 +71,7 @@ export function Menu(props: MenuProps) {
       fixed
       fullHeight={isFullHeight}
       preferredAlignment="right"
+      colorScheme={colorScheme}
     >
       <ActionList onActionAnyItem={onClose} sections={actions} />
       {messageMarkup}

--- a/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/src/components/TopBar/components/SearchField/SearchField.scss
@@ -56,7 +56,7 @@ $stacking-order: (
 
 .Input:focus {
   ~ .Backdrop {
-    background-color: var(--p-surface-neutral, color('white'));
+    background-color: var(--p-on-surface-background, color('white'));
   }
 
   ~ .BackdropShowFocusBorder {
@@ -64,13 +64,13 @@ $stacking-order: (
   }
 
   ~ .Icon {
-    @include recolor-icon(var(--p-icon-subdued, color('ink', 'lightest')));
+    @include recolor-icon(var(--p-icon, color('ink', 'lightest')));
   }
 }
 
 .focused {
   .Backdrop {
-    background-color: var(--p-surface-neutral, color('white'));
+    background-color: var(--p-on-surface-background, color('white'));
   }
 
   .BackdropShowFocusBorder {
@@ -78,7 +78,7 @@ $stacking-order: (
   }
 
   .Icon {
-    @include recolor-icon(var(--p-icon-subdued, color('ink', 'lightest')));
+    @include recolor-icon(var(--p-icon color('ink', 'lightest')));
   }
 }
 
@@ -165,7 +165,10 @@ $stacking-order: (
   right: 0;
   bottom: 0;
   left: 0;
-  background-color: var(--p-surface-neutral, var(--top-bar-background-lighter));
+  background-color: var(
+    --p-on-surface-background,
+    var(--top-bar-background-lighter)
+  );
   will-change: background-color;
   transition: background-color duration() easing();
   border-radius: var(--p-border-radius-base, border-radius());

--- a/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/src/components/TopBar/components/SearchField/SearchField.scss
@@ -56,7 +56,7 @@ $stacking-order: (
 
 .Input:focus {
   ~ .Backdrop {
-    background-color: var(--p-action-secondary, color('white'));
+    background-color: var(--p-surface-neutral, color('white'));
   }
 
   ~ .BackdropShowFocusBorder {
@@ -70,7 +70,7 @@ $stacking-order: (
 
 .focused {
   .Backdrop {
-    background-color: var(--p-action-secondary, color('white'));
+    background-color: var(--p-surface-neutral, color('white'));
   }
 
   .BackdropShowFocusBorder {
@@ -165,10 +165,7 @@ $stacking-order: (
   right: 0;
   bottom: 0;
   left: 0;
-  background-color: var(
-    --p-on-surface-background,
-    var(--top-bar-background-lighter)
-  );
+  background-color: var(--p-surface-neutral, var(--top-bar-background-lighter));
   will-change: background-color;
   transition: background-color duration() easing();
   border-radius: var(--p-border-radius-base, border-radius());
@@ -178,7 +175,7 @@ $stacking-order: (
 @keyframes toLightBackground {
   to {
     background-color: var(
-      --p-action-secondary,
+      --p-surface-neutral,
       var(--top-bar-background-lighter)
     );
   }

--- a/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/src/components/TopBar/components/SearchField/SearchField.scss
@@ -78,7 +78,7 @@ $stacking-order: (
   }
 
   .Icon {
-    @include recolor-icon(var(--p-icon color('ink', 'lightest')));
+    @include recolor-icon(var(--p-icon, color('ink', 'lightest')));
   }
 }
 

--- a/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -1,3 +1,4 @@
+import type {InversableColorScheme} from 'components/ThemeProvider';
 import React from 'react';
 
 import type {IconableAction} from '../../../../types';
@@ -24,6 +25,8 @@ export interface UserMenuProps {
   open: boolean;
   /** A callback function to handle opening and closing the user menu */
   onToggle(): void;
+  /** Accepts a color scheme for the contents of the user menu */
+  colorScheme?: InversableColorScheme;
 }
 
 export function UserMenu({
@@ -35,6 +38,7 @@ export function UserMenu({
   message,
   onToggle,
   open,
+  colorScheme,
 }: UserMenuProps) {
   const showIndicator = Boolean(message);
 
@@ -62,6 +66,7 @@ export function UserMenu({
       onClose={onToggle}
       actions={actions}
       message={message}
+      colorScheme={colorScheme}
     />
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Allows theming of the contents of `Popover` and `Menu`. This allows the `Topbar.UserMenu` to dark mode for its content

### WHAT is this pull request doing?

Makes the `Popover`, `Menu` and `Topbar.UserMenu` components accept a colorScheme prop which sets the color scheme for their contents. Apologies for the prop drilling.

<img width="173" alt="Screen Shot 2020-10-09 at 10 37 37 AM" src="https://user-images.githubusercontent.com/875708/95596496-75b31f00-0a1b-11eb-9063-95be99383d1b.png">

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
