### PR TITLE
Update banner critical icon to use diamond

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Optimized `ThemeProvider` to only output its custom properties in nested `ThemeProvider`s when they differ from the parent context ([#3550](https://github.com/Shopify/polaris-react/pull/3550))
 - Generalized Tooltip's `content` prop's type to not only accept string, but any `React.Node`. ([#3559](https://github.com/Shopify/polaris-react/pull/3559))
 - Updated `TopBar` to show the logo when there is no navigation or search fields ([#3523](https://github.com/Shopify/polaris-react/pull/3523))
+- Updated critical `Banner` icon to be a diamond ([#3567](https://github.com/Shopify/polaris-react/pull/3567))
 
 ### Bug fixes
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "postcolordocs": "yarn run format"
   },
   "dependencies": {
-    "@shopify/polaris-icons": "^4.0.0",
+    "@shopify/polaris-icons": "^4.1.0",
     "@shopify/polaris-tokens": "^2.15.0",
     "@types/react": "^16.9.12",
     "@types/react-dom": "^16.9.4",

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -11,7 +11,7 @@ import {
   CircleTickMajor,
   CircleInformationMajor,
   CircleAlertMajor,
-  CircleDisabledMajor,
+  DiamondAlertMajor,
 } from '@shopify/polaris-icons';
 
 import {classNames, variationName} from '../../utilities/css';
@@ -255,7 +255,7 @@ function useBannerAttributes(
 
     case 'critical':
       return {
-        defaultIcon: CircleDisabledMajor,
+        defaultIcon: DiamondAlertMajor,
         iconColor: newDesignLanguage ? 'critical' : 'redDark',
         ariaRoleType: 'alert',
       };

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -5,7 +5,7 @@ import {
   CircleTickMajor,
   CircleInformationMajor,
   CircleAlertMajor,
-  CircleDisabledMajor,
+  DiamondAlertMajor,
 } from '@shopify/polaris-icons';
 import {mountWithApp} from 'test-utilities/react-testing';
 // eslint-disable-next-line no-restricted-imports
@@ -55,7 +55,7 @@ describe('<Banner />', () => {
 
   it('uses a redDark circleBarred if status is critical and sets an alert aria role', () => {
     const banner = mountWithAppProvider(<Banner status="critical" />);
-    expect(banner.find(Icon).prop('source')).toBe(CircleDisabledMajor);
+    expect(banner.find(Icon).prop('source')).toBe(DiamondAlertMajor);
     expect(banner.find(Icon).prop('color')).toBe('redDark');
     expect(banner.find('div').first().prop('role')).toBe('alert');
   });
@@ -228,7 +228,7 @@ describe('<Banner />', () => {
         'Banner has a critical status',
         'critical',
         'critical',
-        CircleDisabledMajor,
+        DiamondAlertMajor,
       ],
     ])(
       'Sets Icon props when: %s',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2018,10 +2018,10 @@
   dependencies:
     tslib "^1.9.3"
 
-"@shopify/polaris-icons@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-4.0.0.tgz#a4fda8d009d94aff19b1c65e3e27f64f3f3977ad"
-  integrity sha512-g5VxZNmSOkbdCHeE7dI6yL2AuRD1AJ2dZfMkDJYL6u2eeedBAElcoTFWbF8/HJ5I/SKEWngt6rPUefAVsUxeKA==
+"@shopify/polaris-icons@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-4.1.0.tgz#296ff47d22b52cb1592e2fa81a609f8f3c912eb0"
+  integrity sha512-U5ODhOJtfYHJskYUknceIjpF+EhHdMQJ54HSWsjuHAapCWbmA8ROVonAnDEM+cWeEVinpPZzQd2nE/DVJUmKkw==
 
 "@shopify/polaris-tokens@^2.15.0":
   version "2.15.0"


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/478

![Screen Shot 2020-10-27 at 9 28 00 AM](https://user-images.githubusercontent.com/19199063/97308045-cc4f9400-1836-11eb-8fdd-f445d9512275.png)

### WHAT is this pull request doing?

New icon:

![Screen Shot 2020-10-27 at 9 28 00 AM](https://user-images.githubusercontent.com/19199063/97308137-e7ba9f00-1836-11eb-811e-d3714ea9ed6a.png)

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
