### PR TITLE
[new DL] Change actionlist colors

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- The Details Page in Storybook now renders the `SearchDismissOverlay` when typing in the search field. ([#3471](https://github.com/Shopify/polaris-react/pull/3471))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -213,6 +213,7 @@ export function DetailsPage() {
       onSearchResultsDismiss={handleSearchResultsDismiss}
       onNavigationToggle={toggleMobileNavigationActive}
       contextControl={contextControlMarkup}
+      searchResultsOverlayVisible
     />
   );
   // ---- Navigation ----

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -25,6 +25,7 @@ $active-indicator-width: rem(3px);
 
   &.newDesignLanguage {
     padding: 0 spacing(tight);
+    border-color: var(--p-surface-neutral);
 
     // stylelint-disable-next-line selector-max-class
     .Title + & {
@@ -326,11 +327,19 @@ $active-indicator-width: rem(3px);
   margin: (-0.5 * $image-size) spacing() (-0.5 * $image-size) 0;
   background-size: cover;
   background-position: center center;
+
+  &.newDesignLanguage {
+    @include recolor-icon(var(--p-icon));
+  }
 }
 
 .Suffix {
   @include recolor-icon(color('ink', 'light'), color('white'));
   margin-left: spacing();
+
+  &.newDesignLanguage {
+    @include recolor-icon(var(--p-icon));
+  }
 }
 
 .Text {

--- a/src/components/ActionList/components/Item/Item.tsx
+++ b/src/components/ActionList/components/Item/Item.tsx
@@ -46,7 +46,12 @@ export function Item({
     prefixMarkup = <div className={styles.Prefix}>{prefix}</div>;
   } else if (icon) {
     prefixMarkup = (
-      <div className={styles.Prefix}>
+      <div
+        className={classNames(
+          styles.Prefix,
+          newDesignLanguage && styles.newDesignLanguage,
+        )}
+      >
         <Icon source={icon} />
       </div>
     );
@@ -78,7 +83,14 @@ export function Item({
   );
 
   const suffixMarkup = suffix && (
-    <span className={styles.Suffix}>{suffix}</span>
+    <span
+      className={classNames(
+        styles.Suffix,
+        newDesignLanguage && styles.newDesignLanguage,
+      )}
+    >
+      {suffix}
+    </span>
   );
 
   const textMarkup = <div className={styles.Text}>{contentMarkup}</div>;

--- a/src/components/TopBar/components/Search/Search.scss
+++ b/src/components/TopBar/components/Search/Search.scss
@@ -4,6 +4,7 @@
 .Search {
   position: fixed;
   visibility: hidden;
+  z-index: z-index(nav, $fixed-element-stacking-order);
   pointer-events: none;
   top: top-bar-height();
   left: 0;
@@ -39,7 +40,6 @@
 
 .Results {
   position: relative;
-  z-index: z-index(nav, $fixed-element-stacking-order);
   display: flex;
   flex-direction: column;
   max-height: calc(100vh - #{top-bar-height()});

--- a/src/components/TopBar/components/Search/Search.tsx
+++ b/src/components/TopBar/components/Search/Search.tsx
@@ -35,24 +35,26 @@ export function Search({
   ) : null;
 
   return (
-    <div
-      className={classNames(
-        styles.Search,
-        visible && styles.visible,
-        newDesignLanguage && styles.newDesignLanguage,
-      )}
-    >
-      <ThemeProvider theme={{colorScheme: 'dark'}}>
-        <div
-          className={classNames(
-            styles.SearchContent,
-            newDesignLanguage && styles.newDesignLanguage,
-          )}
-        >
-          {overlayMarkup}
-          <div className={styles.Results}>{children}</div>
-        </div>
-      </ThemeProvider>
-    </div>
+    <>
+      {overlayMarkup}
+      <div
+        className={classNames(
+          styles.Search,
+          visible && styles.visible,
+          newDesignLanguage && styles.newDesignLanguage,
+        )}
+      >
+        <ThemeProvider theme={{colorScheme: 'dark'}}>
+          <div
+            className={classNames(
+              styles.SearchContent,
+              newDesignLanguage && styles.newDesignLanguage,
+            )}
+          >
+            <div className={styles.Results}>{children}</div>
+          </div>
+        </ThemeProvider>
+      </div>
+    </>
   );
 }

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
@@ -23,8 +23,8 @@ $backdrop-color: rgba(color('ink'), 0.4);
   animation: fade-in duration() $entry-iterations forwards;
 
   &.newDesignLanguage {
+    background-color: transparent;
     animation: none;
-    background: transparent;
   }
 }
 

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
@@ -23,6 +23,7 @@ $backdrop-color: rgba(color('ink'), 0.4);
   animation: fade-in duration() $entry-iterations forwards;
 
   &.newDesignLanguage {
+    animation: none;
     background: transparent;
   }
 }

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
@@ -21,6 +21,10 @@ $backdrop-color: rgba(color('ink'), 0.4);
 .visible {
   background-color: var(--p-backdrop, $backdrop-color);
   animation: fade-in duration() $entry-iterations forwards;
+
+  &.newDesignLanguage {
+    background: transparent;
+  }
 }
 
 @keyframes fade-in {


### PR DESCRIPTION
Adjusts the **divider** and **icon** colors inside the `ActionList` component.

Before:

<img width="153" alt="Screen Shot 2020-10-13 at 3 16 12 PM" src="https://user-images.githubusercontent.com/875708/95905594-0fa20100-0d67-11eb-854f-16f1fc58d160.png">

After: 

<img width="153" alt="Screen Shot 2020-10-13 at 3 10 59 PM" src="https://user-images.githubusercontent.com/875708/95905462-e2555300-0d66-11eb-9866-769bc5ca1c3c.png">

Changes to light mode should me minimal. It looks like this now:

<img width="158" alt="Screen Shot 2020-10-13 at 3 11 06 PM" src="https://user-images.githubusercontent.com/875708/95905677-29dbdf00-0d67-11eb-834e-7229193a4ad4.png">