### PR TITLE
[new DL] Change backdrop properties 

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- The Details Page in Storybook now renders the `SearchDismissOverlay` when typing in the search field. ([#3471](https://github.com/Shopify/polaris-react/pull/3471))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -213,6 +213,7 @@ export function DetailsPage() {
       onSearchResultsDismiss={handleSearchResultsDismiss}
       onNavigationToggle={toggleMobileNavigationActive}
       contextControl={contextControlMarkup}
+      searchResultsOverlayVisible
     />
   );
   // ---- Navigation ----

--- a/src/components/TopBar/components/Search/Search.scss
+++ b/src/components/TopBar/components/Search/Search.scss
@@ -4,6 +4,7 @@
 .Search {
   position: fixed;
   visibility: hidden;
+  z-index: z-index(nav, $fixed-element-stacking-order);
   pointer-events: none;
   top: top-bar-height();
   left: 0;
@@ -39,7 +40,6 @@
 
 .Results {
   position: relative;
-  z-index: z-index(nav, $fixed-element-stacking-order);
   display: flex;
   flex-direction: column;
   max-height: calc(100vh - #{top-bar-height()});

--- a/src/components/TopBar/components/Search/Search.tsx
+++ b/src/components/TopBar/components/Search/Search.tsx
@@ -35,24 +35,26 @@ export function Search({
   ) : null;
 
   return (
-    <div
-      className={classNames(
-        styles.Search,
-        visible && styles.visible,
-        newDesignLanguage && styles.newDesignLanguage,
-      )}
-    >
-      <ThemeProvider theme={{colorScheme: 'dark'}}>
-        <div
-          className={classNames(
-            styles.SearchContent,
-            newDesignLanguage && styles.newDesignLanguage,
-          )}
-        >
-          {overlayMarkup}
-          <div className={styles.Results}>{children}</div>
-        </div>
-      </ThemeProvider>
-    </div>
+    <>
+      {overlayMarkup}
+      <div
+        className={classNames(
+          styles.Search,
+          visible && styles.visible,
+          newDesignLanguage && styles.newDesignLanguage,
+        )}
+      >
+        <ThemeProvider theme={{colorScheme: 'dark'}}>
+          <div
+            className={classNames(
+              styles.SearchContent,
+              newDesignLanguage && styles.newDesignLanguage,
+            )}
+          >
+            <div className={styles.Results}>{children}</div>
+          </div>
+        </ThemeProvider>
+      </div>
+    </>
   );
 }

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
@@ -23,8 +23,8 @@ $backdrop-color: rgba(color('ink'), 0.4);
   animation: fade-in duration() $entry-iterations forwards;
 
   &.newDesignLanguage {
+    background-color: transparent;
     animation: none;
-    background: transparent;
   }
 }
 

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
@@ -23,6 +23,7 @@ $backdrop-color: rgba(color('ink'), 0.4);
   animation: fade-in duration() $entry-iterations forwards;
 
   &.newDesignLanguage {
+    animation: none;
     background: transparent;
   }
 }

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
@@ -21,6 +21,10 @@ $backdrop-color: rgba(color('ink'), 0.4);
 .visible {
   background-color: var(--p-backdrop, $backdrop-color);
   animation: fade-in duration() $entry-iterations forwards;
+
+  &.newDesignLanguage {
+    background: transparent;
+  }
 }
 
 @keyframes fade-in {


### PR DESCRIPTION
### WHAT is this pull request doing?

- Makes the global search backdrop visible in the DetailsPage
- Changes the background of the backdrop to transparent (when new DL is on)
- Adjusts where in the DOM the backdrop lives. Before, the overlay lived inside the search results. Due to recent changes, the search results has a background, which caused the overlay to overlay that very background. So, I've moved the overlay outside the results wrapper.

<img width="1265" alt="Screen Shot 2020-10-13 at 11 22 18 AM" src="https://user-images.githubusercontent.com/875708/95881348-7f53c400-0d46-11eb-87e2-1eb9add93a2c.png">

<img width="1266" alt="Screen Shot 2020-10-13 at 11 22 08 AM" src="https://user-images.githubusercontent.com/875708/95881334-7cf16a00-0d46-11eb-96fc-4638aeb0de62.png">

![IMG_5652](https://user-images.githubusercontent.com/875708/95881901-14ef5380-0d47-11eb-9292-a4f96614d140.PNG)
![IMG_5653](https://user-images.githubusercontent.com/875708/95881922-191b7100-0d47-11eb-8fe8-e05ff8594744.PNG)
