### PR TITLE
[Page Actions] Re-render without measuring when actions / groups change

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -49,6 +49,11 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Increased contrast of navigation text color ([#3742](https://github.com/Shopify/polaris-react/pull/3742))
 - Removed `-ms-high-contrast` media query from `ms-high-contrast-outline` as it is non-standard and updated the outline color from `windowText` to `transparent` ([#3775](https://github.com/Shopify/polaris-react/pull/3775)).
 - Fixed `Collapsible` expand and collapse animation ([#3779](https://github.com/Shopify/polaris-react/pull/3779))
+- Removed extra bottom border on the `DataTable` and added curved edges to footers ([#3571](https://github.com/Shopify/polaris-react/pull/3571))
+- **`Button`:** `loading` no longer sets the invalid `role="alert"` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
+- Removed `tabIndex=-1` from `Popover` when `preventAutoFocus` is true ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
+- Fixed `Modal` header border color ([#3616](https://github.com/Shopify/polaris-react/pull/3616))
+- Fixed a bug in page actions where actions would not re-render when needed ([#3641](https://github.com/Shopify/polaris-react/pull/3641))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -54,6 +54,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed `tabIndex=-1` from `Popover` when `preventAutoFocus` is true ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
 - Fixed `Modal` header border color ([#3616](https://github.com/Shopify/polaris-react/pull/3616))
 - Fixed a bug in page actions where actions would not re-render when needed ([#3641](https://github.com/Shopify/polaris-react/pull/3641))
+- Fixed a bug in `Page` where re-rendering of `secondaryActions` could cause layout jittering ([#3641](https://github.com/Shopify/polaris-react/pull/3641))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -49,11 +49,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Increased contrast of navigation text color ([#3742](https://github.com/Shopify/polaris-react/pull/3742))
 - Removed `-ms-high-contrast` media query from `ms-high-contrast-outline` as it is non-standard and updated the outline color from `windowText` to `transparent` ([#3775](https://github.com/Shopify/polaris-react/pull/3775)).
 - Fixed `Collapsible` expand and collapse animation ([#3779](https://github.com/Shopify/polaris-react/pull/3779))
-- Removed extra bottom border on the `DataTable` and added curved edges to footers ([#3571](https://github.com/Shopify/polaris-react/pull/3571))
-- **`Button`:** `loading` no longer sets the invalid `role="alert"` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
-- Removed `tabIndex=-1` from `Popover` when `preventAutoFocus` is true ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
-- Fixed `Modal` header border color ([#3616](https://github.com/Shopify/polaris-react/pull/3616))
-- Fixed a bug in page actions where actions would not re-render when needed ([#3641](https://github.com/Shopify/polaris-react/pull/3641))
 - Fixed a bug in `Page` where re-rendering of `secondaryActions` could cause layout jittering ([#3641](https://github.com/Shopify/polaris-react/pull/3641))
 
 ### Documentation

--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -57,6 +57,9 @@ export function DetailsPage() {
   const [mobileNavigationActive, setMobileNavigationActive] = useState(false);
   const [modalActive, setModalActive] = useState(false);
   const [navItemActive, setNavItemActive] = useState('');
+  const initialDescription =
+    'The M60-A represents the benchmark and equilibrium between function and design for us at Rama Works. The gently exaggerated design of the frame is not understated, but rather provocative. Inspiration and evolution from previous models are evident in the beautifully articulated design and the well defined aesthetic, the fingerprint of our ‘Industrial Modern’ designs.';
+  const [previewValue, setPreviewValue] = useState(initialDescription);
   const [nameFieldValue, setNameFieldValue] = useState(
     defaultState.current.nameFieldValue,
   );
@@ -402,9 +405,7 @@ export function DetailsPage() {
   );
 
   // ---- Description ----
-  const [DescriptionValue, setValue] = useState(
-    'The M60-A represents the benchmark and equilibrium between function and design for us at Rama Works. The gently exaggerated design of the frame is not understated, but rather provocative. Inspiration and evolution from previous models are evident in the beautifully articulated design and the well defined aesthetic, the fingerprint of our ‘Industrial Modern’ designs.',
-  );
+  const [descriptionValue, setDescriptionValue] = useState(initialDescription);
 
   // ---- Select ----
   const [selected, setSelected] = useState('today');
@@ -417,7 +418,40 @@ export function DetailsPage() {
     {label: 'Last 7 days', value: 'lastWeek'},
   ];
 
-  const handleChange = useCallback((newValue) => setValue(newValue), []);
+  const handleChange = useCallback((newValue) => {
+    setDescriptionValue(newValue);
+    setPreviewValue(newValue);
+  }, []);
+
+  const actions1 = [
+    {
+      content: 'Duplicate',
+      // eslint-disable-next-line no-console
+      onAction: () => console.log('duplicate'),
+    },
+    {
+      content: 'Print',
+      // eslint-disable-next-line no-console
+      onAction: () => console.log('print'),
+    },
+  ];
+  const actions2 = [
+    {
+      content: 'Print',
+      // eslint-disable-next-line no-console
+      onAction: () => console.log('print'),
+    },
+  ];
+
+  const [actions, setActions] = useState(actions1);
+
+  const toggleActions = () => {
+    if (actions.length === 2) {
+      setActions(actions2);
+    } else {
+      setActions(actions1);
+    }
+  };
 
   // ---- Dropzone ----
   const [files, setFiles] = useState<File[]>([]);
@@ -468,20 +502,13 @@ export function DetailsPage() {
       }}
       additionalMetaData="Created May 8, 2020 at 7:31 am from Developer Tools (via import)"
       secondaryActions={[
-        {
-          content: 'Duplicate',
-          // eslint-disable-next-line no-console
-          onAction: () => console.log('duplicate'),
-        },
+        ...actions,
         {
           content: 'View',
-          // eslint-disable-next-line no-console
-          onAction: () => console.log('view'),
-        },
-        {
-          content: 'Print',
-          // eslint-disable-next-line no-console
-          onAction: () => console.log('print'),
+          onAction: () => {
+            // eslint-disable-next-line no-console
+            console.log(previewValue);
+          },
         },
       ]}
       actionGroups={[
@@ -501,9 +528,8 @@ export function DetailsPage() {
               onAction: () => console.log('embed'),
             },
             {
-              content: 'Share',
-              // eslint-disable-next-line no-console
-              onAction: () => console.log('share'),
+              content: 'Toggle page actions',
+              onAction: toggleActions,
             },
           ],
         },
@@ -525,7 +551,7 @@ export function DetailsPage() {
               />
               <TextField
                 label="Description"
-                value={DescriptionValue}
+                value={descriptionValue}
                 onChange={handleChange}
                 multiline
               />

--- a/src/components/ActionMenu/components/Actions/Actions.tsx
+++ b/src/components/ActionMenu/components/Actions/Actions.tsx
@@ -133,7 +133,6 @@ export function Actions({actions = [], groups = []}: Props) {
       rolledUp: newRolledUpActions,
     });
 
-    // Set timesMeasured to true to prevent re-renders until viewport has been resized or props change
     timesMeasured.current += 1;
     actionsAndGroupsLengthRef.current = actionsAndGroups.length;
   }, [actions, groups, lastMenuGroup, lastMenuGroupWidth, newDesignLanguage]);
@@ -144,7 +143,7 @@ export function Actions({actions = [], groups = []}: Props) {
         () => {
           if (!newDesignLanguage || !actionsLayoutRef.current) return;
           availableWidthRef.current = actionsLayoutRef.current.offsetWidth;
-          // Set timesMeasured to false to allow re-measuring
+          // Set timesMeasured to 0 to allow re-measuring
           timesMeasured.current = 0;
           measureActions();
         },
@@ -161,7 +160,7 @@ export function Actions({actions = [], groups = []}: Props) {
 
     availableWidthRef.current = actionsLayoutRef.current.offsetWidth;
     if (
-      // Allow re-measuring twice
+      // Allow measuring twice
       // This accounts for the initial paint and re-flow
       timesMeasured.current >= 2 &&
       [...actions, ...groups].length === actionsAndGroupsLengthRef.current

--- a/src/components/ActionMenu/components/Actions/Actions.tsx
+++ b/src/components/ActionMenu/components/Actions/Actions.tsx
@@ -24,6 +24,11 @@ interface Props {
   groups?: MenuGroupDescriptor[];
 }
 
+interface MeasuredActions {
+  showable: MenuActionDescriptor[];
+  rolledUp: (MenuActionDescriptor | MenuGroupDescriptor)[];
+}
+
 const ACTION_SPACING = 8;
 
 export function Actions({actions = [], groups = []}: Props) {
@@ -31,17 +36,17 @@ export function Actions({actions = [], groups = []}: Props) {
   const {newDesignLanguage} = useFeatures();
   const actionsLayoutRef = useRef<HTMLDivElement>(null);
   const menuGroupWidthRef = useRef<number>(0);
-  const actionWidthsRef = useRef<number[]>([]);
   const availableWidthRef = useRef<number>(0);
+  const actionsAndGroupsLengthRef = useRef<number>(0);
+  const timesMeasured = useRef(0);
+  const actionWidthsRef = useRef<number[]>([]);
   const [activeMenuGroup, setActiveMenuGroup] = useState<string | undefined>(
     undefined,
   );
-  const [showableActions, setShowableActions] = useState<
-    MenuActionDescriptor[]
-  >([]);
-  const [rolledUpActions, setRolledUpActions] = useState<
-    (MenuActionDescriptor | MenuGroupDescriptor)[]
-  >([]);
+  const [measuredActions, setMeasuredActions] = useState<MeasuredActions>({
+    showable: [],
+    rolledUp: [],
+  });
   const defaultRollupGroup: MenuGroupDescriptor = {
     title: i18n.translate('Polaris.Actions.moreActions'),
     actions: [],
@@ -63,6 +68,26 @@ export function Actions({actions = [], groups = []}: Props) {
     [],
   );
 
+  const updateActions = useCallback(() => {
+    let actionsAndGroups = [...actions, ...groups];
+
+    if (groups.length > 0) {
+      // We don't want to include actions from the last group
+      // since it is always rendered with its own actions
+      actionsAndGroups = [...actionsAndGroups].slice(
+        0,
+        actionsAndGroups.length - 1,
+      );
+    }
+    const showable = actionsAndGroups.slice(0, measuredActions.showable.length);
+    const rolledUp = actionsAndGroups.slice(
+      measuredActions.showable.length,
+      actionsAndGroups.length,
+    );
+
+    setMeasuredActions({showable, rolledUp});
+  }, [actions, groups, measuredActions.showable.length]);
+
   const measureActions = useCallback(() => {
     if (
       !newDesignLanguage ||
@@ -75,7 +100,7 @@ export function Actions({actions = [], groups = []}: Props) {
     const actionsAndGroups = [...actions, ...groups];
 
     if (actionsAndGroups.length === 1) {
-      setShowableActions(actionsAndGroups);
+      setMeasuredActions({showable: actionsAndGroups, rolledUp: []});
       return;
     }
 
@@ -92,18 +117,25 @@ export function Actions({actions = [], groups = []}: Props) {
         currentAvailableWidth;
 
       if (canFitAction) {
-        currentAvailableWidth -= actionWidthsRef.current[index];
+        currentAvailableWidth -=
+          actionWidthsRef.current[index] + ACTION_SPACING * 2;
         newShowableActions = [...newShowableActions, action];
       } else {
+        currentAvailableWidth = 0;
         // Find last group if it exists and always render it as a rolled up action below
         if (action === lastMenuGroup) return;
-        currentAvailableWidth = 0;
         newRolledUpActions = [...newRolledUpActions, action];
       }
     });
 
-    setShowableActions(newShowableActions);
-    setRolledUpActions(newRolledUpActions);
+    setMeasuredActions({
+      showable: newShowableActions,
+      rolledUp: newRolledUpActions,
+    });
+
+    // Set timesMeasured to true to prevent re-renders until viewport has been resized or props change
+    timesMeasured.current += 1;
+    actionsAndGroupsLengthRef.current = actionsAndGroups.length;
   }, [actions, groups, lastMenuGroup, lastMenuGroupWidth, newDesignLanguage]);
 
   const handleResize = useMemo(
@@ -112,10 +144,12 @@ export function Actions({actions = [], groups = []}: Props) {
         () => {
           if (!newDesignLanguage || !actionsLayoutRef.current) return;
           availableWidthRef.current = actionsLayoutRef.current.offsetWidth;
+          // Set timesMeasured to false to allow re-measuring
+          timesMeasured.current = 0;
           measureActions();
         },
-        20,
-        {leading: false, trailing: true, maxWait: 40},
+        50,
+        {leading: false, trailing: true},
       ),
     [newDesignLanguage, measureActions],
   );
@@ -126,8 +160,17 @@ export function Actions({actions = [], groups = []}: Props) {
     }
 
     availableWidthRef.current = actionsLayoutRef.current.offsetWidth;
+    if (
+      // Allow re-measuring twice
+      // This accounts for the initial paint and re-flow
+      timesMeasured.current >= 2 &&
+      [...actions, ...groups].length === actionsAndGroupsLengthRef.current
+    ) {
+      updateActions();
+      return;
+    }
     measureActions();
-  }, [measureActions]);
+  }, [actions, groups, measureActions, updateActions]);
 
   const className = classNames(
     styles.ActionsLayout,
@@ -136,8 +179,8 @@ export function Actions({actions = [], groups = []}: Props) {
 
   const actionsMarkup = actions.map((action) => {
     if (
-      (newDesignLanguage && showableActions.length > 0) ||
-      rolledUpActions.includes(action)
+      (newDesignLanguage && measuredActions.showable.length > 0) ||
+      measuredActions.rolledUp.includes(action)
     )
       return null;
 
@@ -163,8 +206,8 @@ export function Actions({actions = [], groups = []}: Props) {
   });
 
   const rollUppableActionsMarkup =
-    showableActions.length > 0
-      ? showableActions.map(
+    measuredActions.showable.length > 0
+      ? measuredActions.showable.map(
           (action) =>
             action.content && (
               <SecondaryAction
@@ -178,64 +221,76 @@ export function Actions({actions = [], groups = []}: Props) {
         )
       : null;
 
-  const groupsMarkup = [...groups, defaultRollupGroup]
-    .filter((group) => {
-      return groups.length === 0 && group === defaultRollupGroup
-        ? group
-        : group === lastMenuGroup ||
-            (group !== defaultRollupGroup && !rolledUpActions.includes(group));
-    })
-    .map((group) => {
-      const {title, actions: groupActions, ...rest} = group;
-      const finalRolledUpActions = rolledUpActions.reduce((memo, action) => {
+  const filteredGroups = [...groups, defaultRollupGroup].filter((group) => {
+    return groups.length === 0
+      ? group
+      : group === lastMenuGroup ||
+          !measuredActions.rolledUp.some(
+            (rolledUpGroup) =>
+              isMenuGroup(rolledUpGroup) && rolledUpGroup.title === group.title,
+          );
+  });
+
+  const groupsMarkup = filteredGroups.map((group) => {
+    const {title, actions: groupActions, ...rest} = group;
+    const isDefaultGroup = group === defaultRollupGroup;
+    const isLastMenuGroup = group === lastMenuGroup;
+    const finalRolledUpActions = measuredActions.rolledUp.reduce(
+      (memo, action) => {
         memo.push(...(isMenuGroup(action) ? action.actions : [action]));
 
         return memo;
-      }, [] as ActionListItemDescriptor[]);
-
-      const isDefaultGroup = group === defaultRollupGroup;
-
-      if (
-        isDefaultGroup &&
-        groups.length === 0 &&
-        finalRolledUpActions.length > 0
-      ) {
-        return (
-          <MenuGroup
-            key={title}
-            title={title}
-            active={title === activeMenuGroup}
-            actions={[
-              ...(finalRolledUpActions || actions),
-              ...(!isDefaultGroup ? groupActions : []),
-            ]}
-            {...rest}
-            onOpen={handleMenuGroupToggle}
-            onClose={handleMenuGroupClose}
-            getOffsetWidth={handleActionsOffsetWidth}
-          />
-        );
-      } else if (
-        !isDefaultGroup &&
-        (groups.length > 0 || groupActions.length || actions.length)
-      ) {
-        return (
-          <MenuGroup
-            key={title}
-            title={title}
-            active={title === activeMenuGroup}
-            actions={[
-              ...(finalRolledUpActions || actions),
-              ...(!isDefaultGroup ? groupActions : []),
-            ]}
-            {...rest}
-            onOpen={handleMenuGroupToggle}
-            onClose={handleMenuGroupClose}
-            getOffsetWidth={handleActionsOffsetWidth}
-          />
-        );
-      }
-    });
+      },
+      [] as ActionListItemDescriptor[],
+    );
+    if (!isDefaultGroup && !isLastMenuGroup) {
+      // Render a normal MenuGroup with just its actions
+      return (
+        <MenuGroup
+          key={title}
+          title={title}
+          active={title === activeMenuGroup}
+          actions={groupActions}
+          {...rest}
+          onOpen={handleMenuGroupToggle}
+          onClose={handleMenuGroupClose}
+          getOffsetWidth={handleActionsOffsetWidth}
+        />
+      );
+    } else if (!isDefaultGroup && isLastMenuGroup) {
+      // render the last, rollup group with its actions and finalRolledupActions
+      return (
+        <MenuGroup
+          key={title}
+          title={title}
+          active={title === activeMenuGroup}
+          actions={[...finalRolledUpActions, ...groupActions]}
+          {...rest}
+          onOpen={handleMenuGroupToggle}
+          onClose={handleMenuGroupClose}
+          getOffsetWidth={handleActionsOffsetWidth}
+        />
+      );
+    } else if (
+      isDefaultGroup &&
+      groups.length === 0 &&
+      finalRolledUpActions.length
+    ) {
+      // Render the default group to rollup into if one does not exist
+      return (
+        <MenuGroup
+          key={title}
+          title={title}
+          active={title === activeMenuGroup}
+          actions={finalRolledUpActions}
+          {...rest}
+          onOpen={handleMenuGroupToggle}
+          onClose={handleMenuGroupClose}
+          getOffsetWidth={handleActionsOffsetWidth}
+        />
+      );
+    }
+  });
 
   const groupedActionsMarkup = newDesignLanguage ? (
     <ButtonGroup spacing="extraTight">

--- a/src/components/ActionMenu/components/Actions/tests/Actions.test.tsx
+++ b/src/components/ActionMenu/components/Actions/tests/Actions.test.tsx
@@ -90,7 +90,7 @@ describe('<Actions />', () => {
       expect(wrapper.findAll(MenuGroup)).toHaveLength(1);
     });
 
-    it('updates actions when their props change', () => {
+    it('updates actions when they change', () => {
       function ActionsWithToggle() {
         const initialActions: ActionMenuProps['actions'] = [
           {content: 'initial'},
@@ -117,6 +117,38 @@ describe('<Actions />', () => {
       wrapper.find('button')!.trigger('onClick');
       expect(wrapper).toContainReactComponent(SecondaryAction, {
         children: 'updated',
+      });
+    });
+
+    it('updates groups when they change', () => {
+      function ActionsWithToggle() {
+        const initialGroups: ActionMenuProps['groups'] = [
+          {title: 'initial', actions: [{content: 'initial'}]},
+        ];
+
+        const [groups, setGroups] = useState(initialGroups);
+        const handleActivatorClick = useCallback(
+          () =>
+            setGroups([{title: 'updated', actions: [{content: 'updated'}]}]),
+          [],
+        );
+
+        return (
+          <>
+            <button onClick={handleActivatorClick}>Activator</button>
+            <Actions groups={groups} />
+          </>
+        );
+      }
+
+      const wrapper = mountWithApp(<ActionsWithToggle />, {
+        features: {newDesignLanguage: true},
+      });
+
+      wrapper.find('button')!.trigger('onClick');
+      expect(wrapper).toContainReactComponent(MenuGroup, {
+        title: 'updated',
+        actions: [{content: 'updated'}],
       });
     });
 

--- a/src/components/ActionMenu/components/Actions/tests/Actions.test.tsx
+++ b/src/components/ActionMenu/components/Actions/tests/Actions.test.tsx
@@ -1,9 +1,16 @@
-import React from 'react';
+import React, {useCallback, useState} from 'react';
 import {ActionMenuProps, ActionMenu} from 'index';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
-import {MenuAction, RollupActions} from '../..';
+import {
+  Actions,
+  MenuAction,
+  MenuGroup,
+  RollupActions,
+  SecondaryAction,
+} from '../..';
 
 describe('<Actions />', () => {
   const mockProps: ActionMenuProps = {
@@ -34,7 +41,7 @@ describe('<Actions />', () => {
     );
   });
 
-  it('renders actions in their initial order when no indexes are set', () => {
+  it('renders actions in their initial order', () => {
     const actionsBeforeOverriddenOrder: ActionMenuProps['actions'] = [
       {content: 'mock content 0'},
       {content: 'mock content 1'},
@@ -53,6 +60,95 @@ describe('<Actions />', () => {
 
     wrapper.find(MenuAction).forEach((action, index) => {
       expect(action.props()).toMatchObject(expectedOrderAfterOverride[index]);
+    });
+  });
+
+  describe('Actions', () => {
+    it('renders SecondaryActions when the new design language is true', () => {
+      const actionsBeforeOverriddenOrder: ActionMenuProps['actions'] = [
+        {content: 'mock content 0'},
+        {content: 'mock content 1'},
+        {content: 'mock content 2'},
+      ];
+
+      const wrapper = mountWithApp(
+        <ActionMenu actions={actionsBeforeOverriddenOrder} />,
+        {features: {newDesignLanguage: true}},
+      );
+
+      expect(wrapper.findAll(SecondaryAction)).toHaveLength(3);
+    });
+
+    it('renders a MenuGroup when the new design language is true', () => {
+      const wrapper = mountWithApp(
+        <ActionMenu groups={[{title: 'group', actions: []}]} />,
+        {
+          features: {newDesignLanguage: true},
+        },
+      );
+
+      expect(wrapper.findAll(MenuGroup)).toHaveLength(1);
+    });
+
+    it('updates actions when their props change', () => {
+      function ActionsWithToggle() {
+        const initialActions: ActionMenuProps['actions'] = [
+          {content: 'initial'},
+        ];
+
+        const [actions, setActions] = useState(initialActions);
+        const handleActivatorClick = useCallback(
+          () => setActions([{content: 'updated'}]),
+          [],
+        );
+
+        return (
+          <>
+            <button onClick={handleActivatorClick}>Activator</button>
+            <Actions actions={actions} />
+          </>
+        );
+      }
+
+      const wrapper = mountWithApp(<ActionsWithToggle />, {
+        features: {newDesignLanguage: true},
+      });
+
+      wrapper.find('button')!.trigger('onClick');
+      expect(wrapper).toContainReactComponent(SecondaryAction, {
+        children: 'updated',
+      });
+    });
+
+    it('updates actions when their lengths change', () => {
+      function ActionsWithToggle() {
+        const initialActions: ActionMenuProps['actions'] = [
+          {content: 'initial'},
+        ];
+
+        const [actions, setActions] = useState(initialActions);
+        const handleActivatorClick = useCallback(
+          () => setActions([{content: 'updated 0'}, {content: 'updated 1'}]),
+          [],
+        );
+
+        return (
+          <>
+            <button onClick={handleActivatorClick}>Activator</button>
+            <Actions actions={actions} />
+          </>
+        );
+      }
+
+      const wrapper = mountWithApp(<ActionsWithToggle />, {
+        features: {newDesignLanguage: true},
+      });
+
+      expect(wrapper).toContainReactComponentTimes(SecondaryAction, 1);
+
+      wrapper.find('button')!.trigger('onClick');
+
+      expect(wrapper).toContainReactComponentTimes(SecondaryAction, 2);
     });
   });
 });

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -1,8 +1,16 @@
-import React from 'react';
+import React, {useCallback, useState} from 'react';
 import {animationFrame} from '@shopify/jest-dom-mocks';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
-import {Page, PageProps, Card, Avatar, Badge} from 'components';
+import {
+  Page,
+  PageProps,
+  Card,
+  Avatar,
+  Badge,
+  ActionMenuProps,
+} from 'components';
+import {mountWithApp} from 'test-utilities';
 
 import {Header} from '../components';
 
@@ -126,6 +134,67 @@ describe('<Page />', () => {
         <Page {...mockProps} secondaryActions={secondaryActions} />,
       );
       expect(page.find(Header).prop('secondaryActions')).toBe(secondaryActions);
+    });
+
+    it('re-renders secondaryActions when they change', () => {
+      function PageWithSecondaryActionsToggle() {
+        const initialActions: ActionMenuProps['actions'] = [
+          {content: 'initial'},
+        ];
+
+        const [groups, setGroups] = useState(initialActions);
+        const handleActivatorClick = useCallback(
+          () => setGroups([{content: 'updated'}]),
+          [],
+        );
+
+        return (
+          <>
+            <button onClick={handleActivatorClick}>Activator</button>
+            <Page secondaryActions={groups} />
+          </>
+        );
+      }
+
+      const wrapper = mountWithApp(<PageWithSecondaryActionsToggle />, {
+        features: {newDesignLanguage: true},
+      });
+
+      wrapper.find('button')!.trigger('onClick');
+      expect(wrapper).toContainReactComponent(Page, {
+        secondaryActions: [{content: 'updated'}],
+      });
+    });
+
+    it('re-renders actionGroups when they change', () => {
+      function PageWithActionsGroupsToggle() {
+        const initialGroups: ActionMenuProps['groups'] = [
+          {title: 'initial', actions: [{content: 'initial'}]},
+        ];
+
+        const [groups, setGroups] = useState(initialGroups);
+        const handleActivatorClick = useCallback(
+          () =>
+            setGroups([{title: 'updated', actions: [{content: 'updated'}]}]),
+          [],
+        );
+
+        return (
+          <>
+            <button onClick={handleActivatorClick}>Activator</button>
+            <Page actionGroups={groups} />
+          </>
+        );
+      }
+
+      const wrapper = mountWithApp(<PageWithActionsGroupsToggle />, {
+        features: {newDesignLanguage: true},
+      });
+
+      wrapper.find('button')!.trigger('onClick');
+      expect(wrapper).toContainReactComponent(Page, {
+        actionGroups: [{title: 'updated', actions: [{content: 'updated'}]}],
+      });
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes: https://github.com/Shopify/polaris-react/issues/3575
And allows actions and groups to re-render in their previously assigned position, only re-measuring if the lengths of actions and groups changes

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

There's now a toggle in the details page under more actions that changes the actions length. Make sure that works properly and re-measures on toggle

Also make sure that the view button logs out the updated product description

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
