### PR TITLE
[DataTable] Add focus ring to heading

### DIFF
--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -125,6 +125,7 @@ $breakpoint: 768px;
 
 .Heading {
   @include unstyled-button;
+  @include focus-ring;
   position: relative;
   display: inline-flex;
   justify-content: flex-end;
@@ -132,17 +133,21 @@ $breakpoint: 768px;
   @include recolor-icon(var(--p-icon));
   color: var(--p-text, color(ink));
   transition: color duration() easing();
-  padding: spacing();
   cursor: pointer;
+  padding: spacing(tight);
+  margin: spacing(tight);
 
-  &:hover,
-  &:focus {
+  &:hover {
     @include recolor-icon(var(--p-interactive-hovered, color('indigo')));
     color: var(--p-interactive-hovered, color('indigo'));
 
     .Icon {
       opacity: 1;
     }
+  }
+
+  &:focus:not(:active) {
+    @include focus-ring($style: 'focused');
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes part of https://github.com/Shopify/polaris-ux/issues/453

Before:
![image](https://screenshot.click/All_Components__Data_table_-_All_Examples__Storybook_2020-12-08_15-36-06.png)

After:
![image](https://screenshot.click/All_Components__Data_table_-_All_Examples__Storybook_2020-12-08_15-35-49.png)

### WHAT is this pull request doing?

Adds the focus ring to Data Table headings

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Visit the data table page in the chroma link below when it's been generated. Make sure the new design language has been enabled

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
