### PR TITLE
Remove unstyled button styles

### DIFF
--- a/src/components/UnstyledButton/UnstyledButton.scss
+++ b/src/components/UnstyledButton/UnstyledButton.scss
@@ -1,5 +1,0 @@
-@import '../../styles/common';
-
-[data-polaris-unstyled-button] {
-  @include unstyled-button;
-}

--- a/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/UnstyledButton/UnstyledButton.tsx
@@ -3,8 +3,6 @@ import React, {useRef} from 'react';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 import {UnstyledLink} from '../UnstyledLink';
 
-import './UnstyledButton.scss';
-
 export interface UnstyledButtonProps {
   /** The content to display inside the button */
   children?: React.ReactNode;
@@ -146,7 +144,6 @@ export function UnstyledButton({
         aria-controls={ariaControls}
         aria-expanded={ariaExpanded}
         aria-pressed={ariaPressedStatus}
-        data-polaris-unstyled-button
         {...rest}
       >
         {children}


### PR DESCRIPTION
### WHY are these changes introduced?

We are having issues with the data attribute styling and since this isn't actually used yet, we will remove it.

### WHAT is this pull request doing?

This removes the attribute and styles.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Look around storybook and make sure buttons and banners still look correct.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
