### PR TITLE
[ActionList] Align ActionList ::before indicator with OptionList

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -36,6 +36,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added a `alwaysRenderCustomProperties` to `ThemeProvider` for elements that render outside of the DOM tree to their parent context ([#3652](https://github.com/Shopify/polaris-react/pull/3652))
 - Fixed keyboard interactions for the `Tab` component ([#3650](https://github.com/Shopify/polaris-react/pull/3650))
 - Fixed keyboard interaction when selected Tab was focused and rendering the wrong `::before` colour ([#3669](https://github.com/Shopify/polaris-react/pull/3669))
+- **`ActionList`:** aligns `::before` 'indicator' to edge of container ([#3619](https://github.com/Shopify/polaris-react/pull/3619))
 
 ### Documentation
 

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -3,7 +3,6 @@
 $image-size: rem(20px);
 $item-min-height: rem(40px);
 $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
-$active-indicator-width: rem(3px);
 
 .ActionList {
   list-style: none;
@@ -228,7 +227,7 @@ $active-indicator-width: rem(3px);
 
     // Only show when the button is selected, not active
     [aria-selected='true'] > &::before {
-      @include list-single-selection-state;
+      @include list-selected-indicator;
     }
 
     // Active, hovered, focused (:active:hover:focus)

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -228,17 +228,7 @@ $active-indicator-width: rem(3px);
 
     // Only show when the button is selected, not active
     [aria-selected='true'] > &::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: -1 * spacing(extra-tight);
-      height: 100%;
-      width: $active-indicator-width;
-      background-color: var(--p-interactive);
-      border-top-right-radius: var(--p-border-radius-base);
-      border-bottom-right-radius: var(--p-border-radius-base);
-      transform: translateX(-100%);
+      @include list-single-selection-state;
     }
 
     // Active, hovered, focused (:active:hover:focus)

--- a/src/components/OptionList/components/Option/Option.scss
+++ b/src/components/OptionList/components/Option/Option.scss
@@ -3,7 +3,6 @@
 $min-height: control-height();
 $control-size: rem(16px);
 $control-vertical-adjustment: rem(2px);
-$selected-option-identifier-width: rem(3px);
 
 .Option {
   @include unstyled-button;
@@ -164,7 +163,7 @@ $selected-option-identifier-width: rem(3px);
     }
 
     &.select::before {
-      @include list-single-selection-state;
+      @include list-selected-indicator;
     }
   }
 }

--- a/src/components/OptionList/components/Option/Option.scss
+++ b/src/components/OptionList/components/Option/Option.scss
@@ -164,16 +164,7 @@ $selected-option-identifier-width: rem(3px);
     }
 
     &.select::before {
-      background: var(--p-interactive);
-      content: '';
-      position: absolute;
-      top: 0;
-      left: -1 * spacing(tight);
-      height: 100%;
-      display: block;
-      width: $selected-option-identifier-width;
-      border-top-right-radius: var(--p-border-radius-base);
-      border-bottom-right-radius: var(--p-border-radius-base);
+      @include list-single-selection-state;
     }
   }
 }

--- a/src/styles/shared/_interaction-state.scss
+++ b/src/styles/shared/_interaction-state.scss
@@ -25,15 +25,15 @@
   background-image: $backgrounds;
 }
 
-@mixin list-single-selection-state {
-  background: var(--p-interactive);
+@mixin list-selected-indicator($offset: spacing(tight)) {
   content: '';
+  background-color: var(--p-interactive);
   position: absolute;
   top: 0;
-  left: -1 * spacing(tight);
+  left: -1 * $offset;
   height: 100%;
   display: block;
-  width: rem(3px);
+  width: border-width(thicker);
   border-top-right-radius: var(--p-border-radius-base);
   border-bottom-right-radius: var(--p-border-radius-base);
 }

--- a/src/styles/shared/_interaction-state.scss
+++ b/src/styles/shared/_interaction-state.scss
@@ -24,3 +24,16 @@
   }
   background-image: $backgrounds;
 }
+
+@mixin list-single-selection-state {
+  background: var(--p-interactive);
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -1 * spacing(tight);
+  height: 100%;
+  display: block;
+  width: rem(3px);
+  border-top-right-radius: var(--p-border-radius-base);
+  border-bottom-right-radius: var(--p-border-radius-base);
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3611

![image](https://user-images.githubusercontent.com/17032120/98830211-0c676700-2432-11eb-87db-1512cd2d9cee.png)


### WHAT is this pull request doing?

ActionList indicator styles were [updated within Figma to use the same styles as OptionList](https://github.com/Shopify/polaris-react/issues/3258#issuecomment-694931240)

This PR fixes the alignment issue in #3611 by moving the OptionList indicator styles into a shared mixin that can be used by both the OptionList and the ActionList. 

Action list after:

![Action list after changes](https://user-images.githubusercontent.com/17032120/98830461-581a1080-2432-11eb-8416-92e6e1760aba.png)

Option list after:

![Option list after changes](https://user-images.githubusercontent.com/17032120/98830521-68ca8680-2432-11eb-95f1-8d7d5736b3e6.png)

### 🎩 checklist

* [x] Tested on [mobile](Galaxy S5 emulator on Chrome)
* [x] Tested on [multiple browsers](Chrome on MacOS, Safari on MacOS, Firefox on MacOS, Edge on WindowsVM)
* [x] Tested for [accessibility](WHCM on Edge)

