### PR TITLE
[Button] Fix connectedDisclosure height when text has more than 2 lines

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Updated `Textfield` with a `type` of `number` to not render a spinner if step is
 
 ### Bug fixes
 
+- Fixed Button connected disclosure height when button text has more than 2 lines ([#3536](https://github.com/Shopify/polaris-react/pull/3536))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -730,7 +730,6 @@ $stacking-order: (
 
 .ConnectedDisclosureWrapper {
   display: flex;
-  align-items: center;
 }
 
 .ConnectedDisclosure {
@@ -738,6 +737,7 @@ $stacking-order: (
   margin-left: -(border-width());
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
+  height: 100%;
 
   // Because the outline border color has a 40% opacity, the left border appears darker than the rest of the borders because they are layered over one another. Reducing the opacity to zero for the connected disclosure when not focused gives us the expected border color.
   &.outline:not(:focus) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Fixes #3535 

If a button text has more than 2 lines, the connected disclosure height does not follow the button height, it stays at 36px no matter what.

<details>
<summary>See example</summary>

<img width="298" alt="Screen Shot 2020-10-20 at 10 55 23 PM" src="https://user-images.githubusercontent.com/15235605/96668700-bd924a00-1329-11eb-9abb-844b59403353.png">
</details>

This is happening because the connected disclosure div has no height set, and this in combination with the wrapper having a `align-items: center;` is making the connected disclosure height to never change regardless of what happens to its father div.

### WHAT is this pull request doing?
Makes sure the height of the disclosure div has a height of 100%, which will make sure it will follow the parent component height, so when the Button text makes the button bigger, the parent and the sibling (the connected disclosure) will follow the change height.


<details>
<summary>Before</summary>

<img width="321" alt="Screen Shot 2020-10-20 at 11 19 31 PM" src="https://user-images.githubusercontent.com/15235605/96669252-dbac7a00-132a-11eb-9609-a09ce5c7c483.png">
</details>

<details>
<summary>After</summary>

<img width="321" alt="Screen Shot 2020-10-20 at 11 19 15 PM" src="https://user-images.githubusercontent.com/15235605/96669202-c6375000-132a-11eb-8d01-6dd7a47895da.png">
</details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Card, Button} from '../src';

export function Playground() {
  const secondaryActions = [
    {
      content: 'My secondary action',
    },
  ];

  const cardStuff = (
    <div style={{width: 300}}>
      <Button
        outline
        connectedDisclosure={{
          actions: secondaryActions,
        }}
      >
        A super big text that is big enough to take at least 2 lines
      </Button>
    </div>
  );

  return (
    <Page title="Playground">
      <Card sectioned>{cardStuff}</Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
