### PR TITLE
🎨 [Button] Simplify code by utilizing more of UnstyledButton

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Updated `MediaCard` to accept ReactNode as title and make `primaryAction` optional ([#3552](https://github.com/Shopify/polaris-react/pull/3552))
+- **`UnstyledButton`:** Added `loading` prop to apply `role` and `aria-busy` attributes ([#3494](https://github.com/Shopify/polaris-react/pull/3494))
 
 ### Bug fixes
 
@@ -19,5 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Dependency upgrades
 
 ### Code quality
+
+- **`Button`:** Reduced redundant code repeated within `UnstyledButton` ([#3494](https://github.com/Shopify/polaris-react/pull/3494))
 
 ### Deprecations

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -2,7 +2,10 @@ import React, {useRef, useState, useCallback} from 'react';
 import {CaretDownMinor} from '@shopify/polaris-icons';
 
 import {classNames, variationName} from '../../utilities/css';
-import {handleMouseUpByBlurring} from '../../utilities/focus';
+import {
+  handleMouseUpByBlurring,
+  MouseUpBlurHandler,
+} from '../../utilities/focus';
 import {useFeatures} from '../../utilities/features';
 import {useI18n} from '../../utilities/i18n';
 import {Icon} from '../Icon';
@@ -91,14 +94,37 @@ export interface ButtonProps {
   onTouchStart?(): void;
 }
 
+interface CommonButtonProps {
+  id: ButtonProps['id'];
+  className: string;
+}
+
+interface InteractiveButtonProps
+  extends CommonButtonProps,
+    Pick<
+      ButtonProps,
+      | 'accessibilityLabel'
+      | 'onClick'
+      | 'onFocus'
+      | 'onBlur'
+      | 'onMouseEnter'
+      | 'onTouchStart'
+    > {
+  onMouseUp: MouseUpBlurHandler;
+}
+
 const DEFAULT_SIZE = 'medium';
 
 export function Button({
   id,
+  children,
   url,
   disabled,
+  external,
+  download,
+  submit,
   loading,
-  children,
+  pressed,
   accessibilityLabel,
   ariaControls,
   ariaExpanded,
@@ -111,8 +137,6 @@ export function Button({
   onKeyUp,
   onMouseEnter,
   onTouchStart,
-  external,
-  download,
   icon,
   primary,
   outline,
@@ -120,11 +144,9 @@ export function Button({
   disclosure,
   plain,
   monochrome,
-  submit,
   size = DEFAULT_SIZE,
   textAlign,
   fullWidth,
-  pressed,
   connectedDisclosure,
 }: ButtonProps) {
   const {newDesignLanguage} = useFeatures();
@@ -226,7 +248,6 @@ export function Button({
       </span>
     );
 
-  const type = submit ? 'submit' : 'button';
   const ariaPressedStatus = pressed !== undefined ? pressed : ariaPressed;
 
   const [disclosureActive, setDisclosureActive] = useState(false);
@@ -291,28 +312,34 @@ export function Button({
 
   let buttonMarkup;
 
+  const commonProps: CommonButtonProps = {
+    id,
+    className,
+  };
+  const interactiveProps: InteractiveButtonProps = {
+    ...commonProps,
+    accessibilityLabel,
+    onClick,
+    onFocus,
+    onBlur,
+    onMouseUp: handleMouseUpByBlurring,
+    onMouseEnter,
+    onTouchStart,
+  };
+
   if (url) {
     buttonMarkup = isDisabled ? (
       // Render an `<a>` so toggling disabled/enabled state changes only the
       // `href` attribute instead of replacing the whole element.
-      // eslint-disable-next-line jsx-a11y/anchor-is-valid
-      <a id={id} className={className} aria-label={accessibilityLabel}>
+      <a {...commonProps} aria-label={accessibilityLabel}>
         {content}
       </a>
     ) : (
       <UnstyledButton
-        id={id}
+        {...interactiveProps}
         url={url}
         external={external}
         download={download}
-        onClick={onClick}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        onMouseUp={handleMouseUpByBlurring}
-        onMouseEnter={onMouseEnter}
-        onTouchStart={onTouchStart}
-        className={className}
-        aria-label={accessibilityLabel}
       >
         {content}
       </UnstyledButton>
@@ -320,23 +347,15 @@ export function Button({
   } else {
     buttonMarkup = (
       <UnstyledButton
-        id={id}
-        type={type}
-        onClick={onClick}
-        onFocus={onFocus}
-        onBlur={onBlur}
+        {...interactiveProps}
+        submit={submit}
+        disabled={isDisabled}
+        ariaControls={ariaControls}
+        ariaExpanded={ariaExpanded}
+        ariaPressed={ariaPressedStatus}
         onKeyDown={onKeyDown}
         onKeyUp={onKeyUp}
         onKeyPress={onKeyPress}
-        onMouseUp={handleMouseUpByBlurring}
-        onMouseEnter={onMouseEnter}
-        onTouchStart={onTouchStart}
-        className={className}
-        disabled={isDisabled}
-        aria-label={accessibilityLabel}
-        aria-controls={ariaControls}
-        aria-expanded={ariaExpanded}
-        aria-pressed={ariaPressedStatus}
         role={loading ? 'alert' : undefined}
         aria-busy={loading ? true : undefined}
       >

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -13,7 +13,7 @@ import type {IconProps, ConnectedDisclosure} from '../../types';
 import {Spinner} from '../Spinner';
 import {Popover} from '../Popover';
 import {ActionList} from '../ActionList';
-import {UnstyledButton} from '../UnstyledButton';
+import {UnstyledButton, UnstyledButtonProps} from '../UnstyledButton';
 
 import styles from './Button.scss';
 
@@ -21,21 +21,36 @@ type Size = 'slim' | 'medium' | 'large';
 type TextAlign = 'left' | 'right' | 'center';
 type IconSource = IconProps['source'];
 
-export interface ButtonProps {
+export interface ButtonProps
+  extends Pick<
+    UnstyledButtonProps,
+    | 'id'
+    | 'url'
+    | 'external'
+    | 'download'
+    | 'submit'
+    | 'disabled'
+    | 'loading'
+    | 'pressed'
+    | 'accessibilityLabel'
+    | 'ariaControls'
+    | 'ariaExpanded'
+    | 'ariaPressed'
+    | 'onClick'
+    | 'onFocus'
+    | 'onBlur'
+    | 'onKeyPress'
+    | 'onKeyUp'
+    | 'onKeyDown'
+    | 'onMouseEnter'
+    | 'onTouchStart'
+  > {
   /** The content to display inside the button */
   children?: string | string[];
-  /** A destination to link to, rendered in the href attribute of a link */
-  url?: string;
-  /** A unique identifier for the button */
-  id?: string;
   /** Provides extra visual weight and identifies the primary action in a set of buttons */
   primary?: boolean;
   /** Indicates a dangerous or potentially negative action */
   destructive?: boolean;
-  /** Disables the button, disallowing merchant interaction */
-  disabled?: boolean;
-  /** Replaces button text with a spinner while a background action is being performed */
-  loading?: boolean;
   /**
    * Changes the size of the button, giving it more or less padding
    * @default 'medium'
@@ -45,53 +60,18 @@ export interface ButtonProps {
   textAlign?: TextAlign;
   /** Gives the button a subtle alternative to the default button styling, appropriate for certain backdrops */
   outline?: boolean;
-  /** Gives the button the appearance of being pressed */
-  pressed?: boolean;
   /** Allows the button to grow to the width of its container */
   fullWidth?: boolean;
   /** Displays the button with a disclosure icon. Defaults to `down` when set to true */
   disclosure?: 'down' | 'up' | boolean;
-  /** Allows the button to submit a form */
-  submit?: boolean;
   /** Renders a button that looks like a link */
   plain?: boolean;
   /** Makes `plain` and `outline` Button colors (text, borders, icons) the same as the current text color. Also adds an underline to `plain` Buttons */
   monochrome?: boolean;
-  /** Forces url to open in a new tab */
-  external?: boolean;
-  /** Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value */
-  download?: string | boolean;
   /** Icon to display to the left of the button content */
   icon?: React.ReactElement | IconSource;
-  /** Visually hidden text for screen readers */
-  accessibilityLabel?: string;
-  /** Id of the element the button controls */
-  ariaControls?: string;
-  /** Tells screen reader the controlled element is expanded */
-  ariaExpanded?: boolean;
-  /**
-   * @deprecated As of release 4.7.0, replaced by {@link https://polaris.shopify.com/components/structure/page#props-pressed}
-   * Tells screen reader the element is pressed
-   */
-  ariaPressed?: boolean;
   /** Disclosure button connected right of the button. Toggles a popover action list. */
   connectedDisclosure?: ConnectedDisclosure;
-  /** Callback when clicked */
-  onClick?(): void;
-  /** Callback when button becomes focussed */
-  onFocus?(): void;
-  /** Callback when focus leaves button */
-  onBlur?(): void;
-  /** Callback when a keypress event is registered on the button */
-  onKeyPress?(event: React.KeyboardEvent<HTMLButtonElement>): void;
-  /** Callback when a keyup event is registered on the button */
-  onKeyUp?(event: React.KeyboardEvent<HTMLButtonElement>): void;
-  /** Callback when a keydown event is registered on the button */
-  onKeyDown?(event: React.KeyboardEvent<HTMLButtonElement>): void;
-  /** Callback when mouse enter */
-  onMouseEnter?(): void;
-  /** Callback when element is touched */
-  onTouchStart?(): void;
 }
 
 interface CommonButtonProps {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -350,14 +350,13 @@ export function Button({
         {...interactiveProps}
         submit={submit}
         disabled={isDisabled}
+        loading={loading}
         ariaControls={ariaControls}
         ariaExpanded={ariaExpanded}
         ariaPressed={ariaPressedStatus}
         onKeyDown={onKeyDown}
         onKeyUp={onKeyUp}
         onKeyPress={onKeyPress}
-        role={loading ? 'alert' : undefined}
-        aria-busy={loading ? true : undefined}
       >
         {content}
       </UnstyledButton>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState, useCallback} from 'react';
+import React, {useCallback, useState} from 'react';
 import {CaretDownMinor} from '@shopify/polaris-icons';
 
 import {classNames, variationName} from '../../utilities/css';
@@ -141,16 +141,6 @@ export function Button({
   connectedDisclosure,
 }: ButtonProps) {
   const {newDesignLanguage} = useFeatures();
-  const hasGivenDeprecationWarning = useRef(false);
-
-  if (ariaPressed && !hasGivenDeprecationWarning.current) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: The ariaPressed prop has been replaced with pressed',
-    );
-    hasGivenDeprecationWarning.current = true;
-  }
-
   const i18n = useI18n();
 
   const isDisabled = disabled || loading;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -74,24 +74,35 @@ export interface ButtonProps
   connectedDisclosure?: ConnectedDisclosure;
 }
 
-interface CommonButtonProps {
-  id: ButtonProps['id'];
-  className: string;
-}
-
-interface InteractiveButtonProps
-  extends CommonButtonProps,
-    Pick<
-      ButtonProps,
-      | 'accessibilityLabel'
-      | 'onClick'
-      | 'onFocus'
-      | 'onBlur'
-      | 'onMouseEnter'
-      | 'onTouchStart'
-    > {
+interface CommonButtonProps
+  extends Pick<
+    ButtonProps,
+    | 'id'
+    | 'accessibilityLabel'
+    | 'onClick'
+    | 'onFocus'
+    | 'onBlur'
+    | 'onMouseEnter'
+    | 'onTouchStart'
+  > {
+  className: UnstyledButtonProps['className'];
   onMouseUp: MouseUpBlurHandler;
 }
+
+type LinkButtonProps = Pick<ButtonProps, 'url' | 'external' | 'download'>;
+
+type ActionButtonProps = Pick<
+  ButtonProps,
+  | 'submit'
+  | 'disabled'
+  | 'loading'
+  | 'ariaControls'
+  | 'ariaExpanded'
+  | 'ariaPressed'
+  | 'onKeyDown'
+  | 'onKeyUp'
+  | 'onKeyPress'
+>;
 
 const DEFAULT_SIZE = 'medium';
 
@@ -290,14 +301,9 @@ export function Button({
     );
   }
 
-  let buttonMarkup;
-
   const commonProps: CommonButtonProps = {
     id,
     className,
-  };
-  const interactiveProps: InteractiveButtonProps = {
-    ...commonProps,
     accessibilityLabel,
     onClick,
     onFocus,
@@ -306,42 +312,28 @@ export function Button({
     onMouseEnter,
     onTouchStart,
   };
+  const linkProps: LinkButtonProps = {
+    url,
+    external,
+    download,
+  };
+  const actionProps: ActionButtonProps = {
+    submit,
+    disabled: isDisabled,
+    loading,
+    ariaControls,
+    ariaExpanded,
+    ariaPressed: ariaPressedStatus,
+    onKeyDown,
+    onKeyUp,
+    onKeyPress,
+  };
 
-  if (url) {
-    buttonMarkup = isDisabled ? (
-      // Render an `<a>` so toggling disabled/enabled state changes only the
-      // `href` attribute instead of replacing the whole element.
-      <a {...commonProps} aria-label={accessibilityLabel}>
-        {content}
-      </a>
-    ) : (
-      <UnstyledButton
-        {...interactiveProps}
-        url={url}
-        external={external}
-        download={download}
-      >
-        {content}
-      </UnstyledButton>
-    );
-  } else {
-    buttonMarkup = (
-      <UnstyledButton
-        {...interactiveProps}
-        submit={submit}
-        disabled={isDisabled}
-        loading={loading}
-        ariaControls={ariaControls}
-        ariaExpanded={ariaExpanded}
-        ariaPressed={ariaPressedStatus}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyUp}
-        onKeyPress={onKeyPress}
-      >
-        {content}
-      </UnstyledButton>
-    );
-  }
+  const buttonMarkup = (
+    <UnstyledButton {...commonProps} {...linkProps} {...actionProps}>
+      {content}
+    </UnstyledButton>
+  );
 
   return connectedDisclosureMarkup ? (
     <div className={styles.ConnectedDisclosureWrapper}>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useState} from 'react';
 import {CaretDownMinor} from '@shopify/polaris-icons';
 
+import type {BaseButton, ConnectedDisclosure, IconSource} from '../../types';
 import {classNames, variationName} from '../../utilities/css';
 import {
   handleMouseUpByBlurring,
@@ -9,7 +10,6 @@ import {
 import {useFeatures} from '../../utilities/features';
 import {useI18n} from '../../utilities/i18n';
 import {Icon} from '../Icon';
-import type {IconProps, ConnectedDisclosure} from '../../types';
 import {Spinner} from '../Spinner';
 import {Popover} from '../Popover';
 import {ActionList} from '../ActionList';
@@ -17,34 +17,7 @@ import {UnstyledButton, UnstyledButtonProps} from '../UnstyledButton';
 
 import styles from './Button.scss';
 
-type Size = 'slim' | 'medium' | 'large';
-type TextAlign = 'left' | 'right' | 'center';
-type IconSource = IconProps['source'];
-
-export interface ButtonProps
-  extends Pick<
-    UnstyledButtonProps,
-    | 'id'
-    | 'url'
-    | 'external'
-    | 'download'
-    | 'submit'
-    | 'disabled'
-    | 'loading'
-    | 'pressed'
-    | 'accessibilityLabel'
-    | 'ariaControls'
-    | 'ariaExpanded'
-    | 'ariaPressed'
-    | 'onClick'
-    | 'onFocus'
-    | 'onBlur'
-    | 'onKeyPress'
-    | 'onKeyUp'
-    | 'onKeyDown'
-    | 'onMouseEnter'
-    | 'onTouchStart'
-  > {
+export interface ButtonProps extends BaseButton {
   /** The content to display inside the button */
   children?: string | string[];
   /** Provides extra visual weight and identifies the primary action in a set of buttons */
@@ -55,9 +28,9 @@ export interface ButtonProps
    * Changes the size of the button, giving it more or less padding
    * @default 'medium'
    */
-  size?: Size;
+  size?: 'slim' | 'medium' | 'large';
   /** Changes the inner text alignment of the button */
-  textAlign?: TextAlign;
+  textAlign?: 'left' | 'right' | 'center';
   /** Gives the button a subtle alternative to the default button styling, appropriate for certain backdrops */
   outline?: boolean;
   /** Allows the button to grow to the width of its container */

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -3,86 +3,127 @@ import {PlusMinor, CaretDownMinor} from '@shopify/polaris-icons';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
-import {UnstyledLink, Icon, Spinner, ActionList, Popover} from 'components';
+import {ActionList, Icon, Popover, Spinner, UnstyledButton} from 'components';
 
 import {Button} from '../Button';
 import en from '../../../../locales/en.json';
 
 describe('<Button />', () => {
-  describe('url', () => {
-    const mockUrl = 'http://google.com';
-
-    it('renders a link when present', () => {
-      const button = mountWithAppProvider(<Button url={mockUrl} />);
-      expect(button.find(UnstyledLink).exists()).toBeTruthy();
-    });
-
-    it('gets passed into the link', () => {
-      const button = mountWithAppProvider(<Button url={mockUrl} />);
-      expect(button.find(UnstyledLink).prop('url')).toBe(mockUrl);
-    });
-
-    it('renders a button when not present', () => {
-      const button = mountWithAppProvider(<Button />);
-      expect(button.find('button').exists()).toBeTruthy();
-    });
-  });
-
   describe('children', () => {
-    it('renders the given children into the button', () => {
-      const label = 'Click me!';
-      const button = mountWithAppProvider(<Button>{label}</Button>);
-      expect(button.text()).toContain(label);
-    });
+    const mockChildren = 'mock children';
 
-    it('renders the given children into the link', () => {
-      const label = 'Click me!';
-      const button = mountWithAppProvider(
-        <Button url="http://google.com">{label}</Button>,
-      );
-      expect(button.text()).toContain(label);
+    it('passes prop', () => {
+      const button = mountWithAppProvider(<Button>{mockChildren}</Button>);
+      expect(button.find(UnstyledButton).text()).toContain(mockChildren);
     });
   });
 
   describe('id', () => {
-    it('is passed into the button', () => {
-      const id = 'MyID';
+    it('passes prop', () => {
+      const id = 'MockId';
       const button = mountWithAppProvider(<Button id={id} />);
-      expect(button.find('button').prop('id')).toBe(id);
+      expect(button.find(UnstyledButton).prop('id')).toBe(id);
+    });
+  });
+
+  describe('url', () => {
+    const mockUrl = 'https://google.com';
+    // Not including `disabled` or `loading`,
+    // as that leads to a different code path.
+    const mockUnpassedProps = {
+      submit: true,
+      ariaControls: 'mock aria controls',
+      ariaExpanded: true,
+      onKeyDown: noop,
+      onKeyUp: noop,
+      onKeyPress: noop,
+    };
+
+    it('omits subset of props when provided a `url`', () => {
+      const button = mountWithAppProvider(
+        <Button url={mockUrl} {...mockUnpassedProps} />,
+      );
+
+      expect(button.find(UnstyledButton).prop('url')).toBe(mockUrl);
+
+      expect(button.find(UnstyledButton).prop('submit')).toBeUndefined();
+      expect(button.find(UnstyledButton).prop('ariaControls')).toBeUndefined();
+      expect(button.find(UnstyledButton).prop('ariaExpanded')).toBeUndefined();
+      expect(button.find(UnstyledButton).prop('onKeyDown')).toBeUndefined();
+      expect(button.find(UnstyledButton).prop('onKeyUp')).toBeUndefined();
+      expect(button.find(UnstyledButton).prop('onKeyPress')).toBeUndefined();
+    });
+  });
+
+  describe('external', () => {
+    const mockUrl = 'https://google.com';
+
+    it('gets passed alongside url', () => {
+      const button = mountWithAppProvider(<Button url={mockUrl} external />);
+      expect(button.find(UnstyledButton).prop('external')).toBeTruthy();
     });
 
-    it('is passed into the link', () => {
-      const id = 'MyID';
+    it('is false by default', () => {
+      const button = mountWithAppProvider(<Button url={mockUrl} />);
+      expect(button.find(UnstyledButton).prop('external')).toBeFalsy();
+    });
+
+    it('is not passed when url is not provided', () => {
+      const button = mountWithAppProvider(<Button external />);
+      expect(button.find(UnstyledButton).prop('external')).toBeFalsy();
+    });
+  });
+
+  describe('download', () => {
+    const mockUrl = 'https://google.com';
+
+    it('gets passed into the link as a boolean', () => {
+      const button = mountWithAppProvider(<Button url={mockUrl} download />);
+      expect(button.find(UnstyledButton).prop('download')).toBe(true);
+    });
+
+    it('gets passed into the link as a string', () => {
       const button = mountWithAppProvider(
-        <Button url="https://shopify.com" id={id} />,
+        <Button url={mockUrl} download="file.txt" />,
       );
-      expect(button.find(UnstyledLink).prop('id')).toBe(id);
+      expect(button.find(UnstyledButton).prop('download')).toBe('file.txt');
+    });
+
+    it('is false when not set', () => {
+      const button = mountWithAppProvider(<Button url={mockUrl} />);
+      expect(button.find(UnstyledButton).prop('download')).toBeUndefined();
+    });
+
+    it('is not passed when no `url` is provided', () => {
+      const button = mountWithAppProvider(<Button download />);
+      expect(button.find(UnstyledButton).prop('download')).toBeUndefined();
     });
   });
 
   describe('disabled', () => {
-    it('disable without a url renders <button disabled>', () => {
+    it('renders <UnstyledButton /> when url is not passed', () => {
       const button = mountWithAppProvider(<Button disabled />);
-      expect(button.find('button').prop('disabled')).toBeTruthy();
+      expect(button.find(UnstyledButton).prop('disabled')).toBe(true);
     });
 
-    it('disable with a url renders <a> without an href (as <a disabled> is invalid HTML)>', () => {
+    it('renders <a> without an href when url is passed', () => {
       const button = mountWithAppProvider(
-        <Button disabled url="http://google.com" />,
+        <Button disabled url="https://google.com" />,
       );
       expect(button.find('a').prop('href')).toBeFalsy();
     });
   });
 
   describe('loading', () => {
-    it('loading without a url renders <button disabled>', () => {
+    it('renders <UnstyledButton /> when url is not passed', () => {
       const button = mountWithAppProvider(<Button loading />);
-      expect(button.find('button').prop('disabled')).toBe(true);
+      expect(button.find(UnstyledButton).prop('disabled')).toBe(true);
+      expect(button.find(UnstyledButton).prop('loading')).toBe(true);
     });
 
-    it('loading with a url renders <a> without an href (as <a disabled> is invalid HTML)', () => {
+    it('renders <a> without an href when url is passed', () => {
       const button = mountWithAppProvider(
-        <Button loading url="http://google.com" />,
+        <Button loading url="https://google.com" />,
       );
       expect(button.find('a').prop('href')).toBeFalsy();
     });
@@ -91,68 +132,24 @@ describe('<Button />', () => {
       const button = mountWithAppProvider(<Button loading />);
       expect(button.find(Spinner).exists()).toBeTruthy();
     });
+
     it('renders a spinner into the link', () => {
       const button = mountWithAppProvider(
-        <Button loading url="http://google.com">
+        <Button loading url="https://google.com">
           Click me!
         </Button>,
       );
       expect(button.find(Spinner).exists()).toBeTruthy();
     });
 
-    it('sets an alert role on the button', () => {
-      const button = mountWithAppProvider(<Button loading />);
-      expect(button.find('button').prop('role')).toBe('alert');
-    });
-
-    it('sets aria-busy on the button', () => {
-      const button = mountWithAppProvider(<Button loading />);
-      expect(button.find('button').prop('aria-busy')).toBeTruthy();
-    });
+    it.todo('renders a placeholder disclosure icon');
+    it.todo('renders a placeholder inner icon');
   });
 
   describe('submit', () => {
-    it('sets a submit type on the button when present', () => {
+    it('is passed', () => {
       const button = mountWithAppProvider(<Button submit />);
-      expect(button.find('button').prop('type')).toBe('submit');
-    });
-
-    it('sets a button type on the button when not present', () => {
-      const button = mountWithAppProvider(<Button />);
-      expect(button.find('button').prop('type')).toBe('button');
-    });
-  });
-
-  describe('external', () => {
-    it('gets passed into the link', () => {
-      const button = mountWithAppProvider(
-        <Button url="http://google.com" external />,
-      );
-      expect(button.find(UnstyledLink).prop('external')).toBeTruthy();
-    });
-
-    it('is false when not set', () => {
-      const button = mountWithAppProvider(<Button url="http://google.com" />);
-      expect(button.find(UnstyledLink).prop('external')).toBeFalsy();
-    });
-  });
-
-  describe('download', () => {
-    it('gets passed into the link as a boolean', () => {
-      const button = mountWithAppProvider(<Button url="/foo" download />);
-      expect(button.find(UnstyledLink).prop('download')).toBe(true);
-    });
-
-    it('gets passed into the link as a string', () => {
-      const button = mountWithAppProvider(
-        <Button url="/foo" download="file.txt" />,
-      );
-      expect(button.find(UnstyledLink).prop('download')).toBe('file.txt');
-    });
-
-    it('is false when not set', () => {
-      const button = mountWithAppProvider(<Button url="http://google.com" />);
-      expect(button.find(UnstyledLink).prop('download')).toBeFalsy();
+      expect(button.find(UnstyledButton).prop('submit')).toBe(true);
     });
   });
 
@@ -175,46 +172,63 @@ describe('<Button />', () => {
   });
 
   describe('accessibilityLabel', () => {
-    it('sets an aria-label on the button', () => {
-      const label = 'This deletes a thing';
+    const mockAccessibilityLabel = 'mock accessibility label';
+    const mockUrl = 'https://google.com';
+
+    it('passes without `url`', () => {
       const button = mountWithAppProvider(
-        <Button accessibilityLabel={label} />,
+        <Button accessibilityLabel={mockAccessibilityLabel} />,
       );
-      expect(button.find('button').prop('aria-label')).toBe(label);
+      expect(button.find(UnstyledButton).prop('accessibilityLabel')).toBe(
+        mockAccessibilityLabel,
+      );
     });
 
-    it('sets an aria-label on the link', () => {
-      const label = 'This deletes a thing';
+    it('passes with `url`', () => {
       const button = mountWithAppProvider(
-        <Button accessibilityLabel={label} url="http://google.com" />,
+        <Button accessibilityLabel={mockAccessibilityLabel} url={mockUrl} />,
       );
-      expect(button.find(UnstyledLink).prop('aria-label')).toBe(label);
+      expect(button.find(UnstyledButton).prop('accessibilityLabel')).toBe(
+        mockAccessibilityLabel,
+      );
+    });
+
+    // Should also test for `loading`
+    it('passes to `aria-label` when `url` and `disabled`', () => {
+      const button = mountWithAppProvider(
+        <Button
+          accessibilityLabel={mockAccessibilityLabel}
+          url={mockUrl}
+          disabled
+        />,
+      );
+      expect(button.find('a').prop('aria-label')).toBe(mockAccessibilityLabel);
     });
   });
 
   describe('ariaControls', () => {
-    it('sets an aria-controls on the button', () => {
-      const id = 'panel1';
+    it('passes prop', () => {
+      const id = 'mockId';
       const button = mountWithAppProvider(<Button ariaControls={id} />);
-      expect(button.find('button').prop('aria-controls')).toBe(id);
+      expect(button.find(UnstyledButton).prop('ariaControls')).toBe(id);
     });
   });
 
   describe('ariaExpanded', () => {
-    it('sets an aria-expended on the button', () => {
+    it('passes prop', () => {
       const button = mountWithAppProvider(<Button ariaExpanded />);
-      expect(button.find('button').prop('aria-expanded')).toBeTruthy();
+      expect(button.find(UnstyledButton).prop('ariaExpanded')).toBeTruthy();
     });
   });
 
   describe('ariaPressed', () => {
-    it('sets an aria-pressed on the button', () => {
+    it('passes prop', () => {
       const warningSpy = jest
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
 
       const button = mountWithAppProvider(<Button ariaPressed />);
-      expect(button.find('button').prop('aria-pressed')).toBeTruthy();
+      expect(button.find(UnstyledButton).prop('ariaPressed')).toBeTruthy();
 
       warningSpy.mockRestore();
     });
@@ -335,16 +349,16 @@ describe('<Button />', () => {
     it('is called when the button is clicked', () => {
       const onClickSpy = jest.fn();
       const button = mountWithAppProvider(<Button onClick={onClickSpy} />);
-      trigger(button.find('button'), 'onClick');
+      trigger(button.find(UnstyledButton), 'onClick');
       expect(onClickSpy).toHaveBeenCalledTimes(1);
     });
 
     it('is called when the link is clicked', () => {
       const onClickSpy = jest.fn();
       const button = mountWithAppProvider(
-        <Button onClick={onClickSpy} url="http://google.com" />,
+        <Button onClick={onClickSpy} url="https://google.com" />,
       );
-      trigger(button.find(UnstyledLink), 'onClick');
+      trigger(button.find(UnstyledButton), 'onClick');
       expect(onClickSpy).toHaveBeenCalledTimes(1);
     });
   });
@@ -355,16 +369,16 @@ describe('<Button />', () => {
       const button = mountWithAppProvider(
         <Button onMouseEnter={onMouseEnterSpy} />,
       );
-      trigger(button.find('button'), 'onMouseEnter');
+      trigger(button.find(UnstyledButton), 'onMouseEnter');
       expect(onMouseEnterSpy).toHaveBeenCalledTimes(1);
     });
 
     it('is called when the mouse enters link', () => {
       const onMouseEnterSpy = jest.fn();
       const button = mountWithAppProvider(
-        <Button onMouseEnter={onMouseEnterSpy} url="http://google.com" />,
+        <Button onMouseEnter={onMouseEnterSpy} url="https://google.com" />,
       );
-      trigger(button.find(UnstyledLink), 'onMouseEnter');
+      trigger(button.find(UnstyledButton), 'onMouseEnter');
       expect(onMouseEnterSpy).toHaveBeenCalledTimes(1);
     });
   });
@@ -375,16 +389,16 @@ describe('<Button />', () => {
       const button = mountWithAppProvider(
         <Button onTouchStart={onTouchStartSpy} />,
       );
-      trigger(button.find('button'), 'onTouchStart');
+      trigger(button.find(UnstyledButton), 'onTouchStart');
       expect(onTouchStartSpy).toHaveBeenCalledTimes(1);
     });
 
     it('is called when link is pressed', () => {
       const onTouchStartSpy = jest.fn();
       const button = mountWithAppProvider(
-        <Button onTouchStart={onTouchStartSpy} url="http://google.com" />,
+        <Button onTouchStart={onTouchStartSpy} url="https://google.com" />,
       );
-      trigger(button.find(UnstyledLink), 'onTouchStart');
+      trigger(button.find(UnstyledButton), 'onTouchStart');
       expect(onTouchStartSpy).toHaveBeenCalledTimes(1);
     });
   });
@@ -393,16 +407,16 @@ describe('<Button />', () => {
     it('is called when the button is focussed', () => {
       const onFocusSpy = jest.fn();
       const button = mountWithAppProvider(<Button onFocus={onFocusSpy} />);
-      trigger(button.find('button'), 'onFocus');
+      trigger(button.find(UnstyledButton), 'onFocus');
       expect(onFocusSpy).toHaveBeenCalledTimes(1);
     });
 
     it('is called when the link is focussed', () => {
       const onFocusSpy = jest.fn();
       const button = mountWithAppProvider(
-        <Button onFocus={onFocusSpy} url="http://google.com" />,
+        <Button onFocus={onFocusSpy} url="https://google.com" />,
       );
-      trigger(button.find(UnstyledLink), 'onFocus');
+      trigger(button.find(UnstyledButton), 'onFocus');
       expect(onFocusSpy).toHaveBeenCalledTimes(1);
     });
   });
@@ -411,16 +425,16 @@ describe('<Button />', () => {
     it('is called when the button is blurred', () => {
       const onBlurSpy = jest.fn();
       const button = mountWithAppProvider(<Button onBlur={onBlurSpy} />);
-      trigger(button.find('button'), 'onBlur');
+      trigger(button.find(UnstyledButton), 'onBlur');
       expect(onBlurSpy).toHaveBeenCalledTimes(1);
     });
 
     it('is called when the link is blurred', () => {
       const onBlurSpy = jest.fn();
       const button = mountWithAppProvider(
-        <Button onBlur={onBlurSpy} url="http://google.com" />,
+        <Button onBlur={onBlurSpy} url="https://google.com" />,
       );
-      trigger(button.find(UnstyledLink), 'onBlur');
+      trigger(button.find(UnstyledButton), 'onBlur');
       expect(onBlurSpy).toHaveBeenCalledTimes(1);
     });
   });
@@ -430,7 +444,7 @@ describe('<Button />', () => {
       const spy = jest.fn();
       const button = mountWithAppProvider(
         <Button onKeyPress={spy}>Test</Button>,
-      ).find('button');
+      ).find(UnstyledButton);
       trigger(button, 'onKeyPress');
 
       expect(spy).toHaveBeenCalled();
@@ -442,7 +456,7 @@ describe('<Button />', () => {
       const spy = jest.fn();
       const button = mountWithAppProvider(
         <Button onKeyUp={spy}>Test</Button>,
-      ).find('button');
+      ).find(UnstyledButton);
       trigger(button, 'onKeyUp');
       expect(spy).toHaveBeenCalled();
     });
@@ -453,7 +467,7 @@ describe('<Button />', () => {
       const spy = jest.fn();
       const button = mountWithAppProvider(
         <Button onKeyDown={spy}>Test</Button>,
-      ).find('button');
+      ).find(UnstyledButton);
       trigger(button, 'onKeyDown');
       expect(spy).toHaveBeenCalled();
     });
@@ -464,21 +478,21 @@ describe('<Button />', () => {
 
     it('outputs a pressed button', () => {
       const button = mountWithApp(<Button pressed />);
-      expect(button).toContainReactComponent('button', {
+      expect(button).toContainReactComponent(UnstyledButton, {
         className: buttonPressedClasses,
       });
     });
 
     it("doesn't output a pressed button when disabled", () => {
       const button = mountWithApp(<Button pressed disabled />);
-      expect(button).not.toContainReactComponent('button', {
+      expect(button).not.toContainReactComponent(UnstyledButton, {
         className: buttonPressedClasses,
       });
     });
 
     it("doesn't output a pressed button when a url is present", () => {
       const button = mountWithApp(<Button pressed url="/" />);
-      expect(button).not.toContainReactComponent('button', {
+      expect(button).not.toContainReactComponent(UnstyledButton, {
         className: buttonPressedClasses,
       });
     });
@@ -523,7 +537,7 @@ describe('<Button />', () => {
       const button = mountWithApp(<Button />, {
         features: {newDesignLanguage: true},
       });
-      expect(button).toContainReactComponent('button', {
+      expect(button).toContainReactComponent(UnstyledButton, {
         className: 'Button newDesignLanguage',
       });
     });
@@ -532,9 +546,11 @@ describe('<Button />', () => {
       const button = mountWithApp(<Button />, {
         features: {newDesignLanguage: false},
       });
-      expect(button).not.toContainReactComponent('button', {
+      expect(button).not.toContainReactComponent(UnstyledButton, {
         className: 'Button newDesignLanguage',
       });
     });
   });
 });
+
+function noop() {}

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -10,9 +10,8 @@ import en from '../../../../locales/en.json';
 
 describe('<Button />', () => {
   describe('children', () => {
-    const mockChildren = 'mock children';
-
     it('passes prop', () => {
+      const mockChildren = 'mock children';
       const button = mountWithAppProvider(<Button>{mockChildren}</Button>);
       expect(button.find(UnstyledButton).text()).toContain(mockChildren);
     });
@@ -27,76 +26,34 @@ describe('<Button />', () => {
   });
 
   describe('url', () => {
-    const mockUrl = 'https://google.com';
-    // Not including `disabled` or `loading`,
-    // as that leads to a different code path.
-    const mockUnpassedProps = {
-      submit: true,
-      ariaControls: 'mock aria controls',
-      ariaExpanded: true,
-      onKeyDown: noop,
-      onKeyUp: noop,
-      onKeyPress: noop,
-    };
-
-    it('omits subset of props when provided a `url`', () => {
-      const button = mountWithAppProvider(
-        <Button url={mockUrl} {...mockUnpassedProps} />,
-      );
-
+    it('passes prop', () => {
+      const mockUrl = 'https://google.com';
+      const button = mountWithAppProvider(<Button url={mockUrl} />);
       expect(button.find(UnstyledButton).prop('url')).toBe(mockUrl);
-
-      expect(button.find(UnstyledButton).prop('submit')).toBeUndefined();
-      expect(button.find(UnstyledButton).prop('ariaControls')).toBeUndefined();
-      expect(button.find(UnstyledButton).prop('ariaExpanded')).toBeUndefined();
-      expect(button.find(UnstyledButton).prop('onKeyDown')).toBeUndefined();
-      expect(button.find(UnstyledButton).prop('onKeyUp')).toBeUndefined();
-      expect(button.find(UnstyledButton).prop('onKeyPress')).toBeUndefined();
     });
   });
 
   describe('external', () => {
-    const mockUrl = 'https://google.com';
-
-    it('gets passed alongside url', () => {
-      const button = mountWithAppProvider(<Button url={mockUrl} external />);
-      expect(button.find(UnstyledButton).prop('external')).toBeTruthy();
-    });
-
-    it('is false by default', () => {
-      const button = mountWithAppProvider(<Button url={mockUrl} />);
-      expect(button.find(UnstyledButton).prop('external')).toBeFalsy();
-    });
-
-    it('is not passed when url is not provided', () => {
+    it('passes prop', () => {
       const button = mountWithAppProvider(<Button external />);
-      expect(button.find(UnstyledButton).prop('external')).toBeFalsy();
+      expect(button.find(UnstyledButton).prop('external')).toBe(true);
     });
   });
 
   describe('download', () => {
-    const mockUrl = 'https://google.com';
-
-    it('gets passed into the link as a boolean', () => {
-      const button = mountWithAppProvider(<Button url={mockUrl} download />);
+    it('gets passed as a boolean', () => {
+      const button = mountWithAppProvider(<Button download />);
       expect(button.find(UnstyledButton).prop('download')).toBe(true);
     });
 
-    it('gets passed into the link as a string', () => {
+    it('gets passed as a string', () => {
+      const mockDownload = 'file.txt';
+      const mockUrl = 'https://google.com';
+
       const button = mountWithAppProvider(
-        <Button url={mockUrl} download="file.txt" />,
+        <Button url={mockUrl} download={mockDownload} />,
       );
-      expect(button.find(UnstyledButton).prop('download')).toBe('file.txt');
-    });
-
-    it('is false when not set', () => {
-      const button = mountWithAppProvider(<Button url={mockUrl} />);
-      expect(button.find(UnstyledButton).prop('download')).toBeUndefined();
-    });
-
-    it('is not passed when no `url` is provided', () => {
-      const button = mountWithAppProvider(<Button download />);
-      expect(button.find(UnstyledButton).prop('download')).toBeUndefined();
+      expect(button.find(UnstyledButton).prop('download')).toBe(mockDownload);
     });
   });
 
@@ -115,17 +72,9 @@ describe('<Button />', () => {
   });
 
   describe('loading', () => {
-    it('renders <UnstyledButton /> when url is not passed', () => {
+    it('passes prop', () => {
       const button = mountWithAppProvider(<Button loading />);
-      expect(button.find(UnstyledButton).prop('disabled')).toBe(true);
       expect(button.find(UnstyledButton).prop('loading')).toBe(true);
-    });
-
-    it('renders <a> without an href when url is passed', () => {
-      const button = mountWithAppProvider(
-        <Button loading url="https://google.com" />,
-      );
-      expect(button.find('a').prop('href')).toBeFalsy();
     });
 
     it('renders a spinner into the button', () => {
@@ -147,7 +96,7 @@ describe('<Button />', () => {
   });
 
   describe('submit', () => {
-    it('is passed', () => {
+    it('passes prop', () => {
       const button = mountWithAppProvider(<Button submit />);
       expect(button.find(UnstyledButton).prop('submit')).toBe(true);
     });
@@ -172,37 +121,14 @@ describe('<Button />', () => {
   });
 
   describe('accessibilityLabel', () => {
-    const mockAccessibilityLabel = 'mock accessibility label';
-    const mockUrl = 'https://google.com';
-
-    it('passes without `url`', () => {
+    it('passes prop', () => {
+      const mockAccessibilityLabel = 'mock accessibility label';
       const button = mountWithAppProvider(
         <Button accessibilityLabel={mockAccessibilityLabel} />,
       );
       expect(button.find(UnstyledButton).prop('accessibilityLabel')).toBe(
         mockAccessibilityLabel,
       );
-    });
-
-    it('passes with `url`', () => {
-      const button = mountWithAppProvider(
-        <Button accessibilityLabel={mockAccessibilityLabel} url={mockUrl} />,
-      );
-      expect(button.find(UnstyledButton).prop('accessibilityLabel')).toBe(
-        mockAccessibilityLabel,
-      );
-    });
-
-    // Should also test for `loading`
-    it('passes to `aria-label` when `url` and `disabled`', () => {
-      const button = mountWithAppProvider(
-        <Button
-          accessibilityLabel={mockAccessibilityLabel}
-          url={mockUrl}
-          disabled
-        />,
-      );
-      expect(button.find('a').prop('aria-label')).toBe(mockAccessibilityLabel);
     });
   });
 
@@ -352,15 +278,6 @@ describe('<Button />', () => {
       trigger(button.find(UnstyledButton), 'onClick');
       expect(onClickSpy).toHaveBeenCalledTimes(1);
     });
-
-    it('is called when the link is clicked', () => {
-      const onClickSpy = jest.fn();
-      const button = mountWithAppProvider(
-        <Button onClick={onClickSpy} url="https://google.com" />,
-      );
-      trigger(button.find(UnstyledButton), 'onClick');
-      expect(onClickSpy).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('onMouseEnter()', () => {
@@ -368,15 +285,6 @@ describe('<Button />', () => {
       const onMouseEnterSpy = jest.fn();
       const button = mountWithAppProvider(
         <Button onMouseEnter={onMouseEnterSpy} />,
-      );
-      trigger(button.find(UnstyledButton), 'onMouseEnter');
-      expect(onMouseEnterSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it('is called when the mouse enters link', () => {
-      const onMouseEnterSpy = jest.fn();
-      const button = mountWithAppProvider(
-        <Button onMouseEnter={onMouseEnterSpy} url="https://google.com" />,
       );
       trigger(button.find(UnstyledButton), 'onMouseEnter');
       expect(onMouseEnterSpy).toHaveBeenCalledTimes(1);
@@ -392,15 +300,6 @@ describe('<Button />', () => {
       trigger(button.find(UnstyledButton), 'onTouchStart');
       expect(onTouchStartSpy).toHaveBeenCalledTimes(1);
     });
-
-    it('is called when link is pressed', () => {
-      const onTouchStartSpy = jest.fn();
-      const button = mountWithAppProvider(
-        <Button onTouchStart={onTouchStartSpy} url="https://google.com" />,
-      );
-      trigger(button.find(UnstyledButton), 'onTouchStart');
-      expect(onTouchStartSpy).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('onFocus()', () => {
@@ -410,30 +309,12 @@ describe('<Button />', () => {
       trigger(button.find(UnstyledButton), 'onFocus');
       expect(onFocusSpy).toHaveBeenCalledTimes(1);
     });
-
-    it('is called when the link is focussed', () => {
-      const onFocusSpy = jest.fn();
-      const button = mountWithAppProvider(
-        <Button onFocus={onFocusSpy} url="https://google.com" />,
-      );
-      trigger(button.find(UnstyledButton), 'onFocus');
-      expect(onFocusSpy).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('onBlur()', () => {
     it('is called when the button is blurred', () => {
       const onBlurSpy = jest.fn();
       const button = mountWithAppProvider(<Button onBlur={onBlurSpy} />);
-      trigger(button.find(UnstyledButton), 'onBlur');
-      expect(onBlurSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it('is called when the link is blurred', () => {
-      const onBlurSpy = jest.fn();
-      const button = mountWithAppProvider(
-        <Button onBlur={onBlurSpy} url="https://google.com" />,
-      );
       trigger(button.find(UnstyledButton), 'onBlur');
       expect(onBlurSpy).toHaveBeenCalledTimes(1);
     });
@@ -552,5 +433,3 @@ describe('<Button />', () => {
     });
   });
 });
-
-function noop() {}

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -399,20 +399,6 @@ describe('<Button />', () => {
     });
   });
 
-  describe('deprecations', () => {
-    it('warns the ariaPressed prop has been replaced', () => {
-      const warningSpy = jest
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
-      mountWithApp(<Button ariaPressed />);
-
-      expect(warningSpy).toHaveBeenCalledWith(
-        'Deprecation: The ariaPressed prop has been replaced with pressed',
-      );
-      warningSpy.mockRestore();
-    });
-  });
-
   describe('newDesignLanguage', () => {
     it('adds a newDesignLanguage class when newDesignLanguage is enabled', () => {
       const button = mountWithApp(<Button />, {

--- a/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -143,7 +143,9 @@ describe('<ResourceItem />', () => {
         item
           .find(Button)
           .findWhere(
-            (node) => node.prop('accessibilityLabel') === expectedLabel,
+            (node) =>
+              node.prop('plain') &&
+              node.prop('accessibilityLabel') === expectedLabel,
           ),
       ).toHaveLength(1);
     });

--- a/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/UnstyledButton/UnstyledButton.tsx
@@ -20,6 +20,8 @@ export interface UnstyledButtonProps {
   submit?: boolean;
   /** Disables the button, disallowing merchant interaction */
   disabled?: boolean;
+  /** Replaces button text with a spinner while a background action is being performed */
+  loading?: boolean;
   /** Sets the button in a pressed state */
   pressed?: boolean;
   /** Visually hidden text for screen readers */
@@ -61,6 +63,7 @@ export function UnstyledButton({
   download,
   submit,
   disabled,
+  loading,
   pressed,
   accessibilityLabel,
   ariaControls,
@@ -130,6 +133,8 @@ export function UnstyledButton({
         {...interactiveProps}
         type={submit ? 'submit' : 'button'}
         disabled={disabled}
+        role={loading ? 'alert' : undefined}
+        aria-busy={loading ? true : undefined}
         aria-controls={ariaControls}
         aria-expanded={ariaExpanded}
         aria-pressed={ariaPressedStatus}

--- a/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/UnstyledButton/UnstyledButton.tsx
@@ -6,20 +6,20 @@ import {UnstyledLink} from '../UnstyledLink';
 export interface UnstyledButtonProps {
   /** The content to display inside the button */
   children?: React.ReactNode;
-  /** A destination to link to, rendered in the href attribute of a link */
-  url?: string;
   /** A unique identifier for the button */
   id?: string;
   /** A custom class name to apply styles to button */
   className?: string;
-  /** Disables the button, disallowing merchant interaction */
-  disabled?: boolean;
-  /** Allows the button to submit a form */
-  submit?: boolean;
+  /** A destination to link to, rendered in the href attribute of a link */
+  url?: string;
   /** Forces url to open in a new tab */
   external?: boolean;
   /** Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value */
   download?: string | boolean;
+  /** Allows the button to submit a form */
+  submit?: boolean;
+  /** Disables the button, disallowing merchant interaction */
+  disabled?: boolean;
   /** Sets the button in a pressed state */
   pressed?: boolean;
   /** Visually hidden text for screen readers */
@@ -54,10 +54,13 @@ export interface UnstyledButtonProps {
 
 export function UnstyledButton({
   id,
-  url,
-  disabled,
   children,
   className,
+  url,
+  external,
+  download,
+  submit,
+  disabled,
   pressed,
   accessibilityLabel,
   ariaControls,
@@ -71,9 +74,6 @@ export function UnstyledButton({
   onKeyUp,
   onMouseEnter,
   onTouchStart,
-  external,
-  download,
-  submit,
   ...rest
 }: UnstyledButtonProps) {
   const hasGivenDeprecationWarning = useRef(false);
@@ -86,38 +86,38 @@ export function UnstyledButton({
     hasGivenDeprecationWarning.current = true;
   }
 
-  const type = submit ? 'submit' : 'button';
   const ariaPressedStatus = pressed !== undefined ? pressed : ariaPressed;
 
   let buttonMarkup;
+
+  const commonProps = {
+    id,
+    className,
+    'aria-label': accessibilityLabel,
+  };
+  const interactiveProps = {
+    ...commonProps,
+    onClick,
+    onFocus,
+    onBlur,
+    onMouseUp: handleMouseUpByBlurring,
+    onMouseEnter,
+    onTouchStart,
+  };
 
   if (url) {
     buttonMarkup = disabled ? (
       // Render an `<a>` so toggling disabled/enabled state changes only the
       // `href` attribute instead of replacing the whole element.
-      // eslint-disable-next-line jsx-a11y/anchor-is-valid
-      <a
-        id={id}
-        className={className}
-        aria-label={accessibilityLabel}
-        data-polaris-unstyled-button
-      >
+      <a {...commonProps} data-polaris-unstyled-button>
         {children}
       </a>
     ) : (
       <UnstyledLink
-        id={id}
+        {...interactiveProps}
         url={url}
         external={external}
         download={download}
-        onClick={onClick}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        onMouseUp={handleMouseUpByBlurring}
-        onMouseEnter={onMouseEnter}
-        onTouchStart={onTouchStart}
-        className={className}
-        aria-label={accessibilityLabel}
         data-polaris-unstyled-button
         {...rest}
       >
@@ -127,23 +127,15 @@ export function UnstyledButton({
   } else {
     buttonMarkup = (
       <button
-        id={id}
-        type={type}
-        onClick={onClick}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyUp}
-        onKeyPress={onKeyPress}
-        onMouseUp={handleMouseUpByBlurring}
-        onMouseEnter={onMouseEnter}
-        onTouchStart={onTouchStart}
-        className={className}
+        {...interactiveProps}
+        type={submit ? 'submit' : 'button'}
         disabled={disabled}
-        aria-label={accessibilityLabel}
         aria-controls={ariaControls}
         aria-expanded={ariaExpanded}
         aria-pressed={ariaPressedStatus}
+        onKeyDown={onKeyDown}
+        onKeyUp={onKeyUp}
+        onKeyPress={onKeyPress}
         {...rest}
       >
         {children}

--- a/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/UnstyledButton/UnstyledButton.tsx
@@ -1,56 +1,14 @@
 import React, {useRef} from 'react';
 
+import type {BaseButton} from '../../types';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
 import {UnstyledLink} from '../UnstyledLink';
 
-export interface UnstyledButtonProps {
+export interface UnstyledButtonProps extends BaseButton {
   /** The content to display inside the button */
   children?: React.ReactNode;
-  /** A unique identifier for the button */
-  id?: string;
   /** A custom class name to apply styles to button */
   className?: string;
-  /** A destination to link to, rendered in the href attribute of a link */
-  url?: string;
-  /** Forces url to open in a new tab */
-  external?: boolean;
-  /** Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value */
-  download?: string | boolean;
-  /** Allows the button to submit a form */
-  submit?: boolean;
-  /** Disables the button, disallowing merchant interaction */
-  disabled?: boolean;
-  /** Replaces button text with a spinner while a background action is being performed */
-  loading?: boolean;
-  /** Sets the button in a pressed state */
-  pressed?: boolean;
-  /** Visually hidden text for screen readers */
-  accessibilityLabel?: string;
-  /** Id of the element the button controls */
-  ariaControls?: string;
-  /** Tells screen reader the controlled element is expanded */
-  ariaExpanded?: boolean;
-  /**
-   * @deprecated As of release 4.7.0, replaced by {@link https://polaris.shopify.com/components/structure/page#props-pressed}
-   * Tells screen reader the element is pressed
-   */
-  ariaPressed?: boolean;
-  /** Callback when clicked */
-  onClick?(): void;
-  /** Callback when button becomes focussed */
-  onFocus?(): void;
-  /** Callback when focus leaves button */
-  onBlur?(): void;
-  /** Callback when a keypress event is registered on the button */
-  onKeyPress?(event: React.KeyboardEvent<HTMLButtonElement>): void;
-  /** Callback when a keyup event is registered on the button */
-  onKeyUp?(event: React.KeyboardEvent<HTMLButtonElement>): void;
-  /** Callback when a keydown event is registered on the button */
-  onKeyDown?(event: React.KeyboardEvent<HTMLButtonElement>): void;
-  /** Callback when mouse enter */
-  onMouseEnter?(): void;
-  /** Callback when element is touched */
-  onTouchStart?(): void;
   [key: string]: any;
 }
 

--- a/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/UnstyledButton/UnstyledButton.tsx
@@ -112,16 +112,13 @@ export function UnstyledButton({
     buttonMarkup = disabled ? (
       // Render an `<a>` so toggling disabled/enabled state changes only the
       // `href` attribute instead of replacing the whole element.
-      <a {...commonProps} data-polaris-unstyled-button>
-        {children}
-      </a>
+      <a {...commonProps}>{children}</a>
     ) : (
       <UnstyledLink
         {...interactiveProps}
         url={url}
         external={external}
         download={download}
-        data-polaris-unstyled-button
         {...rest}
       >
         {children}

--- a/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
+++ b/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
@@ -7,17 +7,82 @@ import {UnstyledLink} from 'components';
 import {UnstyledButton} from '../UnstyledButton';
 
 describe('<Button />', () => {
-  describe('url', () => {
-    const mockUrl = 'http://google.com';
+  describe('children', () => {
+    const mockChildren = 'mock children';
+    const mockUrl = 'https://google.com';
 
-    it('renders a link when present', () => {
-      const button = mountWithAppProvider(<UnstyledButton url={mockUrl} />);
-      expect(button.find(UnstyledLink).exists()).toBeTruthy();
+    it('renders the given children into the button', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton>{mockChildren}</UnstyledButton>,
+      );
+      expect(button.find('button').text()).toContain(mockChildren);
     });
 
-    it('gets passed into the link', () => {
+    it('renders the given children into the UnstyledLink', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton url={mockUrl}>{mockChildren}</UnstyledButton>,
+      );
+      expect(button.find(UnstyledLink).text()).toContain(mockChildren);
+    });
+
+    // Why is this reporting 2 nodes found?
+    // eslint-disable-next-line jest/no-disabled-tests
+    it.skip('renders the given children into the link when disabled', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton url={mockUrl} disabled>
+          {mockChildren}
+        </UnstyledButton>,
+      );
+      expect(
+        button
+          .find('a')
+          .findWhere((node) => node.prop('href') === undefined)
+          .text(),
+      ).toContain(mockChildren);
+    });
+  });
+
+  describe('id', () => {
+    const mockId = 'MockId';
+
+    it('is passed into the button', () => {
+      const button = mountWithAppProvider(<UnstyledButton id={mockId} />);
+      expect(button.find('button').prop('id')).toBe(mockId);
+    });
+
+    it('is passed into the UnstyledLink', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton id={mockId} url="https://shopify.com" />,
+      );
+      expect(button.find(UnstyledLink).prop('id')).toBe(mockId);
+    });
+
+    it('is passed into the link when disabled', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton id={mockId} url="https://shopify.com" disabled />,
+      );
+      expect(
+        button
+          .find('a')
+          .findWhere((node) => node.prop('href') === undefined)
+          .prop('id'),
+      ).toBe(mockId);
+    });
+  });
+
+  describe('url', () => {
+    const mockUrl = 'https://google.com';
+
+    it('renders a UnstyledLink when present', () => {
       const button = mountWithAppProvider(<UnstyledButton url={mockUrl} />);
       expect(button.find(UnstyledLink).prop('url')).toBe(mockUrl);
+    });
+
+    it('renders a link without an `href` when `disabled`', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton url={mockUrl} disabled />,
+      );
+      expect(button.find('a').prop('href')).toBeUndefined();
     });
 
     it('renders a button when not present', () => {
@@ -26,77 +91,17 @@ describe('<Button />', () => {
     });
   });
 
-  describe('children', () => {
-    it('renders the given children into the button', () => {
-      const label = 'Click me!';
-      const button = mountWithAppProvider(
-        <UnstyledButton>{label}</UnstyledButton>,
-      );
-      expect(button.text()).toContain(label);
-    });
-
-    it('renders the given children into the link', () => {
-      const label = 'Click me!';
-      const button = mountWithAppProvider(
-        <UnstyledButton url="http://google.com">{label}</UnstyledButton>,
-      );
-      expect(button.text()).toContain(label);
-    });
-  });
-
-  describe('id', () => {
-    it('is passed into the button', () => {
-      const id = 'MyID';
-      const button = mountWithAppProvider(<UnstyledButton id={id} />);
-      expect(button.find('button').prop('id')).toBe(id);
-    });
-
-    it('is passed into the link', () => {
-      const id = 'MyID';
-      const button = mountWithAppProvider(
-        <UnstyledButton url="https://shopify.com" id={id} />,
-      );
-      expect(button.find(UnstyledLink).prop('id')).toBe(id);
-    });
-  });
-
-  describe('disabled', () => {
-    it('disable without a url renders <button disabled>', () => {
-      const button = mountWithAppProvider(<UnstyledButton disabled />);
-      expect(button.find('button').prop('disabled')).toBeTruthy();
-    });
-
-    it('disable with a url renders <a> without an href (as <a disabled> is invalid HTML)>', () => {
-      const button = mountWithAppProvider(
-        <UnstyledButton disabled url="http://google.com" />,
-      );
-      expect(button.find('a').prop('href')).toBeFalsy();
-    });
-  });
-
-  describe('submit', () => {
-    it('sets a submit type on the button when present', () => {
-      const button = mountWithAppProvider(<UnstyledButton submit />);
-      expect(button.find('button').prop('type')).toBe('submit');
-    });
-
-    it('sets a button type on the button when not present', () => {
-      const button = mountWithAppProvider(<UnstyledButton />);
-      expect(button.find('button').prop('type')).toBe('button');
-    });
-  });
-
   describe('external', () => {
     it('gets passed into the link', () => {
       const button = mountWithAppProvider(
-        <UnstyledButton url="http://google.com" external />,
+        <UnstyledButton url="https://google.com" external />,
       );
       expect(button.find(UnstyledLink).prop('external')).toBeTruthy();
     });
 
     it('is false when not set', () => {
       const button = mountWithAppProvider(
-        <UnstyledButton url="http://google.com" />,
+        <UnstyledButton url="https://google.com" />,
       );
       expect(button.find(UnstyledLink).prop('external')).toBeFalsy();
     });
@@ -119,35 +124,85 @@ describe('<Button />', () => {
 
     it('is false when not set', () => {
       const button = mountWithAppProvider(
-        <UnstyledButton url="http://google.com" />,
+        <UnstyledButton url="https://google.com" />,
       );
       expect(button.find(UnstyledLink).prop('download')).toBeFalsy();
     });
   });
 
+  describe('submit', () => {
+    it('sets a submit type on the button when present', () => {
+      const button = mountWithAppProvider(<UnstyledButton submit />);
+      expect(button.find('button').prop('type')).toBe('submit');
+    });
+
+    it('sets a button type on the button when not present', () => {
+      const button = mountWithAppProvider(<UnstyledButton />);
+      expect(button.find('button').prop('type')).toBe('button');
+    });
+  });
+
+  describe('disabled', () => {
+    it('passes to `button`', () => {
+      const button = mountWithAppProvider(<UnstyledButton disabled />);
+      expect(button.find('button').prop('disabled')).toBeTruthy();
+    });
+  });
+
+  describe('loading', () => {
+    it('sets an alert role on the button', () => {
+      const button = mountWithAppProvider(<UnstyledButton loading />);
+      expect(button.find('button').prop('role')).toBe('alert');
+    });
+
+    it('sets aria-busy on the button', () => {
+      const button = mountWithAppProvider(<UnstyledButton loading />);
+      expect(button.find('button').prop('aria-busy')).toBeTruthy();
+    });
+  });
+
   describe('accessibilityLabel', () => {
+    const accessibilityLabel = 'mock accessibility label';
+
     it('sets an aria-label on the button', () => {
-      const label = 'This deletes a thing';
       const button = mountWithAppProvider(
-        <UnstyledButton accessibilityLabel={label} />,
+        <UnstyledButton accessibilityLabel={accessibilityLabel} />,
       );
-      expect(button.find('button').prop('aria-label')).toBe(label);
+      expect(button.find('button').prop('aria-label')).toBe(accessibilityLabel);
+    });
+
+    it('sets an aria-label on the UnstyledLink', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton
+          accessibilityLabel={accessibilityLabel}
+          url="https://google.com"
+        />,
+      );
+      expect(button.find(UnstyledLink).prop('aria-label')).toBe(
+        accessibilityLabel,
+      );
     });
 
     it('sets an aria-label on the link', () => {
-      const label = 'This deletes a thing';
       const button = mountWithAppProvider(
-        <UnstyledButton accessibilityLabel={label} url="http://google.com" />,
+        <UnstyledButton
+          accessibilityLabel={accessibilityLabel}
+          url="https://google.com"
+        />,
       );
-      expect(button.find(UnstyledLink).prop('aria-label')).toBe(label);
+      expect(button.find(UnstyledLink).prop('aria-label')).toBe(
+        accessibilityLabel,
+      );
     });
   });
 
   describe('ariaControls', () => {
     it('sets an aria-controls on the button', () => {
-      const id = 'panel1';
-      const button = mountWithAppProvider(<UnstyledButton ariaControls={id} />);
-      expect(button.find('button').prop('aria-controls')).toBe(id);
+      const mockId = 'MockId';
+      const button = mountWithAppProvider(
+        <UnstyledButton ariaControls={mockId} />,
+      );
+      expect(button.find('button').prop('aria-controls')).toBe(mockId);
     });
   });
 
@@ -184,7 +239,7 @@ describe('<Button />', () => {
     it('is called when the link is clicked', () => {
       const onClickSpy = jest.fn();
       const button = mountWithAppProvider(
-        <UnstyledButton onClick={onClickSpy} url="http://google.com" />,
+        <UnstyledButton onClick={onClickSpy} url="https://google.com" />,
       );
       trigger(button.find(UnstyledLink), 'onClick');
       expect(onClickSpy).toHaveBeenCalledTimes(1);
@@ -206,7 +261,7 @@ describe('<Button />', () => {
       const button = mountWithAppProvider(
         <UnstyledButton
           onMouseEnter={onMouseEnterSpy}
-          url="http://google.com"
+          url="https://google.com"
         />,
       );
       trigger(button.find(UnstyledLink), 'onMouseEnter');
@@ -229,7 +284,7 @@ describe('<Button />', () => {
       const button = mountWithAppProvider(
         <UnstyledButton
           onTouchStart={onTouchStartSpy}
-          url="http://google.com"
+          url="https://google.com"
         />,
       );
       trigger(button.find(UnstyledLink), 'onTouchStart');
@@ -250,7 +305,7 @@ describe('<Button />', () => {
     it('is called when the link is focussed', () => {
       const onFocusSpy = jest.fn();
       const button = mountWithAppProvider(
-        <UnstyledButton onFocus={onFocusSpy} url="http://google.com" />,
+        <UnstyledButton onFocus={onFocusSpy} url="https://google.com" />,
       );
       trigger(button.find(UnstyledLink), 'onFocus');
       expect(onFocusSpy).toHaveBeenCalledTimes(1);
@@ -270,7 +325,7 @@ describe('<Button />', () => {
     it('is called when the link is blurred', () => {
       const onBlurSpy = jest.fn();
       const button = mountWithAppProvider(
-        <UnstyledButton onBlur={onBlurSpy} url="http://google.com" />,
+        <UnstyledButton onBlur={onBlurSpy} url="https://google.com" />,
       );
       trigger(button.find(UnstyledLink), 'onBlur');
       expect(onBlurSpy).toHaveBeenCalledTimes(1);

--- a/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
+++ b/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
@@ -73,11 +73,6 @@ describe('<Button />', () => {
   describe('url', () => {
     const mockUrl = 'https://google.com';
 
-    it('renders a UnstyledLink when present', () => {
-      const button = mountWithAppProvider(<UnstyledButton url={mockUrl} />);
-      expect(button.find(UnstyledLink).prop('url')).toBe(mockUrl);
-    });
-
     it('renders a link without an `href` when `disabled`', () => {
       const button = mountWithAppProvider(
         <UnstyledButton url={mockUrl} disabled />,
@@ -87,14 +82,41 @@ describe('<Button />', () => {
 
     it('renders a button when not present', () => {
       const button = mountWithAppProvider(<UnstyledButton />);
-      expect(button.find('button').exists()).toBeTruthy();
+      expect(button.find('button').prop('href')).toBeUndefined();
+    });
+
+    it('omits subset of props when provided a `url`', () => {
+      // Not including `disabled` or `loading`,
+      // as that leads to a different code path.
+      const mockUnpassedProps = {
+        submit: true,
+        ariaControls: 'mock aria controls',
+        ariaExpanded: true,
+        onKeyDown: noop,
+        onKeyUp: noop,
+        onKeyPress: noop,
+      };
+      const button = mountWithAppProvider(
+        <UnstyledButton url={mockUrl} {...mockUnpassedProps} />,
+      );
+
+      expect(button.find(UnstyledLink).prop('url')).toBe(mockUrl);
+
+      expect(button.find(UnstyledLink).prop('submit')).toBeUndefined();
+      expect(button.find(UnstyledLink).prop('ariaControls')).toBeUndefined();
+      expect(button.find(UnstyledLink).prop('ariaExpanded')).toBeUndefined();
+      expect(button.find(UnstyledLink).prop('onKeyDown')).toBeUndefined();
+      expect(button.find(UnstyledLink).prop('onKeyUp')).toBeUndefined();
+      expect(button.find(UnstyledLink).prop('onKeyPress')).toBeUndefined();
     });
   });
 
   describe('external', () => {
-    it('gets passed into the link', () => {
+    const mockUrl = 'https://google.com';
+
+    it('gets passed into the UnstyledLink', () => {
       const button = mountWithAppProvider(
-        <UnstyledButton url="https://google.com" external />,
+        <UnstyledButton url={mockUrl} external />,
       );
       expect(button.find(UnstyledLink).prop('external')).toBeTruthy();
     });
@@ -105,9 +127,23 @@ describe('<Button />', () => {
       );
       expect(button.find(UnstyledLink).prop('external')).toBeFalsy();
     });
+
+    it('is not passed when `url` is missing', () => {
+      const button = mountWithAppProvider(<UnstyledButton external />);
+      expect(button.find('button').prop('external')).toBeUndefined();
+    });
+
+    it('is not passed when `url + disabled`', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton url={mockUrl} external disabled />,
+      );
+      expect(button.find('a').prop('external')).toBeUndefined();
+    });
   });
 
   describe('download', () => {
+    const mockUrl = 'https://google.com';
+
     it('gets passed into the link as a boolean', () => {
       const button = mountWithAppProvider(
         <UnstyledButton url="/foo" download />,
@@ -123,10 +159,20 @@ describe('<Button />', () => {
     });
 
     it('is false when not set', () => {
-      const button = mountWithAppProvider(
-        <UnstyledButton url="https://google.com" />,
-      );
+      const button = mountWithAppProvider(<UnstyledButton url={mockUrl} />);
       expect(button.find(UnstyledLink).prop('download')).toBeFalsy();
+    });
+
+    it('is not passed when `url` is missing', () => {
+      const button = mountWithAppProvider(<UnstyledButton download />);
+      expect(button.find('button').prop('download')).toBeUndefined();
+    });
+
+    it('is not passed when `url + disabled`', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton url={mockUrl} download disabled />,
+      );
+      expect(button.find('a').prop('download')).toBeUndefined();
     });
   });
 
@@ -143,9 +189,18 @@ describe('<Button />', () => {
   });
 
   describe('disabled', () => {
+    const mockUrl = 'https://google.com';
+
     it('passes to `button`', () => {
       const button = mountWithAppProvider(<UnstyledButton disabled />);
       expect(button.find('button').prop('disabled')).toBeTruthy();
+    });
+
+    it('does not pass to link', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton url={mockUrl} disabled />,
+      );
+      expect(button.find('a').prop('disabled')).toBeUndefined();
     });
   });
 
@@ -188,11 +243,15 @@ describe('<Button />', () => {
         <UnstyledButton
           accessibilityLabel={accessibilityLabel}
           url="https://google.com"
+          disabled
         />,
       );
-      expect(button.find(UnstyledLink).prop('aria-label')).toBe(
-        accessibilityLabel,
-      );
+      expect(
+        button
+          .find('a')
+          .findWhere((node) => node.prop('href') === undefined)
+          .prop('aria-label'),
+      ).toBe(accessibilityLabel);
     });
   });
 
@@ -380,3 +439,5 @@ describe('<Button />', () => {
     });
   });
 });
+
+function noop() {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,52 @@ export type Error =
   | React.ReactElement
   | (string | React.ReactElement)[];
 
+export interface BaseButton {
+  /** A unique identifier for the button */
+  id?: string;
+  /** A destination to link to, rendered in the href attribute of a link */
+  url?: string;
+  /** Forces url to open in a new tab */
+  external?: boolean;
+  /** Tells the browser to download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value */
+  download?: string | boolean;
+  /** Allows the button to submit a form */
+  submit?: boolean;
+  /** Disables the button, disallowing merchant interaction */
+  disabled?: boolean;
+  /** Replaces button text with a spinner while a background action is being performed */
+  loading?: boolean;
+  /** Sets the button in a pressed state */
+  pressed?: boolean;
+  /** Visually hidden text for screen readers */
+  accessibilityLabel?: string;
+  /** Id of the element the button controls */
+  ariaControls?: string;
+  /** Tells screen reader the controlled element is expanded */
+  ariaExpanded?: boolean;
+  /**
+   * @deprecated As of release 4.7.0, replaced by {@link https://polaris.shopify.com/components/structure/page#props-pressed}
+   * Tells screen reader the element is pressed
+   */
+  ariaPressed?: boolean;
+  /** Callback when clicked */
+  onClick?(): void;
+  /** Callback when button becomes focussed */
+  onFocus?(): void;
+  /** Callback when focus leaves button */
+  onBlur?(): void;
+  /** Callback when a keypress event is registered on the button */
+  onKeyPress?(event: React.KeyboardEvent<HTMLButtonElement>): void;
+  /** Callback when a keyup event is registered on the button */
+  onKeyUp?(event: React.KeyboardEvent<HTMLButtonElement>): void;
+  /** Callback when a keydown event is registered on the button */
+  onKeyDown?(event: React.KeyboardEvent<HTMLButtonElement>): void;
+  /** Callback when mouse enter */
+  onMouseEnter?(): void;
+  /** Callback when element is touched */
+  onTouchStart?(): void;
+}
+
 export interface BaseAction {
   /** A unique identifier for the action */
   id?: string;

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -1,17 +1,17 @@
 import {isElementInViewport} from './is-element-in-viewport';
 
 type Filter = (element: Element) => void;
+export type MouseUpBlurHandler = (
+  event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+) => void;
 
 const FOCUSABLE_SELECTOR =
   'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]';
 const KEYBOARD_FOCUSABLE_SELECTORS =
   'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]:not([tabindex="-1"])';
 
-export function handleMouseUpByBlurring({
-  currentTarget,
-}: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) {
+export const handleMouseUpByBlurring: MouseUpBlurHandler = ({currentTarget}) =>
   currentTarget.blur();
-}
 
 export function nextFocusableNode(
   node: HTMLElement,


### PR DESCRIPTION
**The goal of this PR is to consolidate concerns between `UnstyledButton` and `Button`.**

### Preamble

Not too long ago, [I posted this message on Slack](https://shopify.slack.com/archives/CJJD1Q7PT/p1602599400307500), which got answered by @dfmcphee - revealing that a [`UnstyledButton`](https://github.com/Shopify/polaris-react/pull/3406) had just got merged to help folks utilize the mechanics of `<Button />` while applying their own styling.

`UnstyledButton` will allow me to do away with a custom "action" component I crafted, and instead consume the Polaris component while passing my own styles + `children`. There will be some more work to be done however... and I am planning to propose a few API additions / component tweaks in the near future.

Before I do that, I thought it best to dig into what `UnstyledButton + Button` give me. I realized there was some repeated code between the two files, so I set about reducing the redundancy. While at it, I realized `Button.test.tsx` probably wasn't updated after `UnstyledButton` was introduced, so I went through the tests and did my best to clean them up.

### Changes

While this PR is mostly just cleaning up some code, there are a few changes worth documenting:
- The `loading` prop was not used by `UnstyledButton`, but some of the side-effects of that prop looked relevant to include. So, I've added `loading` to `UnstyledButton` so that both `role` and `aria-busy` can be toggled.
- ~`Button.tsx` did not apply `data-polaris-unstyled-button` to the `<a />` or `UnstyledLink`, but `UnstyledButton` did. I've removed some redundant code paths inside `Button.tsx` and the `data-polaris-unstyled-button` prop now gets applied.~

### Questions

(1) Do we really want `[key: string]: any;` as part of `UnstyledButtonProps`?
- I realize this is done so we can pass any arbitrary prop, such as `data-whatever`.
- But is this a bit too free-wheelin'?

(2) Should we pass `onClick` when `url`?
- Does this make sense? What is the execution order?

(3) Why do we use `toBeFalsey` when a value is `undefined`? Should we not be more explicit?

(4) Does the way I am extending `UnstyledButtonProps` within `Button.tsx` affect how descriptions get surfaced in the styleguide?

~(5) Do we always want to apply `data-polaris-unstyled-button` to the `<a />` and `UnstyledLink`?`~
- ~`Button.tsx` did not use this attribute, so I am wondering if we should have a `boolean` prop for `unstyledLink`?~

### Playground

<details>
<summary><strong>Copy + Paste</strong></summary>

```jsx
import React from 'react';

import {Page, Button, Stack} from '../src';

export function Playground() {
  // eslint-disable-next-line no-console
  const handleOnClick = () => console.log('onClick');

  return (
    <Page title="Playground">
      <Stack wrap>
        <Button onClick={handleOnClick}>Basic onClick</Button>
        <Button onClick={handleOnClick} disabled>
          Basic onClick and disabled
        </Button>
        <Button onClick={handleOnClick} loading>
          Basic onClick and loading
        </Button>
        <Button url="https://shopify.com" onClick={handleOnClick}>
          With URL
        </Button>
        <Button url="https://shopify.com" onClick={handleOnClick} disabled>
          With URL and disabled
        </Button>
        <Button url="https://shopify.com" onClick={handleOnClick} loading>
          With URL and loading
        </Button>
      </Stack>
    </Page>
  );
}
```

</details>