### PR TITLE
[DataTable] Styling improvements to borders in the new design language

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Removed extra bottom border on the `DataTable` and added curved edges to footers ([#3571](https://github.com/Shopify/polaris-react/pull/3571))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -59,10 +59,15 @@ $breakpoint: 768px;
   }
 }
 
+// stylelint-disable selector-max-class, selector-max-combinators
+.TableRow + .TableRow {
+  .Cell {
+    border-top: border('divider');
+  }
+}
+
 .Cell {
   padding: spacing();
-  border-bottom: border-width() solid
-    var(--p-border-subdued, color('sky', 'light'));
   white-space: nowrap;
   text-align: left;
   transition: background-color 0.2s ease-in-out;
@@ -161,6 +166,8 @@ $breakpoint: 768px;
 .Cell-total-footer {
   border-top: border('divider');
   border-bottom: none;
+  border-bottom-left-radius: var(--p-border-radius-base, border-radius());
+  border-bottom-right-radius: var(--p-border-radius-base, border-radius());
 }
 
 .Footer {
@@ -168,4 +175,7 @@ $breakpoint: 768px;
   background: var(--p-surface-subdued, color('sky', 'light'));
   color: var(--p-text-subdued, color('ink', 'lighter'));
   text-align: center;
+  border-top: border('divider');
+  border-bottom-left-radius: var(--p-border-radius-base, border-radius());
+  border-bottom-right-radius: var(--p-border-radius-base, border-radius());
 }


### PR DESCRIPTION
### WHY are these changes introduced?

A better looking DataTable in the NDL.

### WHAT is this pull request doing?

- Only rows that come after rows have a `top border` divider to avoid an extra bottom border on the last element (without a footer)

<kbd>![image](https://user-images.githubusercontent.com/22782157/97360650-d98b7380-1874-11eb-8133-1d6b62547798.png)</kbd>

- Added missing border radius' to the footer elements.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
