### PR TITLE
[UnstyledLink] Fix mismatch for url / href

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Removed extra bottom border on the `DataTable` and added curved edges to footers ([#3571](https://github.com/Shopify/polaris-react/pull/3571))
+- Fixed a bug where `UnstyledLink` wasn't properly converting the url prop to href ([#3598](https://github.com/Shopify/polaris-react/pull/3598))
 
 ### Documentation
 

--- a/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/src/components/UnstyledLink/UnstyledLink.tsx
@@ -17,7 +17,7 @@ export const UnstyledLink = memo(
   forwardRef<unknown, UnstyledLinkProps>(function UnstyledLink(props, _ref) {
     const LinkComponent = useLink();
     if (LinkComponent) {
-      return <LinkComponent {...unstyled.props} {...props} />;
+      return <LinkComponent {...unstyled.props} {...props} href={props.url} />;
     }
 
     const {external, url, ...rest} = props;

--- a/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
+++ b/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
@@ -15,6 +15,16 @@ describe('<UnstyledLink />', () => {
       expect(anchorElement).toHaveLength(1);
     });
 
+    it('converts url prop to href', () => {
+      const CustomLinkComponent = () => <div />;
+      const anchorElement = mountWithAppProvider(
+        <UnstyledLink url="https://shopify.com" />,
+        {link: CustomLinkComponent},
+      ).find(CustomLinkComponent);
+
+      expect(anchorElement.prop('href')).toBe('https://shopify.com');
+    });
+
     it('doesn’t have polaris prop', () => {
       const CustomLinkComponent = () => <div />;
       const anchorElement = mountWithAppProvider(


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/503

This took a bit of digging but I realized after changing `<LinkComponent />` to a regular `<a />` and passing props in I was able to see that url wasn't being transformed to `href={url}` which was why it wasn't getting an href in web. 

### WHAT is this pull request doing?

![image](https://screenshot.click/Shopify_2020-11-03_10-53-46.png)
![image](https://screenshot.click/Storybook_2020-11-03_10-53-33.png)

Building this branch for web fixes the skip to content issue
![image](https://screenshot.click/screencast_2020-11-03_11-24-11.gif)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
