### PR TITLE
[Button] Add iconPosition support to button component

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added color fallback values to `focus-ring` mixin ([#3626](https://github.com/Shopify/polaris-react/pull/3626))
 - Added `role="presentational"` to list items for `Tabs` ([#3647](https://github.com/Shopify/polaris-react/pull/3647))
 - Allowed consumers to set custom container element on `PortalsManager` ([#3644](https://github.com/Shopify/polaris-react/pull/3644))
+- **`Button`:** New `iconPosition` prop for `<button />` ([#3666](https://github.com/Shopify/polaris-react/pull/3666))
 
 ### Bug fixes
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -124,11 +124,15 @@ $stacking-order: (
   margin-left: -(spacing(extra-tight));
 
   &:last-child {
-    // This compensates for the disclosure icon, which is substantially
-    // inset within the viewbox (and makes it look like there is too much
-    // spacing on the right of the button)
-    margin-right: -(spacing(tight));
+    margin-right: -(spacing(extra-tight));
     margin-left: spacing(extra-tight);
+
+    &.insetIcon {
+      // This compensates for the disclosure icon, which is substantially
+      // inset within the viewbox (and makes it look like there is too much
+      // spacing on the right of the button)
+      margin-right: -(spacing(tight));
+    }
   }
 
   + *:not(.Icon) {

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -124,11 +124,15 @@ $stacking-order: (
   margin-left: -(spacing(extra-tight));
 
   &:last-child {
-    // This compensates for the disclosure icon, which is substantially
-    // inset within the viewbox (and makes it look like there is too much
-    // spacing on the right of the button)
-    margin-right: -(spacing(tight));
     margin-left: spacing(extra-tight);
+    margin-right: -(spacing(extra-tight));
+
+    .disclosure & {
+      // This compensates for the disclosure icon, which is substantially
+      // inset within the viewbox (and makes it look like there is too much
+      // spacing on the right of the button)
+      margin-right: -(spacing(tight));
+    }
   }
 
   + *:not(.Icon) {

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -124,15 +124,11 @@ $stacking-order: (
   margin-left: -(spacing(extra-tight));
 
   &:last-child {
+    // This compensates for the disclosure icon, which is substantially
+    // inset within the viewbox (and makes it look like there is too much
+    // spacing on the right of the button)
+    margin-right: -(spacing(tight));
     margin-left: spacing(extra-tight);
-    margin-right: -(spacing(extra-tight));
-
-    .disclosure & {
-      // This compensates for the disclosure icon, which is substantially
-      // inset within the viewbox (and makes it look like there is too much
-      // spacing on the right of the button)
-      margin-right: -(spacing(tight));
-    }
   }
 
   + *:not(.Icon) {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -43,6 +43,8 @@ export interface ButtonProps extends BaseButton {
   monochrome?: boolean;
   /** Icon to display to the left of the button content */
   icon?: React.ReactElement | IconSource;
+  /** Position of the Icon, defaults to left */
+  iconPosition?: 'left' | 'right';
   /** Disclosure button connected right of the button. Toggles a popover action list. */
   connectedDisclosure?: ConnectedDisclosure;
 }
@@ -104,6 +106,7 @@ export function Button({
   onMouseEnter,
   onTouchStart,
   icon,
+  iconPosition = 'left',
   primary,
   outline,
   destructive,
@@ -193,8 +196,9 @@ export function Button({
     iconMarkup || disclosureIconMarkup ? (
       <span className={styles.Content}>
         {spinnerSVGMarkup}
-        {iconMarkup}
+        {iconPosition === 'left' && iconMarkup}
         {childMarkup}
+        {iconPosition === 'right' && !disclosureIconMarkup && iconMarkup}
         {disclosureIconMarkup}
       </span>
     ) : (

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -41,10 +41,10 @@ export interface ButtonProps extends BaseButton {
   plain?: boolean;
   /** Makes `plain` and `outline` Button colors (text, borders, icons) the same as the current text color. Also adds an underline to `plain` Buttons */
   monochrome?: boolean;
-  /** Icon to display to the left of the button content */
+  /** Icon to display before or after the button content */
   icon?: React.ReactElement | IconSource;
-  /** Position of the Icon, defaults to left */
-  iconPosition?: 'left' | 'right';
+  /** Icon position relative to button content, defaults to before */
+  iconPosition?: 'before' | 'after';
   /** Disclosure button connected right of the button. Toggles a popover action list. */
   connectedDisclosure?: ConnectedDisclosure;
 }
@@ -106,7 +106,7 @@ export function Button({
   onMouseEnter,
   onTouchStart,
   icon,
-  iconPosition = 'left',
+  iconPosition = 'before',
   primary,
   outline,
   destructive,
@@ -146,7 +146,7 @@ export function Button({
   );
 
   const disclosureIconMarkup = disclosure ? (
-    <span className={styles.Icon}>
+    <span className={classNames(styles.Icon, !plain && styles.insetIcon)}>
       <div
         className={classNames(
           styles.DisclosureIcon,
@@ -196,9 +196,9 @@ export function Button({
     iconMarkup || disclosureIconMarkup ? (
       <span className={styles.Content}>
         {spinnerSVGMarkup}
-        {iconPosition === 'left' && iconMarkup}
+        {iconPosition === 'before' && iconMarkup}
         {childMarkup}
-        {iconPosition === 'right' && !disclosureIconMarkup && iconMarkup}
+        {iconPosition === 'after' && !disclosureIconMarkup && iconMarkup}
         {disclosureIconMarkup}
       </span>
     ) : (

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -139,6 +139,7 @@ export function Button({
     fullWidth && styles.fullWidth,
     icon && children == null && styles.iconOnly,
     connectedDisclosure && styles.connectedDisclosure,
+    disclosure && styles.disclosure,
   );
 
   const disclosureIcon = (

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -139,7 +139,6 @@ export function Button({
     fullWidth && styles.fullWidth,
     icon && children == null && styles.iconOnly,
     connectedDisclosure && styles.connectedDisclosure,
-    disclosure && styles.disclosure,
   );
 
   const disclosureIcon = (

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -314,6 +314,51 @@ function DisclosureButtion() {
 }
 ```
 
+### Button with icon
+
+<!-- example-for: web -->
+
+Adds an icon before the button content
+
+```jsx
+function IconButtonBefore() {
+  return (
+    <Button
+      icon={() => (
+        <svg viewBox="0 0 20 20" focusable="false" aria-hidden="true">
+          <path d="M15 2a1 1 0 0 1 1 1v13.5a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 4 16.5V3a1 1 0 1 1 2 0v1a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V3a1 1 0 0 1 1-1zm-4 2H9a1 1 0 1 1 0-2h2a1 1 0 1 1 0 2z"></path>
+        </svg>
+      )}
+    >
+      Paste
+    </Button>
+  );
+}
+```
+
+### Button with icon after content
+
+<!-- example-for: web -->
+
+Adds an icon after the button content
+
+```jsx
+function IconButtonAfter() {
+  return (
+    <Button
+      icon={() => (
+        <svg viewBox="0 0 20 20" focusable="false" aria-hidden="true">
+          <path d="M15 2a1 1 0 0 1 1 1v13.5a1.5 1.5 0 0 1-1.5 1.5h-9A1.5 1.5 0 0 1 4 16.5V3a1 1 0 1 1 2 0v1a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2V3a1 1 0 0 1 1-1zm-4 2H9a1 1 0 1 1 0-2h2a1 1 0 1 1 0 2z"></path>
+        </svg>
+      )}
+      iconPosition="after"
+    >
+      Paste
+    </Button>
+  );
+}
+```
+
 ### Split button
 
 <!-- example-for: web -->


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3665

In this web feature request https://github.com/Shopify/intl-shipping-methods/issues/910 it is proposed to have a connected button to paste tracking numbers directly into the text field. The clipboard icon is displayed after the button content. See below:

![image](https://user-images.githubusercontent.com/72969127/100672224-e9a9dd80-3361-11eb-8a27-dfbe11ee11da.png)
 
### WHAT is this pull request doing?

Add iconPosition support to display icons before or after the button content.

Before / After:

![image](https://user-images.githubusercontent.com/72969127/100644086-28786d00-333b-11eb-90ea-24bc5b1a0a37.png)

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
