### PR TITLE
[ThemeProvider] Add prop to force custom properties on elements that render outside of context

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,7 +26,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added focus styles to `CloseButton` in `Modal` ([#3628](https://github.com/Shopify/polaris-react/pull/3628))
 - Fixed `Filters` duplicated `ConnectedFilter` ids ([#3651](https://github.com/Shopify/polaris-react/pull/3651))
 - Fixed `Banner` `secondaryAction` only rendering if `action` is set ([#2949](https://github.com/Shopify/polaris-react/pull/2949))
-- Added a `rendersOutsideOfContext` to `ThemeProvider` for elements that render outside of parent context ([#3652](https://github.com/Shopify/polaris-react/pull/3652))
+- Added a `rendersOutsideOfAppFrame` to `ThemeProvider` for elements that render outside of the DOM tree to their parent context ([#3652](https://github.com/Shopify/polaris-react/pull/3652))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,6 +26,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added focus styles to `CloseButton` in `Modal` ([#3628](https://github.com/Shopify/polaris-react/pull/3628))
 - Fixed `Filters` duplicated `ConnectedFilter` ids ([#3651](https://github.com/Shopify/polaris-react/pull/3651))
 - Fixed `Banner` `secondaryAction` only rendering if `action` is set ([#2949](https://github.com/Shopify/polaris-react/pull/2949))
+- Added a `rendersOutsideOfContext` to `ThemeProvider` for elements that render outside of parent context ([#3652](https://github.com/Shopify/polaris-react/pull/3652))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,7 +26,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added focus styles to `CloseButton` in `Modal` ([#3628](https://github.com/Shopify/polaris-react/pull/3628))
 - Fixed `Filters` duplicated `ConnectedFilter` ids ([#3651](https://github.com/Shopify/polaris-react/pull/3651))
 - Fixed `Banner` `secondaryAction` only rendering if `action` is set ([#2949](https://github.com/Shopify/polaris-react/pull/2949))
-- Added a `rendersOutsideOfAppFrame` to `ThemeProvider` for elements that render outside of the DOM tree to their parent context ([#3652](https://github.com/Shopify/polaris-react/pull/3652))
+- Added a `alwaysRenderCustomProperties` to `ThemeProvider` for elements that render outside of the DOM tree to their parent context ([#3652](https://github.com/Shopify/polaris-react/pull/3652))
 
 ### Documentation
 

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -232,7 +232,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
           tabIndex={0}
           onFocus={this.handleFocusFirstItem}
         />
-        <ThemeProvider rendersOutsideOfAppFrame theme={{colorScheme}}>
+        <ThemeProvider alwaysRenderCustomProperties theme={{colorScheme}}>
           <div className={styles.Wrapper}>{content}</div>
         </ThemeProvider>
         <div

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -232,7 +232,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
           tabIndex={0}
           onFocus={this.handleFocusFirstItem}
         />
-        <ThemeProvider theme={{colorScheme, rendersOutsideOfContext: true}}>
+        <ThemeProvider rendersOutsideOfAppFrame theme={{colorScheme}}>
           <div className={styles.Wrapper}>{content}</div>
         </ThemeProvider>
         <div

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -232,7 +232,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
           tabIndex={0}
           onFocus={this.handleFocusFirstItem}
         />
-        <ThemeProvider theme={{colorScheme}}>
+        <ThemeProvider theme={{colorScheme, rendersOutsideOfContext: true}}>
           <div className={styles.Wrapper}>{content}</div>
         </ThemeProvider>
         <div

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -31,14 +31,14 @@ interface ThemeProviderProps {
    * For use in components such as portals which render outside of parent context
    * Forces the render of custom properties
    */
-  rendersOutsideOfAppFrame?: boolean;
+  alwaysRenderCustomProperties?: boolean;
   /** The content to display */
   children?: React.ReactNode;
 }
 
 export function ThemeProvider({
   theme: themeConfig,
-  rendersOutsideOfAppFrame = false,
+  alwaysRenderCustomProperties = false,
   children,
 }: ThemeProviderProps) {
   const {newDesignLanguage} = useFeatures();
@@ -104,7 +104,7 @@ export function ThemeProvider({
   if (isParentThemeProvider) {
     style = customProperties;
   } else if (
-    rendersOutsideOfAppFrame ||
+    alwaysRenderCustomProperties ||
     (!isParentThemeProvider &&
       parentContext!.cssCustomProperties !== toString(customProperties))
   ) {

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -27,12 +27,18 @@ interface ThemeProviderThemeConfig extends Discard<ThemeConfig, 'colorScheme'> {
 interface ThemeProviderProps {
   /** Custom logos and colors provided to select components */
   theme: ThemeProviderThemeConfig;
+  /**
+   * For use in components such as portals which render outside of parent context
+   * Forces the render of custom properties
+   */
+  rendersOutsideOfAppFrame?: boolean;
   /** The content to display */
   children?: React.ReactNode;
 }
 
 export function ThemeProvider({
   theme: themeConfig,
+  rendersOutsideOfAppFrame,
   children,
 }: ThemeProviderProps) {
   const {newDesignLanguage} = useFeatures();
@@ -85,7 +91,6 @@ export function ThemeProvider({
   // Otherwise, setting a style property to `undefined` does not remove it from the DOM.
   const backgroundColor = customProperties['--p-background'] || '';
   const color = customProperties['--p-text'] || '';
-  const {rendersOutsideOfContext} = themeConfig;
 
   useEffect(() => {
     if (isParentThemeProvider) {
@@ -99,7 +104,7 @@ export function ThemeProvider({
   if (isParentThemeProvider) {
     style = customProperties;
   } else if (
-    rendersOutsideOfContext ||
+    rendersOutsideOfAppFrame ||
     (!isParentThemeProvider &&
       parentContext!.cssCustomProperties !== toString(customProperties))
   ) {

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -85,6 +85,7 @@ export function ThemeProvider({
   // Otherwise, setting a style property to `undefined` does not remove it from the DOM.
   const backgroundColor = customProperties['--p-background'] || '';
   const color = customProperties['--p-text'] || '';
+  const {rendersOutsideOfContext} = themeConfig;
 
   useEffect(() => {
     if (isParentThemeProvider) {
@@ -98,8 +99,9 @@ export function ThemeProvider({
   if (isParentThemeProvider) {
     style = customProperties;
   } else if (
-    !isParentThemeProvider &&
-    parentContext!.cssCustomProperties !== toString(customProperties)
+    rendersOutsideOfContext ||
+    (!isParentThemeProvider &&
+      parentContext!.cssCustomProperties !== toString(customProperties))
   ) {
     style = {...customProperties, ...{color}};
   } else {

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -28,8 +28,9 @@ interface ThemeProviderProps {
   /** Custom logos and colors provided to select components */
   theme: ThemeProviderThemeConfig;
   /**
-   * For use in components such as portals which render outside of parent context
-   * Forces the render of custom properties
+   * By default, Polaris avoids re-declaring custom properties within the same React tree
+   * This prop ensures that the CSS custom properties are always rendered. This is useful
+   * for components such as portals that render outside of the root DOM node
    */
   alwaysRenderCustomProperties?: boolean;
   /** The content to display */

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -38,7 +38,7 @@ interface ThemeProviderProps {
 
 export function ThemeProvider({
   theme: themeConfig,
-  rendersOutsideOfAppFrame,
+  rendersOutsideOfAppFrame = false,
   children,
 }: ThemeProviderProps) {
   const {newDesignLanguage} = useFeatures();

--- a/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -216,10 +216,13 @@ describe('<ThemeProvider />', () => {
       });
     });
 
-    it('renders custom properties if themes are identical but rendersOutsideOfAppFrame is true', () => {
+    it('renders custom properties if themes are identical but alwaysRenderCustomProperties is true', () => {
       const themeProvider = mountWithNewDesignLanguage(
         <ThemeProvider theme={{colorScheme: 'dark'}}>
-          <ThemeProvider theme={{colorScheme: 'dark'}} rendersOutsideOfAppFrame>
+          <ThemeProvider
+            theme={{colorScheme: 'dark'}}
+            alwaysRenderCustomProperties
+          >
             <p>Hello</p>
           </ThemeProvider>
         </ThemeProvider>,

--- a/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/src/components/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -216,6 +216,32 @@ describe('<ThemeProvider />', () => {
       });
     });
 
+    it('renders custom properties if themes are identical but rendersOutsideOfAppFrame is true', () => {
+      const themeProvider = mountWithNewDesignLanguage(
+        <ThemeProvider theme={{colorScheme: 'dark'}}>
+          <ThemeProvider theme={{colorScheme: 'dark'}} rendersOutsideOfAppFrame>
+            <p>Hello</p>
+          </ThemeProvider>
+        </ThemeProvider>,
+        {newDesignLanguage: true},
+      );
+
+      expect(themeProvider.findAll('div')[1]).toHaveReactProps({
+        style: expect.objectContaining({
+          '--p-background': expect.any(String),
+          '--p-text': expect.any(String),
+          '--p-interactive': expect.any(String),
+          '--p-action-secondary': expect.any(String),
+          '--p-action-primary': expect.any(String),
+          '--p-action-critical': expect.any(String),
+          '--p-surface-warning': expect.any(String),
+          '--p-surface-highlight': expect.any(String),
+          '--p-surface-success': expect.any(String),
+          '--p-decorative-one-text': expect.any(String),
+        }),
+      });
+    });
+
     it('adds css custom properties for color roles provided', () => {
       const themeProvider = mountWithNewDesignLanguage(
         <ThemeProvider

--- a/src/utilities/theme/types.ts
+++ b/src/utilities/theme/types.ts
@@ -52,9 +52,6 @@ export interface ThemeConfig {
   colors?: Partial<RoleColors> & LegacyColors;
   colorScheme?: ColorScheme;
   config?: Config;
-  /** For use in components such as portals which render outside of parent context */
-  /** Forces the render of custom properties */
-  rendersOutsideOfContext?: boolean;
   frameOffset?: number;
 }
 

--- a/src/utilities/theme/types.ts
+++ b/src/utilities/theme/types.ts
@@ -52,6 +52,9 @@ export interface ThemeConfig {
   colors?: Partial<RoleColors> & LegacyColors;
   colorScheme?: ColorScheme;
   config?: Config;
+  /** For use in components such as portals which render outside of parent context */
+  /** Forces the render of custom properties */
+  rendersOutsideOfContext?: boolean;
   frameOffset?: number;
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3634

The react render tree has theme provider wrapping portals so that portals can receive that context. 

They're doing sort of the right thing in terms of not rendering the custom properties when the color schemes match i.e. a theme provider with dark color scheme wrapping a popover with a dark color scheme won't render the custom properties because it's determining that it doesn't have to based on context. The problem is that it renders outside of where those properties are set in the DOM

### WHAT is this pull request doing?

This adds a `rendersOutsideOfContext` prop specifically for portal items that depend on context but also render outside of it.

I've thought of alternate approaches as well:
1. Wrapping this around portal provider. This doesn't work because it's still outside of where the context is set. `rendersOutsideOfContext` needs to be set directly on the element that is comparing against context
2. There's no way to be clever about this inside of the ThemeProvider unless we directly checked the DOM

Open to other suggestions

### How to 🎩

Playground included:

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {ActionList, Frame, Button, Popover, ThemeProvider, Toast} from '../src';

export function Playground() {
  const [popoverActive, setPopoverActive] = useState(true);
  const [, setToastActive] = useState(true);

  const togglePopoverActive = useCallback(
    () => setPopoverActive((popoverActive) => !popoverActive),
    [],
  );

  const activator = (
    <Button onClick={togglePopoverActive} disclosure>
      More actions
    </Button>
  );

  return (
    <Frame>
      <h1>dark / dark</h1>
      <ThemeProvider theme={{colorScheme: 'dark'}}>
        <div style={{height: '250px'}}>
          <Popover
            active={popoverActive}
            activator={activator}
            onClose={togglePopoverActive}
            colorScheme="dark"
          >
            <ActionList items={[{content: 'Import'}, {content: 'Export'}]} />
          </Popover>
        </div>
      </ThemeProvider>
      <h1>light / light</h1>
      <ThemeProvider theme={{colorScheme: 'light'}}>
        <div style={{height: '250px'}}>
          <Popover
            active={popoverActive}
            activator={activator}
            onClose={togglePopoverActive}
            colorScheme="light"
          >
            <ActionList items={[{content: 'Import'}, {content: 'Export'}]} />
          </Popover>
        </div>
      </ThemeProvider>
      <h1>light / dark</h1>
      <ThemeProvider theme={{colorScheme: 'light'}}>
        <div style={{height: '250px'}}>
          <Popover
            active={popoverActive}
            activator={activator}
            onClose={togglePopoverActive}
            colorScheme="dark"
          >
            <ActionList items={[{content: 'Import'}, {content: 'Export'}]} />
          </Popover>
        </div>
      </ThemeProvider>
      <h1>dark / light</h1>
      <ThemeProvider theme={{colorScheme: 'dark'}}>
        <div style={{height: '250px'}}>
          <Popover
            active={popoverActive}
            activator={activator}
            onClose={togglePopoverActive}
            colorScheme="light"
          >
            <ActionList items={[{content: 'Import'}, {content: 'Export'}]} />
          </Popover>
        </div>
      </ThemeProvider>
      <Toast onDismiss={() => setToastActive(false)} content="sup" />
    </Frame>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
