### PR TITLE
[Link] Fix focus state bug                                                                                                              of multi-line link

### DIFF
--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -26,10 +26,8 @@
     outline: var(--p-override-none, $chrome-default-outline);
   }
 
-  @include focus-ring;
-
   &:focus:not(:active) {
-    @include focus-ring($style: 'focused');
+    outline: var(--p-focused) auto 1px;
   }
 
   &:active {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3372

Before, Link component's that would span two lines would try to compromise it's focus state in the middle of the two lines with a weird small box. Now it simply wraps around the text in the same way a browser would intuitively.

### WHAT is this pull request doing?

**CHROME:**
Before: 
<img width="530" alt="Screen Shot 2020-10-22 at 4 10 46 PM" src="https://user-images.githubusercontent.com/31415327/96927707-75883a00-1485-11eb-9030-8a9bb3b191f4.png">

After:
<img width="527" alt="Screen Shot 2020-10-22 at 4 40 14 PM" src="https://user-images.githubusercontent.com/31415327/96927734-7f11a200-1485-11eb-9752-080bf57d93ce.png">

**SAFARI:**
Before:
<img width="515" alt="Screen Shot 2020-10-22 at 4 47 19 PM" src="https://user-images.githubusercontent.com/31415327/96928275-550caf80-1486-11eb-82cb-b6eb984ef8dd.png">

After:
<img width="515" alt="Screen Shot 2020-10-22 at 4 49 01 PM" src="https://user-images.githubusercontent.com/31415327/96928410-84232100-1486-11eb-97af-22b247598b6d.png">

**FIREFOX:**
Before:
<img width="487" alt="Screen Shot 2020-10-22 at 4 47 32 PM" src="https://user-images.githubusercontent.com/31415327/96928258-4de5a180-1486-11eb-9605-0a3b885bd8a9.png">

After:
<img width="482" alt="Screen Shot 2020-10-22 at 4 43 24 PM" src="https://user-images.githubusercontent.com/31415327/96928178-31e20000-1486-11eb-94ec-beca9a05c1af.png">

^^  One thing to note is that the Firefox screenshot has that line dividing the two lines, but Firefox has bad focus states in the first place so it's up to y'all


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

1. Run your local playground
2. Copy the code below into `Playground.tsx`
3. Make sure the New Design Language dropdown is set to `Enabled - light mode`
4. Inspect the first Link and set it's state to `:focus`
5. Shrink the window down horizontally until the Link spans two lines
6. Observe 👁 👄 👁

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Card, Link, Page, TextContainer} from '../src';
export function Playground() {
  return (
    <Page title="Playground">
      <Card sectioned>
        <TextContainer>
          <p>
            Some text here{' '}
            <Link url="#">
              Google merchant center's requirements Google merchant center's
              requirements
            </Link>
          </p>
          <p>
            Some text here{' '}
            <a href="#">
              Google merchant center's requirementsGoogle merchant center's
              requirements
            </a>
          </p>
        </TextContainer>
      </Card>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
