### PR TITLE
[ThemeProvider] Add prop to disable rendering of custom properties

### DIFF
--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -26,12 +26,18 @@ interface ThemeProviderThemeConfig extends Discard<ThemeConfig, 'colorScheme'> {
 interface ThemeProviderProps {
   /** Custom logos and colors provided to select components */
   theme: ThemeProviderThemeConfig;
+  /**
+   * Render custom properties to the DOM
+   * @default true
+   */
+  renderCustomProperties?: boolean;
   /** The content to display */
   children?: React.ReactNode;
 }
 
 export function ThemeProvider({
   theme: themeConfig,
+  renderCustomProperties = true,
   children,
 }: ThemeProviderProps) {
   const {newDesignLanguage} = useFeatures();
@@ -84,7 +90,10 @@ export function ThemeProvider({
     }
   }, [backgroundColor, color, isParentThemeProvider]);
 
-  const style = {...customProperties, ...(!isParentThemeProvider && {color})};
+  const style = {
+    ...(renderCustomProperties && customProperties),
+    ...(!isParentThemeProvider && {color}),
+  };
 
   return (
     <ThemeContext.Provider value={{...theme, textColor: color}}>

--- a/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -188,6 +188,21 @@ describe('<ThemeProvider />', () => {
     });
   });
 
+  it('does not render custom properties when renderCustomProperties is false', () => {
+    const themeProvider = mountWithNewDesignLanguage(
+      <ThemeProvider theme={{}} renderCustomProperties={false}>
+        <p>Hello</p>
+      </ThemeProvider>,
+      {newDesignLanguage: true},
+    );
+
+    expect(themeProvider.find('div')).not.toHaveReactProps({
+      style: expect.objectContaining({
+        '--p-background': expect.any(String),
+      }),
+    });
+  });
+
   describe('when nested', () => {
     it('sets a default theme', () => {
       const themeProvider = mountWithNewDesignLanguage(


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue in web where we don't always need to pass custom properties to the theme provider node

We initially had two identical providers, one from AppProvider and one from ThemeProvider rendering two sets of custom properties but adding no value. This gives us control over when we need these properties to render

![image](https://screenshot.click/Shop_1__Home__Shopify_2020-10-21_19-24-47.png)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
