### PR TITLE
[Actions] Do not re-measure on every re-render

### DIFF
--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -57,6 +57,7 @@ export function DetailsPage() {
   const [mobileNavigationActive, setMobileNavigationActive] = useState(false);
   const [modalActive, setModalActive] = useState(false);
   const [navItemActive, setNavItemActive] = useState('');
+  const [previewValue, setPreviewValue] = useState('');
   const [nameFieldValue, setNameFieldValue] = useState(
     defaultState.current.nameFieldValue,
   );
@@ -416,7 +417,10 @@ export function DetailsPage() {
     {label: 'Last 7 days', value: 'lastWeek'},
   ];
 
-  const handleChange = useCallback((newValue) => setValue(newValue), []);
+  const handleChange = useCallback((newValue) => {
+    setValue(newValue);
+    setPreviewValue(newValue);
+  }, []);
 
   // ---- Dropzone ----
   const [files, setFiles] = useState<File[]>([]);
@@ -475,7 +479,7 @@ export function DetailsPage() {
         {
           content: 'View',
           // eslint-disable-next-line no-console
-          onAction: () => console.log('view'),
+          onAction: () => console.log(previewValue),
         },
         {
           content: 'Print',

--- a/src/components/ActionMenu/components/Actions/Actions.tsx
+++ b/src/components/ActionMenu/components/Actions/Actions.tsx
@@ -36,8 +36,9 @@ export function Actions({actions = [], groups = []}: Props) {
   const {newDesignLanguage} = useFeatures();
   const actionsLayoutRef = useRef<HTMLDivElement>(null);
   const menuGroupWidthRef = useRef<number>(0);
-  const actionWidthsRef = useRef<number[]>([]);
   const availableWidthRef = useRef<number>(0);
+  const hasMeasured = useRef<boolean>(false);
+  const actionWidthsRef = useRef<number[]>([]);
   const [activeMenuGroup, setActiveMenuGroup] = useState<string | undefined>(
     undefined,
   );
@@ -70,7 +71,8 @@ export function Actions({actions = [], groups = []}: Props) {
     if (
       !newDesignLanguage ||
       actionWidthsRef.current.length === 0 ||
-      availableWidthRef.current === 0
+      availableWidthRef.current === 0 ||
+      hasMeasured.current
     ) {
       return;
     }
@@ -105,10 +107,14 @@ export function Actions({actions = [], groups = []}: Props) {
         newRolledUpActions = [...newRolledUpActions, action];
       }
     });
+
     setMeasuredActions({
       showable: newShowableActions,
       rolledUp: newRolledUpActions,
     });
+
+    // Set hasMeasured to true to prevent re-renders until viewport has been resized
+    hasMeasured.current = true;
   }, [actions, groups, lastMenuGroup, lastMenuGroupWidth, newDesignLanguage]);
 
   const handleResize = useMemo(
@@ -117,6 +123,8 @@ export function Actions({actions = [], groups = []}: Props) {
         () => {
           if (!newDesignLanguage || !actionsLayoutRef.current) return;
           availableWidthRef.current = actionsLayoutRef.current.offsetWidth;
+          // Set hasMeasured to false to allow re-measuring
+          hasMeasured.current = false;
           measureActions();
         },
         50,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3575

[Screencast](https://screenshot.click/screencast_2020-11-11_12-09-38.mp4)

### WHAT is this pull request doing?

Update the measuring calculation.
Stricter check on rolled up groups.
Only re-measure when showable actions and rolled up actions length are 0

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

This change should be tophatted in web because our playground behaves slightly differently in web. Although I did add some changes to the details page that should better reflect what's happening in web.

`yarn run build-consumer web`
Tophat around admin pages

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
