### PR TITLE
[Popover] Focus first focusable node

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,16 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Allowed `Thumbnail` `source` property to support `icons` ([#3328](https://github.com/Shopify/polaris-react/pull/3328))
+- **`Button`:** New `role` prop for `<button />` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
+- Added `preventFocusOnClose` to `Popover` ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
+- Added color fallback values to `focus-ring` mixin ([#3626](https://github.com/Shopify/polaris-react/pull/3626))
+- Added `role="presentational"` to list items for `Tabs` ([#3647](https://github.com/Shopify/polaris-react/pull/3647))
+- Allowed consumers to set custom container element on `PortalsManager` ([#3644](https://github.com/Shopify/polaris-react/pull/3644))
+- **`Button`:** New `stretchContent` prop for `<button />` ([#3664](https://github.com/Shopify/polaris-react/pull/3664))
+- **`Popover`:** New `autofocusTarget` prop to extend autofocus options ([#3600](https://github.com/Shopify/polaris-react/pull/3600))
+- Deprecated `Popover`'s prop `preventAutofocus`. Use `autofocusTarget` instead ([#3602](https://github.com/Shopify/polaris-react/issues/3602))
+
 ### Bug fixes
 
 ### Documentation

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,15 +6,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-- Allowed `Thumbnail` `source` property to support `icons` ([#3328](https://github.com/Shopify/polaris-react/pull/3328))
-- **`Button`:** New `role` prop for `<button />` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
-- Added `preventFocusOnClose` to `Popover` ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
-- Added color fallback values to `focus-ring` mixin ([#3626](https://github.com/Shopify/polaris-react/pull/3626))
-- Added `role="presentational"` to list items for `Tabs` ([#3647](https://github.com/Shopify/polaris-react/pull/3647))
-- Allowed consumers to set custom container element on `PortalsManager` ([#3644](https://github.com/Shopify/polaris-react/pull/3644))
-- **`Button`:** New `stretchContent` prop for `<button />` ([#3664](https://github.com/Shopify/polaris-react/pull/3664))
-- **`Popover`:** New `autofocusTarget` prop to extend autofocus options ([#3600](https://github.com/Shopify/polaris-react/pull/3600))
-- Deprecated `Popover`'s prop `preventAutofocus`. Use `autofocusTarget` instead ([#3602](https://github.com/Shopify/polaris-react/issues/3602))
+- **`Popover`:** New `autofocusTarget` prop to enhance autofocus options ([#3600](https://github.com/Shopify/polaris-react/pull/3600))
 
 ### Bug fixes
 
@@ -27,3 +19,5 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Code quality
 
 ### Deprecations
+
+- Deprecated `Popover`'s prop `preventAutofocus`. Use `autofocusTarget` instead ([#3602](https://github.com/Shopify/polaris-react/issues/3602))

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -18,6 +18,7 @@ import {useUniqueId} from '../../utilities/unique-id';
 
 import {
   PopoverCloseSource,
+  PopoverAutofocusTarget,
   Pane,
   PopoverOverlay,
   PopoverOverlayProps,
@@ -26,6 +27,7 @@ import {
 import {setActivatorAttributes} from './set-activator-attributes';
 
 export {PopoverCloseSource};
+export type {PopoverAutofocusTarget};
 
 export interface PopoverProps {
   /** The content to display inside the popover */
@@ -48,7 +50,10 @@ export interface PopoverProps {
    * @default 'div'
    */
   activatorWrapper?: string;
-  /** Prevent automatic focus of the popover on activation */
+  /**
+   * Prevent automatic focus of the popover on activation
+   * @deprecated Use autofocusTarget: 'none' instead.
+   * */
   preventAutofocus?: boolean;
   /** Prevents focusing the activator or the next focusable element when the popover is deactivated */
   preventFocusOnClose?: boolean;
@@ -70,6 +75,11 @@ export interface PopoverProps {
   onClose(source: PopoverCloseSource): void;
   /** Accepts a color scheme for the contents of the popover */
   colorScheme?: InversableColorScheme;
+  /**
+   * The preferred auto focus target defaulting to the popover container
+   * @default 'container'
+   */
+  autofocusTarget?: PopoverAutofocusTarget;
 }
 
 // TypeScript can't generate types that correctly infer the typing of

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -421,7 +421,7 @@ A popover can contain many numerous types of content. Whether it's a menu, grid 
 
 ### Keyboard support
 
-- When a popover opens, focus moves to the popover container
+- When a popover opens, focus moves to the first focusable element or to the popover container
 - Once focus is in the popover, merchants can access controls in the popover using the <kbd>tab</kbd> key (and <kbd>shift</kbd> + <kbd>tab</kbd> backwards) and standard keystrokes for interacting
 - Merchants can dismiss the popover by tabbing out of it, pressing the <kbd>esc</kbd> key, or clicking outside of it
 - When the popover is closed, focus returns to the element that launched it

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -1,6 +1,7 @@
 import React, {PureComponent, Children, createRef} from 'react';
 import {durationBase} from '@shopify/polaris-tokens';
 
+import {findFirstFocusableNode} from '../../../../utilities/focus';
 import {InversableColorScheme, ThemeProvider} from '../../../ThemeProvider';
 import {classNames} from '../../../../utilities/css';
 import {
@@ -24,6 +25,8 @@ export enum PopoverCloseSource {
   FocusOut,
   ScrollOut,
 }
+
+export type PopoverAutofocusTarget = 'none' | 'first-node' | 'container';
 
 enum TransitionStatus {
   Entering = 'entering',
@@ -49,6 +52,7 @@ export interface PopoverOverlayProps {
   hideOnPrint?: boolean;
   onClose(source: PopoverCloseSource): void;
   colorScheme?: InversableColorScheme;
+  autofocusTarget?: PopoverAutofocusTarget;
 }
 
 interface State {
@@ -157,10 +161,20 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
   }
 
   private focusContent() {
-    if (this.props.preventAutofocus) {
-      return;
+    const {autofocusTarget = 'container', preventAutofocus} = this.props;
+
+    if (preventAutofocus) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Deprecation: The preventAutofocus prop has been deprecated. Use autofocusTarget: "none" instead. Read more at [https://github.com/Shopify/polaris-react/issues/3602]',
+      );
     }
-    if (this.contentNode == null) {
+
+    if (
+      preventAutofocus ||
+      autofocusTarget === 'none' ||
+      this.contentNode == null
+    ) {
       return;
     }
 
@@ -169,9 +183,17 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
         return;
       }
 
-      this.contentNode.current.focus({
-        preventScroll: process.env.NODE_ENV === 'development',
-      });
+      const focusableChild = findFirstFocusableNode(this.contentNode.current);
+
+      if (focusableChild && autofocusTarget === 'first-node') {
+        focusableChild.focus({
+          preventScroll: process.env.NODE_ENV === 'development',
+        });
+      } else {
+        this.contentNode.current.focus({
+          preventScroll: process.env.NODE_ENV === 'development',
+        });
+      }
     });
   }
 
@@ -191,6 +213,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
       hideOnPrint,
       colorScheme,
       preventAutofocus,
+      autofocusTarget,
     } = this.props;
 
     const className = classNames(
@@ -212,7 +235,9 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
     const content = (
       <div
         id={id}
-        tabIndex={preventAutofocus ? undefined : -1}
+        tabIndex={
+          preventAutofocus || autofocusTarget === 'none' ? undefined : -1
+        }
         className={contentClassNames}
         style={contentStyles}
         ref={this.contentNode}

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -5,6 +5,7 @@ import {
   ReactWrapper,
   trigger,
 } from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities/react-testing';
 import {TextContainer, TextField, EventListener} from 'components';
 
 import {Key} from '../../../../../types';
@@ -363,6 +364,70 @@ describe('<PopoverOverlay />', () => {
 
       expect(focusSpy).toHaveBeenCalledTimes(1);
       expect(focusSpy).toHaveBeenCalledWith({preventScroll: true});
+    });
+
+    it('focuses the container when autofocusTarget is not set', () => {
+      const id = 'PopoverOverlay-1';
+      const popoverOverlay = mountWithApp(
+        <PopoverOverlay active id={id} activator={activator} onClose={noop} />,
+      );
+
+      const focusTarget = popoverOverlay.find('div', {id})!.domNode;
+      expect(document.activeElement).toBe(focusTarget);
+    });
+
+    it('focuses the container when autofocusTarget is set to Container', () => {
+      const id = 'PopoverOverlay-1';
+      const popoverOverlay = mountWithApp(
+        <PopoverOverlay
+          active
+          id={id}
+          activator={activator}
+          onClose={noop}
+          autofocusTarget="container"
+        />,
+      );
+
+      const focusTarget = popoverOverlay.find('div', {id})!.domNode;
+      expect(document.activeElement).toBe(focusTarget);
+    });
+
+    it('focuses the first focusbale node when autofocusTarget is set to FirstNode', () => {
+      const popoverOverlay = mountWithApp(
+        <PopoverOverlay
+          active
+          id="PopoverOverlay-1"
+          activator={activator}
+          onClose={noop}
+          autofocusTarget="first-node"
+        >
+          <input type="text" />
+        </PopoverOverlay>,
+      );
+
+      const focusTarget = popoverOverlay.find('input', {})!.domNode;
+      expect(document.activeElement).toBe(focusTarget);
+    });
+
+    it('does not focus when autofocusTarget is set to None', () => {
+      const id = 'PopoverOverlay-1';
+      const popoverOverlay = mountWithApp(
+        <PopoverOverlay
+          active
+          id={id}
+          activator={activator}
+          onClose={noop}
+          autofocusTarget="none"
+        >
+          <input type="text" />
+        </PopoverOverlay>,
+      );
+
+      const focusTargetContainer = popoverOverlay.find('div', {id})!.domNode;
+      const focusTargetFirstNode = popoverOverlay.find('input', {})!.domNode;
+
+      expect(document.activeElement).not.toBe(focusTargetContainer);
+      expect(document.activeElement).not.toBe(focusTargetFirstNode);
     });
   });
 });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -196,7 +196,7 @@ export {PolarisTestProvider} from './PolarisTestProvider';
 export type {WithPolarisTestProviderOptions} from './PolarisTestProvider';
 
 export {Popover, PopoverCloseSource} from './Popover';
-export type {PopoverProps} from './Popover';
+export type {PopoverProps, PopoverAutofocusTarget} from './Popover';
 
 export {Portal} from './Portal';
 export type {PortalProps} from './Portal';


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3602

By using the existing utility function `findFirstFocusableNode` try to find the first focusable child node and set the focus on it when the `Popover` is activated.

If no focusable nodes are present keep the current focus on the container.

### WHAT is this pull request doing?

This PR extends the `focusContent` functionality of the `PopoverOverlay` component by searching for the first focusable node and setting the focus on it if available.
Simply enhancing the focus to look for the first focusable node would change the behaviour of the component so I decided to add a new prop `autofocusTarget` which can have three options: `none`, `container`, `first-node`.

- `none` is equal with the current `preventAutofocus`:`true` prop so I would suggest to gradually replace it
- `container` would be default option and would work the same way as the `Popover` works today
- `first-node` would be the new functionality which looks for the first focusable node.

What do you think?

The approach is already used by the forked [Popover](https://github.com/Shopify/web/blob/master/packages/%40shopify/polaris-next/components/Popover/PopoverOverlay.tsx#L97-L98) component in the Admin.

Before:
![popover-no-focus](https://user-images.githubusercontent.com/6481236/98124043-aa7e8e80-1e80-11eb-9073-ec4eeb2a5291.gif)


After (notice the search field is focused automatically)
![popover-focus](https://user-images.githubusercontent.com/6481236/98121780-bddc2a80-1e7d-11eb-95e6-436b08d66c02.gif)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {ActionList, Button, Page, Popover, TextField} from '../src';

export function Playground() {
  const [popoverActive, setPopoverActive] = useState(false);

  const togglePopoverActive = useCallback(
    () => setPopoverActive((popoverActive) => !popoverActive),
    [],
  );

  const activator = (
    <Button onClick={togglePopoverActive} disclosure>
      Open
    </Button>
  );

  return (
    <Page title="Playground">
      <Popover
        active={popoverActive}
        activator={activator}
        onClose={togglePopoverActive}
        autofocusTarget="first-node"
      >
        <Popover.Pane fixed>
          <TextField label="" placeholder="Search" onChange={() => {}} />
        </Popover.Pane>
        <Popover.Pane>
          <ActionList
            items={[
              {content: 'Online store'},
              {content: 'Facebook'},
              {content: 'Shopify POS'},
            ]}
          />
        </Popover.Pane>
      </Popover>
    </Page>
  );
}
```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
