### PR TITLE
[Modal] Use correct color for header border

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed extra bottom border on the `DataTable` and added curved edges to footers ([#3571](https://github.com/Shopify/polaris-react/pull/3571))
 - **`Button`:** `loading` no longer sets the invalid `role="alert"` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
 - Removed `tabIndex=-1` from `Popover` when `preventAutoFocus` is true ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
+- Fixed `Modal` header border color ([#3616](https://github.com/Shopify/polaris-react/pull/3616))
 
 ### Documentation
 

--- a/src/components/Modal/components/Header/Header.scss
+++ b/src/components/Modal/components/Header/Header.scss
@@ -5,7 +5,7 @@
   align-items: flex-start;
   flex-shrink: 0;
   padding: spacing() spacing(loose);
-  border-bottom: var(--p-thin-border-subdued, border());
+  border-bottom: border('divider');
 }
 
 .Title {


### PR DESCRIPTION
This is supposed to be using the divider color. `border('divider')` returns `var(--p-divider)` with the new design language.