### PR TITLE
[Card] Add hideOverflow prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Add `hideOverflow` prop to card ([#3508](https://github.com/Shopify/polaris-react/pull/3508))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -25,6 +25,10 @@
   background-color: var(--p-surface-subdued, color('sky', 'lighter'));
 }
 
+.hideOverflow {
+  overflow: hidden;
+}
+
 .Header {
   padding: spacing() spacing() 0;
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -23,6 +23,8 @@ export interface CardProps {
   subdued?: boolean;
   /** Auto wrap content in section */
   sectioned?: boolean;
+  /** Hide overflow content */
+  hideOverflow?: boolean;
   /** Card header actions */
   actions?: DisableableAction[];
   /** Primary action in the card footer */
@@ -49,6 +51,7 @@ export const Card: React.FunctionComponent<CardProps> & {
   title,
   subdued,
   sectioned,
+  hideOverflow,
   actions,
   primaryFooterAction,
   secondaryFooterActions,
@@ -65,6 +68,7 @@ export const Card: React.FunctionComponent<CardProps> & {
   const className = classNames(
     styles.Card,
     subdued && styles.subdued,
+    hideOverflow && styles.hideOverflow,
     newDesignLanguage && styles.newDesignLanguage,
   );
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue on home where it is impossible to provide necessary border-radius to cards

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
