### PR TITLE
Adding focus-visible styles with polyfill

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,8 +6,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-- Added `flush` prop to `Card.Section` ([#3645](https://github.com/Shopify/polaris-react/pull/3645))
-- Added `stretchContent` prop for `Button` ([#3664](https://github.com/Shopify/polaris-react/pull/3664))
 - Added `focus-visible` polyfill and default styles ([#3695](https://github.com/Shopify/polaris-react/pull/3695))
 
 ### Bug fixes

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,10 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added `flush` prop to `Card.Section` ([#3645](https://github.com/Shopify/polaris-react/pull/3645))
+- Added `stretchContent` prop for `Button` ([#3664](https://github.com/Shopify/polaris-react/pull/3664))
+- Added `focus-visible` polyfill and default styles ([#3695](https://github.com/Shopify/polaris-react/pull/3695))
+
 ### Bug fixes
 
 - Fixed virtual cursor leaving dialog in `Modal`, `Navigation` and `Sheet` ([#3931](https://github.com/Shopify/polaris-react/pull/3931))

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@types/react": "^16.9.12",
     "@types/react-dom": "^16.9.4",
     "@types/react-transition-group": "^4.4.0",
+    "focus-visible": "^5.2.0",
     "lodash": "^4.17.4",
     "react-transition-group": "^4.4.1"
   },

--- a/src/components/AppProvider/AppProvider.scss
+++ b/src/components/AppProvider/AppProvider.scss
@@ -62,6 +62,29 @@ body {
   box-sizing: border-box;
 }
 
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 rem(2px) var(--p-focused, color('indigo'));
+  border-radius: var(--p-border-radius-base);
+}
+
+[data-js-focus-visible] {
+  :focus:not([data-focus-visible-added]) {
+    outline: none;
+  }
+
+  // stylelint-disable-next-line selector-max-attribute
+  [data-focus-visible-added] {
+    outline: none;
+    box-shadow: 0 0 0 rem(2px) var(--p-focused, color('indigo'));
+    border-radius: var(--p-border-radius-base);
+  }
+}
+
 h1,
 h2,
 h3,

--- a/src/components/AppProvider/AppProvider.scss
+++ b/src/components/AppProvider/AppProvider.scss
@@ -62,29 +62,6 @@ body {
   box-sizing: border-box;
 }
 
-:focus:not(:focus-visible) {
-  outline: none;
-}
-
-:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 rem(2px) var(--p-focused, color('indigo'));
-  border-radius: var(--p-border-radius-base);
-}
-
-[data-js-focus-visible] {
-  :focus:not([data-focus-visible-added]) {
-    outline: none;
-  }
-
-  // stylelint-disable-next-line selector-max-attribute
-  [data-focus-visible-added] {
-    outline: none;
-    box-shadow: 0 0 0 rem(2px) var(--p-focused, color('indigo'));
-    border-radius: var(--p-border-radius-base);
-  }
-}
-
 h1,
 h2,
 h3,

--- a/src/components/AppProvider/AppProvider.tsx
+++ b/src/components/AppProvider/AppProvider.tsx
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import 'focus-visible/dist/focus-visible';
 
 import type {ThemeConfig} from '../../utilities/theme';
 import {ThemeProvider} from '../ThemeProvider';

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -405,7 +405,7 @@ describe('<PopoverOverlay />', () => {
         </PopoverOverlay>,
       );
 
-      expect(document.activeElement?.className).toBe('Content');
+      expect(document.activeElement?.className).toContain('Content');
     });
 
     it('does not focus when autofocusTarget is set to None', () => {

--- a/src/components/Tooltip/README.md
+++ b/src/components/Tooltip/README.md
@@ -68,8 +68,8 @@ Use only when necessary to provide an explanation for an interface element.
 
 ```jsx
 <div style={{padding: '75px 0'}}>
-  <Tooltip content="This order has shipping labels.">
-    <Link>Order #1001</Link>
+  <Tooltip active content="This order has shipping labels.">
+    <TextStyle variation="strong">Order #1001</TextStyle>
   </Tooltip>
 </div>
 ```

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -60,6 +60,7 @@ export function Tooltip({
 
     accessibilityNode.tabIndex = 0;
     accessibilityNode.setAttribute('aria-describedby', id);
+    accessibilityNode.setAttribute('data-polaris-tooltip-activator', 'true');
   }, [id, children]);
 
   const handleKeyUp = useCallback(

--- a/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
+++ b/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
@@ -34,3 +34,17 @@ $content-max-width: rem(200px);
   padding: spacing(extra-tight) spacing(tight);
   word-break: break-word;
 }
+
+[data-polaris-tooltip-activator] {
+  outline: 0;
+  @include focus-ring;
+
+  &:focus-visible {
+    @include focus-ring($style: 'focused');
+  }
+}
+
+// stylelint-disable-next-line selector-max-attribute
+[data-polaris-tooltip-activator][data-focus-visible-added] {
+  @include focus-ring($style: 'focused');
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9755,6 +9755,18 @@ focus-lock@^0.6.6:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.6.tgz#98119a755a38cfdbeda0280eaa77e307eee850c7"
   integrity sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw==
 
+focus-visible@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
+  integrity sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
+
 follow-redirects@^1.0.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"


### PR DESCRIPTION
### WHY are these changes introduced?

Currently we use a hack for not showing focus rings on things like buttons by blurring on `mouseup`. This works, but it takes adding this behaviour specifically to every component that needs it.

This adds the `focus-visible` polyfill so that we can start taking a CSS approach to this that will eventually be supported by browsers and we can remove the polyfill at that point.

Right now this would be about a __1kb__ bundle increase, but I think we could get it to about the same once we start removing the custom click/blur code.

Here is an example of clicking or tabbing to a tooltip activator before this change:

<img width="295" alt="Screen Shot 2020-12-09 at 1 15 56 PM" src="https://user-images.githubusercontent.com/478990/101670186-d90ffc00-3a20-11eb-9b11-ef3f4d180ac4.png">

And after this change clicking would show this:
<img width="233" alt="Screen Shot 2020-12-09 at 1 16 21 PM" src="https://user-images.githubusercontent.com/478990/101670232-e927db80-3a20-11eb-94d0-45439ac8f450.png">

And tabbing to would show this:
<img width="261" alt="Screen Shot 2020-12-09 at 1 16 13 PM" src="https://user-images.githubusercontent.com/478990/101670250-edec8f80-3a20-11eb-8b70-6faf5ed2e20f.png">

### WHAT is this pull request doing?

This adds the polyfill package as well as some default `focus-visible` styles for all elements.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}

```

</details>

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
