### PR TITLE
[Page actions] Always render single action

### DIFF
--- a/src/components/ActionMenu/components/Actions/Actions.tsx
+++ b/src/components/ActionMenu/components/Actions/Actions.tsx
@@ -72,20 +72,24 @@ export function Actions({actions = [], groups = []}: Props) {
       return;
     }
 
+    const actionsAndGroups = [...actions, ...groups];
+
+    if (actionsAndGroups.length === 1) {
+      setShowableActions(actionsAndGroups);
+      return;
+    }
+
     let currentAvailableWidth = availableWidthRef.current;
     let newShowableActions: MenuActionDescriptor[] = [];
     let newRolledUpActions: (MenuActionDescriptor | MenuGroupDescriptor)[] = [];
-    const actionsAndGroups = [...actions, ...groups];
 
     actionsAndGroups.forEach((action, index) => {
-      const isSingleAction = actionsAndGroups.length === 1;
       const canFitAction =
-        isSingleAction ||
         actionWidthsRef.current[index] +
           menuGroupWidthRef.current +
           ACTION_SPACING +
           lastMenuGroupWidth <=
-          currentAvailableWidth;
+        currentAvailableWidth;
 
       if (canFitAction) {
         currentAvailableWidth -= actionWidthsRef.current[index];

--- a/src/components/ActionMenu/components/Actions/Actions.tsx
+++ b/src/components/ActionMenu/components/Actions/Actions.tsx
@@ -73,17 +73,19 @@ export function Actions({actions = [], groups = []}: Props) {
     }
 
     let currentAvailableWidth = availableWidthRef.current;
-
     let newShowableActions: MenuActionDescriptor[] = [];
     let newRolledUpActions: (MenuActionDescriptor | MenuGroupDescriptor)[] = [];
+    const actionsAndGroups = [...actions, ...groups];
 
-    [...actions, ...groups].forEach((action, index) => {
+    actionsAndGroups.forEach((action, index) => {
+      const isSingleAction = actionsAndGroups.length === 1;
       const canFitAction =
+        isSingleAction ||
         actionWidthsRef.current[index] +
           menuGroupWidthRef.current +
           ACTION_SPACING +
           lastMenuGroupWidth <=
-        currentAvailableWidth;
+          currentAvailableWidth;
 
       if (canFitAction) {
         currentAvailableWidth -= actionWidthsRef.current[index];


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3581

https://screenshot.click/screencast_2020-10-29_09-16-24.mp4

### WHAT is this pull request doing?

If there is only one action or group, always render it before rolling up to a default menu group

### How to 🎩

~~I'll add a chroma link~~ I can't because I can't modify the details page 🤦 

On the details page: Remove all secondary actions except for duplicate, remove both action groups. 
Make sure that only duplicate appears and not the `More actions` dropdown

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
