### PR TITLE
Export `NewDesignLanguageColor` type

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added `OutlineableAction` to the `ComplexAction` type ([#3405](https://github.com/Shopify/polaris-react/pull/3405))
 - Added `UnstyledButton` component and refactored `Banner` to use it ([#32326](https://github.com/Shopify/polaris-react/pull/32326))
 - Added `prefix` field to `options` prop on `Select` ([#3373](https://github.com/Shopify/polaris-react/pull/3373))
+- Exported the `NewDesignLanguageColor` type ([#3463](https://github.com/Shopify/polaris-react/pull/3463))
 
 ### Bug fixes
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ const NEW_DESIGN_LANGUAGE_COLORS = [
   'success',
   'primary',
 ];
-type NewDesignLanguageColor =
+export type NewDesignLanguageColor =
   | 'base'
   | 'subdued'
   | 'critical'


### PR DESCRIPTION
### WHAT is this pull request doing?

Exports the `NewDesignLanguageColor` type so consumers can easily access it for internal component typings.