### PR TITLE
[Filters] Make Filters Query Text Field Optional [#SOPS-81]

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,14 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Added `flush` prop to `Card.Section` ([#3645](https://github.com/Shopify/polaris-react/pull/3645))
 - Added `stretchContent` prop for `Button` ([#3664](https://github.com/Shopify/polaris-react/pull/3664))
+- Allowed `Thumbnail` `source` property to support `icons` ([#3328](https://github.com/Shopify/polaris-react/pull/3328))
+- **`Button`:** New `role` prop for `<button />` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
+- Added `preventFocusOnClose` to `Popover` ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
+- Added color fallback values to `focus-ring` mixin ([#3626](https://github.com/Shopify/polaris-react/pull/3626))
+- Added `role="presentational"` to list items for `Tabs` ([#3647](https://github.com/Shopify/polaris-react/pull/3647))
+- Allowed consumers to set custom container element on `PortalsManager` ([#3644](https://github.com/Shopify/polaris-react/pull/3644))
+- **`Button`:** New `stretchContent` prop for `<button />` ([#3664](https://github.com/Shopify/polaris-react/pull/3664))
+- Added ability to hide query text field in `Filters` component using `hideQueryField` prop ([#3674](https://github.com/Shopify/polaris-react/pull/3674))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,13 +10,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Added `flush` prop to `Card.Section` ([#3645](https://github.com/Shopify/polaris-react/pull/3645))
 - Added `stretchContent` prop for `Button` ([#3664](https://github.com/Shopify/polaris-react/pull/3664))
-- Allowed `Thumbnail` `source` property to support `icons` ([#3328](https://github.com/Shopify/polaris-react/pull/3328))
-- **`Button`:** New `role` prop for `<button />` ([#3590](https://github.com/Shopify/polaris-react/pull/3590))
-- Added `preventFocusOnClose` to `Popover` ([#3595](https://github.com/Shopify/polaris-react/pull/3595))
-- Added color fallback values to `focus-ring` mixin ([#3626](https://github.com/Shopify/polaris-react/pull/3626))
-- Added `role="presentational"` to list items for `Tabs` ([#3647](https://github.com/Shopify/polaris-react/pull/3647))
-- Allowed consumers to set custom container element on `PortalsManager` ([#3644](https://github.com/Shopify/polaris-react/pull/3644))
-- **`Button`:** New `stretchContent` prop for `<button />` ([#3664](https://github.com/Shopify/polaris-react/pull/3664))
 - Added ability to hide query text field in `Filters` component using `hideQueryField` prop ([#3674](https://github.com/Shopify/polaris-react/pull/3674))
 
 ### Bug fixes

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -87,6 +87,8 @@ export interface FiltersProps {
   helpText?: string | React.ReactNode;
   /** Hide tags for applied filters */
   hideTags?: boolean;
+  /** Hide the query field */
+  hideQueryField?: boolean;
 }
 
 type CombinedProps = FiltersProps & {
@@ -133,6 +135,7 @@ class FiltersInner extends Component<CombinedProps, State> {
       disabled = false,
       helpText,
       hideTags,
+      hideQueryField,
       features: {newDesignLanguage},
       i18n,
       mediaQuery: {isNavigationCollapsed},
@@ -253,35 +256,38 @@ class FiltersInner extends Component<CombinedProps, State> {
         auxiliary={children}
         disabled={disabled}
         forceShowMorefiltersButton={filters.length > transformedFilters.length}
+        queryFieldHidden={hideQueryField}
       >
-        <TextField
-          placeholder={
-            queryPlaceholder ||
-            i18n.translate('Polaris.Filters.filter', {
-              resourceName: filterResourceName.plural,
-            })
-          }
-          onChange={onQueryChange}
-          onBlur={onQueryBlur}
-          onFocus={onQueryFocus}
-          value={queryValue}
-          focused={focused}
-          label={
-            queryPlaceholder ||
-            i18n.translate('Polaris.Filters.filter', {
-              resourceName: filterResourceName.plural,
-            })
-          }
-          labelHidden
-          prefix={
-            <span className={styles.SearchIcon}>
-              <Icon source={SearchMinor} />
-            </span>
-          }
-          clearButton
-          onClearButtonClick={onQueryClear}
-          disabled={disabled}
-        />
+        {hideQueryField ? null : (
+          <TextField
+            placeholder={
+              queryPlaceholder ||
+              i18n.translate('Polaris.Filters.filter', {
+                resourceName: filterResourceName.plural,
+              })
+            }
+            onChange={onQueryChange}
+            onBlur={onQueryBlur}
+            onFocus={onQueryFocus}
+            value={queryValue}
+            focused={focused}
+            label={
+              queryPlaceholder ||
+              i18n.translate('Polaris.Filters.filter', {
+                resourceName: filterResourceName.plural,
+              })
+            }
+            labelHidden
+            prefix={
+              <span className={styles.SearchIcon}>
+                <Icon source={SearchMinor} />
+              </span>
+            }
+            clearButton
+            onClearButtonClick={onQueryClear}
+            disabled={disabled}
+          />
+        )}
       </ConnectedFilterControl>
     );
 

--- a/src/components/Filters/README.md
+++ b/src/components/Filters/README.md
@@ -523,6 +523,205 @@ function DataTableFiltersExample() {
 }
 ```
 
+### Filters with query field hidden
+
+```jsx
+function ResourceListFiltersExample() {
+  const [accountStatus, setAccountStatus] = useState(null);
+  const [moneySpent, setMoneySpent] = useState(null);
+  const [taggedWith, setTaggedWith] = useState(null);
+  const [queryValue, setQueryValue] = useState(null);
+
+  const handleAccountStatusChange = useCallback(
+    (value) => setAccountStatus(value),
+    [],
+  );
+  const handleMoneySpentChange = useCallback(
+    (value) => setMoneySpent(value),
+    [],
+  );
+  const handleTaggedWithChange = useCallback(
+    (value) => setTaggedWith(value),
+    [],
+  );
+  const handleFiltersQueryChange = useCallback(
+    (value) => setQueryValue(value),
+    [],
+  );
+  const handleAccountStatusRemove = useCallback(
+    () => setAccountStatus(null),
+    [],
+  );
+  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+  const handleFiltersClearAll = useCallback(() => {
+    handleAccountStatusRemove();
+    handleMoneySpentRemove();
+    handleTaggedWithRemove();
+    handleQueryValueRemove();
+  }, [
+    handleAccountStatusRemove,
+    handleMoneySpentRemove,
+    handleQueryValueRemove,
+    handleTaggedWithRemove,
+  ]);
+
+  const filters = [
+    {
+      key: 'accountStatus',
+      label: 'Account status',
+      filter: (
+        <ChoiceList
+          title="Account status"
+          titleHidden
+          choices={[
+            {label: 'Enabled', value: 'enabled'},
+            {label: 'Not invited', value: 'not invited'},
+            {label: 'Invited', value: 'invited'},
+            {label: 'Declined', value: 'declined'},
+          ]}
+          selected={accountStatus || []}
+          onChange={handleAccountStatusChange}
+          allowMultiple
+        />
+      ),
+      shortcut: true,
+    },
+    {
+      key: 'taggedWith',
+      label: 'Tagged with',
+      filter: (
+        <TextField
+          label="Tagged with"
+          value={taggedWith}
+          onChange={handleTaggedWithChange}
+          labelHidden
+        />
+      ),
+      shortcut: true,
+    },
+    {
+      key: 'moneySpent',
+      label: 'Money spent',
+      filter: (
+        <RangeSlider
+          label="Money spent is between"
+          labelHidden
+          value={moneySpent || [0, 500]}
+          prefix="$"
+          output
+          min={0}
+          max={2000}
+          step={1}
+          onChange={handleMoneySpentChange}
+        />
+      ),
+    },
+  ];
+
+  const appliedFilters = [];
+  if (!isEmpty(accountStatus)) {
+    const key = 'accountStatus';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, accountStatus),
+      onRemove: handleAccountStatusRemove,
+    });
+  }
+  if (!isEmpty(moneySpent)) {
+    const key = 'moneySpent';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, moneySpent),
+      onRemove: handleMoneySpentRemove,
+    });
+  }
+  if (!isEmpty(taggedWith)) {
+    const key = 'taggedWith';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, taggedWith),
+      onRemove: handleTaggedWithRemove,
+    });
+  }
+
+  return (
+    <div style={{height: '568px'}}>
+      <Card>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          filterControl={
+            <Filters
+              queryValue={queryValue}
+              filters={filters}
+              appliedFilters={appliedFilters}
+              onQueryChange={handleFiltersQueryChange}
+              onQueryClear={handleQueryValueRemove}
+              onClearAll={handleFiltersClearAll}
+              hideQueryField
+            />
+          }
+          items={[
+            {
+              id: 341,
+              url: 'customers/341',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            },
+            {
+              id: 256,
+              url: 'customers/256',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="medium" name={name} />;
+
+            return (
+              <ResourceList.Item
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <h3>
+                  <TextStyle variation="strong">{name}</TextStyle>
+                </h3>
+                <div>{location}</div>
+              </ResourceList.Item>
+            );
+          }}
+        />
+      </Card>
+    </div>
+  );
+
+  function disambiguateLabel(key, value) {
+    switch (key) {
+      case 'moneySpent':
+        return `Money spent is between $${value[0]} and $${value[1]}`;
+      case 'taggedWith':
+        return `Tagged with ${value}`;
+      case 'accountStatus':
+        return value.map((val) => `Customer ${val}`).join(', ');
+      default:
+        return value;
+    }
+  }
+
+  function isEmpty(value) {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else {
+      return value === '' || value == null;
+    }
+  }
+}
+```
+
 ### Filters with children content
 
 ```jsx

--- a/src/components/Filters/README.md
+++ b/src/components/Filters/README.md
@@ -523,205 +523,6 @@ function DataTableFiltersExample() {
 }
 ```
 
-### Filters with query field hidden
-
-```jsx
-function ResourceListFiltersExample() {
-  const [accountStatus, setAccountStatus] = useState(null);
-  const [moneySpent, setMoneySpent] = useState(null);
-  const [taggedWith, setTaggedWith] = useState(null);
-  const [queryValue, setQueryValue] = useState(null);
-
-  const handleAccountStatusChange = useCallback(
-    (value) => setAccountStatus(value),
-    [],
-  );
-  const handleMoneySpentChange = useCallback(
-    (value) => setMoneySpent(value),
-    [],
-  );
-  const handleTaggedWithChange = useCallback(
-    (value) => setTaggedWith(value),
-    [],
-  );
-  const handleFiltersQueryChange = useCallback(
-    (value) => setQueryValue(value),
-    [],
-  );
-  const handleAccountStatusRemove = useCallback(
-    () => setAccountStatus(null),
-    [],
-  );
-  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
-  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
-  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
-  const handleFiltersClearAll = useCallback(() => {
-    handleAccountStatusRemove();
-    handleMoneySpentRemove();
-    handleTaggedWithRemove();
-    handleQueryValueRemove();
-  }, [
-    handleAccountStatusRemove,
-    handleMoneySpentRemove,
-    handleQueryValueRemove,
-    handleTaggedWithRemove,
-  ]);
-
-  const filters = [
-    {
-      key: 'accountStatus',
-      label: 'Account status',
-      filter: (
-        <ChoiceList
-          title="Account status"
-          titleHidden
-          choices={[
-            {label: 'Enabled', value: 'enabled'},
-            {label: 'Not invited', value: 'not invited'},
-            {label: 'Invited', value: 'invited'},
-            {label: 'Declined', value: 'declined'},
-          ]}
-          selected={accountStatus || []}
-          onChange={handleAccountStatusChange}
-          allowMultiple
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'taggedWith',
-      label: 'Tagged with',
-      filter: (
-        <TextField
-          label="Tagged with"
-          value={taggedWith}
-          onChange={handleTaggedWithChange}
-          labelHidden
-        />
-      ),
-      shortcut: true,
-    },
-    {
-      key: 'moneySpent',
-      label: 'Money spent',
-      filter: (
-        <RangeSlider
-          label="Money spent is between"
-          labelHidden
-          value={moneySpent || [0, 500]}
-          prefix="$"
-          output
-          min={0}
-          max={2000}
-          step={1}
-          onChange={handleMoneySpentChange}
-        />
-      ),
-    },
-  ];
-
-  const appliedFilters = [];
-  if (!isEmpty(accountStatus)) {
-    const key = 'accountStatus';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, accountStatus),
-      onRemove: handleAccountStatusRemove,
-    });
-  }
-  if (!isEmpty(moneySpent)) {
-    const key = 'moneySpent';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, moneySpent),
-      onRemove: handleMoneySpentRemove,
-    });
-  }
-  if (!isEmpty(taggedWith)) {
-    const key = 'taggedWith';
-    appliedFilters.push({
-      key,
-      label: disambiguateLabel(key, taggedWith),
-      onRemove: handleTaggedWithRemove,
-    });
-  }
-
-  return (
-    <div style={{height: '568px'}}>
-      <Card>
-        <ResourceList
-          resourceName={{singular: 'customer', plural: 'customers'}}
-          filterControl={
-            <Filters
-              queryValue={queryValue}
-              filters={filters}
-              appliedFilters={appliedFilters}
-              onQueryChange={handleFiltersQueryChange}
-              onQueryClear={handleQueryValueRemove}
-              onClearAll={handleFiltersClearAll}
-              hideQueryField
-            />
-          }
-          items={[
-            {
-              id: 341,
-              url: 'customers/341',
-              name: 'Mae Jemison',
-              location: 'Decatur, USA',
-            },
-            {
-              id: 256,
-              url: 'customers/256',
-              name: 'Ellen Ochoa',
-              location: 'Los Angeles, USA',
-            },
-          ]}
-          renderItem={(item) => {
-            const {id, url, name, location} = item;
-            const media = <Avatar customer size="medium" name={name} />;
-
-            return (
-              <ResourceList.Item
-                id={id}
-                url={url}
-                media={media}
-                accessibilityLabel={`View details for ${name}`}
-              >
-                <h3>
-                  <TextStyle variation="strong">{name}</TextStyle>
-                </h3>
-                <div>{location}</div>
-              </ResourceList.Item>
-            );
-          }}
-        />
-      </Card>
-    </div>
-  );
-
-  function disambiguateLabel(key, value) {
-    switch (key) {
-      case 'moneySpent':
-        return `Money spent is between $${value[0]} and $${value[1]}`;
-      case 'taggedWith':
-        return `Tagged with ${value}`;
-      case 'accountStatus':
-        return value.map((val) => `Customer ${val}`).join(', ');
-      default:
-        return value;
-    }
-  }
-
-  function isEmpty(value) {
-    if (Array.isArray(value)) {
-      return value.length === 0;
-    } else {
-      return value === '' || value == null;
-    }
-  }
-}
-```
-
 ### Filters with children content
 
 ```jsx
@@ -1264,6 +1065,205 @@ function ResourceListFiltersExample() {
               onClearAll={handleFiltersClearAll}
               helpText="To reactivate filtering, remove your current filters."
               disabled
+            />
+          }
+          items={[
+            {
+              id: 341,
+              url: 'customers/341',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            },
+            {
+              id: 256,
+              url: 'customers/256',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="medium" name={name} />;
+
+            return (
+              <ResourceList.Item
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <h3>
+                  <TextStyle variation="strong">{name}</TextStyle>
+                </h3>
+                <div>{location}</div>
+              </ResourceList.Item>
+            );
+          }}
+        />
+      </Card>
+    </div>
+  );
+
+  function disambiguateLabel(key, value) {
+    switch (key) {
+      case 'moneySpent':
+        return `Money spent is between $${value[0]} and $${value[1]}`;
+      case 'taggedWith':
+        return `Tagged with ${value}`;
+      case 'accountStatus':
+        return value.map((val) => `Customer ${val}`).join(', ');
+      default:
+        return value;
+    }
+  }
+
+  function isEmpty(value) {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else {
+      return value === '' || value == null;
+    }
+  }
+}
+```
+
+### Filters with query field hidden
+
+```jsx
+function ResourceListFiltersExample() {
+  const [accountStatus, setAccountStatus] = useState(null);
+  const [moneySpent, setMoneySpent] = useState(null);
+  const [taggedWith, setTaggedWith] = useState(null);
+  const [queryValue, setQueryValue] = useState(null);
+
+  const handleAccountStatusChange = useCallback(
+    (value) => setAccountStatus(value),
+    [],
+  );
+  const handleMoneySpentChange = useCallback(
+    (value) => setMoneySpent(value),
+    [],
+  );
+  const handleTaggedWithChange = useCallback(
+    (value) => setTaggedWith(value),
+    [],
+  );
+  const handleFiltersQueryChange = useCallback(
+    (value) => setQueryValue(value),
+    [],
+  );
+  const handleAccountStatusRemove = useCallback(
+    () => setAccountStatus(null),
+    [],
+  );
+  const handleMoneySpentRemove = useCallback(() => setMoneySpent(null), []);
+  const handleTaggedWithRemove = useCallback(() => setTaggedWith(null), []);
+  const handleQueryValueRemove = useCallback(() => setQueryValue(null), []);
+  const handleFiltersClearAll = useCallback(() => {
+    handleAccountStatusRemove();
+    handleMoneySpentRemove();
+    handleTaggedWithRemove();
+    handleQueryValueRemove();
+  }, [
+    handleAccountStatusRemove,
+    handleMoneySpentRemove,
+    handleQueryValueRemove,
+    handleTaggedWithRemove,
+  ]);
+
+  const filters = [
+    {
+      key: 'accountStatus',
+      label: 'Account status',
+      filter: (
+        <ChoiceList
+          title="Account status"
+          titleHidden
+          choices={[
+            {label: 'Enabled', value: 'enabled'},
+            {label: 'Not invited', value: 'not invited'},
+            {label: 'Invited', value: 'invited'},
+            {label: 'Declined', value: 'declined'},
+          ]}
+          selected={accountStatus || []}
+          onChange={handleAccountStatusChange}
+          allowMultiple
+        />
+      ),
+      shortcut: true,
+    },
+    {
+      key: 'taggedWith',
+      label: 'Tagged with',
+      filter: (
+        <TextField
+          label="Tagged with"
+          value={taggedWith}
+          onChange={handleTaggedWithChange}
+          labelHidden
+        />
+      ),
+      shortcut: true,
+    },
+    {
+      key: 'moneySpent',
+      label: 'Money spent',
+      filter: (
+        <RangeSlider
+          label="Money spent is between"
+          labelHidden
+          value={moneySpent || [0, 500]}
+          prefix="$"
+          output
+          min={0}
+          max={2000}
+          step={1}
+          onChange={handleMoneySpentChange}
+        />
+      ),
+    },
+  ];
+
+  const appliedFilters = [];
+  if (!isEmpty(accountStatus)) {
+    const key = 'accountStatus';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, accountStatus),
+      onRemove: handleAccountStatusRemove,
+    });
+  }
+  if (!isEmpty(moneySpent)) {
+    const key = 'moneySpent';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, moneySpent),
+      onRemove: handleMoneySpentRemove,
+    });
+  }
+  if (!isEmpty(taggedWith)) {
+    const key = 'taggedWith';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, taggedWith),
+      onRemove: handleTaggedWithRemove,
+    });
+  }
+
+  return (
+    <div style={{height: '568px'}}>
+      <Card>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          filterControl={
+            <Filters
+              queryValue={queryValue}
+              filters={filters}
+              appliedFilters={appliedFilters}
+              onQueryChange={handleFiltersQueryChange}
+              onQueryClear={handleQueryValueRemove}
+              onClearAll={handleFiltersClearAll}
+              hideQueryField
             />
           }
           items={[

--- a/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
+++ b/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
@@ -51,8 +51,8 @@ $stacking-order: (
 
   &.right.newDesignLanguage {
     .CenterContainer * {
-      border-top-right-radius: var(--p-border-radius-base); // check
-      border-bottom-right-radius: var(--p-border-radius-base); // check
+      border-top-right-radius: var(--p-border-radius-base);
+      border-bottom-right-radius: var(--p-border-radius-base);
     }
   }
 }
@@ -94,8 +94,8 @@ $stacking-order: (
 
 .newDesignLanguage .RightContainer {
   .Item:first-of-type > div > button {
-    border-top-left-radius: var(--p-border-radius-base); // check
-    border-bottom-left-radius: var(--p-border-radius-base); // check
+    border-top-left-radius: var(--p-border-radius-base);
+    border-bottom-left-radius: var(--p-border-radius-base);
   }
 }
 

--- a/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
+++ b/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
@@ -78,6 +78,19 @@ $stacking-order: (
   }
 }
 
+.RightContainer.queryFieldHidden {
+  .Item:first-of-type > * > * {
+    border-top-left-radius: var(
+      --p-border-radius-base,
+      border-radius()
+    ) !important;
+    border-bottom-left-radius: var(
+      --p-border-radius-base,
+      border-radius()
+    ) !important;
+  }
+}
+
 .RightContainerWithoutMoreFilters {
   .Item:last-child > * > * {
     border-top-right-radius: var(

--- a/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
+++ b/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
@@ -123,7 +123,7 @@ $stacking-order: (
 }
 
 .MoreFiltersButtonContainer.onlyButtonVisible * {
-  border-radius: var(--p-border-radius-base) !important;
+  border-radius: var(--p-border-radius-base, border-radius()) !important;
 }
 
 .Wrapper {

--- a/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
+++ b/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
@@ -5,6 +5,7 @@
 // stylelint-disable selector-max-combinators
 // stylelint-disable selector-max-specificity
 // stylelint-disable selector-max-compound-selectors
+// stylelint-disable selector-max-type
 // 🐦🐀
 $stacking-order: (
   item: 10,
@@ -67,7 +68,7 @@ $stacking-order: (
 .RightContainer {
   display: flex;
 
-  .Item > * > * {
+  .Item > div > button {
     margin-right: var(--p-button-group-item-spacing, 0);
     margin-left: var(--p-override-none, -1px);
     border-radius: 0 !important;
@@ -79,7 +80,7 @@ $stacking-order: (
 }
 
 .RightContainer.queryFieldHidden {
-  .Item:first-of-type > * > * {
+  .Item:first-of-type > div > button {
     border-top-left-radius: var(
       --p-border-radius-base,
       border-radius()
@@ -92,7 +93,7 @@ $stacking-order: (
 }
 
 .RightContainerWithoutMoreFilters {
-  .Item:last-child > * > * {
+  .Item:last-child > div > button {
     border-top-right-radius: var(
       --p-border-radius-base,
       border-radius()
@@ -105,7 +106,7 @@ $stacking-order: (
 }
 
 .newDesignLanguage .RightContainer {
-  .Item:first-of-type > * > * {
+  .Item:first-of-type > div > button {
     border-top-left-radius: var(--p-border-radius-base) !important;
     border-bottom-left-radius: var(--p-border-radius-base) !important;
   }
@@ -136,5 +137,6 @@ $stacking-order: (
 // stylelint-enable selector-max-specificity
 // stylelint-enable selector-max-combinators
 // stylelint-enable selector-max-class
+// stylelint-enable selector-max-type
 // stylelint-enable declaration-no-important
 // stylelint-enable selector-max-compound-selectors

--- a/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
+++ b/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.scss
@@ -1,6 +1,5 @@
 @import '../../../../styles/common';
 
-// stylelint-disable declaration-no-important
 // stylelint-disable selector-max-class
 // stylelint-disable selector-max-combinators
 // stylelint-disable selector-max-specificity
@@ -45,15 +44,15 @@ $stacking-order: (
 
   &.right {
     .CenterContainer * {
-      border-top-right-radius: 0 !important;
-      border-bottom-right-radius: 0 !important;
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
     }
   }
 
   &.right.newDesignLanguage {
     .CenterContainer * {
-      border-top-right-radius: var(--p-border-radius-base) !important;
-      border-bottom-right-radius: var(--p-border-radius-base) !important;
+      border-top-right-radius: var(--p-border-radius-base); // check
+      border-bottom-right-radius: var(--p-border-radius-base); // check
     }
   }
 }
@@ -71,7 +70,7 @@ $stacking-order: (
   .Item > div > button {
     margin-right: var(--p-button-group-item-spacing, 0);
     margin-left: var(--p-override-none, -1px);
-    border-radius: 0 !important;
+    border-radius: 0;
   }
 
   .Item {
@@ -81,50 +80,41 @@ $stacking-order: (
 
 .RightContainer.queryFieldHidden {
   .Item:first-of-type > div > button {
-    border-top-left-radius: var(
-      --p-border-radius-base,
-      border-radius()
-    ) !important;
-    border-bottom-left-radius: var(
-      --p-border-radius-base,
-      border-radius()
-    ) !important;
+    border-top-left-radius: var(--p-border-radius-base, border-radius());
+    border-bottom-left-radius: var(--p-border-radius-base, border-radius());
   }
 }
 
 .RightContainerWithoutMoreFilters {
   .Item:last-child > div > button {
-    border-top-right-radius: var(
-      --p-border-radius-base,
-      border-radius()
-    ) !important;
-    border-bottom-right-radius: var(
-      --p-border-radius-base,
-      border-radius()
-    ) !important;
+    border-top-right-radius: var(--p-border-radius-base, border-radius());
+    border-bottom-right-radius: var(--p-border-radius-base, border-radius());
   }
 }
 
 .newDesignLanguage .RightContainer {
   .Item:first-of-type > div > button {
-    border-top-left-radius: var(--p-border-radius-base) !important;
-    border-bottom-left-radius: var(--p-border-radius-base) !important;
+    border-top-left-radius: var(--p-border-radius-base); // check
+    border-bottom-left-radius: var(--p-border-radius-base); // check
   }
 }
 
-.MoreFiltersButtonContainer * {
-  border-top-left-radius: 0 !important;
-  border-bottom-left-radius: 0 !important;
-  flex-shrink: 0;
-  white-space: nowrap;
-
+.MoreFiltersButtonContainer {
   > div {
     margin-left: var(--p-override-none, -1px);
   }
+
+  .Item > div > button {
+    white-space: nowrap;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
 }
 
-.MoreFiltersButtonContainer.onlyButtonVisible * {
-  border-radius: var(--p-border-radius-base, border-radius()) !important;
+.MoreFiltersButtonContainer.onlyButtonVisible {
+  .Item > div > button {
+    border-radius: var(--p-border-radius-base, border-radius());
+  }
 }
 
 .Wrapper {
@@ -138,5 +128,4 @@ $stacking-order: (
 // stylelint-enable selector-max-combinators
 // stylelint-enable selector-max-class
 // stylelint-enable selector-max-type
-// stylelint-enable declaration-no-important
 // stylelint-enable selector-max-compound-selectors

--- a/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.tsx
@@ -115,7 +115,7 @@ export class ConnectedFilterControl extends Component<
     const moreFiltersButtonContainerClassname = classNames(
       styles.MoreFiltersButtonContainer,
       actionsToRender.length === 0 &&
-        newDesignLanguage &&
+        (newDesignLanguage || queryFieldHidden) &&
         styles.onlyButtonVisible,
     );
 
@@ -197,9 +197,13 @@ export class ConnectedFilterControl extends Component<
         .width;
       const filtersActionWidth = 0;
 
+      const filterFieldMinWidth = this.props.queryFieldHidden
+        ? 0
+        : FILTER_FIELD_MIN_WIDTH;
+
       const availableWidth =
         containerWidth -
-        FILTER_FIELD_MIN_WIDTH -
+        filterFieldMinWidth -
         moreFiltersButtonWidth -
         filtersActionWidth;
 

--- a/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.tsx
@@ -26,6 +26,7 @@ export interface ConnectedFilterControlProps {
   auxiliary?: React.ReactNode;
   disabled?: boolean;
   forceShowMorefiltersButton?: boolean;
+  queryFieldHidden?: boolean;
 }
 
 interface ComputedProperty {
@@ -76,6 +77,7 @@ export class ConnectedFilterControl extends Component<
       rightAction,
       auxiliary,
       forceShowMorefiltersButton = true,
+      queryFieldHidden,
     } = this.props;
 
     const actionsToRender =
@@ -97,6 +99,7 @@ export class ConnectedFilterControl extends Component<
     const RightContainerClassName = classNames(
       styles.RightContainer,
       !shouldRenderMoreFiltersButton && styles.RightContainerWithoutMoreFilters,
+      queryFieldHidden && styles.queryFieldHidden,
     );
 
     const rightMarkup =
@@ -148,9 +151,11 @@ export class ConnectedFilterControl extends Component<
         {proxyButtonMarkup}
         <div className={styles.Wrapper}>
           <div className={className} ref={this.container}>
-            <div className={styles.CenterContainer}>
-              <Item>{children}</Item>
-            </div>
+            {children ? (
+              <div className={styles.CenterContainer}>
+                <Item>{children}</Item>
+              </div>
+            ) : null}
             {rightMarkup}
             {rightActionMarkup}
             <EventListener event="resize" handler={this.handleResize} />

--- a/src/components/Filters/components/ConnectedFilterControl/tests/ConnectedFilterControl.test.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/tests/ConnectedFilterControl.test.tsx
@@ -202,6 +202,24 @@ describe('<ConnectedFilterControl />', () => {
       disabled: true,
     });
   });
+
+  it('does not render CenterContainer when no child element is "null"', () => {
+    const connectedFilterControl = mountWithAppProvider(
+      <ConnectedFilterControl>{null}</ConnectedFilterControl>,
+    );
+
+    expect(connectedFilterControl.find('.CenterContainer')).toHaveLength(0);
+  });
+
+  it('renders CenterContainer when no child element is not "null"', () => {
+    const connectedFilterControl = mountWithAppProvider(
+      <ConnectedFilterControl>
+        <MockChild />
+      </ConnectedFilterControl>,
+    );
+
+    expect(connectedFilterControl.find('.CenterContainer')).toHaveLength(1);
+  });
 });
 
 function noop() {}

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -85,7 +85,7 @@ describe('<Filters />', () => {
     expect(onQueryFocus).toHaveBeenCalledTimes(1);
   });
 
-  it('hides the TextField when "hideQueryField" is "true"', () => {
+  it('does not render the TextField when "hideQueryField" is "true"', () => {
     const filters = mountWithAppProvider(
       <Filters {...mockProps} hideQueryField />,
     );
@@ -93,7 +93,7 @@ describe('<Filters />', () => {
     expect(filters.find(TextField).exists()).toBe(false);
   });
 
-  it('shows the TextField when "hideQueryField" is falsy', () => {
+  it('renders the TextField when "hideQueryField" is false', () => {
     const filters = mountWithAppProvider(<Filters {...mockProps} />);
 
     expect(filters.find(TextField).exists()).toBe(true);

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -85,6 +85,20 @@ describe('<Filters />', () => {
     expect(onQueryFocus).toHaveBeenCalledTimes(1);
   });
 
+  it('hides the TextField when "hideQueryField" is "true"', () => {
+    const filters = mountWithAppProvider(
+      <Filters {...mockProps} hideQueryField />,
+    );
+
+    expect(filters.find(TextField).exists()).toBe(false);
+  });
+
+  it('shows the TextField when "hideQueryField" is falsy', () => {
+    const filters = mountWithAppProvider(<Filters {...mockProps} />);
+
+    expect(filters.find(TextField).exists()).toBe(true);
+  });
+
   describe('toggleFilters()', () => {
     it('opens the sheet on toggle button click', () => {
       const resourceFilters = mountWithAppProvider(<Filters {...mockProps} />);
@@ -238,6 +252,16 @@ describe('<Filters />', () => {
         resourceFilters.find(ConnectedFilterControl).props()
           .rightPopoverableActions,
       ).toHaveLength(2);
+    });
+
+    it('receives the expected props when the query field is hidden', () => {
+      const resourceFilters = mountWithAppProvider(
+        <Filters {...mockPropsWithShortcuts} hideQueryField />,
+      );
+
+      expect(
+        resourceFilters.find(ConnectedFilterControl).props().queryFieldHidden,
+      ).toBe(true);
     });
 
     it('forces showing the "More Filters" button if there are filters without shortcuts', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Whenever a `Filters` component is used, it always includes the search text input field. 
Text search doesn't make sense in all contexts that a `Filters` can be used in.

Related Feature Request
https://github.com/Shopify/polaris-react/issues/3671

Original PR that was closed:
https://github.com/Shopify/polaris-react/pull/3674

### WHAT is this pull request doing?

This PR adds an optional boolean prop named `hideQueryField` which hides the query text field.

Here is the how the Filters component currently looks:
<img width="774" alt="Current view of Filters Component" src="https://user-images.githubusercontent.com/72987032/100774400-07ae2700-33d0-11eb-9352-ec79d37666b4.png">

Here is what the Filters component looks with the query text field hidden:
<img width="955" alt="Filters Component with the query field hidden" src="https://user-images.githubusercontent.com/72987032/100777649-18f93280-33d4-11eb-9381-753765ae2430.png">

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

You can use any of the existing `Filters` examples and add the `hideQueryField` prop. 
This should hide the query filter text field.

**NOTE: I tried tophatting the documentation but I don't see my new example (`Filters with query field hidden`) showing as an example in the drop-down. I'm not sure if this is expected or if I'm doing something wrong.**

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
