### PR TITLE
Search clear button iOS alignment

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - **`Button`:** `loading` no longer sets the invalid `role="alert"` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
 - Removed `tabIndex=-1` from `Popover` when `preventAutoFocus` is true ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
 - Fixed `Modal` header border color ([#3616](https://github.com/Shopify/polaris-react/pull/3616))
+- Fixed `TopBar` search clear button alignment on iOS ([#3618](https://github.com/Shopify/polaris-react/pull/3618))
 
 ### Documentation
 

--- a/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/src/components/TopBar/components/SearchField/SearchField.scss
@@ -4,7 +4,7 @@
 $icon-size: rem(20px);
 $input-height: rem(34px);
 $new-input-height: rem(36px);
-$clear-button-width: $icon-size + spacing();
+$search-icon-width: $icon-size + spacing();
 
 $stacking-order: (
   backdrop: 1,
@@ -85,9 +85,9 @@ $stacking-order: (
 .Input {
   @include text-style-input;
   z-index: z-index(input, $stacking-order);
-  width: calc(100% - #{$clear-button-width});
+  width: calc(100% - #{$search-icon-width});
   height: $input-height;
-  padding: 0 0 0 $clear-button-width;
+  padding: 0 0 0 $search-icon-width;
   border: none;
   background-color: transparent;
   outline: none;
@@ -133,11 +133,10 @@ $stacking-order: (
   @include focus-ring($size: 'wide');
   position: relative;
   z-index: z-index(action, $stacking-order);
-  align-self: stretch;
   border: none;
   appearance: none;
   background: transparent;
-  width: $clear-button-width;
+  padding: spacing(tight);
 
   &:focus,
   &:hover {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/33665

### WHAT is this pull request doing?

- [x] Center aligns the search clear button on iOS
- [x] Creates a bigger touch target
- [x] Retains the clear style in all other browsers and devices

### How to 🎩

1. `dev up && dev s`
1. Open 192.168.0.11:6006 on an iOS device with safari
1. Go to the details page and type into the search input
1. Test in other browsers to make sure the clear button has no regressions

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
