### PR TITLE
✨ [Button] Add new role prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,11 +10,11 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Allow `Thumbnail` `source` property to support `icons` ([#3328](https://github.com/Shopify/polaris-react/pull/3328))
 - **`Button`:** New `role` prop for `<button />` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
-- **`Button`:** `loading` can now set `role="alert"` on links ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
 
 ### Bug fixes
 
 - Removed extra bottom border on the `DataTable` and added curved edges to footers ([#3571](https://github.com/Shopify/polaris-react/pull/3571))
+- **`Button`:** `loading` no longer sets the invalid `role="alert"` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Allow `Thumbnail` `source` property to support `icons` ([#3328](https://github.com/Shopify/polaris-react/pull/3328))
+- **`Button`:** New `role` prop for `<button />` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
+- **`Button`:** `loading` can now set `role="alert"` on links ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
 
 ### Bug fixes
 

--- a/scripts/accessibility-check.js
+++ b/scripts/accessibility-check.js
@@ -100,8 +100,6 @@ console.log(`Running ${concurrentCount} concurrent pages at a time`);
       'id=all-components-autocomplete--autocomplete-with-lazy-loading&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
       'id=all-components-autocomplete--autocomplete-with-empty-state': 1,
       'id=all-components-autocomplete--autocomplete-with-empty-state&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
-      'id=all-components-button--loading-state': 2,
-      'id=all-components-button--loading-state&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 2,
       'id=all-components-filters--filtering-with-a-resource-list': 1,
       'id=all-components-filters--filtering-with-a-resource-list&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
       'id=all-components-filters--filtering-with-a-data-table': 1,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -69,6 +69,7 @@ type ActionButtonProps = Pick<
   | 'submit'
   | 'disabled'
   | 'loading'
+  | 'role'
   | 'ariaControls'
   | 'ariaExpanded'
   | 'ariaPressed'
@@ -90,6 +91,7 @@ export function Button({
   loading,
   pressed,
   accessibilityLabel,
+  role,
   ariaControls,
   ariaExpanded,
   ariaPressed,
@@ -285,6 +287,7 @@ export function Button({
     submit,
     disabled: isDisabled,
     loading,
+    role,
     ariaControls,
     ariaExpanded,
     ariaPressed: ariaPressedStatus,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -52,6 +52,7 @@ interface CommonButtonProps
     ButtonProps,
     | 'id'
     | 'accessibilityLabel'
+    | 'role'
     | 'onClick'
     | 'onFocus'
     | 'onBlur'
@@ -69,7 +70,6 @@ type ActionButtonProps = Pick<
   | 'submit'
   | 'disabled'
   | 'loading'
-  | 'role'
   | 'ariaControls'
   | 'ariaExpanded'
   | 'ariaPressed'
@@ -271,6 +271,7 @@ export function Button({
     id,
     className,
     accessibilityLabel,
+    role,
     onClick,
     onFocus,
     onBlur,
@@ -287,7 +288,6 @@ export function Button({
     submit,
     disabled: isDisabled,
     loading,
-    role,
     ariaControls,
     ariaExpanded,
     ariaPressed: ariaPressedStatus,

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -132,6 +132,14 @@ describe('<Button />', () => {
     });
   });
 
+  describe('role', () => {
+    it('passes prop', () => {
+      const mockRole = 'menuitem';
+      const button = mountWithAppProvider(<Button role={mockRole} />);
+      expect(button.find(UnstyledButton).prop('role')).toBe(mockRole);
+    });
+  });
+
   describe('ariaControls', () => {
     it('passes prop', () => {
       const id = 'mockId';

--- a/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/UnstyledButton/UnstyledButton.tsx
@@ -24,6 +24,7 @@ export function UnstyledButton({
   loading,
   pressed,
   accessibilityLabel,
+  role,
   ariaControls,
   ariaExpanded,
   ariaPressed,
@@ -88,7 +89,7 @@ export function UnstyledButton({
         {...interactiveProps}
         type={submit ? 'submit' : 'button'}
         disabled={disabled}
-        role={loading ? 'alert' : undefined}
+        role={loading ? 'alert' : role}
         aria-busy={loading ? true : undefined}
         aria-controls={ariaControls}
         aria-expanded={ariaExpanded}

--- a/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/UnstyledButton/UnstyledButton.tsx
@@ -12,8 +12,6 @@ export interface UnstyledButtonProps extends BaseButton {
   [key: string]: any;
 }
 
-const ARIA_ROLE_ALERT = 'alert';
-
 export function UnstyledButton({
   id,
   children,
@@ -61,9 +59,7 @@ export function UnstyledButton({
   };
   const interactiveProps = {
     ...commonProps,
-    role: loading
-      ? [...new Set([ARIA_ROLE_ALERT, ...(role?.split(' ') || [])])].join(' ')
-      : role,
+    role,
     onClick,
     onFocus,
     onBlur,

--- a/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/UnstyledButton/UnstyledButton.tsx
@@ -53,9 +53,6 @@ export function UnstyledButton({
   const ariaPressedStatus = pressed !== undefined ? pressed : ariaPressed;
 
   let buttonMarkup;
-  const buttonRole = loading
-    ? [...new Set([ARIA_ROLE_ALERT, ...(role?.split(' ') || [])])].join(' ')
-    : role;
 
   const commonProps = {
     id,
@@ -64,6 +61,9 @@ export function UnstyledButton({
   };
   const interactiveProps = {
     ...commonProps,
+    role: loading
+      ? [...new Set([ARIA_ROLE_ALERT, ...(role?.split(' ') || [])])].join(' ')
+      : role,
     onClick,
     onFocus,
     onBlur,
@@ -94,7 +94,6 @@ export function UnstyledButton({
         {...interactiveProps}
         type={submit ? 'submit' : 'button'}
         disabled={disabled}
-        role={buttonRole}
         aria-busy={loading ? true : undefined}
         aria-controls={ariaControls}
         aria-expanded={ariaExpanded}

--- a/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/UnstyledButton/UnstyledButton.tsx
@@ -12,6 +12,8 @@ export interface UnstyledButtonProps extends BaseButton {
   [key: string]: any;
 }
 
+const ARIA_ROLE_ALERT = 'alert';
+
 export function UnstyledButton({
   id,
   children,
@@ -51,6 +53,9 @@ export function UnstyledButton({
   const ariaPressedStatus = pressed !== undefined ? pressed : ariaPressed;
 
   let buttonMarkup;
+  const buttonRole = loading
+    ? [...new Set([ARIA_ROLE_ALERT, ...(role?.split(' ') || [])])].join(' ')
+    : role;
 
   const commonProps = {
     id,
@@ -89,7 +94,7 @@ export function UnstyledButton({
         {...interactiveProps}
         type={submit ? 'submit' : 'button'}
         disabled={disabled}
-        role={loading ? 'alert' : role}
+        role={buttonRole}
         aria-busy={loading ? true : undefined}
         aria-controls={ariaControls}
         aria-expanded={ariaExpanded}

--- a/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
+++ b/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
@@ -205,9 +205,17 @@ describe('<Button />', () => {
   });
 
   describe('loading', () => {
-    it('sets an alert role on the button', () => {
+    it('sets `role="alert"` on the button', () => {
       const button = mountWithAppProvider(<UnstyledButton loading />);
       expect(button.find('button').prop('role')).toBe('alert');
+    });
+
+    it('adds `alert` to an existing `role`', () => {
+      const mockRole = 'menuitem link';
+      const button = mountWithAppProvider(
+        <UnstyledButton role={mockRole} loading />,
+      );
+      expect(button.find('button').prop('role')).toBe('alert menuitem link');
     });
 
     it('sets aria-busy on the button', () => {
@@ -271,16 +279,16 @@ describe('<Button />', () => {
       expect(button.find('button').prop('role')).toBeUndefined();
     });
 
-    it('passes to button when `loading` is `false`', () => {
+    it('passes to button', () => {
       const button = mountWithAppProvider(<UnstyledButton role={mockRole} />);
       expect(button.find('button').prop('role')).toBe(mockRole);
     });
 
-    it('forgoes custom `role` in favour of `loading`', () => {
+    it('does not duplicate `alert` if included in `role` value and `loading`', () => {
       const button = mountWithAppProvider(
-        <UnstyledButton role={mockRole} loading />,
+        <UnstyledButton role="menuitem alert link" loading />,
       );
-      expect(button.find('button').prop('role')).toBe('alert');
+      expect(button.find('button').prop('role')).toBe('alert menuitem link');
     });
 
     it('does not pass when `url`', () => {

--- a/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
+++ b/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
@@ -210,6 +210,13 @@ describe('<Button />', () => {
       expect(button.find('button').prop('role')).toBe('alert');
     });
 
+    it('sets `role="alert"` when `url`', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton url="https://google.com" loading />,
+      );
+      expect(button.find(UnstyledLink).prop('role')).toBe('alert');
+    });
+
     it('adds `alert` to an existing `role`', () => {
       const mockRole = 'menuitem link';
       const button = mountWithAppProvider(
@@ -223,11 +230,10 @@ describe('<Button />', () => {
       expect(button.find('button').prop('aria-busy')).toBe(true);
     });
 
-    it('does not pass any aria state when `url`', () => {
+    it('does not set aria-busy when `url`', () => {
       const button = mountWithAppProvider(
         <UnstyledButton url="https://google.com" loading />,
       );
-      expect(button.find(UnstyledLink).prop('role')).toBeUndefined();
       expect(button.find(UnstyledLink).prop('aria-busy')).toBeUndefined();
     });
   });
@@ -284,18 +290,18 @@ describe('<Button />', () => {
       expect(button.find('button').prop('role')).toBe(mockRole);
     });
 
+    it('passes to link', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton role={mockRole} url="https://google.com" />,
+      );
+      expect(button.find(UnstyledLink).prop('role')).toBe(mockRole);
+    });
+
     it('does not duplicate `alert` if included in `role` value and `loading`', () => {
       const button = mountWithAppProvider(
         <UnstyledButton role="menuitem alert link" loading />,
       );
       expect(button.find('button').prop('role')).toBe('alert menuitem link');
-    });
-
-    it('does not pass when `url`', () => {
-      const button = mountWithAppProvider(
-        <UnstyledButton role={mockRole} url="https://google.com" />,
-      );
-      expect(button.find(UnstyledLink).prop('role')).toBeUndefined();
     });
   });
 

--- a/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
+++ b/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
@@ -205,26 +205,6 @@ describe('<Button />', () => {
   });
 
   describe('loading', () => {
-    it('sets `role="alert"` on the button', () => {
-      const button = mountWithAppProvider(<UnstyledButton loading />);
-      expect(button.find('button').prop('role')).toBe('alert');
-    });
-
-    it('sets `role="alert"` when `url`', () => {
-      const button = mountWithAppProvider(
-        <UnstyledButton url="https://google.com" loading />,
-      );
-      expect(button.find(UnstyledLink).prop('role')).toBe('alert');
-    });
-
-    it('adds `alert` to an existing `role`', () => {
-      const mockRole = 'menuitem link';
-      const button = mountWithAppProvider(
-        <UnstyledButton role={mockRole} loading />,
-      );
-      expect(button.find('button').prop('role')).toBe('alert menuitem link');
-    });
-
     it('sets aria-busy on the button', () => {
       const button = mountWithAppProvider(<UnstyledButton loading />);
       expect(button.find('button').prop('aria-busy')).toBe(true);
@@ -295,13 +275,6 @@ describe('<Button />', () => {
         <UnstyledButton role={mockRole} url="https://google.com" />,
       );
       expect(button.find(UnstyledLink).prop('role')).toBe(mockRole);
-    });
-
-    it('does not duplicate `alert` if included in `role` value and `loading`', () => {
-      const button = mountWithAppProvider(
-        <UnstyledButton role="menuitem alert link" loading />,
-      );
-      expect(button.find('button').prop('role')).toBe('alert menuitem link');
     });
   });
 

--- a/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
+++ b/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
@@ -212,7 +212,15 @@ describe('<Button />', () => {
 
     it('sets aria-busy on the button', () => {
       const button = mountWithAppProvider(<UnstyledButton loading />);
-      expect(button.find('button').prop('aria-busy')).toBeTruthy();
+      expect(button.find('button').prop('aria-busy')).toBe(true);
+    });
+
+    it('does not pass any aria state when `url`', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton url="https://google.com" loading />,
+      );
+      expect(button.find(UnstyledLink).prop('role')).toBeUndefined();
+      expect(button.find(UnstyledLink).prop('aria-busy')).toBeUndefined();
     });
   });
 
@@ -252,6 +260,34 @@ describe('<Button />', () => {
           .findWhere((node) => node.prop('href') === undefined)
           .prop('aria-label'),
       ).toBe(accessibilityLabel);
+    });
+  });
+
+  describe('role', () => {
+    const mockRole = 'menuitem';
+
+    it('is `undefined` by default', () => {
+      const button = mountWithAppProvider(<UnstyledButton />);
+      expect(button.find('button').prop('role')).toBeUndefined();
+    });
+
+    it('passes to button when `loading` is `false`', () => {
+      const button = mountWithAppProvider(<UnstyledButton role={mockRole} />);
+      expect(button.find('button').prop('role')).toBe(mockRole);
+    });
+
+    it('forgoes custom `role` in favour of `loading`', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton role={mockRole} loading />,
+      );
+      expect(button.find('button').prop('role')).toBe('alert');
+    });
+
+    it('does not pass when `url`', () => {
+      const button = mountWithAppProvider(
+        <UnstyledButton role={mockRole} url="https://google.com" />,
+      );
+      expect(button.find(UnstyledLink).prop('role')).toBeUndefined();
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,8 @@ export interface BaseButton {
   pressed?: boolean;
   /** Visually hidden text for screen readers */
   accessibilityLabel?: string;
+  /** A valid WAI-ARIA role to define the semantic value of this element */
+  role?: string;
   /** Id of the element the button controls */
   ariaControls?: string;
   /** Tells screen reader the controlled element is expanded */


### PR DESCRIPTION
Following up on https://github.com/Shopify/polaris-react/pull/3494 - I am adding a `role` prop to both the `UnstyledButton` and `Button` components.

We utilize this in `online-store-ui` to set a `menuitem` value for our `RTE > Toolbar` items.

We could have gotten away with passing any arbitrary prop to `UnstyledButton`, since it accepts `[key: string]: any;` in its `Props` interface... but! We do apply a `role="alert"` if `loading`... so it is best to explicitly define a `role` prop on the interface so that we can pass a custom value.

### Questions

- Do I need to update the `Button > README` to include some information on this new `role` prop?
- Should we pass `role` to `UnstyledLink`?
  - I ask because we did not set `role="alert"` when `loading`
  - If we disallow `role` on `UnstyledLink`, should be log a `dev` warning to the `console` _(like we do with `ariaPressed`)_?
- Should we concatenate roles? Looks like multiple space separated roles are valid
  - https://act-rules.github.io/rules/674b10