### PR TITLE
Change breakpoint for page title

### DIFF
--- a/src/components/Page/components/Header/components/Title/Title.scss
+++ b/src/components/Page/components/Header/components/Title/Title.scss
@@ -4,6 +4,16 @@
   @include text-breakword;
 }
 
+.newDesignLanguageTitle {
+  @include text-emphasis-strong;
+  font-size: rem(24px);
+  line-height: rem(28px);
+
+  @include when-typography-not-condensed {
+    font-size: rem(20px);
+  }
+}
+
 .SubTitle {
   margin-top: spacing(tight);
   color: var(--p-text-subdued, inherit);

--- a/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/src/components/Page/components/Header/components/Title/Title.tsx
@@ -6,7 +6,6 @@ import type {AvatarProps} from '../../../../../Avatar';
 import type {ThumbnailProps} from '../../../../../Thumbnail';
 import {classNames} from '../../../../../../utilities/css';
 import {useFeatures} from '../../../../../../utilities/features';
-import {useMediaQuery} from '../../../../../../utilities/media-query';
 
 import styles from './Title.scss';
 
@@ -25,17 +24,16 @@ export interface TitleProps {
 
 export function Title({title, subtitle, titleMetadata, thumbnail}: TitleProps) {
   const {newDesignLanguage} = useFeatures();
-  const {isNavigationCollapsed} = useMediaQuery();
-  const displaySize = isNavigationCollapsed ? 'large' : 'small';
+
+  const titleElement = newDesignLanguage ? (
+    <h1 className={styles.newDesignLanguageTitle}>{title}</h1>
+  ) : (
+    <DisplayText size="large" element="h1">
+      <TextStyle variation="strong">{title}</TextStyle>
+    </DisplayText>
+  );
   const titleMarkup = title ? (
-    <div className={styles.Title}>
-      <DisplayText
-        size={newDesignLanguage ? displaySize : 'large'}
-        element="h1"
-      >
-        <TextStyle variation="strong">{title}</TextStyle>
-      </DisplayText>
-    </div>
+    <div className={styles.Title}>{titleElement}</div>
   ) : null;
 
   const titleMetadataMarkup = titleMetadata ? (


### PR DESCRIPTION
### WHY are these changes introduced?

This is a part of https://github.com/Shopify/polaris-rails/issues/2182

### WHAT is this pull request doing?

Changes the fontsize and breakpoints for the page title in the new design language.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
