### PR TITLE
Separate progress & status labels

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -25,6 +25,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `Modal` header border color ([#3616](https://github.com/Shopify/polaris-react/pull/3616))
 - Added focus styles to `CloseButton` in `Modal` ([#3628](https://github.com/Shopify/polaris-react/pull/3628))
 - Fixed `Filters` duplicated `ConnectedFilter` ids ([#3651](https://github.com/Shopify/polaris-react/pull/3651))
+- Internationalize `Badge` labels ([#3655](https://github.com/Shopify/polaris-react/pull/3655))
 - Fixed `Banner` `secondaryAction` only rendering if `action` is set ([#2949](https://github.com/Shopify/polaris-react/pull/2949))
 
 ### Documentation

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -20,7 +20,8 @@
         "attention": "Upozornění",
         "new": "Nové",
         "critical": "Kritický"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Načítání",

--- a/locales/da.json
+++ b/locales/da.json
@@ -20,7 +20,8 @@
         "attention": "Bemærk",
         "new": "Nye",
         "critical": "Kritisk"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Indlæser",

--- a/locales/de.json
+++ b/locales/de.json
@@ -20,7 +20,8 @@
         "attention": "Prüfung erforderlich",
         "new": "Neu",
         "critical": "Kritisch"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Wird geladen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -23,7 +23,8 @@
         "critical": "Critical",
         "attention": "Attention",
         "new": "New"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Loading",

--- a/locales/es.json
+++ b/locales/es.json
@@ -20,7 +20,8 @@
         "attention": "Atención",
         "new": "Nuevo",
         "critical": "Crítico"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Cargando",

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -20,7 +20,8 @@
         "attention": "Huomio",
         "new": "Uusi",
         "critical": "Kriittinen"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Ladataan",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -20,7 +20,8 @@
         "attention": "Attention",
         "new": "Nouveau",
         "critical": "Critique"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Chargement",

--- a/locales/it.json
+++ b/locales/it.json
@@ -20,7 +20,8 @@
         "attention": "Attenzione",
         "new": "Nuovi",
         "critical": "Critico"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Caricamento",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -20,7 +20,8 @@
         "attention": "注意",
         "new": "新規",
         "critical": "クリティカル"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "読み込んでいます",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -20,7 +20,8 @@
         "attention": "주의",
         "new": "신규",
         "critical": "중요"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "로드 중",

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -20,7 +20,8 @@
         "attention": "Obs",
         "new": "Ny",
         "critical": "Kritisk"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Laster inn",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -20,7 +20,8 @@
         "attention": "Attentie",
         "new": "Nieuw",
         "critical": "Kritiek"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Laden",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -20,7 +20,8 @@
         "attention": "Uwaga",
         "new": "Nowe",
         "critical": "Krytyczny"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Ładowanie",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -20,7 +20,8 @@
         "attention": "Atenção",
         "new": "Novo",
         "critical": "Crítico"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Carregando",

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -20,7 +20,8 @@
         "attention": "Atenção",
         "new": "Novo",
         "critical": "Crítico"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Carregar",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -20,7 +20,8 @@
         "attention": "Observera",
         "new": "Ny",
         "critical": "Kritisk"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Laddar",

--- a/locales/th.json
+++ b/locales/th.json
@@ -20,7 +20,8 @@
         "attention": "ระวัง",
         "new": "ใหม่",
         "critical": "ร้ายแรง"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "กำลังโหลด",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -20,7 +20,8 @@
         "attention": "Dikkat",
         "new": "Yeni",
         "critical": "Kritik"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "Yükleniyor",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -20,7 +20,8 @@
         "attention": "注意",
         "new": "新建",
         "critical": "重要信息"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "正在加载",

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -20,7 +20,8 @@
         "attention": "注意",
         "new": "新增",
         "critical": "重要"
-      }
+      },
+      "progressAndStatus": "{statusLabel} {progressLabel}"
     },
     "Button": {
       "spinnerAccessibilityLabel": "載入中",

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -59,59 +59,63 @@ export function Badge({
     withinFilter && styles.withinFilter,
   );
 
-  let progressMarkup;
+  let progressLabel = '';
   switch (progress) {
     case PROGRESS_LABELS.incomplete:
-      progressMarkup = i18n.translate(
+      progressLabel = i18n.translate(
         'Polaris.Badge.PROGRESS_LABELS.incomplete',
       );
       break;
     case PROGRESS_LABELS.partiallyComplete:
-      progressMarkup = i18n.translate(
+      progressLabel = i18n.translate(
         'Polaris.Badge.PROGRESS_LABELS.partiallyComplete',
       );
       break;
     case PROGRESS_LABELS.complete:
-      progressMarkup = i18n.translate('Polaris.Badge.PROGRESS_LABELS.complete');
+      progressLabel = i18n.translate('Polaris.Badge.PROGRESS_LABELS.complete');
       break;
   }
 
-  const pipMarkup = progress ? (
-    <span className={styles.Pip}>
-      <VisuallyHidden>{progressMarkup}</VisuallyHidden>
-    </span>
-  ) : null;
-
-  let statusMarkup;
+  let statusLabel = '';
   switch (status) {
     case STATUS_LABELS.info:
-      statusMarkup = i18n.translate('Polaris.Badge.STATUS_LABELS.info');
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.info');
       break;
     case STATUS_LABELS.success:
-      statusMarkup = i18n.translate('Polaris.Badge.STATUS_LABELS.success');
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.success');
       break;
     case STATUS_LABELS.warning:
-      statusMarkup = i18n.translate('Polaris.Badge.STATUS_LABELS.warning');
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.warning');
       break;
     case STATUS_LABELS.critical:
-      statusMarkup = i18n.translate('Polaris.Badge.STATUS_LABELS.critical');
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.critical');
       break;
     case STATUS_LABELS.attention:
-      statusMarkup = i18n.translate('Polaris.Badge.STATUS_LABELS.attention');
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.attention');
       break;
     case STATUS_LABELS.new:
-      statusMarkup = i18n.translate('Polaris.Badge.STATUS_LABELS.new');
+      statusLabel = i18n.translate('Polaris.Badge.STATUS_LABELS.new');
       break;
   }
 
-  const statusLabelMarkup = status ? (
-    <VisuallyHidden>{statusMarkup}</VisuallyHidden>
-  ) : null;
+  const accessibilityLabel = i18n.translate('Polaris.Badge.progressAndStatus', {
+    progressLabel,
+    statusLabel,
+  });
+
+  const accessibilityMarkup = (progress || status) && (
+    <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>
+  );
+
+  const contentClassNames = classNames(progressLabel && styles.Pip);
+
+  const contentMarkup = accessibilityLabel && (
+    <span className={contentClassNames}>{accessibilityMarkup}</span>
+  );
 
   return (
     <span className={className}>
-      {statusLabelMarkup}
-      {pipMarkup}
+      {contentMarkup}
       {children}
     </span>
   );

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -103,19 +103,19 @@ export function Badge({
     statusLabel,
   });
 
-  const accessibilityMarkup = (progress || status) && (
+  let accessibilityMarkup = (progress || status) && (
     <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>
   );
 
-  const contentClassNames = classNames(progressLabel && styles.Pip);
-
-  const contentMarkup = accessibilityLabel && (
-    <span className={contentClassNames}>{accessibilityMarkup}</span>
-  );
+  if (progressLabel) {
+    accessibilityMarkup = (
+      <span className={styles.Pip}>{accessibilityMarkup}</span>
+    );
+  }
 
   return (
     <span className={className}>
-      {contentMarkup}
+      {accessibilityMarkup}
       {children}
     </span>
   );

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -103,7 +103,7 @@ export function Badge({
     statusLabel,
   });
 
-  let accessibilityMarkup = (progress || status) && (
+  let accessibilityMarkup = (progressLabel || statusLabel) && (
     <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>
   );
 

--- a/src/components/Badge/tests/Badge.test.tsx
+++ b/src/components/Badge/tests/Badge.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {VisuallyHidden} from 'components';
 
 import {Badge} from '../Badge';
@@ -19,5 +20,31 @@ describe('<Badge />', () => {
   it('accepts a progress prop and renders a visually hidden label', () => {
     const badge = mountWithAppProvider(<Badge progress="incomplete" />);
     expect(badge.find(VisuallyHidden).exists()).toBe(true);
+  });
+
+  it('renders progress and status labels in the same element', () => {
+    const badge = mountWithApp(
+      <Badge progress="incomplete" status="attention" />,
+    );
+
+    expect(badge).toContainReactComponentTimes(VisuallyHidden, 1, {
+      children: 'Attention Incomplete',
+    });
+  });
+
+  it('does not add pip styles when progress is not provided', () => {
+    const badge = mountWithApp(<Badge status="attention" />);
+
+    expect(badge).not.toContainReactComponent('span', {
+      className: 'Pip',
+    });
+  });
+
+  it('renders with pip styles when progress is provided', () => {
+    const badge = mountWithApp(<Badge progress="incomplete" />);
+
+    expect(badge).toContainReactComponent('span', {
+      className: 'Pip',
+    });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Linking internal issue below

### Gif
![Screen Recording 2020-11-23 at 02 18 47 PM](https://user-images.githubusercontent.com/24610840/100022835-db801e00-2db1-11eb-8414-80fe104c8e39.gif)


### WHAT is this pull request doing?

Separating progress & status labels. Previously they're combined (placing adjacent markup in spans). Resulting in `AttentionComplete` for example. Apart from being a single word, we're assuming this is optional for all locales. I added a separate translation key, so the correct orientation can be applied for each language.

### How to 🎩

* Play around with progress/status and voice tools.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Card, Badge} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Example />
    </Page>
  );
}

function Example() {
  return (
    <div style={{height: '200px'}}>
      <Card sectioned>
        <Badge progress="complete" status="attention">
          status & progress
        </Badge>
        <Badge status="attention">status</Badge>
        <Badge progress="complete">progress</Badge>
      </Card>
    </div>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
