### PR TITLE
[new DL] Change actionlist colors

### DIFF
--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -25,6 +25,7 @@ $active-indicator-width: rem(3px);
 
   &.newDesignLanguage {
     padding: 0 spacing(tight);
+    border-color: var(--p-surface-neutral);
 
     // stylelint-disable-next-line selector-max-class
     .Title + & {
@@ -326,11 +327,19 @@ $active-indicator-width: rem(3px);
   margin: (-0.5 * $image-size) spacing() (-0.5 * $image-size) 0;
   background-size: cover;
   background-position: center center;
+
+  &.newDesignLanguage {
+    @include recolor-icon(var(--p-icon));
+  }
 }
 
 .Suffix {
   @include recolor-icon(color('ink', 'light'), color('white'));
   margin-left: spacing();
+
+  &.newDesignLanguage {
+    @include recolor-icon(var(--p-icon));
+  }
 }
 
 .Text {

--- a/src/components/ActionList/components/Item/Item.tsx
+++ b/src/components/ActionList/components/Item/Item.tsx
@@ -46,7 +46,12 @@ export function Item({
     prefixMarkup = <div className={styles.Prefix}>{prefix}</div>;
   } else if (icon) {
     prefixMarkup = (
-      <div className={styles.Prefix}>
+      <div
+        className={classNames(
+          styles.Prefix,
+          newDesignLanguage && styles.newDesignLanguage,
+        )}
+      >
         <Icon source={icon} />
       </div>
     );
@@ -78,7 +83,14 @@ export function Item({
   );
 
   const suffixMarkup = suffix && (
-    <span className={styles.Suffix}>{suffix}</span>
+    <span
+      className={classNames(
+        styles.Suffix,
+        newDesignLanguage && styles.newDesignLanguage,
+      )}
+    >
+      {suffix}
+    </span>
   );
 
   const textMarkup = <div className={styles.Text}>{contentMarkup}</div>;


### PR DESCRIPTION
Adjusts the **divider** and **icon** colors inside the `ActionList` component.

Before:

<img width="153" alt="Screen Shot 2020-10-13 at 3 16 12 PM" src="https://user-images.githubusercontent.com/875708/95905594-0fa20100-0d67-11eb-854f-16f1fc58d160.png">

After: 

<img width="153" alt="Screen Shot 2020-10-13 at 3 10 59 PM" src="https://user-images.githubusercontent.com/875708/95905462-e2555300-0d66-11eb-9866-769bc5ca1c3c.png">

Changes to light mode should me minimal. It looks like this now:

<img width="158" alt="Screen Shot 2020-10-13 at 3 11 06 PM" src="https://user-images.githubusercontent.com/875708/95905677-29dbdf00-0d67-11eb-834e-7229193a4ad4.png">