### PR TITLE
[DatePicker] Fix selector order

### DIFF
--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -203,9 +203,9 @@ $range-end-border-radius: rem(30px);
     }
   }
 
-  .Day-selected {
-    background: var(--p-interactive);
-    color: var(--p-text-on-interactive);
+  .Day-inRange {
+    border-radius: 0;
+    background: var(--p-surface-selected);
 
     @media (-ms-high-contrast: active) {
       -ms-high-contrast-adjust: none;
@@ -220,9 +220,9 @@ $range-end-border-radius: rem(30px);
     }
   }
 
-  .Day-inRange {
-    border-radius: 0;
-    background: var(--p-surface-selected);
+  .Day-selected {
+    background: var(--p-interactive);
+    color: var(--p-text-on-interactive);
 
     @media (-ms-high-contrast: active) {
       -ms-high-contrast-adjust: none;


### PR DESCRIPTION
### WHY are these changes introduced?

Before:
![image](https://screenshot.click/20-10-r0qv0-bvr2f.png)

After:
https://screenshot.click/screencast_2020-10-19_11-22-39.mp4

