### PR TITLE
💄 [SCSS] Apply old design language color fallback to focus-ring

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Allow `Thumbnail` `source` property to support `icons` ([#3328](https://github.com/Shopify/polaris-react/pull/3328))
 - **`Button`:** New `role` prop for `<button />` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
 - Added `preventFocusOnClose` to `Popover` ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
+- Added color fallback values to `focus-ring` mixin ([#3626](https://github.com/Shopify/polaris-react/pull/3626))
 
 ### Bug fixes
 

--- a/src/styles/foundation/_focus-ring.scss
+++ b/src/styles/foundation/_focus-ring.scss
@@ -30,13 +30,13 @@
       left: $negative-offset;
       display: block;
       pointer-events: none;
-      box-shadow: 0 0 0 $negative-offset var(--p-focused);
+      box-shadow: 0 0 0 $negative-offset var(--p-focused, color('indigo'));
       transition: box-shadow duration(fast) var(--p-ease);
       border-radius: calc(#{$border-radius} + #{rem(1px)});
     }
   } @else if $style == 'focused' {
     &::after {
-      box-shadow: 0 0 0 $stroke var(--p-focused);
+      box-shadow: 0 0 0 $stroke var(--p-focused, color('indigo'));
       @include high-contrast-outline;
     }
   }


### PR DESCRIPTION
This PR updates the `focus-ring` mixin to include `color('indigo')` as a fallback value for the `box-shadow` color.

This allows me to use `@include focus-ring` in my consuming app/library without the need to detect the "new design language" and have conditions in both my `TSX` and `SCSS`:

```tsx
import {classNames} from '@shopify/css-utilities';
import {useFeatures} from '../FeaturesProvider';

// Hook to detect if app is using `new design language`
const {newDesignLanguage} = useFeatures();

const myClassNames = classNames(styles.MyComponent, {
  [styles.newDesignLanguage]: newDesignLanguage,
});
```

```scss
.MyComponent:not(.newDesignLanguage) {
  // Old design language focus styles
}

.MyComponent.newDesignLanguage {
  // New design language focus styles
}
```

This will still be "new design language"-only without _at least one_ adjustment on the consumer-side:
`--p-non-null-content: '';`

Here is how I am using the `focus-ring` for both "old design language" and "new design language" within my app:

```scss
// Intended only for the Polaris focus-ring mixin
@mixin focus-ring-suppress {
  &::after {
    box-shadow: 0 0 0 0 transparent;

    @media (-ms-high-contrast: active) {
      outline: none;
    }
  }
}

// This can be simplified once we reach widespread `focus-visible` support.
@mixin interaction-focus-ring($width: rem(0)) {
  // CSS custom property overrides can be removed with Polaris v6.
  --p-non-null-content: '';
  --p-border-radius-base: #{rem(4px)};

  @include focus-ring($border-width: $width);

  &:focus {
    @include focus-ring($style: 'focused');
  }

  &:focus:not(:focus-visible) {
    @include focus-ring-suppress;
  }

  &:focus-visible {
    @include focus-ring($style: 'focused');
  }
}

.ActionComponent {
  @include focus-ring;
}
```

I imagine Polaris uses `content: var(--p-non-null-content, none)` as a way to scope `focus-ring` to "new design language" apps. When `-p-non-null-content` is not defined, `content` is `none`. Without a "non-null" `content` value, pseudo elements simply do not render.

This could still be a problem if the "old design language" component/styles utilize a `::after` pseudo element of their own... because `focus-ring` might collide with those styles and cause problems. Regardless, I can see how the `content` trick is a nice way to keep "new design language" conditions out of some Polaris code. For this reason, I feel like the addition of color fallback values is a harmless code change.

This has been tested in my consuming app and works nicely!