### PR TITLE
[new DL] Adjust ActionList pressed state color

### DIFF
--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -213,7 +213,7 @@ $active-indicator-width: rem(3px);
     &.active,
     &:active {
       background-image: none;
-      background-color: var(--p-surface-selected);
+      background-color: var(--p-surface-pressed);
       @include recolor-icon(var(--p-interactive));
     }
 

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -213,8 +213,15 @@ $active-indicator-width: rem(3px);
     &.active,
     &:active {
       background-image: none;
-      background-color: var(--p-surface-pressed);
       @include recolor-icon(var(--p-interactive));
+    }
+
+    &:active {
+      background-color: var(--p-surface-selected);
+    }
+
+    &.active {
+      background-color: var(--p-surface-selected);
     }
 
     // Only show when the button is selected, not active


### PR DESCRIPTION
### WHAT is this pull request doing?

Adjusts the color of the pressed state of ActionList items

Before:
<img width="207" alt="Screen Shot 2020-10-18 at 2 06 41 PM" src="https://user-images.githubusercontent.com/875708/96376194-7189ae80-114b-11eb-9bdd-c69616de9154.png">

After:
<img width="204" alt="Screen Shot 2020-10-18 at 2 06 17 PM" src="https://user-images.githubusercontent.com/875708/96376192-6f275480-114b-11eb-9eed-6436dd63085f.png">



</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
