### PR TITLE
[Icon] - Added `interactive` color to [NewDesignLanguage] color types for icon recolor

### DIFF
--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -393,6 +393,10 @@
   @include recolor-icon(var(--p-action-primary));
 }
 
+.colorInteractive {
+  @include recolor-icon(var(--p-interactive));
+}
+
 .Svg,
 .Img {
   position: relative;

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ const NEW_DESIGN_LANGUAGE_COLORS = [
   'highlight',
   'success',
   'primary',
+  'interactive',
 ];
 type NewDesignLanguageColor =
   | 'base'
@@ -52,7 +53,8 @@ type NewDesignLanguageColor =
   | 'warning'
   | 'highlight'
   | 'success'
-  | 'primary';
+  | 'primary'
+  | 'interactive';
 
 export function isNewDesignLanguageColor(
   color: Color | NewDesignLanguageColor,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

There is a use case for an icon to be interactive (a.k.a blue). For example when the icon is used in supplement to an actionable item. 

### WHAT is this pull request doing?

Adds interactive color to color types in order to use the `color` prop in icons, instead of re-coloring the svg in the consumer app. 


### How to 🎩

1) Go to `Icon` > `README`
2) Add `color="interactive"` to the first example

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
