### PR TITLE
[color-transformers > rgbToHsbl] Fix brightness precision of HSB conversions by increasing from 2 decimal digits to 4

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,7 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed `tabIndex=-1` from `Popover` when `preventAutoFocus` is true ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
 - Fixed `Modal` header border color ([#3616](https://github.com/Shopify/polaris-react/pull/3616))
 - Fixed `TopBar` search clear button alignment on iOS ([#3618](https://github.com/Shopify/polaris-react/pull/3618))
-- Fixes HSB brightness conversion by increasing precision from 2 decimals to 4
+- Fixed HSB brightness conversion by increasing precision from 2 decimals to 4
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - **`Button`:** `loading` no longer sets the invalid `role="alert"` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
 - Removed `tabIndex=-1` from `Popover` when `preventAutoFocus` is true ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
 - Fixed `Modal` header border color ([#3616](https://github.com/Shopify/polaris-react/pull/3616))
+- Fixes HSB brightness conversion by increasing precision from 2 decimals to 4
 
 ### Documentation
 

--- a/src/utilities/color-transformers.ts
+++ b/src/utilities/color-transformers.ts
@@ -170,7 +170,7 @@ function rgbToHsbl(color: RGBAColor, type: 'b' | 'l' = 'b'): HSBLAColor {
   return {
     hue: clamp(hue, 0, 360) || 0,
     saturation: parseFloat(clamp(saturation, 0, 1).toFixed(2)),
-    brightness: parseFloat(clamp(largestComponent, 0, 1).toFixed(2)),
+    brightness: parseFloat(clamp(largestComponent, 0, 1).toFixed(4)),
     lightness: parseFloat(lightness.toFixed(2)),
     alpha: parseFloat(alpha.toFixed(2)),
   };

--- a/src/utilities/tests/color-transformers.test.ts
+++ b/src/utilities/tests/color-transformers.test.ts
@@ -105,6 +105,32 @@ describe('colorUtilities', () => {
       expect(saturation).toBe(1);
       expect(brightness).toBe(1);
     });
+
+    // test for an issue where Hex colours were losing precision during the conversion because we limit rounding to two decimal places
+    // https://github.com/Shopify/shopify/issues/265949
+    it('returns 0/0/0.5333 hsb value with four decimals of brightness precision when passed rgb(136, 136, 136)', () => {
+      const {hue, saturation, brightness} = rgbToHsb({
+        red: 136,
+        green: 136,
+        blue: 136,
+      });
+      expect(hue).toBe(0);
+      expect(saturation).toBe(0);
+      expect(brightness).toBe(0.5333);
+    });
+
+    // test for an issue where Hex colours were losing precision during the conversion because we limit rounding to two decimal places
+    // https://github.com/Shopify/shopify/issues/265949
+    it('returns 0/0/0.5294 hsb value when passed rgb(135, 135, 135)', () => {
+      const {hue, saturation, brightness} = rgbToHsb({
+        red: 135,
+        green: 135,
+        blue: 135,
+      });
+      expect(hue).toBe(0);
+      expect(saturation).toBe(0);
+      expect(brightness).toBe(0.5294);
+    });
   });
 
   describe('colorToHsla', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

I was originally investigating this issue in Shopify web https://github.com/Shopify/shopify/issues/265949

and found that the color-transformers on Polaris would convert both hex values `#888888` and `#878787` to the same HSB value `{ hue: 0, saturation: 0, brightness: 0.53 }`. The calculating actually looked correct, `#888888` was being converted to `0.5333` and `#878787` was being converted to `0.5294`. But the final step of the conversion limits these to only two decimal places, which resulted in the brightness values being rounded to `0.53` in both cases and losing their precision.

The Shopify Web ticket has more details on the original issue.


### WHAT is this pull request doing?

This PR fixes the `color-transformers` issue by increasing the brightness value's precision from 2 decimal points to 4. 

It also adds two tests for the failing conversions from the Shopify web issue for `rgb(135, 135, 135)` and `rgb(136, 136, 136)` to ensure they're both translated to the correct expected values.


# Questions for reviewers

* Is this change a bug fix? Or would we consider changing the number of decimal digits as a breaking change?
* Thoughts on updating Polaris version in Shopify web? Should we create a workaround/short term fix in Shopify web for now instead of updating Polaris during the holiday critical phase?


### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers) **_(Firefox and Chrome)_**
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] ~Updated the component's `README.md` with documentation changes~ **_(Didn't see any README for utilities)_**
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->