### PR TITLE
Add accessibilityLabel to Link component

### DIFF
--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -23,6 +23,8 @@ export interface LinkProps {
   monochrome?: boolean;
   /** Callback when a link is clicked */
   onClick?(): void;
+  /** Descriptive text to be read to screenreaders */
+  accessibilityLabel?: string;
 }
 
 export function Link({
@@ -32,6 +34,7 @@ export function Link({
   external,
   id,
   monochrome,
+  accessibilityLabel,
 }: LinkProps) {
   const i18n = useI18n();
   let childrenMarkup = children;
@@ -72,11 +75,18 @@ export function Link({
             url={url}
             external={external}
             id={id}
+            accessibilityLabel={accessibilityLabel}
           >
             {childrenMarkup}
           </UnstyledLink>
         ) : (
-          <button type="button" onClick={onClick} className={className} id={id}>
+          <button
+            type="button"
+            onClick={onClick}
+            className={className}
+            id={id}
+            aria-label={accessibilityLabel}
+          >
             {childrenMarkup}
           </button>
         );

--- a/src/components/Link/tests/Link.test.tsx
+++ b/src/components/Link/tests/Link.test.tsx
@@ -123,4 +123,32 @@ describe('<Link />', () => {
       });
     });
   });
+
+  describe('accessibilityLabel', () => {
+    it('passes prop to the button url is not provided', () => {
+      const mockAccessibilityLabel = 'mock accessibility label';
+      const link = mountWithAppProvider(
+        <Link accessibilityLabel={mockAccessibilityLabel} />,
+      );
+
+      expect(link.find('button').prop('aria-label')).toBe(
+        mockAccessibilityLabel,
+      );
+    });
+
+    it('passes prop', () => {
+      const mockAccessibilityLabel = 'mock accessibility label';
+
+      const link = mountWithAppProvider(
+        <Link
+          url="https://shopify.com"
+          accessibilityLabel={mockAccessibilityLabel}
+        />,
+      );
+
+      expect(link.find(Link).prop('accessibilityLabel')).toBe(
+        mockAccessibilityLabel,
+      );
+    });
+  });
 });

--- a/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/src/components/UnstyledLink/UnstyledLink.tsx
@@ -20,11 +20,18 @@ export const UnstyledLink = memo(
       return <LinkComponent {...unstyled.props} {...props} />;
     }
 
-    const {external, url, ...rest} = props;
+    const {external, url, accessibilityLabel, ...rest} = props;
     const target = external ? '_blank' : undefined;
     const rel = external ? 'noopener noreferrer' : undefined;
     return (
-      <a target={target} {...rest} href={url} rel={rel} {...unstyled.props} />
+      <a
+        target={target}
+        {...rest}
+        aria-label={accessibilityLabel}
+        href={url}
+        rel={rel}
+        {...unstyled.props}
+      />
     );
   }),
 );

--- a/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
+++ b/src/components/UnstyledLink/tests/UnstyledLink.test.tsx
@@ -57,5 +57,17 @@ describe('<UnstyledLink />', () => {
       ).find('a');
       expect(anchorElement.prop('download')).toBeFalsy();
     });
+
+    describe('accessibilityLabel', () => {
+      it('passes prop', () => {
+        const mockAccessibilityLabel = 'mock accessibility label';
+        const anchorElement = mountWithAppProvider(
+          <UnstyledLink accessibilityLabel={mockAccessibilityLabel} />,
+        );
+        expect(anchorElement.find('a').prop('aria-label')).toBe(
+          mockAccessibilityLabel,
+        );
+      });
+    });
   });
 });

--- a/src/utilities/link/types.ts
+++ b/src/utilities/link/types.ts
@@ -8,6 +8,8 @@ export interface LinkLikeComponentProps
   external?: boolean;
   /** Makes the browser download the url instead of opening it. Provides a hint for the downloaded filename if it is a string value. */
   download?: string | boolean;
+  /** Descriptive text to be read to screenreaders */
+  accessibilityLabel?: string;
   [key: string]: any;
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/458 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds the `accessibilityLabel` prop to the `Link` component

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

- Add the `accessibilityLabel` prop to the `Link` component and observe the `aria-label` prop is added to the component

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [X] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [X] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
