### PR TITLE
[Fix types] Change aliased import to relative path

### DIFF
--- a/src/components/TopBar/components/Menu/Menu.tsx
+++ b/src/components/TopBar/components/Menu/Menu.tsx
@@ -1,6 +1,6 @@
-import type {InversableColorScheme} from 'components/ThemeProvider';
 import React from 'react';
 
+import type {InversableColorScheme} from '../../../ThemeProvider';
 import {ActionList, ActionListProps} from '../../../ActionList';
 import {Popover} from '../../../Popover';
 

--- a/src/components/TopBar/components/UserMenu/UserMenu.tsx
+++ b/src/components/TopBar/components/UserMenu/UserMenu.tsx
@@ -1,6 +1,6 @@
-import type {InversableColorScheme} from 'components/ThemeProvider';
 import React from 'react';
 
+import type {InversableColorScheme} from '../../../ThemeProvider';
 import type {IconableAction} from '../../../../types';
 import {Avatar, AvatarProps} from '../../../Avatar';
 import {MessageIndicator} from '../../../MessageIndicator';


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes a build failure we discovered while bumping to Polaris 5.8.1 in online-store-ui: https://buildkite.com/shopify/online-store-ui-ci-builder/builds/8306#27f9ee5a-def9-4cb1-91de-95d85ac9e0ba

The failures were introduced by this PR: https://github.com/Shopify/polaris-react/pull/3444, specifically, these commits:

- https://github.com/Shopify/polaris-react/pull/3444/files#diff-bb31735a2c3f8b76eb4bbf583ac614656bb24f0ddc16b96f8d1d8de0e7537e45R1
- https://github.com/Shopify/polaris-react/pull/3444/files#diff-6b3d63bdf419ad7549aa371f3c9553aaa45f93ea222df174c043ed1109f8b50bR1

The problem is that those imports should be relative paths rather than using aliased imports.

### WHAT is this pull request doing?
Changes the imports to relative paths
