### PR TITLE
[AutoSuggest] Add options as dependency to useCallback function

### DIFF
--- a/src/components/Autocomplete/README.md
+++ b/src/components/Autocomplete/README.md
@@ -237,7 +237,7 @@ function AutocompleteExample() {
         setLoading(false);
       }, 300);
     },
-    [deselectedOptions],
+    [deselectedOptions, options, loading],
   );
 
   const updateSelection = useCallback((selected) => {
@@ -249,7 +249,7 @@ function AutocompleteExample() {
     });
     setSelectedOptions(selected);
     setInputValue(selectedText);
-  }, []);
+  }, [options]);
 
   const textField = (
     <Autocomplete.TextField
@@ -297,7 +297,7 @@ function AutoCompleteLazyLoadExample() {
     if (nextVisibleOptionIndex <= options.length - 1) {
       setVisibleOptionIndex(nextVisibleOptionIndex);
     }
-  }, [visibleOptionIndex]);
+  }, [visibleOptionIndex, options.length]);
 
   const removeTag = useCallback(
     (tag) => () => {
@@ -328,7 +328,7 @@ function AutoCompleteLazyLoadExample() {
       }
       setOptions(resultOptions);
     },
-    [deselectedOptions],
+    [deselectedOptions, options],
   );
 
   const textField = (

--- a/src/components/Autocomplete/README.md
+++ b/src/components/Autocomplete/README.md
@@ -67,17 +67,20 @@ function AutocompleteExample() {
     [deselectedOptions],
   );
 
-  const updateSelection = useCallback((selected) => {
-    const selectedValue = selected.map((selectedItem) => {
-      const matchedOption = options.find((option) => {
-        return option.value.match(selectedItem);
+  const updateSelection = useCallback(
+    (selected) => {
+      const selectedValue = selected.map((selectedItem) => {
+        const matchedOption = options.find((option) => {
+          return option.value.match(selectedItem);
+        });
+        return matchedOption && matchedOption.label;
       });
-      return matchedOption && matchedOption.label;
-    });
 
-    setSelectedOptions(selected);
-    setInputValue(selectedValue);
-  }, [options]);
+      setSelectedOptions(selected);
+      setInputValue(selectedValue);
+    },
+    [options],
+  );
 
   const textField = (
     <Autocomplete.TextField
@@ -240,16 +243,19 @@ function AutocompleteExample() {
     [deselectedOptions, options, loading],
   );
 
-  const updateSelection = useCallback((selected) => {
-    const selectedText = selected.map((selectedItem) => {
-      const matchedOption = options.find((option) => {
-        return option.value.match(selectedItem);
+  const updateSelection = useCallback(
+    (selected) => {
+      const selectedText = selected.map((selectedItem) => {
+        const matchedOption = options.find((option) => {
+          return option.value.match(selectedItem);
+        });
+        return matchedOption && matchedOption.label;
       });
-      return matchedOption && matchedOption.label;
-    });
-    setSelectedOptions(selected);
-    setInputValue(selectedText);
-  }, [options]);
+      setSelectedOptions(selected);
+      setInputValue(selectedText);
+    },
+    [options],
+  );
 
   const textField = (
     <Autocomplete.TextField

--- a/src/components/Autocomplete/README.md
+++ b/src/components/Autocomplete/README.md
@@ -77,7 +77,7 @@ function AutocompleteExample() {
 
     setSelectedOptions(selected);
     setInputValue(selectedValue);
-  }, []);
+  }, [options]);
 
   const textField = (
     <Autocomplete.TextField


### PR DESCRIPTION
The useCallback function requires any variables used within the callback to be listed as dependencies. In three of the five example code samples, there are missing dependencies for the `useCallback` functions. This triggers the `list options as dependency` linting error.

### WHY are these changes introduced?

No issue created, context given above - this is fixing the example code for this component

### WHAT is this pull request doing?

Adds the dependencies to the `useCallback` dependency list for:

* basic autocomplete
* autocomplete with loading
* autocomplete with lazy loading

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

