### PR TITLE
[Badge] Set border width to 0 in new design language

### DIFF
--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -21,8 +21,7 @@ $pip-spacing: ($height - $pip-size) / 2;
   align-items: center;
   padding: $vertical-padding $horizontal-padding;
   background-color: var(--p-surface-neutral, color('sky'));
-  border: var(--p-override-zero, border-width(thick)) solid
-    var(--p-override-transparent, color('white'));
+  border: var(--p-override-zero, border-width(thick)) solid color('white');
   border-radius: $height;
   font-size: rem(13px);
   line-height: $extra-small-height;

--- a/src/components/Badge/Badge.scss
+++ b/src/components/Badge/Badge.scss
@@ -21,7 +21,7 @@ $pip-spacing: ($height - $pip-size) / 2;
   align-items: center;
   padding: $vertical-padding $horizontal-padding;
   background-color: var(--p-surface-neutral, color('sky'));
-  border: border-width(thick) solid
+  border: var(--p-override-zero, border-width(thick)) solid
     var(--p-override-transparent, color('white'));
   border-radius: $height;
   font-size: rem(13px);


### PR DESCRIPTION
### WHY are these changes introduced?

Currently badges are a bit too big in the new design language

### WHAT is this pull request doing?

This sets the border width to 0 so they are the correct size.

*Before*
<img width="140" alt="Screen Shot 2020-10-09 at 5 14 50 PM" src="https://user-images.githubusercontent.com/478990/95632326-66e85e80-0a53-11eb-9f56-8f0fb6382b02.png">

*After*
<img width="125" alt="Screen Shot 2020-10-09 at 5 14 59 PM" src="https://user-images.githubusercontent.com/478990/95632335-6c45a900-0a53-11eb-952d-d365ea615e2c.png">

