### PR TITLE
[Tabs][a11y]: implement focus ring for disclosure and fix high contrast mode on focus and hover

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,23 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed `FocusManager` from tracking inactive items that prevented trap focusing([#3630](https://github.com/Shopify/polaris-react/pull/3630))
+- Added escape keybind to `Tooltip` ([#3627](https://github.com/Shopify/polaris-react/pull/3627))
+- Removed extra bottom border on the `DataTable` and added curved edges to footers ([#3571](https://github.com/Shopify/polaris-react/pull/3571))
+- **`Button`:** `loading` no longer sets the invalid `role="alert"` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
+- Added semantic headers to `Filters` ([#3629](https://github.com/Shopify/polaris-react/pull/3629))
+- Fixed `Filters` not announcing applied filters ([#3632](https://github.com/Shopify/polaris-react/pull/3632))
+- Removed `tabIndex=-1` from `Popover` when `preventAutoFocus` is true ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
+- Fixed `Modal` header border color ([#3616](https://github.com/Shopify/polaris-react/pull/3616))
+- Added focus styles to `CloseButton` in `Modal` ([#3628](https://github.com/Shopify/polaris-react/pull/3628))
+- Fixed `Filters` duplicated `ConnectedFilter` ids ([#3651](https://github.com/Shopify/polaris-react/pull/3651))
+- Fixed `Banner` `secondaryAction` only rendering if `action` is set ([#2949](https://github.com/Shopify/polaris-react/pull/2949))
+- Added a `alwaysRenderCustomProperties` to `ThemeProvider` for elements that render outside of the DOM tree to their parent context ([#3652](https://github.com/Shopify/polaris-react/pull/3652))
+- Fixed keyboard interactions for the `Tab` component ([#3650](https://github.com/Shopify/polaris-react/pull/3650))
+- Fixed keyboard interaction when selected Tab was focused and rendering the wrong `::before` colour ([#3669](https://github.com/Shopify/polaris-react/pull/3669))
+- Added focus ring to disclosure tab when tabbing with keyboard([#3675](https://github.com/Shopify/polaris-react/pull/3675))
+- Fixed windows high contrast mode on hover within disclosure menu and displaying active state upon click for `::before` ([#3675](https://github.com/Shopify/polaris-react/pull/3675))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -185,7 +185,7 @@ $range-end-border-radius: rem(30px);
     &:hover {
       background: var(--p-interactive-hovered);
       color: var(--p-text-on-interactive);
-      @include high-contrast-outline;
+      @include ms-high-contrast-outline($border-width: rem(1px));
     }
 
     @include focus-ring;

--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -185,7 +185,7 @@ $range-end-border-radius: rem(30px);
     &:hover {
       background: var(--p-interactive-hovered);
       color: var(--p-text-on-interactive);
-      @include ms-high-contrast-outline($border-width: rem(1px));
+      @include ms-high-contrast-outline;
     }
 
     @include focus-ring;

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -184,7 +184,7 @@ $dropzone-stacking-order: (
     }
 
     &:hover {
-      @include high-contrast-outline;
+      @include ms-high-contrast-outline($border-width: rem(1px));
     }
   }
 

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -184,7 +184,7 @@ $dropzone-stacking-order: (
     }
 
     &:hover {
-      @include ms-high-contrast-outline($border-width: rem(1px));
+      @include ms-high-contrast-outline;
     }
   }
 

--- a/src/components/Filters/Filters.scss
+++ b/src/components/Filters/Filters.scss
@@ -135,7 +135,7 @@ $list-filters-footer-height: rem(70px);
     }
 
     &:hover {
-      @include high-contrast-outline;
+      @include ms-high-contrast-outline($border-width: rem(1px));
     }
   }
 }

--- a/src/components/Filters/Filters.scss
+++ b/src/components/Filters/Filters.scss
@@ -135,7 +135,7 @@ $list-filters-footer-height: rem(70px);
     }
 
     &:hover {
-      @include ms-high-contrast-outline($border-width: rem(1px));
+      @include ms-high-contrast-outline;
     }
   }
 }

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -242,7 +242,7 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
     }
   }
   &:active {
-    background-color: var(--p-surface-pressed);
+    background-color: var(--p-surface-primary-selected-pressed);
   }
 
   @include focus-ring;
@@ -276,13 +276,10 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
   outline: none;
   text-align: center;
 
-  &:hover {
-    .Title {
-      @include recolor-icon(var(--p-icon, color('ink', 'lighter')));
-      background-color: var(--p-surface-hovered, transparent);
-      border-bottom: var(--p-override-none, $underline-height) solid
-        color('sky');
-    }
+  &:hover .Title {
+    @include recolor-icon(var(--p-icon, color('ink', 'lighter')));
+    background-color: var(--p-surface-hovered, transparent);
+    border-bottom: var(--p-override-none, $underline-height) solid color('sky');
   }
 
   &:focus {
@@ -298,10 +295,8 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
     }
   }
 
-  &:active {
-    .Title {
-      background-color: var(--p-surface-pressed, transparent);
-    }
+  &:active .Title {
+    background-color: var(--p-surface-pressed, transparent);
   }
 }
 
@@ -351,11 +346,15 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 
   .DisclosureActivator {
     &:hover .Title {
+      background: none;
+
       &::before {
         background: var(--p-border-hovered);
       }
+
       @media (-ms-high-contrast: active) {
         outline: rem(1px) solid ms-high-contrast-color('text');
+
         // stylelint-disable-next-line max-nesting-depth
         &::before {
           display: none;
@@ -369,6 +368,14 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
       &::before {
         background: var(--p-border-hovered);
       }
+      @media (-ms-high-contrast: active) {
+        outline: rem(1px) solid ms-high-contrast-color('text');
+
+        // stylelint-disable-next-line max-nesting-depth
+        &::before {
+          display: none;
+        }
+      }
     }
 
     &:active .Title::before {
@@ -380,6 +387,7 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
     &:hover .Title {
       @media (-ms-high-contrast: active) {
         outline: rem(3px) solid ms-high-contrast-color('text');
+
         // stylelint-disable-next-line max-nesting-depth
         &::before {
           display: none;
@@ -390,6 +398,7 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
     &:focus .Title {
       @media (-ms-high-contrast: active) {
         outline: rem(3px) solid ms-high-contrast-color('text');
+
         // stylelint-disable-next-line max-nesting-depth
         &::before {
           display: none;

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -6,6 +6,18 @@ $item-vertical-padding: $item-min-height / 2;
 $underline-height: border-width(thicker);
 $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 
+@mixin reset-before-pseudo-content {
+  &::before {
+    content: none;
+  }
+}
+
+@mixin focus-ring-override {
+  @include ms-high-contrast-outline {
+    @include reset-before-pseudo-content;
+  }
+}
+
 .Tabs {
   display: flex;
   flex-wrap: wrap;
@@ -118,7 +130,9 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
       border-bottom: var(--p-override-none, $underline-height) solid
         color('indigo');
 
-      @include ms-high-contrast-outline($border-width: rem(3px));
+      @include ms-high-contrast-outline($border-width: border-width(thicker)) {
+        @include reset-before-pseudo-content;
+      }
     }
   }
 }
@@ -233,14 +247,10 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 .Item.newDesignLanguage {
   border-radius: var(--p-border-radius-base);
   &:hover {
+    @include focus-ring-override;
     background-color: var(--p-surface-hovered);
-
-    @include ms-high-contrast-outline(
-      $border-width: (
-        rem(1px),
-      )
-    );
   }
+
   &:active {
     background-color: var(--p-surface-primary-selected-pressed);
   }
@@ -328,11 +338,13 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
     padding: spacing(tight) spacing(extra-tight);
 
     &:hover .Title {
-      @include focus-ring-ms-high-contrast($border-width: rem(1px));
+      @include focus-ring-override;
     }
 
     &:focus .Title {
-      @include focus-ring-ms-high-contrast($border-width: rem(1px));
+      @media (-ms-high-contrast: active) {
+        @include reset-before-pseudo-content;
+      }
 
       &::before {
         background: var(--p-border-hovered);
@@ -346,7 +358,7 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 
   .DisclosureActivator {
     &:hover .Title {
-      @include focus-ring-ms-high-contrast($border-width: rem(1px));
+      @include focus-ring-override;
       background: none;
 
       &::before {
@@ -355,12 +367,15 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
     }
 
     &:focus .Title {
-      @include focus-ring-ms-high-contrast($border-width: rem(1px));
       @include focus-ring($style: 'focused');
       @include recolor-icon(var(--p-icon, color('ink', 'lighter')));
 
       &::before {
         background: var(--p-border-hovered);
+      }
+
+      @media (-ms-high-contrast: active) {
+        @include reset-before-pseudo-content;
       }
     }
 
@@ -371,9 +386,9 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 
   .Tab-selected {
     &:hover .Title {
-      @include focus-ring-ms-high-contrast(
-        $border-width: border-width(thicker)
-      );
+      @include ms-high-contrast-outline($border-width: border-width(thicker)) {
+        @include reset-before-pseudo-content;
+      }
     }
 
     &:focus .Title {

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -119,7 +119,7 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
         color('indigo');
 
       @media (-ms-high-contrast: active) {
-        outline: 1px solid;
+        outline: rem(3px) solid ms-high-contrast-color('text');
       }
     }
   }
@@ -236,6 +236,10 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
   border-radius: var(--p-border-radius-base);
   &:hover {
     background-color: var(--p-surface-hovered);
+
+    @media (-ms-high-contrast: active) {
+      outline: rem(1px) solid ms-high-contrast-color('text');
+    }
   }
   &:active {
     background-color: var(--p-surface-pressed);
@@ -327,6 +331,14 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 
   .Tab {
     padding: spacing(tight) spacing(extra-tight);
+    &:hover .Title {
+      @media (-ms-high-contrast: active) {
+        outline: rem(1px) solid ms-high-contrast-color('text');
+        &::before {
+          display: none;
+        }
+      }
+    }
 
     &:focus .Title::before {
       background: var(--p-border-hovered);
@@ -338,13 +350,55 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
   }
 
   .DisclosureActivator {
-    margin: 1px 0 -1px;
-    padding: spacing(tight) spacing(tight) spacing(tight) 0;
+    &:hover .Title {
+      &::before {
+        background: var(--p-border-hovered);
+      }
+      @media (-ms-high-contrast: active) {
+        outline: rem(1px) solid ms-high-contrast-color('text');
+        // stylelint-disable-next-line max-nesting-depth
+        &::before {
+          display: none;
+        }
+      }
+    }
+
+    &:focus .Title {
+      @include focus-ring($style: 'focused');
+
+      &::before {
+        background: var(--p-border-hovered);
+      }
+    }
+
+    &:active .Title::before {
+      background: var(--p-surface-primary-selected-pressed);
+    }
   }
 
   .Tab-selected {
-    &:focus .Title::before {
-      background: var(--p-action-primary);
+    &:hover .Title {
+      @media (-ms-high-contrast: active) {
+        outline: rem(3px) solid ms-high-contrast-color('text');
+        // stylelint-disable-next-line max-nesting-depth
+        &::before {
+          display: none;
+        }
+      }
+    }
+
+    &:focus .Title {
+      @media (-ms-high-contrast: active) {
+        outline: rem(3px) solid ms-high-contrast-color('text');
+        // stylelint-disable-next-line max-nesting-depth
+        &::before {
+          display: none;
+        }
+      }
+
+      &::before {
+        background: var(--p-action-primary);
+      }
     }
 
     .Title {

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -118,9 +118,7 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
       border-bottom: var(--p-override-none, $underline-height) solid
         color('indigo');
 
-      @media (-ms-high-contrast: active) {
-        outline: rem(3px) solid ms-high-contrast-color('text');
-      }
+      @include ms-high-contrast-outline($border-width: rem(3px));
     }
   }
 }
@@ -237,9 +235,11 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
   &:hover {
     background-color: var(--p-surface-hovered);
 
-    @media (-ms-high-contrast: active) {
-      outline: rem(1px) solid ms-high-contrast-color('text');
-    }
+    @include ms-high-contrast-outline(
+      $border-width: (
+        rem(1px),
+      )
+    );
   }
   &:active {
     background-color: var(--p-surface-primary-selected-pressed);
@@ -326,17 +326,17 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 
   .Tab {
     padding: spacing(tight) spacing(extra-tight);
+
     &:hover .Title {
-      @media (-ms-high-contrast: active) {
-        outline: rem(1px) solid ms-high-contrast-color('text');
-        &::before {
-          display: none;
-        }
-      }
+      @include focus-ring-ms-high-contrast($border-width: rem(1px));
     }
 
-    &:focus .Title::before {
-      background: var(--p-border-hovered);
+    &:focus .Title {
+      @include focus-ring-ms-high-contrast($border-width: rem(1px));
+
+      &::before {
+        background: var(--p-border-hovered);
+      }
     }
 
     &:active .Title::before {
@@ -346,35 +346,22 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 
   .DisclosureActivator {
     &:hover .Title {
+      @include focus-ring-ms-high-contrast($border-width: rem(1px));
+
       background: none;
 
       &::before {
         background: var(--p-border-hovered);
       }
-
-      @media (-ms-high-contrast: active) {
-        outline: rem(1px) solid ms-high-contrast-color('text');
-
-        // stylelint-disable-next-line max-nesting-depth
-        &::before {
-          display: none;
-        }
-      }
     }
 
     &:focus .Title {
+      @include focus-ring-ms-high-contrast($border-width: rem(1px));
       @include focus-ring($style: 'focused');
+      @include recolor-icon(var(--p-icon, color('ink', 'lighter')));
 
       &::before {
         background: var(--p-border-hovered);
-      }
-      @media (-ms-high-contrast: active) {
-        outline: rem(1px) solid ms-high-contrast-color('text');
-
-        // stylelint-disable-next-line max-nesting-depth
-        &::before {
-          display: none;
-        }
       }
     }
 
@@ -385,25 +372,13 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 
   .Tab-selected {
     &:hover .Title {
-      @media (-ms-high-contrast: active) {
-        outline: rem(3px) solid ms-high-contrast-color('text');
-
-        // stylelint-disable-next-line max-nesting-depth
-        &::before {
-          display: none;
-        }
-      }
+      @include focus-ring-ms-high-contrast(
+        $border-width: border-width(thicker)
+      );
     }
 
     &:focus .Title {
-      @media (-ms-high-contrast: active) {
-        outline: rem(3px) solid ms-high-contrast-color('text');
-
-        // stylelint-disable-next-line max-nesting-depth
-        &::before {
-          display: none;
-        }
-      }
+      @include ms-high-contrast-outline($border-width: border-width(thicker));
 
       &::before {
         background: var(--p-action-primary);
@@ -411,18 +386,11 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
     }
 
     .Title {
+      @include ms-high-contrast-outline($border-width: border-width(thicker));
       color: var(--p-text);
 
       &::before {
         background: var(--p-action-primary);
-      }
-
-      @media (-ms-high-contrast: active) {
-        outline: rem(3px) solid ms-high-contrast-color('text');
-        // stylelint-disable-next-line max-nesting-depth
-        &::before {
-          display: none;
-        }
       }
     }
   }

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -347,7 +347,6 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
   .DisclosureActivator {
     &:hover .Title {
       @include focus-ring-ms-high-contrast($border-width: rem(1px));
-
       background: none;
 
       &::before {

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -328,12 +328,12 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
   .Tab {
     padding: spacing(tight) spacing(extra-tight);
 
-    &:active .Title::before {
-      background: var(--p-action-primary-pressed);
-    }
-
     &:focus .Title::before {
       background: var(--p-border-hovered);
+    }
+
+    &:active .Title::before {
+      background: var(--p-surface-primary-selected-pressed);
     }
   }
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -134,10 +134,9 @@ class TabsInner extends PureComponent<CombinedProps, State> {
       newDesignLanguage && styles.newDesignLanguage,
     );
 
-    const disclosureButtonClassName = classNames(
-      styles.DisclosureActivator,
-      hasCustomDisclosure && styles.Tab,
-    );
+    const disclosureButtonClassName = hasCustomDisclosure
+      ? classNames(hasCustomDisclosure && styles.Tab)
+      : classNames(styles.DisclosureActivator);
 
     const disclosureButtonContentWrapperClassName = classNames(
       styles.Title,

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -134,9 +134,10 @@ class TabsInner extends PureComponent<CombinedProps, State> {
       newDesignLanguage && styles.newDesignLanguage,
     );
 
-    const disclosureButtonClassName = hasCustomDisclosure
-      ? classNames(hasCustomDisclosure && styles.Tab)
-      : classNames(styles.DisclosureActivator);
+    const disclosureButtonClassName = classNames(
+      styles.DisclosureActivator,
+      hasCustomDisclosure && styles.Tab,
+    );
 
     const disclosureButtonContentWrapperClassName = classNames(
       styles.Title,

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -116,7 +116,7 @@ $icon-size: rem(16px);
 
     &:hover {
       background: var(--p-surface-neutral-hovered);
-      @include ms-high-contrast-outline($border-width: rem(1px));
+      @include ms-high-contrast-outline;
     }
 
     &:focus {

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -116,7 +116,7 @@ $icon-size: rem(16px);
 
     &:hover {
       background: var(--p-surface-neutral-hovered);
-      @include high-contrast-outline;
+      @include ms-high-contrast-outline($border-width: rem(1px));
     }
 
     &:focus {

--- a/src/styles/foundation/_accessibility.scss
+++ b/src/styles/foundation/_accessibility.scss
@@ -1,5 +1,15 @@
-@mixin high-contrast-outline {
+@mixin ms-high-contrast-outline($border-width: border-width()) {
   @media (-ms-high-contrast: active) {
-    outline: 1px solid ms-high-contrast-color('text');
+    outline: $border-width solid ms-high-contrast-color('text');
+  }
+}
+
+@mixin focus-ring-ms-high-contrast($border-width: border-width()) {
+  @media (-ms-high-contrast: active) {
+    outline: $border-width solid ms-high-contrast-color('text');
+
+    &::before {
+      content: none;
+    }
   }
 }

--- a/src/styles/foundation/_accessibility.scss
+++ b/src/styles/foundation/_accessibility.scss
@@ -1,15 +1,7 @@
 @mixin ms-high-contrast-outline($border-width: border-width()) {
   @media (-ms-high-contrast: active) {
     outline: $border-width solid ms-high-contrast-color('text');
-  }
-}
 
-@mixin focus-ring-ms-high-contrast($border-width: border-width()) {
-  @media (-ms-high-contrast: active) {
-    outline: $border-width solid ms-high-contrast-color('text');
-
-    &::before {
-      content: none;
-    }
+    @content;
   }
 }

--- a/src/styles/foundation/_focus-ring.scss
+++ b/src/styles/foundation/_focus-ring.scss
@@ -37,7 +37,7 @@
   } @else if $style == 'focused' {
     &::after {
       box-shadow: 0 0 0 $stroke var(--p-focused, color('indigo'));
-      @include ms-high-contrast-outline($border-width: rem(1px));
+      @include ms-high-contrast-outline;
     }
   }
 }

--- a/src/styles/foundation/_focus-ring.scss
+++ b/src/styles/foundation/_focus-ring.scss
@@ -37,7 +37,7 @@
   } @else if $style == 'focused' {
     &::after {
       box-shadow: 0 0 0 $stroke var(--p-focused, color('indigo'));
-      @include high-contrast-outline;
+      @include ms-high-contrast-outline($border-width: rem(1px));
     }
   }
 }

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -79,7 +79,7 @@
 
     &:hover {
       background: var(--p-action-secondary-hovered);
-      @include ms-high-contrast-outline($border-width: rem(1px));
+      @include ms-high-contrast-outline;
     }
 
     &:focus {

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -79,7 +79,7 @@
 
     &:hover {
       background: var(--p-action-secondary-hovered);
-      @include high-contrast-outline;
+      @include ms-high-contrast-outline($border-width: rem(1px));
     }
 
     &:focus {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3673 (while navigating tabs via keyboard, the disclosure tab is not visibly accessible with `tab` key)

### WHAT is this pull request doing?

**1. Fixes Windows High Contrast hover state** 
#### Windows High Contrast on Hover
| Before        | After           |
| ------------- |:-------------:|
|![CURRENThoverstate](https://user-images.githubusercontent.com/43223543/101379122-eb9fff00-3881-11eb-8f24-08566f45e464.jpg)|![NOW with no disclosure](https://user-images.githubusercontent.com/43223543/101379346-273ac900-3882-11eb-9833-0f6b495fea8a.jpg)

#### Windows High Contrast on Hover within Disclosure Tab
(please note: that the mouse is CURRENTLY on `Prospects` on the `Before` photo, but there is no outline)
(ignore the different order - will post issue after)
| Before        | After           |
| ------------- |:-------------:|
|![currentHOVER overProspects](https://user-images.githubusercontent.com/43223543/101379232-0bcfbe00-3882-11eb-9e23-808644c754a8.jpg)|![NOW](https://user-images.githubusercontent.com/43223543/101379147-f2c70d00-3881-11eb-9e80-ea28961381b8.jpg)

**2. Adds a focus ring upon `tab` in the new design language***
**3. Adds active state colour (green) when tab is `active` (upon click)**
**4. Adds `::before` grey underline on disclosure on hover**

### Related GIFs (expand below)
<details>
<summary>Related GIF (please expand)</summary>

#### BEFORE (no active green colour, no focus ring on tab) 
![BEFORE fix TABS](https://user-images.githubusercontent.com/43223543/101381170-6ec25480-3884-11eb-9950-cd559f9f04c5.gif)

#### AFTER (with active green colour, AND focus ring on tab, AND grey underline on disclosure)
![Tab-withActivePressed](https://user-images.githubusercontent.com/43223543/101372902-5fd6a480-387a-11eb-83a6-fcae61bf40d2.gif)

</details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

1. Test new changes after pulling branch in [this playground](http://localhost:6006/iframe.html?id=all-components-tabs--all-examples&contexts=New%20Design%20Language%3DEnabled%20-%20Light%20Mode&viewMode=story) (post `dev s`) 

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
     * tested on Google Pixel 2 XL (with TalkBack on Android)✅
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
     * tested on Windows10 Edge ✅
     * tested on FireFox  ✅ 
     * tested on Chrome ✅
     * tested on Safari ✅
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
     * tested Voiceover on MacOS (Safari) ✅
     * tested JAWs on Windows (Chrome) ✅
     * tested Windows High Contrast (Edge) ✅ (see screenshots above)
     * tested Zoom on MacOS (FireFox)  ✅ 
* [ ] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit