### PR TITLE
Optimize ThemeProvider custom properties output

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,8 +9,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Updated `MediaCard` to accept ReactNode as title and make `primaryAction` optional ([#3552](https://github.com/Shopify/polaris-react/pull/3552))
-- Updated Textfield with a type of number to not render a spinner if step is set to 0 ([#3477](https://github.com/Shopify/polaris-react/pull/3477))
-- Refactored `Portal` to render all `Portals` in a single container ([#3544](https://github.com/Shopify/polaris-react/pull/3544))
 
 - Optimized `ThemeProvider` to only output its custom properties in nested `ThemeProvider`s when they differ from the parent context ([#3550](https://github.com/Shopify/polaris-react/pull/3550))
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,10 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Updated `MediaCard` to accept ReactNode as title and make `primaryAction` optional ([#3552](https://github.com/Shopify/polaris-react/pull/3552))
+- Updated Textfield with a type of number to not render a spinner if step is set to 0 ([#3477](https://github.com/Shopify/polaris-react/pull/3477))
+- Refactored `Portal` to render all `Portals` in a single container ([#3544](https://github.com/Shopify/polaris-react/pull/3544))
+
+- Optimized `ThemeProvider` to only output its custom properties in nested `ThemeProvider`s when they differ from the parent context ([#3550](https://github.com/Shopify/polaris-react/pull/3550))
 
 ### Bug fixes
 

--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -35,7 +35,6 @@ import {
   Stack,
   TextContainer,
   TextField,
-  ThemeProvider,
   Thumbnail,
   Toast,
   TopBar,
@@ -611,21 +610,19 @@ export function DetailsPage() {
   );
 
   return (
-    <ThemeProvider theme={{colorScheme: 'light'}}>
-      <Frame
-        topBar={topBarMarkup}
-        navigation={navigationMarkup}
-        showMobileNavigation={mobileNavigationActive}
-        onNavigationDismiss={toggleMobileNavigationActive}
-        skipToContentTarget={skipToContentRef}
-      >
-        {contextualSaveBarMarkup}
-        {loadingMarkup}
-        {pageMarkup}
-        {toastMarkup}
-        {modalMarkup}
-      </Frame>
-    </ThemeProvider>
+    <Frame
+      topBar={topBarMarkup}
+      navigation={navigationMarkup}
+      showMobileNavigation={mobileNavigationActive}
+      onNavigationDismiss={toggleMobileNavigationActive}
+      skipToContentTarget={skipToContentRef}
+    >
+      {contextualSaveBarMarkup}
+      {loadingMarkup}
+      {pageMarkup}
+      {toastMarkup}
+      {modalMarkup}
+    </Frame>
   );
 }
 

--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -35,6 +35,7 @@ import {
   Stack,
   TextContainer,
   TextField,
+  ThemeProvider,
   Thumbnail,
   Toast,
   TopBar,
@@ -610,19 +611,21 @@ export function DetailsPage() {
   );
 
   return (
-    <Frame
-      topBar={topBarMarkup}
-      navigation={navigationMarkup}
-      showMobileNavigation={mobileNavigationActive}
-      onNavigationDismiss={toggleMobileNavigationActive}
-      skipToContentTarget={skipToContentRef}
-    >
-      {contextualSaveBarMarkup}
-      {loadingMarkup}
-      {pageMarkup}
-      {toastMarkup}
-      {modalMarkup}
-    </Frame>
+    <ThemeProvider theme={{colorScheme: 'light'}}>
+      <Frame
+        topBar={topBarMarkup}
+        navigation={navigationMarkup}
+        showMobileNavigation={mobileNavigationActive}
+        onNavigationDismiss={toggleMobileNavigationActive}
+        skipToContentTarget={skipToContentRef}
+      >
+        {contextualSaveBarMarkup}
+        {loadingMarkup}
+        {pageMarkup}
+        {toastMarkup}
+        {modalMarkup}
+      </Frame>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -6,6 +6,7 @@ import {
   ThemeConfig,
   buildThemeContext,
   buildCustomProperties,
+  toString,
   Tokens,
 } from '../../utilities/theme';
 import {useFeatures} from '../../utilities/features';
@@ -84,7 +85,18 @@ export function ThemeProvider({
     }
   }, [backgroundColor, color, isParentThemeProvider]);
 
-  const style = {...customProperties, ...(!isParentThemeProvider && {color})};
+  let style;
+
+  if (isParentThemeProvider) {
+    style = customProperties;
+  } else if (
+    !isParentThemeProvider &&
+    parentContext!.cssCustomProperties !== toString(customProperties)
+  ) {
+    style = {...customProperties, ...{color}};
+  } else {
+    style = {color};
+  }
 
   return (
     <ThemeContext.Provider value={{...theme, textColor: color}}>

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -101,13 +101,14 @@ export function ThemeProvider({
     !isParentThemeProvider &&
     parentContext!.cssCustomProperties !== toString(customProperties)
   ) {
-    style = {...customProperties, ...{color}};
+    customProperties.color = color;
+    style = customProperties;
   } else {
     style = {color};
   }
 
   return (
-    <ThemeContext.Provider value={{...theme}}>
+    <ThemeContext.Provider value={theme}>
       <div style={style}>{children}</div>
     </ThemeContext.Provider>
   );

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -101,8 +101,7 @@ export function ThemeProvider({
     !isParentThemeProvider &&
     parentContext!.cssCustomProperties !== toString(customProperties)
   ) {
-    customProperties.color = color;
-    style = customProperties;
+    style = {...customProperties, ...{color}};
   } else {
     style = {color};
   }

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -39,15 +39,16 @@ export function ThemeProvider({
 
   const parentContext = useContext(ThemeContext);
   const isParentThemeProvider = parentContext === undefined;
-  const processedThemeConfig = useMemo(() => {
-    const parentColorScheme =
-      parentContext && parentContext.colorScheme && parentContext.colorScheme;
-    const parentColors =
-      parentContext && parentContext.colors && parentContext.colors;
 
+  const parentColorScheme =
+    parentContext && parentContext.colorScheme && parentContext.colorScheme;
+  const parentColors =
+    parentContext && parentContext.colors && parentContext.colors;
+
+  const [customProperties, theme] = useMemo(() => {
     const {colors, colorScheme, ...rest} = themeConfig;
 
-    return {
+    const processedThemeConfig = {
       ...rest,
       ...{colorScheme: getColorScheme(colorScheme, parentColorScheme)},
       colors: {
@@ -56,22 +57,29 @@ export function ThemeProvider({
         ...colors,
       },
     };
-  }, [parentContext, themeConfig, isParentThemeProvider]);
 
-  const customProperties = useMemo(
-    () =>
-      buildCustomProperties(processedThemeConfig, newDesignLanguage, Tokens),
-    [processedThemeConfig, newDesignLanguage],
-  );
+    const customProperties = buildCustomProperties(
+      processedThemeConfig,
+      newDesignLanguage,
+      Tokens,
+    );
 
-  const theme = useMemo(
-    () =>
-      buildThemeContext(
+    const theme = {
+      ...buildThemeContext(
         processedThemeConfig,
         newDesignLanguage ? customProperties : undefined,
       ),
-    [customProperties, processedThemeConfig, newDesignLanguage],
-  );
+      textColor: customProperties['--p-text'] || '',
+    };
+
+    return [customProperties, theme];
+  }, [
+    isParentThemeProvider,
+    newDesignLanguage,
+    parentColorScheme,
+    parentColors,
+    themeConfig,
+  ]);
 
   // We want these values to be empty string instead of `undefined` when not set.
   // Otherwise, setting a style property to `undefined` does not remove it from the DOM.
@@ -99,7 +107,7 @@ export function ThemeProvider({
   }
 
   return (
-    <ThemeContext.Provider value={{...theme, textColor: color}}>
+    <ThemeContext.Provider value={{...theme}}>
       <div style={style}>{children}</div>
     </ThemeContext.Provider>
   );

--- a/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -189,7 +189,7 @@ describe('<ThemeProvider />', () => {
   });
 
   describe('when nested', () => {
-    it('sets a default theme', () => {
+    it('does not render custom properties if themes are identical', () => {
       const themeProvider = mountWithNewDesignLanguage(
         <ThemeProvider theme={{}}>
           <ThemeProvider theme={{}}>
@@ -200,7 +200,7 @@ describe('<ThemeProvider />', () => {
       );
 
       expect(themeProvider.findAll('div')[1]).toHaveReactProps({
-        style: expect.objectContaining({
+        style: expect.not.objectContaining({
           '--p-background': expect.any(String),
           '--p-text': expect.any(String),
           '--p-interactive': expect.any(String),
@@ -234,7 +234,7 @@ describe('<ThemeProvider />', () => {
       );
 
       expect(themeProvider.findAll('div')[1]).toHaveReactProps({
-        style: expect.objectContaining({
+        style: expect.not.objectContaining({
           '--p-surface': 'rgba(255, 255, 255, 1)',
         }),
       });

--- a/src/utilities/theme/index.ts
+++ b/src/utilities/theme/index.ts
@@ -8,6 +8,7 @@ export {
   buildCustomProperties,
   buildThemeContext,
   toCssCustomPropertySyntax,
+  toString,
 } from './utils';
 
 export * from './tokens';

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -55,7 +55,7 @@ export function buildThemeContext(
   };
 }
 
-function toString(obj?: CustomPropertiesLike) {
+export function toString(obj?: CustomPropertiesLike) {
   if (obj) {
     return Object.entries(obj)
       .map((pair) => pair.join(':'))


### PR DESCRIPTION
This is an alternative approach to https://github.com/Shopify/polaris-react/pull/3546.

### WHY are these changes introduced?

Currently we output the custom properties on each level of `ThemeProvider` even if they are identical to the parent.

### WHAT is this pull request doing?

This changes the ThemeProvider to compare the generated custom properties with the parent context and only output them if they differ.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

I committed a change to the Details Page example to try this out. If you change to the new design language light mode, you should see only one top level output of the custom properties since the AppProvider's ThemeProvider and the ThemeProvider wrapping the Details Page frame match. If you switch to dark mode you should see it output on both and that the page stays in light mode because of the nested ThemeProvider's custom properties.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
