### PR TITLE
🚚 [Utilities] Move isNewDesignLanguageColor to a new file

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import {useFeatures} from '../../utilities/features';
 import {classNames, variationName} from '../../utilities/css';
+import {isNewDesignLanguageColor} from '../../utilities/color-new-design-language';
+import {useFeatures} from '../../utilities/features';
 import {useI18n} from '../../utilities/i18n';
-import {IconProps, isNewDesignLanguageColor} from '../../types';
+import type {IconProps} from '../../types';
 
 import styles from './Icon.scss';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ export {
   rgbaString,
 } from './utilities/color-transformers';
 
+export {isNewDesignLanguageColor} from './utilities/color-new-design-language';
+
 export {ScrollLockManagerContext as _SECRET_INTERNAL_SCROLL_LOCK_MANAGER_CONTEXT} from './utilities/scroll-lock-manager';
 export {WithinContentContext as _SECRET_INTERNAL_WITHIN_CONTENT_CONTEXT} from './utilities/within-content-context';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,16 +36,7 @@ export type Color =
   | 'redDark'
   | 'purple';
 
-const NEW_DESIGN_LANGUAGE_COLORS = [
-  'base',
-  'subdued',
-  'critical',
-  'warning',
-  'highlight',
-  'success',
-  'primary',
-];
-type NewDesignLanguageColor =
+export type NewDesignLanguageColor =
   | 'base'
   | 'subdued'
   | 'critical'
@@ -53,12 +44,6 @@ type NewDesignLanguageColor =
   | 'highlight'
   | 'success'
   | 'primary';
-
-export function isNewDesignLanguageColor(
-  color: Color | NewDesignLanguageColor,
-): color is NewDesignLanguageColor {
-  return NEW_DESIGN_LANGUAGE_COLORS.includes(color as NewDesignLanguageColor);
-}
 
 export type IconSource =
   | React.SFC<React.SVGProps<SVGSVGElement>>

--- a/src/utilities/color-new-design-language.ts
+++ b/src/utilities/color-new-design-language.ts
@@ -1,0 +1,17 @@
+import type {Color, NewDesignLanguageColor} from '../types';
+
+const NEW_DESIGN_LANGUAGE_COLORS = [
+  'base',
+  'subdued',
+  'critical',
+  'warning',
+  'highlight',
+  'success',
+  'primary',
+];
+
+export function isNewDesignLanguageColor(
+  color: Color | NewDesignLanguageColor,
+): color is NewDesignLanguageColor {
+  return NEW_DESIGN_LANGUAGE_COLORS.includes(color as NewDesignLanguageColor);
+}


### PR DESCRIPTION
Just happened to notice this while working on some other code. I'm moving a utility function out of `/types` and into its own `/utilities` file.