### PR TITLE
[Page] Only re-render actions when needed

### DIFF
--- a/src/components/ActionMenu/components/Actions/Actions.tsx
+++ b/src/components/ActionMenu/components/Actions/Actions.tsx
@@ -72,11 +72,7 @@ export function Actions({actions = [], groups = []}: Props) {
       return;
     }
 
-    console.log('measuring...');
-
     let currentAvailableWidth = availableWidthRef.current;
-
-    console.log(currentAvailableWidth);
 
     let newShowableActions: MenuActionDescriptor[] = [];
     let newRolledUpActions: (MenuActionDescriptor | MenuGroupDescriptor)[] = [];


### PR DESCRIPTION
### WHY are these changes introduced?

This improves the rendering performance of the page actions.

### WHAT is this pull request doing?

Rather than storing everything in state, this moves some of the variables to refs and only uses state for the rollup and showable actions. This way all the calculations are done and then the actions get set which will cause the render.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
Try the details page in Storybook. It should behave the same as before but a little more performant.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
