### PR TITLE
🎨 [Icon] Added `disabled` color to new design language colors for Icons.

### DIFF
--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -369,6 +369,10 @@
   @include recolor-icon(var(--p-icon));
 }
 
+.colorDisabled {
+  @include recolor-icon(var(--p-icon-disabled));
+}
+
 .colorSubdued {
   @include recolor-icon(var(--p-icon-subdued));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,8 @@ export type NewDesignLanguageColor =
   | 'warning'
   | 'highlight'
   | 'success'
-  | 'primary';
+  | 'primary'
+  | 'disabled';
 
 export type IconSource =
   | React.SFC<React.SVGProps<SVGSVGElement>>

--- a/src/utilities/color-new-design-language.ts
+++ b/src/utilities/color-new-design-language.ts
@@ -8,6 +8,7 @@ const NEW_DESIGN_LANGUAGE_COLORS = [
   'highlight',
   'success',
   'primary',
+  'disabled',
 ];
 
 export function isNewDesignLanguageColor(


### PR DESCRIPTION
### WHY are these changes introduced?

Added a new color to the new-design-language colors in order for an icon to be recolored to `--p-icon-disabled` using the color prop

### WHAT is this pull request doing?

Adds new color so that an Icon can be recolored

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
