### PR TITLE
[Link] underlined by default and add removeUnderline prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Breaking changes
 
+- `Link` is underlined by default, added `removeUnderline` prop to remove underline ([#3705](https://github.com/Shopify/polaris-react/pull/3705))
 - Remove `light` property from `Tooltip` as it now defaults to a light background ([#3846](https://github.com/Shopify/polaris-react/pull/3846))
 - Made `title` property required in `Modal` for accessibility label, added `hideTitle` property ([#3803](https://github.com/Shopify/polaris-react/pull/3803))
 - Added required `ariaLabel` property in `Sheet` ([#3852](https://github.com/Shopify/polaris-react/pull/3852))

--- a/src/components/DataTable/README.md
+++ b/src/components/DataTable/README.md
@@ -279,7 +279,11 @@ Use to help merchants find relevant, finer grained data sets.
 function DataTableLinkExample() {
   const rows = [
     [
-      <Link url="https://www.example.com" key="emerald-silk-gown">
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="emerald-silk-gown"
+      >
         Emerald Silk Gown
       </Link>,
       '$875.00',
@@ -288,7 +292,11 @@ function DataTableLinkExample() {
       '$122,500.00',
     ],
     [
-      <Link url="https://www.example.com" key="mauve-cashmere-scarf">
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="mauve-cashmere-scarf"
+      >
         Mauve Cashmere Scarf
       </Link>,
       '$230.00',
@@ -297,7 +305,11 @@ function DataTableLinkExample() {
       '$19,090.00',
     ],
     [
-      <Link url="https://www.example.com" key="navy-merino-wool">
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="navy-merino-wool"
+      >
         Navy Merino Wool Blazer with khaki chinos and yellow belt
       </Link>,
       '$445.00',
@@ -338,7 +350,11 @@ function FullDataTableExample() {
 
   const initiallySortedRows = [
     [
-      <Link url="https://www.example.com" key="emerald-silk-gown">
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="emerald-silk-gown"
+      >
         Emerald Silk Gown
       </Link>,
       '$875.00',
@@ -347,7 +363,11 @@ function FullDataTableExample() {
       '$121,500.00',
     ],
     [
-      <Link url="https://www.example.com" key="mauve-cashmere-scarf">
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="mauve-cashmere-scarf"
+      >
         Mauve Cashmere Scarf
       </Link>,
       '$230.00',
@@ -356,7 +376,11 @@ function FullDataTableExample() {
       '$19,090.00',
     ],
     [
-      <Link url="https://www.example.com" key="navy-merino-wool">
+      <Link
+        removeUnderline
+        url="https://www.example.com"
+        key="navy-merino-wool"
+      >
         Navy Merino Wool Blazer with khaki chinos and yellow belt
       </Link>,
       '$445.00',

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -9,18 +9,17 @@
   border: 0;
   font-size: inherit;
   color: var(--p-interactive);
-  text-decoration: none;
+  text-decoration: underline;
   cursor: pointer;
 
   &:hover {
     color: var(--p-interactive-hovered);
-    text-decoration: underline;
+    text-decoration: none;
   }
 
   &:focus {
     $chrome-default-outline: rgba(0, 103, 244, 0.247) auto rem(4.5px);
     outline: var(--p-override-none);
-    text-decoration: underline;
   }
 
   &:focus:not(:active) {
@@ -30,7 +29,6 @@
   &:active {
     position: relative;
     color: var(--p-interactive-pressed);
-    text-decoration: underline;
 
     &::before {
       content: '';
@@ -68,11 +66,14 @@
 
 .monochrome {
   color: inherit;
-  text-decoration: underline;
 
   &:hover,
   &:focus,
   &:active {
     color: inherit;
   }
+}
+
+.removeUnderline {
+  text-decoration: none;
 }

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -20,6 +20,8 @@ export interface LinkProps {
   external?: boolean;
   /** Makes the link color the same as the current text color and adds an underline */
   monochrome?: boolean;
+  /** Removes text decoration underline to the link*/
+  removeUnderline?: boolean;
   /** Callback when a link is clicked */
   onClick?(): void;
   /** Descriptive text to be read to screenreaders */
@@ -33,6 +35,7 @@ export function Link({
   external,
   id,
   monochrome,
+  removeUnderline,
   accessibilityLabel,
 }: LinkProps) {
   const i18n = useI18n();
@@ -63,6 +66,7 @@ export function Link({
         const className = classNames(
           styles.Link,
           shouldBeMonochrome && styles.monochrome,
+          removeUnderline && styles.removeUnderline,
         );
 
         return url ? (

--- a/src/components/Link/README.md
+++ b/src/components/Link/README.md
@@ -110,6 +110,31 @@ Use for text links that should open in a new browser tab (or window, depending o
 
 Use the `url` prop to give the link component a valid `href` value. This allows the element to be identified as a link to assistive technologies and gives it default keyboard support.
 
+The Link component is underlined to give interactive elements a shape. This allows links to not rely on color from being the only way users can tell if an element is interactive.
+
+<!-- usageblock -->
+
+#### Do
+
+- Remove the link underline when link is repeated in a list or navigation
+- Use underlines for links when used inline content
+
+```jsx
+<p>
+  Learn more about <Link>Fraud Protect</Link>.
+</p>
+```
+
+#### Don’t
+
+- Remove underlines when the user cannot determine it's interactivity
+
+```jsx
+<Link removeUnderline>Learn more about Fraud Protect.</Link>
+```
+
+<!-- end -->
+
 ### Submitting data
 
 Merchants generally expect links to navigate, and not to submit data or take action. If you need a component that doesn’t have a URL associated with it, then use the [button component](https://polaris.shopify.com/components/actions/button) instead.

--- a/src/components/Link/tests/Link.test.tsx
+++ b/src/components/Link/tests/Link.test.tsx
@@ -140,4 +140,12 @@ describe('<Link />', () => {
       });
     });
   });
+
+  describe('removesUnderline', () => {
+    it('passes prop to the button url is not provided', () => {
+      const link = mountWithAppProvider(<Link removeUnderline>Test</Link>);
+
+      expect(link.find('button').hasClass('removeUnderline')).toBe(true);
+    });
+  });
 });

--- a/src/components/Link/tests/Link.test.tsx
+++ b/src/components/Link/tests/Link.test.tsx
@@ -142,7 +142,7 @@ describe('<Link />', () => {
   });
 
   describe('removesUnderline', () => {
-    it('passes prop to the button url is not provided', () => {
+    it('adds removeUnderline class to the link', () => {
       const link = mountWithAppProvider(<Link removeUnderline>Test</Link>);
 
       expect(link.find('button').hasClass('removeUnderline')).toBe(true);


### PR DESCRIPTION
### WHY are these changes introduced?
These changes are introduced after discussions regarding if the link component should be underline by default (https://github.com/Shopify/polaris-react/pull/3697), and if color alone is able to convey controls (https://github.com/Shopify/polaris-ux/issues/455). It was determined that making the link component underline by default makes the component more accessible when color is the only way to convey a link is interactive. It was also determined that it would be easier to add a 'removeUnderline' prop if the underline was not required, as opposed to adding an underline prop every time.

Fixes Shopify/polaris-ux#455

### WHAT is this pull request doing?
This pull request makes the link component underline by default, and adds a 'removeUnderline' prop that removes the underline on the link.

This screenshot shows the Link component, which is underline by default. 
![Screen Shot 2020-12-11 at 10 35 33 AM](https://user-images.githubusercontent.com/54586463/101922856-a0952d00-3b9c-11eb-89ae-02bf5d78703c.png)

This screenshot shows the Link component when the removeUnderline prop is added. 
![Screen Shot 2020-12-11 at 10 34 47 AM](https://user-images.githubusercontent.com/54586463/101922773-85c2b880-3b9c-11eb-810b-6fd66c93af01.png)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Link} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Link url="https://help.shopify.com/manual">Link default</Link>
    </Page>
  );
}

```

```jsx
import React from 'react';

import {Page, Link} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Link url="https://help.shopify.com/manual" removeUnderline>
        No underline
      </Link>
    </Page>
  );
}

```
</details>

### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
