### PR TITLE
[TopBar] Show logo when no navigation and search fields

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Optimized `ThemeProvider` to only output its custom properties in nested `ThemeProvider`s when they differ from the parent context ([#3550](https://github.com/Shopify/polaris-react/pull/3550))
 - Generalized Tooltip's `content` prop's type to not only accept string, but any `React.Node`. ([#3559](https://github.com/Shopify/polaris-react/pull/3559))
 
+- Updated `TopBar` to show the logo when there is no navigation or search fields ([#3523](https://github.com/Shopify/polaris-react/pull/3523))
+
 ### Bug fixes
 
 ### Documentation

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,10 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Updated `MediaCard` to accept ReactNode as title and make `primaryAction` optional ([#3552](https://github.com/Shopify/polaris-react/pull/3552))
 - **`UnstyledButton`:** Added `loading` prop to apply `role` and `aria-busy` attributes ([#3494](https://github.com/Shopify/polaris-react/pull/3494))
-
 - Optimized `ThemeProvider` to only output its custom properties in nested `ThemeProvider`s when they differ from the parent context ([#3550](https://github.com/Shopify/polaris-react/pull/3550))
 - Generalized Tooltip's `content` prop's type to not only accept string, but any `React.Node`. ([#3559](https://github.com/Shopify/polaris-react/pull/3559))
-
 - Updated `TopBar` to show the logo when there is no navigation or search fields ([#3523](https://github.com/Shopify/polaris-react/pull/3523))
 
 ### Bug fixes

--- a/src/components/TopBar/TopBar.scss
+++ b/src/components/TopBar/TopBar.scss
@@ -26,17 +26,24 @@ $context-control-expand-after: 1400px;
   box-shadow: var(--p-top-bar-shadow);
 }
 
-.LogoContainer {
+.LogoDisplayControl {
   display: none;
   @include breakpoint-after(nav-min-window-corrected()) {
     display: flex;
-    flex: 0 0 layout-width(nav);
-    align-items: center;
-    height: 100%;
-    padding: 0 spacing(tight) 0 spacing(base);
-    @include safe-area-for(flex-basis, layout-width(nav), left);
-    @include safe-area-for(padding-left, spacing(), left);
   }
+}
+
+.LogoDisplayContainer {
+  display: flex;
+}
+
+.LogoContainer {
+  flex: 0 0 layout-width(nav);
+  align-items: center;
+  height: 100%;
+  padding: 0 spacing(tight) 0 spacing(base);
+  @include safe-area-for(flex-basis, layout-width(nav), left);
+  @include safe-area-for(padding-left, spacing(), left);
 }
 
 .Logo,

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -99,8 +99,15 @@ export const TopBar: React.FunctionComponent<TopBarProps> & {
       </div>
     );
   } else if (logo) {
+    const className = classNames(
+      styles.LogoContainer,
+      showNavigationToggle || searchField
+        ? styles.LogoDisplayControl
+        : styles.LogoDisplayContainer,
+    );
+
     contextMarkup = (
-      <div className={styles.LogoContainer}>
+      <div className={className}>
         <UnstyledLink
           url={logo.url || ''}
           className={styles.LogoLink}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #3522  <!-- link to issue if one exists -->

Currently, if I don't set `showNavigationToggle` or `searchField` but have a `logo` specified in my theme, the `logo` disappears when the screen width is smaller than `769px`. 
This PR fixes that by always showing the logo when `showNavigationToggle` or `searchField` is not set.

### WHAT is this pull request doing?

Video: https://screenshot.click/19-12-ukcl3-vzxzx.mp4

If `showNavigationToggle`  or `searchField` is set, we use the current css, just split into 2. This keeps the current functionality. 
If `showNavigationToggle` or `searchField` is NOT set, we always set `display: flex`. The result is the `logo` is always shown.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {TopBar, ThemeProvider} from '../src';
import {PlayIcon} from '../src/components/VideoThumbnail/illustrations';

export function Playground() {
  return (
    <ThemeProvider theme={{logo: {topBarSource: PlayIcon, width: 40}}}>
      <TopBar />
    </ThemeProvider>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
