### PR TITLE
[Button] Add content stretch capability, fix 3663

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added color fallback values to `focus-ring` mixin ([#3626](https://github.com/Shopify/polaris-react/pull/3626))
 - Added `role="presentational"` to list items for `Tabs` ([#3647](https://github.com/Shopify/polaris-react/pull/3647))
 - Allowed consumers to set custom container element on `PortalsManager` ([#3644](https://github.com/Shopify/polaris-react/pull/3644))
+- **`Button`:** New `stretchContent` prop for `<button />` ([#3664](https://github.com/Shopify/polaris-react/pull/3664))
 
 ### Bug fixes
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -116,6 +116,11 @@ $stacking-order: (
   text-align: right;
 }
 
+.stretchContent:not(.loading) > .Content {
+  justify-content: space-between;
+  width: 100%;
+}
+
 .Icon {
   transition: color duration() easing();
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -43,6 +43,8 @@ export interface ButtonProps extends BaseButton {
   monochrome?: boolean;
   /** Icon to display to the left of the button content */
   icon?: React.ReactElement | IconSource;
+  /** Stretch the content (text + icon) from side to side */
+  stretchContent?: boolean;
   /** Disclosure button connected right of the button. Toggles a popover action list. */
   connectedDisclosure?: ConnectedDisclosure;
 }
@@ -114,6 +116,7 @@ export function Button({
   textAlign,
   fullWidth,
   connectedDisclosure,
+  stretchContent,
 }: ButtonProps) {
   const {newDesignLanguage} = useFeatures();
   const i18n = useI18n();
@@ -136,6 +139,7 @@ export function Button({
     fullWidth && styles.fullWidth,
     icon && children == null && styles.iconOnly,
     connectedDisclosure && styles.connectedDisclosure,
+    stretchContent && styles.stretchContent,
   );
 
   const disclosureIcon = (

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -314,6 +314,33 @@ function DisclosureButtion() {
 }
 ```
 
+### Stretched disclosure button
+
+<!-- example-for: web -->
+
+Stretch disclosure button content its full width for a dropdown look
+
+```jsx
+function StretchedDisclosureButton() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div style={{width: '200px'}}>
+      <Button
+        disclosure={expanded ? 'up' : 'down'}
+        fullWidth
+        stretchContent
+        onClick={() => {
+          setExpanded(!expanded);
+        }}
+      >
+        {expanded ? 'Show less' : 'Show more'}
+      </Button>
+    </div>
+  );
+}
+```
+
 ### Split button
 
 <!-- example-for: web -->

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -330,9 +330,7 @@ function StretchedDisclosureButton() {
         disclosure={expanded ? 'up' : 'down'}
         fullWidth
         stretchContent
-        onClick={() => {
-          setExpanded(!expanded);
-        }}
+        onClick={() => setExpanded(!expanded)}
       >
         {expanded ? 'Show less' : 'Show more'}
       </Button>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3663

Adds possibility to stretch button content over its full width for dropdown triggers.

Corresponding feature request: https://github.com/Shopify/intl-shipping-methods/issues/910

### WHAT is this pull request doing?

![image](https://user-images.githubusercontent.com/72969127/100612807-d40dc700-3313-11eb-8432-f1f6e79ac39f.png)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
       <Button disclosure fullWidth stretchContent>
          Stretched Button
       </Button>
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
