### PR TITLE
Add type-check to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ jobs:
   include:
     - name: 'Type Check and Build'
       script:
-        # Includes running type checking and build validation tests
+        # Run `type-check` separately as the TypeScript compile that generates
+        # d.ts files in `build` does not run against test files
+        - yarn run type-check
         - yarn run build
 
     - name: 'Lint'

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -14,7 +14,7 @@ import {BannerContext} from 'utilities/banner-context';
 import {Button, Icon, UnstyledLink, Heading} from 'components';
 
 import {WithinContentContext} from '../../../utilities/within-content-context';
-import {Banner} from '../Banner';
+import {Banner, BannerHandles} from '../Banner';
 
 describe('<Banner />', () => {
   it('renders a title', () => {
@@ -134,7 +134,7 @@ describe('<Banner />', () => {
   describe('focus', () => {
     it('exposes a function that allows the banner to be programmatically focused', () => {
       function Test() {
-        const banner = useRef<Banner>(null);
+        const banner = useRef<BannerHandles>(null);
 
         useEffect(() => {
           banner.current && banner.current.focus();

--- a/src/components/BulkActions/BulkActions.tsx
+++ b/src/components/BulkActions/BulkActions.tsx
@@ -6,7 +6,12 @@ import {CSSTransition, Transition} from 'react-transition-group';
 import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
 import {clamp} from '../../utilities/clamp';
-import type {DisableableAction, Action, ActionListSection} from '../../types';
+import type {
+  BadgeAction,
+  DisableableAction,
+  Action,
+  ActionListSection,
+} from '../../types';
 import {ActionList} from '../ActionList';
 import {Popover} from '../Popover';
 import {Button} from '../Button';
@@ -17,7 +22,7 @@ import {CheckableButton} from '../CheckableButton';
 import {BulkActionButton} from './components';
 import styles from './BulkActions.scss';
 
-type BulkAction = DisableableAction;
+type BulkAction = DisableableAction & BadgeAction;
 
 type BulkActionListSection = ActionListSection;
 

--- a/src/components/BulkActions/tests/BulkActions.test.tsx
+++ b/src/components/BulkActions/tests/BulkActions.test.tsx
@@ -55,7 +55,9 @@ describe('<BulkActions />', () => {
         <BulkActions
           {...bulkActionProps}
           promotedActions={[]}
-          actions={[{content: 'Action', badge: {status: 'new'}}]}
+          actions={[
+            {content: 'Action', badge: {status: 'new', content: 'Badge'}},
+          ]}
         />,
       );
 

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -1263,10 +1263,6 @@ describe('<ResourceList />', () => {
 
 function noop() {}
 
-function idForItem(item: any) {
-  return JSON.stringify(item);
-}
-
 function renderCustomMarkup(item: any) {
   return <li key={item.id}>{item.title}</li>;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

`yarn run type-check` currently fails thanks to errors in test files. This is not picked up in CI as we don't currently run `type-check` on CI. We run `build` but the TypeScript compilation in that does not run over test files - as we don't want to ship d.ts files for tests.

We should check for these errors in test files on CI.

### WHAT is this pull request doing?

- Add running `yarn run type-check` to build
- Fix TS issues in test files so `yarn run type-check` passes.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

- Check CI fails on the first commit, that introduces type-check into CI
- Check CI passes on the second commit that fixes the issues