### PR TITLE
Fixes bulk actions from hiding actions when on small screen sizes

### DIFF
--- a/src/components/BulkActions/BulkActions.tsx
+++ b/src/components/BulkActions/BulkActions.tsx
@@ -5,6 +5,7 @@ import {CSSTransition, Transition} from 'react-transition-group';
 
 import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
+import {clamp} from '../../utilities/clamp';
 import type {DisableableAction, Action, ActionListSection} from '../../types';
 import {ActionList} from '../ActionList';
 import {Popover} from '../Popover';
@@ -141,7 +142,7 @@ class BulkActionsInner extends PureComponent<CombinedProps, State> {
       }
     }
 
-    return counter;
+    return clamp(counter, 0, promotedActions.length);
   }
 
   private hasActions() {


### PR DESCRIPTION
Co-Authored-By: Andrew Musgrave <24610840+andrewmusgrave@users.noreply.github.com>

### WHY are these changes introduced?

Fixes bulk actions from hiding actions when on small screen sizes.

### WHAT is this pull request doing?

Adding a clamp around the counter to stop it from returning `-1`.

### How to 🎩

@AndrewMusgrave and Alex tophatted this in a build consumer for web.

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
