### PR TITLE
[Frame] Change skip to content from button to anchor tag

### DIFF
--- a/src/components/Frame/Frame.scss
+++ b/src/components/Frame/Frame.scss
@@ -258,5 +258,20 @@ $skip-vertical-offset: rem(10px);
   &.focused {
     pointer-events: all;
     opacity: 1;
+    > a {
+      @include focus-ring($style: 'focused');
+    }
+  }
+
+  > a {
+    @include button-base;
+    @include text-style-button;
+    @include focus-ring($border-width: rem(1px));
+    color: var(--p-text);
+
+    &:focus {
+      border-color: none;
+      box-shadow: none;
+    }
   }
 }

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -10,7 +10,6 @@ import {classNames} from '../../utilities/css';
 import {Icon} from '../Icon';
 import {EventListener} from '../EventListener';
 import {Backdrop} from '../Backdrop';
-import {Button} from '../Button';
 import {TrapFocus} from '../TrapFocus';
 import {dataPolarisTopBar, layer} from '../shared';
 import {setRootProperty} from '../../utilities/set-root-property';
@@ -220,20 +219,20 @@ class FrameInner extends PureComponent<CombinedProps, State> {
       skipFocused && styles.focused,
     );
 
-    const skipTarget = skipToContentTarget
-      ? (skipToContentTarget.current && skipToContentTarget.current.id) || ''
+    const skipTarget = skipToContentTarget?.current
+      ? skipToContentTarget.current.id
       : APP_FRAME_MAIN_ANCHOR_TARGET;
 
     const skipMarkup = (
       <div className={skipClassName}>
-        <Button
-          url={`#${skipTarget}`}
+        <a
+          href={`#${skipTarget}`}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           onClick={this.handleClick}
         >
           {i18n.translate('Polaris.Frame.skipToContent')}
-        </Button>
+        </a>
       </div>
     );
 

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -15,7 +15,6 @@ import {
   ContextualSaveBar as FrameContextualSavebar,
   Loading as FrameLoading,
 } from '../components';
-import {Button} from '../../Button';
 
 window.matchMedia =
   window.matchMedia ||
@@ -55,7 +54,7 @@ describe('<Frame />', () => {
 
     it('sets focus to the main content target anchor element when the skip to content link is clicked', () => {
       const frame = mountWithApp(<Frame />);
-      const skipLink = frame.find(Button, {children: 'Skip to content'});
+      const skipLink = frame.find('a', {children: 'Skip to content'});
 
       skipLink!.trigger('onClick');
       expect(document.activeElement).toBe(


### PR DESCRIPTION
### WHY are these changes introduced?

Alternative to https://github.com/Shopify/polaris-react/pull/3598

### WHAT is this pull request doing?

Buttons use `Link` under the hood and web will not render an href for any links that may contain JS. This link does not need to use React router so why not just make it a plain anchor?
