### PR TITLE
[new DL][ActionList] Force color and no text decoration

### DIFF
--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -202,6 +202,8 @@ $active-indicator-width: rem(3px);
     &:hover {
       background-image: none;
       background-color: var(--p-surface-hovered);
+      color: inherit;
+      text-decoration: none;
 
       @media (-ms-high-contrast: active) {
         outline: 1px solid ms-high-contrast-color('text');


### PR DESCRIPTION
### WHAT is this pull request doing?

When rendered in Rails, ActionList items using the `<a>` element (not `<button>`), gets underlines and blue color when hovered. 

<img width="232" alt="Screen Shot 2020-10-18 at 2 45 11 PM" src="https://user-images.githubusercontent.com/875708/96377034-97fe1880-1150-11eb-9b63-9353e2a16112.png">

This PR forces the link to inherit the color and not to have an underline.

### How I validated the PR
- In the Storybook, I modified the `Playground` so that the ActionList items renders link elements, not buttons. This is done by passing a url for each item.
- I then injected a bit of CSS into the the page:

```jsx
     <style
        dangerouslySetInnerHTML={{
          __html: 'a:hover { color: red; text-decoration: underline; }',
        }}
      />

```

When inspecting each item, I could see that the injected styles were overridden...

<img width="325" alt="Screen Shot 2020-10-18 at 2 41 03 PM" src="https://user-images.githubusercontent.com/875708/96376999-46ee2480-1150-11eb-8530-0750eba5e507.png">

...by the new styles that this PR adds:

<img width="318" alt="Screen Shot 2020-10-18 at 2 41 09 PM" src="https://user-images.githubusercontent.com/875708/96376998-46558e00-1150-11eb-8bb0-7fbc5e64e019.png">
