### PR TITLE
[Page actions] Only measure actions on horizontal resize

### DIFF
--- a/src/components/ActionMenu/components/Actions/Actions.tsx
+++ b/src/components/ActionMenu/components/Actions/Actions.tsx
@@ -33,6 +33,7 @@ export function Actions({actions = [], groups = []}: Props) {
   const menuGroupWidthRef = useRef<number>(0);
   const actionWidthsRef = useRef<number[]>([]);
   const availableWidthRef = useRef<number>(0);
+  const windowWidthRef = useRef<number>(0);
   const [activeMenuGroup, setActiveMenuGroup] = useState<string | undefined>(
     undefined,
   );
@@ -104,7 +105,15 @@ export function Actions({actions = [], groups = []}: Props) {
     () =>
       debounce(
         () => {
-          if (!newDesignLanguage || !actionsLayoutRef.current) return;
+          if (
+            !newDesignLanguage ||
+            !actionsLayoutRef.current ||
+            (typeof window !== 'undefined' &&
+              windowWidthRef.current === window.innerWidth)
+          )
+            return;
+
+          windowWidthRef.current = window.innerWidth;
           availableWidthRef.current = actionsLayoutRef.current.offsetWidth;
           measureActions();
         },
@@ -118,7 +127,7 @@ export function Actions({actions = [], groups = []}: Props) {
     if (!actionsLayoutRef.current) {
       return;
     }
-
+    windowWidthRef.current = window.innerWidth;
     availableWidthRef.current = actionsLayoutRef.current.offsetWidth;
     measureActions();
   }, [measureActions]);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3575

### WHAT is this pull request doing?

Checking the window width before measuring actions and updating the layout

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Details page. Add content, resize the screen vertically. There should be no content jump

It might help to add a console log on line 115 of Actions.tsx to see when updates are being made

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
