### PR TITLE
[Card] Adds flushed prop to <Card/> Section

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Allowed `Thumbnail` `source` property to support `icons` ([#3328](https://github.com/Shopify/polaris-react/pull/3328))
+- Added `flush` prop to `Card.Section` ([#3645](https://github.com/Shopify/polaris-react/pull/3645))
+- Allow `Thumbnail` `source` property to support `icons` ([#3328](https://github.com/Shopify/polaris-react/pull/3328))
 - **`Button`:** New `role` prop for `<button />` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
 - Added `preventFocusOnClose` to `Popover` ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
 - Added color fallback values to `focus-ring` mixin ([#3626](https://github.com/Shopify/polaris-react/pull/3626))

--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -63,6 +63,14 @@
   }
 }
 
+.Section-flush {
+  padding: spacing(none);
+
+  @include page-content-when-not-fully-condensed {
+    padding: spacing(none);
+  }
+}
+
 .Section-subdued {
   background-color: var(--p-surface-subdued, color('sky', 'lighter'));
 

--- a/src/components/Card/README.md
+++ b/src/components/Card/README.md
@@ -669,6 +669,29 @@ Use as a broad example that includes most props available to card.
 </Card>
 ```
 
+### Card with flushed sections
+
+<!-- example-for: web -->
+
+Use when you need further control over the spacing of your card sections.
+
+```jsx
+<Card>
+  <Card.Section flush>
+    <Image
+      source="https://polaris.shopify.com/bundles/bc7087219578918d62ac40bf4b4f99ce.png"
+      alt="turtle illustration centered with body text and a button"
+    />
+  </Card.Section>
+  <Card.Section subdued>
+    <TextContainer>
+      You can use sales reports to see information about your customers’ orders
+      based on criteria such as sales over time, by channel, or by staff.
+    </TextContainer>
+  </Card.Section>
+</Card>
+```
+
 ---
 
 ## Related components

--- a/src/components/Card/components/Section/Section.tsx
+++ b/src/components/Card/components/Section/Section.tsx
@@ -12,6 +12,7 @@ export interface SectionProps {
   title?: React.ReactNode;
   children?: React.ReactNode;
   subdued?: boolean;
+  flush?: boolean;
   fullWidth?: boolean;
   actions?: ComplexAction[];
 }
@@ -20,11 +21,13 @@ export function Section({
   children,
   title,
   subdued,
+  flush,
   fullWidth,
   actions,
 }: SectionProps) {
   const className = classNames(
     styles.Section,
+    flush && styles['Section-flush'],
     subdued && styles['Section-subdued'],
     fullWidth && styles['Section-fullWidth'],
   );


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Addresses: https://github.com/Shopify/marketing-integrations/issues/1052

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Adds a `flushed` prop to `Card.Section`. The `flushed` prop removes both the vertical and horizontal padding on the corresponding `Card.Section` that it has been applied to. 

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="https://user-images.githubusercontent.com/10606336/99573460-23fb9e00-29a4-11eb-8d6c-625855a18b4c.png
" alt="Card with the first section without padding and the second section with padding">
    </details>
-->

Without the `flush` prop:
![image](https://user-images.githubusercontent.com/10606336/100631672-f8f54080-32f9-11eb-8cb4-e060734fb079.png)

Withe the `flush` prop:
<img src="https://user-images.githubusercontent.com/10606336/101398556-447c9100-389c-11eb-8537-112337be5b73.png" alt="Card with the first section without padding and the second section with padding">


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Card, TextContainer} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Card>
  <Card.Section flush>
    <Image
      source="https://polaris.shopify.com/bundles/bc7087219578918d62ac40bf4b4f99ce.png"
      alt="turtle illustration centered with body text and a button"
    />
  </Card.Section>
  <Card.Section subdued>
    <TextContainer>
      You can use sales reports to see information about your customers’ orders
      based on criteria such as sales over time, by channel, or by staff.
    </TextContainer>
  </Card.Section>
</Card>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
