### PR TITLE
Investigation junk for ThemeProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "postcolordocs": "yarn run format"
   },
   "dependencies": {
+    "@shopify/performance": "^1.2.9",
     "@shopify/polaris-icons": "^4.0.0",
     "@shopify/polaris-tokens": "^2.15.0",
     "@types/react": "^16.9.12",

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -40,12 +40,12 @@ export function ThemeProvider({
   const isParentThemeProvider = parentContext === undefined;
 
   const processedThemeConfig = useMemo(() => {
-    console.log(
-      'trigger processedThemeConfig',
-      parentContext,
-      themeConfig,
-      isParentThemeProvider,
-    );
+    // console.log(
+    //   'trigger processedThemeConfig',
+    //   parentContext,
+    //   themeConfig,
+    //   isParentThemeProvider,
+    // );
 
     const parentColorScheme =
       parentContext && parentContext.colorScheme && parentContext.colorScheme;
@@ -66,7 +66,7 @@ export function ThemeProvider({
   }, [parentContext, themeConfig, isParentThemeProvider]);
 
   const customProperties = useMemo(() => {
-    console.log('trigger buildCustomProperties');
+    // console.log('trigger buildCustomProperties');
 
     return buildCustomProperties(
       processedThemeConfig,
@@ -81,7 +81,7 @@ export function ThemeProvider({
   const color = customProperties['--p-text'] || '';
 
   const theme = useMemo(() => {
-    console.log('trigger buildThemeContext');
+    // console.log('trigger buildThemeContext');
 
     return {
       ...buildThemeContext(

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,5 +1,6 @@
 import React, {useMemo, useEffect, useContext} from 'react';
 import DefaultThemeColors from '@shopify/polaris-tokens/dist-modern/theme/base.json';
+import {now} from '@shopify/performance';
 
 import {
   ThemeContext,
@@ -34,6 +35,7 @@ export function ThemeProvider({
   theme: themeConfig,
   children,
 }: ThemeProviderProps) {
+  const start = now();
   const {newDesignLanguage} = useFeatures();
 
   const parentContext = useContext(ThemeContext);
@@ -46,6 +48,8 @@ export function ThemeProvider({
     //   themeConfig,
     //   isParentThemeProvider,
     // );
+
+    console.log('trigger processedThemeConfig');
 
     const parentColorScheme =
       parentContext && parentContext.colorScheme && parentContext.colorScheme;
@@ -66,7 +70,7 @@ export function ThemeProvider({
   }, [parentContext, themeConfig, isParentThemeProvider]);
 
   const customProperties = useMemo(() => {
-    // console.log('trigger buildCustomProperties');
+    console.log('trigger buildCustomProperties');
 
     return buildCustomProperties(
       processedThemeConfig,
@@ -100,6 +104,8 @@ export function ThemeProvider({
   }, [backgroundColor, color, isParentThemeProvider]);
 
   const style = {...customProperties, ...(!isParentThemeProvider && {color})};
+  const end = now();
+  console.log(`Rendering ThemeProvider took ${end - start} milliseconds.`);
 
   return (
     <ThemeContext.Provider value={theme}>

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -38,7 +38,15 @@ export function ThemeProvider({
 
   const parentContext = useContext(ThemeContext);
   const isParentThemeProvider = parentContext === undefined;
+
   const processedThemeConfig = useMemo(() => {
+    console.log(
+      'trigger processedThemeConfig',
+      parentContext,
+      themeConfig,
+      isParentThemeProvider,
+    );
+
     const parentColorScheme =
       parentContext && parentContext.colorScheme && parentContext.colorScheme;
     const parentColors =
@@ -57,25 +65,32 @@ export function ThemeProvider({
     };
   }, [parentContext, themeConfig, isParentThemeProvider]);
 
-  const customProperties = useMemo(
-    () =>
-      buildCustomProperties(processedThemeConfig, newDesignLanguage, Tokens),
-    [processedThemeConfig, newDesignLanguage],
-  );
+  const customProperties = useMemo(() => {
+    console.log('trigger buildCustomProperties');
 
-  const theme = useMemo(
-    () =>
-      buildThemeContext(
-        processedThemeConfig,
-        newDesignLanguage ? customProperties : undefined,
-      ),
-    [customProperties, processedThemeConfig, newDesignLanguage],
-  );
+    return buildCustomProperties(
+      processedThemeConfig,
+      newDesignLanguage,
+      Tokens,
+    );
+  }, [processedThemeConfig, newDesignLanguage]);
 
   // We want these values to be empty string instead of `undefined` when not set.
   // Otherwise, setting a style property to `undefined` does not remove it from the DOM.
   const backgroundColor = customProperties['--p-background'] || '';
   const color = customProperties['--p-text'] || '';
+
+  const theme = useMemo(() => {
+    console.log('trigger buildThemeContext');
+
+    return {
+      ...buildThemeContext(
+        processedThemeConfig,
+        newDesignLanguage ? customProperties : undefined,
+      ),
+      textColor: color,
+    };
+  }, [customProperties, processedThemeConfig, newDesignLanguage, color]);
 
   useEffect(() => {
     if (isParentThemeProvider) {
@@ -87,7 +102,7 @@ export function ThemeProvider({
   const style = {...customProperties, ...(!isParentThemeProvider && {color})};
 
   return (
-    <ThemeContext.Provider value={{...theme, textColor: color}}>
+    <ThemeContext.Provider value={theme}>
       <div style={style}>{children}</div>
     </ThemeContext.Provider>
   );

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -2,6 +2,7 @@ import tokens from '@shopify/polaris-tokens';
 import {colorFactory} from '@shopify/polaris-tokens/dist-modern';
 import {mergeConfigs} from '@shopify/polaris-tokens/dist-modern/utils';
 import {config as base} from '@shopify/polaris-tokens/dist-modern/configs/base';
+import {now} from '@shopify/performance';
 
 import type {HSLColor, HSLAColor} from '../color-types';
 import {colorToHsla, hslToString, hslToRgb} from '../color-transformers';
@@ -26,7 +27,7 @@ export function buildCustomProperties(
   newDesignLanguage: boolean,
   tokens?: Record<string, string>,
 ): CustomPropertiesLike {
-  const t0 = Date.now();
+  const start = now();
   const {colors = {}, colorScheme, config, frameOffset = 0} = themeConfig;
   const mergedConfig = mergeConfigs(base, config || {});
 
@@ -41,8 +42,8 @@ export function buildCustomProperties(
         ...customPropertyTransformer({frameOffset: `${frameOffset}px`}),
       };
 
-  const t1 = Date.now();
-  console.log(`Call to colorFactory took ${t1 - t0} milliseconds.`);
+  const end = now();
+  console.log(`customPropertyTransformer took ${end - start} milliseconds.`);
 
   return properties;
 }

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -26,10 +26,11 @@ export function buildCustomProperties(
   newDesignLanguage: boolean,
   tokens?: Record<string, string>,
 ): CustomPropertiesLike {
+  const t0 = Date.now();
   const {colors = {}, colorScheme, config, frameOffset = 0} = themeConfig;
   const mergedConfig = mergeConfigs(base, config || {});
 
-  return newDesignLanguage
+  const properties = newDesignLanguage
     ? customPropertyTransformer({
         ...colorFactory(colors, colorScheme, mergedConfig),
         ...tokens,
@@ -39,6 +40,11 @@ export function buildCustomProperties(
         ...buildLegacyColors(themeConfig),
         ...customPropertyTransformer({frameOffset: `${frameOffset}px`}),
       };
+
+  const t1 = Date.now();
+  console.log(`Call to colorFactory took ${t1 - t0} milliseconds.`);
+
+  return properties;
 }
 
 export function buildThemeContext(
@@ -68,6 +74,7 @@ function toString(obj?: CustomPropertiesLike) {
 function customPropertyTransformer(
   properties: Record<string, HSLAColor | string>,
 ) {
+  console.log('Transforming custom properties');
   return Object.entries(properties).reduce(
     (transformed, [key, value]) => ({
       ...transformed,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2018,6 +2018,11 @@
   dependencies:
     tslib "^1.9.3"
 
+"@shopify/performance@^1.2.9":
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/@shopify/performance/-/performance-1.2.9.tgz#21d79792cc16536e7c6d2b69cb19ec10e60c5c95"
+  integrity sha512-SlguWoUAQ4y+4u9LCTrlKYrHkfJfgpEagQK+EiFhXfu0+LM69MwdywhipKx0AaAgdXMbOQlrzM1J7YL598uNdg==
+
 "@shopify/polaris-icons@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-4.0.0.tgz#a4fda8d009d94aff19b1c65e3e27f64f3f3977ad"


### PR DESCRIPTION
### WHY are these changes introduced?

We've saw some memory leakage / high render time issues. Our hunch is this is due to the ThemeProvider's being expensive due to useMemo() stuff not actually memoising things properly - every render busts the memo cache so we end up doing all the work on every render instead of using a cached value. This also means we add a new item to useMemo's lookup table one every render too.

- High render time issues due to doing lots of computation on every render of a ThemeProvider
- High memory usage due to adding new data to a lookup table on every render of a ThemeProvider

You can kinda see this in a Playground. 

### WHAT is this pull request doing?

- Adds some debug logging so you can see the issue

### How to 🎩

Using the following playground:

- Disable "Strict mode" toolbar to reduce console noise from  strict mode triggering double renders (and thus doubling the amount of console logging)
- Click the first button
  - Note that `trigger processedThemeConfig`, `trigger buildCustomProperties` and `trigger buildThemeContext` logs are triggered each time you click the first button.

In ThemeProvider edit the dependencies on the useMemo that builds `processedThemeConfig` and remove `themeConfig` from the dependency array and repeat the above steps and note that no console logs are called each time you click the first button.  

This suggests that *there's something happening where `themeConfig` is being considered as changed between renders where it should have the same value*. This shouldn't happen.

If we can fix that then memory leaks should be solved. However to fixup higher render times we'll need to work out how to stop initial slowness. I think @martenbjork was saying buildThemeContext was where that slowness was.

IDEA: Having 3 interdependent useMemos feels like like overkill - could we refactor this code to be all placed in a single useMemo that returns both `theme` and `style`?

TODO: Once we fix this we should investigate if the useMemo cache is shared between multiple instances of a ThemeProvider so that we can utilize even more caching. this might involve abstracting the "working out all the theme stuff" out into a hook. (I thinks this might mean that the cache can be shared between multiple renderings of ThemeProvider if it isn't already)

```
import React, {useState, useCallback} from 'react';

import {Page, ThemeProvider, Button} from '../src';

export function Playground() {
  const [baseTheme, setBaseTheme] = useState<any>('light');

  const toggle = useCallback(() =>
    setBaseTheme(baseTheme == 'light' ? 'dark' : 'light'),
  );

  return (
    <Page title="Playground">
      <Button onClick={toggle}>First</Button>
      <ThemeProvider theme={{colorScheme: baseTheme}}>
        <Button>Second</Button>
        <ThemeProvider theme={{colorScheme: 'inverse'}}>
          <Button>Third</Button>
        </ThemeProvider>
      </ThemeProvider>
    </Page>
  );
}
```