### PR TITLE
[Filters/FocusManager] Manage filter focusing

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,7 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed alignment of `Page` and `TopBar` so the search aligns to the page. ([#3610](https://github.com/Shopify/polaris-react/pull/3610))
-- Fixed `FocusManager` adding inactive items([#3630](https://github.com/Shopify/polaris-react/pull/3630))
+- Fixed `FocusManager` from tracking inactive items that prevented trap focusing([#3630](https://github.com/Shopify/polaris-react/pull/3630))
 - Removed extra bottom border on the `DataTable` and added curved edges to footers ([#3571](https://github.com/Shopify/polaris-react/pull/3571))
 - **`Button`:** `loading` no longer sets the invalid `role="alert"` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
 - Removed `tabIndex=-1` from `Popover` when `preventAutoFocus` is true ([#3595](https://github.com/Shopify/polaris-react/pull/3595))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed alignment of `Page` and `TopBar` so the search aligns to the page. ([#3610](https://github.com/Shopify/polaris-react/pull/3610))
+- Fixed `FocusManager` adding inactive items([#3630](https://github.com/Shopify/polaris-react/pull/3630))
 - Removed extra bottom border on the `DataTable` and added curved edges to footers ([#3571](https://github.com/Shopify/polaris-react/pull/3571))
 - **`Button`:** `loading` no longer sets the invalid `role="alert"` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
 - Removed `tabIndex=-1` from `Popover` when `preventAutoFocus` is true ([#3595](https://github.com/Shopify/polaris-react/pull/3595))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,7 +15,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
-
 - Fixed `FocusManager` from tracking inactive items that prevented trap focusing([#3630](https://github.com/Shopify/polaris-react/pull/3630))
 - Added escape keybind to `Tooltip` ([#3627](https://github.com/Shopify/polaris-react/pull/3627))
 - Removed extra bottom border on the `DataTable` and added curved edges to footers ([#3571](https://github.com/Shopify/polaris-react/pull/3571))

--- a/src/components/FocusManager/tests/FocusManager.test.tsx
+++ b/src/components/FocusManager/tests/FocusManager.test.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../utilities/focus-manager';
 
 const Component = ({id}: {id: string}) =>
-  useFocusManager().canSafelyFocus ? <div id={id} /> : null;
+  useFocusManager({trapping: true}).canSafelyFocus ? <div id={id} /> : null;
 
 describe('FocusManager', () => {
   it('allows the first component added to be safely focused', () => {

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -22,7 +22,7 @@ export function TrapFocus({trapping = true, children}: TrapFocusProps) {
   const [shouldFocusSelf, setFocusSelf] = useState<boolean | undefined>(
     undefined,
   );
-  const {canSafelyFocus} = useFocusManager();
+  const {canSafelyFocus} = useFocusManager({trapping});
   const focusTrapWrapper = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/src/utilities/focus-manager/hooks.ts
+++ b/src/utilities/focus-manager/hooks.ts
@@ -5,7 +5,11 @@ import {MissingAppProviderError} from '../errors';
 
 import {FocusManagerContext} from './context';
 
-export function useFocusManager() {
+interface Options {
+  trapping: boolean;
+}
+
+export function useFocusManager({trapping}: Options) {
   const focusManager = useContext(FocusManagerContext);
   const id = useUniqueId();
 
@@ -19,14 +23,16 @@ export function useFocusManager() {
     remove: removeFocusItem,
   } = focusManager;
   const canSafelyFocus = trapFocusList[0] === id;
+
   const value = useMemo(() => ({canSafelyFocus}), [canSafelyFocus]);
 
   useEffect(() => {
+    if (!trapping) return;
     addFocusItem(id);
     return () => {
       removeFocusItem(id);
     };
-  }, [addFocusItem, id, removeFocusItem]);
+  }, [addFocusItem, id, removeFocusItem, trapping]);
 
   return value;
 }

--- a/src/utilities/focus-manager/tests/hooks.test.tsx
+++ b/src/utilities/focus-manager/tests/hooks.test.tsx
@@ -11,7 +11,9 @@ import {
 let consoleErrorSpy: jest.SpyInstance;
 
 const Component = () =>
-  typeof useFocusManager().canSafelyFocus === 'boolean' ? <div /> : null;
+  typeof useFocusManager({trapping: true}).canSafelyFocus === 'boolean' ? (
+    <div />
+  ) : null;
 
 describe('useFocusManager', () => {
   beforeEach(() => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes - internal issue linked below

### WHAT is this pull request doing?

* Only add a focus item when trapping is true - multiple trap focusing can be on a page, while not active

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

* Build consumer into web & test focus management with the Filters components
