### PR TITLE
[MediaCard] Update to accept ReactNode as title and optional primaryAction

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,8 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-Updated `MediaCard` to accept ReactNode as title
-Updated `MediaCard` to make `primaryAction` optional
+- Updated `MediaCard` to accept ReactNode as title
+- Updated `MediaCard` to make `primaryAction` optional
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,8 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-- Updated `MediaCard` to accept ReactNode as title
-- Updated `MediaCard` to make `primaryAction` optional
+- Updated `MediaCard` to accept ReactNode as title and make `primaryAction` optional ([#3552](https://github.com/Shopify/polaris-react/pull/3552))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 Updated `Textfield` with a `type` of `number` to not render a spinner if step is set to `0` ([#3477](https://github.com/Shopify/polaris-react/pull/3477))
+Updated `MediaCard` to accept ReactNode as title
+Updated `MediaCard` to make `primaryAction` optional
 
 ### Bug fixes
 

--- a/src/components/MediaCard/MediaCard.tsx
+++ b/src/components/MediaCard/MediaCard.tsx
@@ -21,11 +21,11 @@ interface MediaCardProps {
   /** The visual media to display in the card */
   children: React.ReactNode;
   /** Heading content */
-  title: string;
+  title: React.ReactNode;
   /** Body content */
   description: string;
   /** Main call to action, rendered as a basic button */
-  primaryAction: Action;
+  primaryAction?: Action;
   /** Secondary call to action, rendered as a plain button */
   secondaryAction?: Action;
   /** Action list items to render in ellipsis popover */
@@ -52,6 +52,13 @@ export function MediaCard({
 }: MediaCardProps) {
   const i18n = useI18n();
   const {value: popoverActive, toggle: togglePopoverActive} = useToggle(false);
+
+  let headerMarkup = null;
+  if (title) {
+    const headerContent =
+      typeof title === 'string' ? <Heading>{title}</Heading> : title;
+    headerMarkup = <div className={styles.Heading}>{headerContent}</div>;
+  }
 
   const popoverActivator = (
     <Button
@@ -81,9 +88,9 @@ export function MediaCard({
       </div>
     ) : null;
 
-  const primaryActionMarkup = (
+  const primaryActionMarkup = primaryAction ? (
     <div className={styles.PrimaryAction}>{buttonFrom(primaryAction)}</div>
-  );
+  ) : null;
 
   const secondaryActionMarkup = secondaryAction ? (
     <div className={styles.SecondaryAction}>
@@ -130,9 +137,7 @@ export function MediaCard({
           <Card.Section>
             {popoverActionsMarkup}
             <Stack vertical spacing="tight">
-              <div className={styles.Heading}>
-                <Heading>{title}</Heading>
-              </div>
+              {headerMarkup}
               <p className={styles.Description}>{description}</p>
               {actionMarkup}
             </Stack>

--- a/src/components/MediaCard/README.md
+++ b/src/components/MediaCard/README.md
@@ -287,7 +287,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-The `title` prop gives the media card a level 2 heading (`<h2>`). This helps with readability and provides structure to screen reader users. It can also accept a ReactNode.
+The required `title` prop gives the media card a level 2 heading (`<h2>`). This helps with readability and provides structure to screen reader users. It can also accept a ReactNode.
 
 Use [actionable language](https://polaris.shopify.com/content/actionable-language#navigation) to ensure that the purpose of the media card is clear to all merchants, including those with issues related to reading and language.
 

--- a/src/components/MediaCard/README.md
+++ b/src/components/MediaCard/README.md
@@ -287,7 +287,7 @@ See Apple’s Human Interface Guidelines and API documentation about accessibili
 
 <!-- content-for: web -->
 
-The required `title` prop gives the media card a level 2 heading (`<h2>`). This helps with readability and provides structure to screen reader users.
+The `title` prop gives the media card a level 2 heading (`<h2>`). This helps with readability and provides structure to screen reader users. It can also accept a ReactNode.
 
 Use [actionable language](https://polaris.shopify.com/content/actionable-language#navigation) to ensure that the purpose of the media card is clear to all merchants, including those with issues related to reading and language.
 

--- a/src/components/MediaCard/tests/MediaCard.test.tsx
+++ b/src/components/MediaCard/tests/MediaCard.test.tsx
@@ -24,7 +24,7 @@ describe('<MediaCard>', () => {
     expect(videoCard).toContainReactComponent(Heading, {children: title});
   });
 
-  it('title can have any valid react elemen', () => {
+  it('title can have any valid react element', () => {
     const titleString = 'Online store';
     const badgeString = 'I am a badge';
     const title = (

--- a/src/components/MediaCard/tests/MediaCard.test.tsx
+++ b/src/components/MediaCard/tests/MediaCard.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import {Heading, Popover, Button, ActionList} from 'components';
+import {Heading, Popover, Button, ActionList, Badge} from 'components';
 import {mountWithApp} from 'test-utilities';
+// eslint-disable-next-line no-restricted-imports
+import {mountWithAppProvider} from 'test-utilities/legacy';
 
 import {MediaCard} from '../MediaCard';
 
@@ -20,6 +22,25 @@ describe('<MediaCard>', () => {
     const videoCard = mountWithApp(<MediaCard {...mockProps} title={title} />);
 
     expect(videoCard).toContainReactComponent(Heading, {children: title});
+  });
+
+  it('title can have any valid react elemen', () => {
+    const titleString = 'Online store';
+    const badgeString = 'I am a badge';
+    const title = (
+      <h2>
+        {titleString}
+        <Badge>{badgeString}</Badge>
+      </h2>
+    );
+    const videoCard = mountWithAppProvider(
+      <MediaCard {...mockProps} title={title} />,
+    );
+
+    const headerMarkup = videoCard.find('h2');
+
+    expect(headerMarkup.text()).toContain(titleString);
+    expect(headerMarkup.find('Badge').text()).toBe(badgeString);
   });
 
   it('renders the description as a paragraph', () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

To keep add more functionality to the MediaCard similar to what regular Cards are already doing. So far, MediaCards do not accept ReactNodes as a title. If you do, the console log throws a bunch of warnings that you shouldn't nest stuff in paragraphs.

Also, when using a MediaCard, you are forced to set a primaryAction. This is not always wanted behavior. Maybe you just want to display something.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

It allows the MediaCard title to accept a ReactNode. In addition, it makes the primaryAction optional.

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
