### PR TITLE
[Popover ] Fix for preventAutofocus and remove focus onClose

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,13 +10,17 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Allow `Thumbnail` `source` property to support `icons` ([#3328](https://github.com/Shopify/polaris-react/pull/3328))
 - **`Button`:** New `role` prop for `<button />` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
+- Added `preventFocusOnClose` to `Popover` ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
 
 ### Bug fixes
 
 - Removed extra bottom border on the `DataTable` and added curved edges to footers ([#3571](https://github.com/Shopify/polaris-react/pull/3571))
 - **`Button`:** `loading` no longer sets the invalid `role="alert"` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
+- Removed `tabIndex=-1` from `Popover` when `preventAutoFocus` is true ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
 
 ### Documentation
+
+- Fixed `preventAutoFocus` prop description for `Popover` ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
 
 ### Development workflow
 

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -48,8 +48,10 @@ export interface PopoverProps {
    * @default 'div'
    */
   activatorWrapper?: string;
-  /** Prevent automatic focus of the first field on activation */
+  /** Prevent automatic focus of the popover on activation */
   preventAutofocus?: boolean;
+  /** Prevents focusing the activator or the next focusable element when the popover is deactivated */
+  preventFocusOnClose?: boolean;
   /** Automatically add wrap content in a section */
   sectioned?: boolean;
   /** Allow popover to stretch to the full width of its activator */
@@ -83,6 +85,7 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
   children,
   onClose,
   activator,
+  preventFocusOnClose,
   active,
   fixed,
   ariaHaspopup,
@@ -120,8 +123,7 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
 
   const handleClose = (source: PopoverCloseSource) => {
     onClose(source);
-
-    if (activatorContainer.current == null) {
+    if (activatorContainer.current == null || preventFocusOnClose) {
       return;
     }
 

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -190,6 +190,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
       fluidContent,
       hideOnPrint,
       colorScheme,
+      preventAutofocus,
     } = this.props;
 
     const className = classNames(
@@ -211,7 +212,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
     const content = (
       <div
         id={id}
-        tabIndex={-1}
+        tabIndex={preventAutofocus ? undefined : -1}
         className={contentClassNames}
         style={contentStyles}
         ref={this.contentNode}

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -169,6 +169,26 @@ describe('<PopoverOverlay />', () => {
     ).toBe(false);
   });
 
+  it("doesn't include a tabindex prop when preventAutofocus is true", () => {
+    const popoverOverlay = mountWithAppProvider(
+      <PopoverOverlay
+        active
+        id="PopoverOverlay-1"
+        activator={activator}
+        onClose={noop}
+        fixed
+        preventAutofocus
+        preferInputActivator={false}
+      >
+        {children}
+      </PopoverOverlay>,
+    );
+
+    expect(
+      popoverOverlay.find(PositionedOverlay).prop('preferInputActivator'),
+    ).toBe(false);
+  });
+
   it('calls the onClose callback when the escape key is pressed', () => {
     const spy = jest.fn();
 

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -299,6 +299,36 @@ describe('<Popover />', () => {
 
     expect(document.activeElement).toBe(focusTarget);
   });
+
+  it("doesn't focuses the activator or another focusable element when the popover is closed", () => {
+    const activatorId = 'activator1';
+    const nextElementId = 'activator2';
+    function PopoverTest() {
+      return (
+        <>
+          <div>
+            <Popover
+              active
+              activator={<button id={activatorId} />}
+              preventFocusOnClose
+              onClose={noop}
+            />
+          </div>
+          <button id={nextElementId} />
+        </>
+      );
+    }
+
+    const popover = mountWithApp(<PopoverTest />);
+
+    popover.find(PopoverOverlay)!.trigger('onClose');
+    const activatorTarget = popover.find('button', {id: activatorId})!.domNode;
+    const nextElementTarget = popover.find('button', {id: nextElementId})!
+      .domNode;
+
+    expect(document.activeElement).not.toBe(activatorTarget);
+    expect(document.activeElement).not.toBe(nextElementTarget);
+  });
 });
 
 function noop() {}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -150,7 +150,7 @@ export type {KeypressListenerProps} from './KeypressListener';
 export {KonamiCode} from './KonamiCode';
 export type {KonamiCodeProps} from './KonamiCode';
 
-export {Label} from './Label';
+export {Label, labelID} from './Label';
 export type {LabelProps} from './Label';
 
 export {Labelled} from './Labelled';


### PR DESCRIPTION
### WHY are these changes introduced?

I'm currently working on an alternate implementation of Autocomplete and need a few minor changes done to Polaris. Although these will not impact the current Autocomplete they will help fix issues there as well should it be needed.

I'm also using this PR to export the `labelId` function, which I also need for a11y on my implementation of Autocomplete.

### WHAT is this pull request doing?

1. export the `labelId` function from label. This will be used to assign an `aria-labelledby` prop to the list/
2. added a `preventFocusOnClose` prop to popover to prevent the textfield to gain focus when tab out of the field.
3. remove the `tabindex=-1` when preventAutoFocus is enabled. This triggered the focus to that div when scrolling the popover which is not the desired behavior for popover and can be unexpected outside popover. 
 

### How to 🎩

For the popover add the `preventFocusOnClose` to a popover and ensure the activator doesn't get focus on close.


### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
