### PR TITLE
[Page] Fix up print styles

### DIFF
--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -56,6 +56,8 @@ $action-menu-rollup-computed-width: rem(40px);
   &.newDesignLanguage {
     margin-right: spacing();
   }
+
+  @include print-hidden;
 }
 
 .PaginationWrapper {
@@ -79,6 +81,8 @@ $action-menu-rollup-computed-width: rem(40px);
       }
     }
   }
+
+  @include print-hidden;
 }
 
 .AdditionalNavigationWrapper {
@@ -94,6 +98,8 @@ $action-menu-rollup-computed-width: rem(40px);
   .newDesignLanguage & {
     margin-right: 0;
   }
+
+  @include print-hidden;
 }
 
 ///
@@ -263,6 +269,11 @@ $action-menu-rollup-computed-width: rem(40px);
   .noBreadcrumbs.newDesignLanguage & {
     margin-left: 0;
   }
+
+  @include when-printing {
+    // stylelint-disable-next-line declaration-no-important
+    margin-left: 0 !important;
+  }
 }
 
 .Actions {
@@ -279,4 +290,8 @@ $action-menu-rollup-computed-width: rem(40px);
   > :first-child {
     flex: 1;
   }
+}
+
+.HideFromPrint {
+  @include print-hidden;
 }

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -141,11 +141,13 @@ export function Header({
           <div className={styles.ActionMenuWrapper}>{children}</div>
         )}
       >
-        <ActionMenu
-          actions={secondaryActions}
-          groups={actionGroups}
-          rollup={isNavigationCollapsed}
-        />
+        <div className={styles.HideFromPrint}>
+          <ActionMenu
+            actions={secondaryActions}
+            groups={actionGroups}
+            rollup={isNavigationCollapsed}
+          />
+        </div>
       </ConditionalWrapper>
     ) : null;
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3457. When rebuilding Page for the new design language I stripped much of the extra styling, wrappers, etc in an effort simplify the component to a basic conditional layout of primitives and subcomponents. Although a few of those wrappers handle the hiding of actions, etc when printing. 

Printing is frequently used on order pages.

### WHAT is this pull request doing?

Hiding elements that should not be printed.

|Legacy|Before|After|
|---|---|---|
|<img width="731" alt="Screen Shot 2020-10-09 at 12 54 44 PM" src="https://user-images.githubusercontent.com/344839/95626269-d566f580-0a2e-11eb-9b49-e66f25d762f5.png">|<img width="718" alt="Screen Shot 2020-10-09 at 12 56 03 PM" src="https://user-images.githubusercontent.com/344839/95626281-db5cd680-0a2e-11eb-916d-b33c9fdfa776.png">|<img width="697" alt="Screen Shot 2020-10-09 at 12 54 50 PM" src="https://user-images.githubusercontent.com/344839/95626301-e31c7b00-0a2e-11eb-9183-0b950629e0fa.png">|

### 🎩 checklist

* [x] 🎩 
