### PR TITLE
Portals with provider

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,12 +8,12 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-Updated `Textfield` with a `type` of `number` to not render a spinner if step is set to `0` ([#3477](https://github.com/Shopify/polaris-react/pull/3477))
-- Changed `Portal` to render all `Portals` in a single div ([#3465](https://github.com/Shopify/polaris-react/pull/3465))
+- Updated Textfield with a type of number to not render a spinner if step is set to 0 ([#3477](https://github.com/Shopify/polaris-react/pull/3477))
+- Refactored `Portal` to render all `Portals` in a single container ([#3544](https://github.com/Shopify/polaris-react/pull/3544))
 
 ### Bug fixes
 
-Fixed `Filters` overflow ([#3532](https://github.com/Shopify/polaris-react/pull/3532))
+- Fixed `Filters` overflow ([#3532](https://github.com/Shopify/polaris-react/pull/3532))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 Updated `Textfield` with a `type` of `number` to not render a spinner if step is set to `0` ([#3477](https://github.com/Shopify/polaris-react/pull/3477))
+- Changed `Portal` to render all `Portals` in a single div ([#3465](https://github.com/Shopify/polaris-react/pull/3465))
 
 ### Bug fixes
 

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -104,10 +104,8 @@ export class AppProvider extends Component<AppProviderProps, State> {
                   <ThemeProvider theme={theme}>
                     <MediaQueryProvider>
                       <PortalsManagerProvider>
-                        <FocusManager>
-                          {children}
-                          <PortalsContainer />
-                        </FocusManager>
+                        <FocusManager>{children}</FocusManager>
+                        <PortalsContainer />
                       </PortalsManagerProvider>
                     </MediaQueryProvider>
                   </ThemeProvider>

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -20,6 +20,10 @@ import {
   UniqueIdFactoryContext,
   globalIdGeneratorFactory,
 } from '../../utilities/unique-id';
+import {
+  PortalsManagerProvider,
+  PortalsContainer,
+} from '../../utilities/portals';
 
 import './AppProvider.scss';
 
@@ -99,7 +103,12 @@ export class AppProvider extends Component<AppProviderProps, State> {
                 <LinkContext.Provider value={link}>
                   <ThemeProvider theme={theme}>
                     <MediaQueryProvider>
-                      <FocusManager>{children}</FocusManager>
+                      <PortalsManagerProvider>
+                        <FocusManager>
+                          {children}
+                          <PortalsContainer />
+                        </FocusManager>
+                      </PortalsManagerProvider>
                     </MediaQueryProvider>
                   </ThemeProvider>
                 </LinkContext.Provider>

--- a/src/components/Frame/components/ToastManager/ToastManager.tsx
+++ b/src/components/Frame/components/ToastManager/ToastManager.tsx
@@ -61,7 +61,7 @@ export const ToastManager = memo(function ToastManager({
   });
 
   return (
-    <Portal idPrefix="toast-manager">
+    <Portal>
       <EventListener event="resize" handler={updateToasts} />
       <div className={styles.ToastManager} aria-live="polite">
         <TransitionGroup component={null}>{toastsMarkup}</TransitionGroup>

--- a/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
+++ b/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
@@ -38,8 +38,7 @@ describe('<ToastManager />', () => {
         toastMessages={[{id: '1', content: 'Hello', onDismiss: noop}]}
       />,
     );
-
-    expect(toastManager.find('div').at(0).prop('aria-live')).toBe('polite');
+    expect(toastManager.find('[aria-live]').prop('aria-live')).toBe('polite');
   });
 });
 

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -62,13 +62,12 @@ describe('<Modal>', () => {
     );
   });
 
-  it('focuses the next focusable node on mount', () => {
-    const modal = mountWithAppProvider(<Modal onClose={jest.fn()} open />);
-    const focusedNode = focusUtils.findFirstFocusableNode(
-      modal.find(Dialog).getDOMNode(),
+  it('focuses the dialog node on mount', () => {
+    const modal = mountWithAppProvider(
+      <Modal onClose={jest.fn()} open instant />,
     );
 
-    expect(document.activeElement).toBe(focusedNode);
+    expect(document.activeElement).toBe(modal.find(Dialog).getDOMNode());
   });
 
   describe('src', () => {
@@ -198,14 +197,14 @@ describe('<Modal>', () => {
   });
 
   describe('open', () => {
-    it('renders <Portal /> with idPrefix modal', () => {
+    it('renders <Portal />', () => {
       const modal = mountWithAppProvider(
         <Modal onClose={jest.fn()} open>
           <Badge />
         </Modal>,
       );
 
-      expect(modal.find(Portal).prop('idPrefix')).toBe('modal');
+      expect(modal.find(Portal)).toHaveLength(1);
     });
   });
 

--- a/src/components/Pagination/tests/Pagination.test.tsx
+++ b/src/components/Pagination/tests/Pagination.test.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import {
-  mountWithAppProvider,
-  findByTestID,
-  ReactWrapper,
-} from 'test-utilities/legacy';
+import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {Tooltip, TextField} from 'components';
 
@@ -17,6 +13,13 @@ import {ButtonGroup} from '../../ButtonGroup';
 interface HandlerMap {
   [eventName: string]: (event: any) => void;
 }
+
+jest.mock('../../Portal', () => ({
+  ...(jest.requireActual('../../Portal') as any),
+  Portal() {
+    return null;
+  },
+}));
 
 const listenerMap: HandlerMap = {};
 
@@ -47,12 +50,10 @@ describe('<Pagination />', () => {
 
   describe('tooltip', () => {
     it('renders a tooltip if nextTooltip is provided and hasNext is true', () => {
-      const pagination = mountWithAppProvider(
-        <Pagination nextTooltip="k" hasNext />,
-      );
-      pagination.find(Tooltip).simulate('focus');
-
-      expect(findByTestID(pagination, 'TooltipOverlayLabel').text()).toBe('k');
+      const pagination = mountWithApp(<Pagination nextTooltip="k" hasNext />);
+      expect(pagination).toContainReactComponent(Tooltip, {
+        content: 'k',
+      });
     });
 
     it('does not render a tooltip if nextTooltip is provided and hasNext is false', () => {
@@ -63,12 +64,12 @@ describe('<Pagination />', () => {
     });
 
     it('renders a tooltip if previousToolTip is provided and hasPrevious is true', () => {
-      const pagination = mountWithAppProvider(
+      const pagination = mountWithApp(
         <Pagination previousTooltip="j" hasPrevious />,
       );
-      pagination.find(Tooltip).simulate('focus');
-
-      expect(findByTestID(pagination, 'TooltipOverlayLabel').text()).toBe('j');
+      expect(pagination).toContainReactComponent(Tooltip, {
+        content: 'j',
+      });
     });
 
     it('does not render  tooltip if previousToolTip is provided and hasPrevious is false', () => {

--- a/src/components/PolarisTestProvider/PolarisTestProvider.tsx
+++ b/src/components/PolarisTestProvider/PolarisTestProvider.tsx
@@ -26,6 +26,10 @@ import {
   UniqueIdFactoryContext,
   globalIdGeneratorFactory,
 } from '../../utilities/unique-id';
+import {
+  PortalsManagerProvider,
+  PortalsContainer,
+} from '../../utilities/portals';
 
 type FrameContextType = NonNullable<React.ContextType<typeof FrameContext>>;
 type MediaQueryContextType = NonNullable<
@@ -100,11 +104,14 @@ export function PolarisTestProvider({
                 <LinkContext.Provider value={link}>
                   <ThemeContext.Provider value={mergedTheme}>
                     <MediaQueryContext.Provider value={mergedMediaQuery}>
-                      <FocusManager>
-                        <FrameContext.Provider value={mergedFrame}>
-                          {children}
-                        </FrameContext.Provider>
-                      </FocusManager>
+                      <PortalsManagerProvider>
+                        <FocusManager>
+                          <FrameContext.Provider value={mergedFrame}>
+                            {children}
+                          </FrameContext.Provider>
+                        </FocusManager>
+                        <PortalsContainer />
+                      </PortalsManagerProvider>
                     </MediaQueryContext.Provider>
                   </ThemeContext.Provider>
                 </LinkContext.Provider>

--- a/src/components/PolarisTestProvider/tests/PolarisTestProvider.test.tsx
+++ b/src/components/PolarisTestProvider/tests/PolarisTestProvider.test.tsx
@@ -41,7 +41,7 @@ describe('PolarisTestProvider', () => {
     it('allows isNavigationCollapsed to be overwritten', () => {
       function Component() {
         const {isNavigationCollapsed} = useMediaQuery();
-        return isNavigationCollapsed ? <div /> : null;
+        return isNavigationCollapsed ? <span /> : null;
       }
 
       const polarisTestProvider = mountWithApp(
@@ -50,7 +50,7 @@ describe('PolarisTestProvider', () => {
         </PolarisTestProvider>,
       );
 
-      expect(polarisTestProvider).toContainReactComponentTimes('div', 1);
+      expect(polarisTestProvider).toContainReactComponentTimes('span', 1);
     });
   });
 });

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -74,10 +74,13 @@ export function Portal({
     }
 
     return function cleanup() {
-      if (portalNode.current && portalsContainerNode.current) {
-        portalsContainerNode.current.removeChild(portalNode.current);
-        if (portalsContainerNode.current.childElementCount === 0) {
-          document.body.removeChild(portalsContainerNode.current);
+      const containerNode = portalsContainerNode.current
+        ? portalsContainerNode.current
+        : document.getElementById(UNIQUE_CONTAINER_ID);
+      if (portalNode.current && containerNode) {
+        containerNode.removeChild(portalNode.current);
+        if (containerNode && containerNode.childElementCount === 0) {
+          document.body.removeChild(containerNode);
         }
       }
     };

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -15,6 +15,8 @@ interface State {
   isMounted: boolean;
 }
 
+export const UNIQUE_CONTAINER_ID = 'polaris-portal-container';
+
 const getUniqueID = globalIdGeneratorFactory('portal-');
 
 export class Portal extends PureComponent<PortalProps, State> {
@@ -26,37 +28,53 @@ export class Portal extends PureComponent<PortalProps, State> {
 
   private portalNode: HTMLElement | null = null;
 
+  private portalContainerNode: HTMLElement | null = null;
+
   private portalId =
     this.props.idPrefix !== ''
       ? `${this.props.idPrefix}-${getUniqueID()}`
       : getUniqueID();
 
   componentDidMount() {
+    const constainerNode = document.getElementById(UNIQUE_CONTAINER_ID);
+
+    this.portalContainerNode = constainerNode || document.createElement('div');
+
+    if (!constainerNode)
+      this.portalContainerNode.setAttribute('id', UNIQUE_CONTAINER_ID);
     this.portalNode = document.createElement('div');
     this.portalNode.setAttribute(portal.props[0], this.portalId);
 
-    if (this.context != null) {
+    if (this.context != null && !constainerNode) {
       const {cssCustomProperties} = this.context;
       if (cssCustomProperties != null) {
-        this.portalNode.setAttribute('style', cssCustomProperties);
+        this.portalContainerNode.setAttribute('style', cssCustomProperties);
       } else {
-        this.portalNode.removeAttribute('style');
+        this.portalContainerNode.removeAttribute('style');
       }
     }
-    document.body.appendChild(this.portalNode);
+
+    if (!constainerNode) {
+      document.body.appendChild(this.portalContainerNode);
+    }
+
+    this.portalContainerNode.appendChild(this.portalNode);
+
     this.setState({isMounted: true});
   }
 
   componentDidUpdate(_: PortalProps, prevState: State) {
     const {onPortalCreated = noop} = this.props;
 
-    if (this.portalNode && this.context != null) {
+    if (this.portalContainerNode && this.context != null) {
       const {cssCustomProperties, textColor} = this.context;
       if (cssCustomProperties != null) {
-        const style = `${cssCustomProperties};color:${textColor};`;
-        this.portalNode.setAttribute('style', style);
+        const style = textColor
+          ? `${cssCustomProperties};color:${textColor};`
+          : `${cssCustomProperties}`;
+        this.portalContainerNode.setAttribute('style', style);
       } else {
-        this.portalNode.removeAttribute('style');
+        this.portalContainerNode.removeAttribute('style');
       }
     }
     if (!prevState.isMounted && this.state.isMounted) {
@@ -65,8 +83,11 @@ export class Portal extends PureComponent<PortalProps, State> {
   }
 
   componentWillUnmount() {
-    if (this.portalNode) {
-      document.body.removeChild(this.portalNode);
+    if (this.portalNode && this.portalContainerNode) {
+      this.portalContainerNode.removeChild(this.portalNode);
+      if (this.portalContainerNode.childElementCount === 0) {
+        document.body.removeChild(this.portalContainerNode);
+      }
     }
   }
 

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -1,9 +1,7 @@
 import React, {useState, useRef, useContext, useEffect} from 'react';
 import {createPortal} from 'react-dom';
 
-import {ThemeContext} from '../../utilities/theme';
-import {globalIdGeneratorFactory} from '../../utilities/unique-id';
-import {portal} from '../shared';
+import {PortalsManagerContext} from '../../utilities/portals';
 
 export interface PortalProps {
   children?: React.ReactNode;
@@ -13,78 +11,13 @@ export interface PortalProps {
 
 export const UNIQUE_CONTAINER_ID = 'polaris-portal-container';
 
-const getUniqueID = globalIdGeneratorFactory('portal-');
-
-export function Portal({
-  children,
-  idPrefix = '',
-  onPortalCreated = noop,
-}: PortalProps) {
+export function Portal({children, onPortalCreated = noop}: PortalProps) {
   const [isMounted, setIsMounted] = useState(false);
-  const portalNode = useRef<HTMLElement | null>(null);
-  const portalsContainerNode = useRef<HTMLElement | null>(null);
-  const context = useContext(ThemeContext);
-
-  const portalId =
-    idPrefix !== '' ? `${idPrefix}-${getUniqueID()}` : getUniqueID();
+  const portalsContext = useContext(PortalsManagerContext);
 
   useEffect(() => {
-    const containerNode = document.getElementById(UNIQUE_CONTAINER_ID);
-
-    portalsContainerNode.current =
-      containerNode || document.createElement('div');
-
-    if (!containerNode)
-      portalsContainerNode.current.setAttribute('id', UNIQUE_CONTAINER_ID);
-    portalNode.current = document.createElement('div');
-    portalNode.current.setAttribute(portal.props[0], portalId);
-
-    if (context != null && !containerNode) {
-      const {cssCustomProperties} = context;
-      if (cssCustomProperties != null) {
-        portalsContainerNode.current.setAttribute('style', cssCustomProperties);
-      } else {
-        portalsContainerNode.current.removeAttribute('style');
-      }
-    }
-
-    if (!containerNode) {
-      document.body.appendChild(portalsContainerNode.current);
-    }
-
-    portalsContainerNode.current.appendChild(portalNode.current);
-
     setIsMounted(true);
-  }, [isMounted, context, portalId]);
-
-  useEffect(() => {
-    if (isMounted && portalsContainerNode.current && context != null) {
-      const {cssCustomProperties, textColor} = context;
-      if (cssCustomProperties != null) {
-        const style = textColor
-          ? `${cssCustomProperties};color:${textColor};`
-          : `${cssCustomProperties}`;
-        const currentStyle = portalsContainerNode.current.getAttribute('style');
-        if (style !== currentStyle) {
-          portalsContainerNode.current.setAttribute('style', style);
-        }
-      } else {
-        portalsContainerNode.current.removeAttribute('style');
-      }
-    }
-
-    return function cleanup() {
-      const containerNode = portalsContainerNode.current
-        ? portalsContainerNode.current
-        : document.getElementById(UNIQUE_CONTAINER_ID);
-      if (portalNode.current && containerNode) {
-        containerNode.removeChild(portalNode.current);
-        if (containerNode && containerNode.childElementCount === 0) {
-          document.body.removeChild(containerNode);
-        }
-      }
-    };
-  }, [isMounted, context]);
+  }, []);
 
   useEffect(() => {
     if (isMounted) {
@@ -92,8 +25,12 @@ export function Portal({
     }
   }, [isMounted, onPortalCreated]);
 
-  return portalNode.current && isMounted
-    ? createPortal(children, portalNode.current)
+  if (!portalsContext) {
+    return;
+  }
+
+  return portalsContext.portalsContainerRef && isMounted
+    ? createPortal(children, portalsContext.portalsContainerRef)
     : null;
 }
 

--- a/src/components/Portal/tests/Portal.test.tsx
+++ b/src/components/Portal/tests/Portal.test.tsx
@@ -1,9 +1,7 @@
-import React, {createRef} from 'react';
+import React from 'react';
 import {mount, mountWithApp} from 'test-utilities';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
 
-import {Portal, UNIQUE_CONTAINER_ID} from '../Portal';
+import {Portal} from '../Portal';
 import {portal} from '../../shared';
 
 jest.mock('react-dom', () => ({
@@ -28,110 +26,36 @@ describe('<Portal />', () => {
     createPortalSpy.mockRestore();
   });
 
-  describe('container', () => {
-    it('creates a portal container with the UNIQUE_CONTAINER_ID', () => {
-      const appendChildSpy = jest.spyOn(document.body, 'appendChild');
-      mountWithApp(<Portal />);
-      expect(appendChildSpy).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          id: UNIQUE_CONTAINER_ID,
-        }),
-      );
-      appendChildSpy.mockReset();
-    });
-
-    it('sets CSS custom properties on the portal node', () => {
-      const setSpy = jest.spyOn(Element.prototype, 'setAttribute');
-      const portal = mountWithAppProvider(<Portal />, {
-        features: {newDesignLanguage: true},
-        theme: {
-          colors: {surface: '#000000'},
-        },
-      });
-
-      expect(setSpy).toHaveBeenLastCalledWith(
-        'style',
-        portal.context().cssCustomProperties,
-      );
-      setSpy.mockRestore();
-    });
-
-    it('removes CSS custom properties from the portal node', () => {
-      const removeSpy = jest.spyOn(Element.prototype, 'removeAttribute');
-      mountWithAppProvider(<Portal />);
-      expect(removeSpy).toHaveBeenCalledWith('style');
-    });
-  });
-
   describe('children', () => {
     it('get passed into the portal creation method', () => {
       const children = <div />;
-      mountWithAppProvider(<Portal>{children}</Portal>);
-      expect(createPortalSpy).toHaveBeenCalledWith(children, expect.anything());
+      mountWithApp(<Portal>{children}</Portal>);
+      const [portalNode] = lastSpyCall(createPortalSpy);
+      expect(portalNode.props.children).toBe(children);
     });
   });
 
   describe('idPrefix', () => {
     it('is used to prefix the portal ID', () => {
       const idPrefix = 'test';
-      mountWithAppProvider(<Portal idPrefix={idPrefix} />);
-      const [, portalNode] = lastSpyCall(createPortalSpy);
-      expect(portalNode.getAttribute(portal.props[0])).toMatch(
+      mountWithApp(<Portal idPrefix={idPrefix} />);
+      const [portalNode] = lastSpyCall(createPortalSpy);
+      expect(portalNode.props[portal.props[0]]).toMatch(
         new RegExp(`^${idPrefix}-Polarisportal`),
       );
     });
 
     it('is ignored when not defined', () => {
-      mountWithAppProvider(<Portal />);
-      const [, portalNode] = lastSpyCall(createPortalSpy);
-      expect(portalNode.getAttribute(portal.props[0])).toMatch(
-        /^Polarisportal/,
-      );
-    });
-  });
-
-  describe('DOM node', () => {
-    it('gets added to the DOM on mount', () => {
-      const appendChildSpy = jest.spyOn(document.body, 'appendChild');
-      mountWithAppProvider(<Portal />);
-      expect(appendChildSpy).toHaveBeenCalledWith(expect.any(HTMLDivElement));
-      appendChildSpy.mockRestore();
-    });
-
-    it('gets removed from the DOM when the component unmounts', () => {
-      const removeChildSpy = jest.spyOn(document.body, 'removeChild');
-      const portal = mountWithAppProvider(<Portal />);
-      portal.unmount();
-      expect(removeChildSpy).toHaveBeenCalledWith(expect.any(HTMLDivElement));
-      removeChildSpy.mockRestore();
+      mountWithApp(<Portal />);
+      const [portalNode] = lastSpyCall(createPortalSpy);
+      expect(portalNode.props[portal.props[0]]).toMatch(/^Polarisportal/);
     });
   });
 
   it('fires onPortalCreated callback when mounted', () => {
     const spy = jest.fn();
-    mountWithAppProvider(<Portal onPortalCreated={spy} />);
+    mountWithApp(<Portal onPortalCreated={spy} />);
     expect(spy).toHaveBeenCalledTimes(1);
-  });
-
-  it('has a child ref defined when onPortalCreated callback is called', () => {
-    createPortalSpy.mockImplementation(
-      jest.requireActual('react-dom').createPortal,
-    );
-    const ref: React.RefObject<HTMLDivElement> = createRef();
-    const handlePortalCreated = jest.fn(() =>
-      expect(ref.current).not.toBeNull(),
-    );
-
-    function PortalParent() {
-      return (
-        <Portal onPortalCreated={handlePortalCreated}>
-          <div ref={ref} />
-        </Portal>
-      );
-    }
-
-    mountWithAppProvider(<PortalParent />);
-    expect(handlePortalCreated).toHaveBeenCalledTimes(1);
   });
 
   it('renders okay when theme context is undefined', () => {

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -9,6 +9,13 @@ import {getVisibleAndHiddenTabIndices} from '../utilities';
 import {FeaturesContext} from '../../../utilities/features';
 import {Popover} from '../../Popover';
 
+jest.mock('../../Portal', () => ({
+  ...(jest.requireActual('../../Portal') as any),
+  Portal() {
+    return null;
+  },
+}));
+
 describe('<Tabs />', () => {
   const tabs: TabsProps['tabs'] = [
     {content: 'Tab 1', id: 'tab-1'},

--- a/src/utilities/portals/PortalsContainer.tsx
+++ b/src/utilities/portals/PortalsContainer.tsx
@@ -1,0 +1,15 @@
+import React, {useContext} from 'react';
+
+import {PortalsManagerContext} from './context';
+
+export function PortalsContainer() {
+  const portalsManagerContext = useContext(PortalsManagerContext);
+
+  if (!portalsManagerContext) {
+    return null;
+  }
+
+  const {setContainerNode} = portalsManagerContext;
+
+  return <div id="PolarisPortalsContainer" ref={setContainerNode} />;
+}

--- a/src/utilities/portals/PortalsManagerProvider.tsx
+++ b/src/utilities/portals/PortalsManagerProvider.tsx
@@ -1,0 +1,31 @@
+import React, {useState, useCallback} from 'react';
+
+import {PortalsManagerContext} from './context';
+
+export interface PortalsManagerProviderProps {
+  children: React.ReactNode;
+}
+
+export function PortalsManagerProvider({
+  children,
+}: PortalsManagerProviderProps) {
+  const [
+    portalsContainerRef,
+    setPortalsContainerRef,
+  ] = useState<HTMLDivElement | null>(null);
+
+  const setContainerNode = useCallback((ref) => {
+    setPortalsContainerRef(ref);
+  }, []);
+
+  return (
+    <PortalsManagerContext.Provider
+      value={{
+        setContainerNode,
+        portalsContainerRef,
+      }}
+    >
+      {children}
+    </PortalsManagerContext.Provider>
+  );
+}

--- a/src/utilities/portals/context.tsx
+++ b/src/utilities/portals/context.tsx
@@ -1,0 +1,10 @@
+import {createContext} from 'react';
+
+export interface PortalsManager {
+  portalsContainerRef: HTMLDivElement | null;
+  setContainerNode(node: HTMLDivElement): void;
+}
+
+export const PortalsManagerContext = createContext<PortalsManager | undefined>(
+  undefined,
+);

--- a/src/utilities/portals/hooks.ts
+++ b/src/utilities/portals/hooks.ts
@@ -1,0 +1,1 @@
+export function usePortals() {}

--- a/src/utilities/portals/index.ts
+++ b/src/utilities/portals/index.ts
@@ -1,0 +1,6 @@
+export * from './context';
+
+export * from './hooks';
+
+export * from './PortalsContainer';
+export * from './PortalsManagerProvider';


### PR DESCRIPTION
### WHY are these changes introduced?

This is an alternative approach to https://github.com/Shopify/polaris-react/pull/3465. 

### WHAT is this pull request doing?

It changes the portals to use a provider that passes context for the container to render into instead of relying on all the manual DOM manipulation we have currently.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
