### PR TITLE
[ResourceItem] Fix border-radius on last element

### DIFF
--- a/src/components/ResourceItem/ResourceItem.scss
+++ b/src/components/ResourceItem/ResourceItem.scss
@@ -349,6 +349,16 @@ $resource-list-item-variables: (
     border-top: border('divider');
   }
 
+  &:last-of-type {
+    border-bottom-left-radius: var(--p-border-radius-wide, border-radius());
+    border-bottom-right-radius: var(--p-border-radius-wide, border-radius());
+
+    .ItemWrapper {
+      border-bottom-left-radius: var(--p-border-radius-wide, border-radius());
+      border-bottom-right-radius: var(--p-border-radius-wide, border-radius());
+    }
+  }
+
   &.newDesignLanguage {
     position: relative;
     @include focus-ring($border-width: rem(-1px));


### PR DESCRIPTION
Before: https://screenshot.click/screencast_2020-11-02_16-28-41.mp4
After: https://screenshot.click/screencast_2020-11-02_16-29-15.mp4

### WHAT is this pull request doing?

Adding border-bottom-radii to the last item in resource list

### How to 🎩

Hover over the last item in a resource list and its border radius gets weird. 

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
