### PR TITLE
[i18n] Add Vietnamese to supported languages

### DIFF
--- a/translation.yml
+++ b/translation.yml
@@ -20,6 +20,7 @@ target_languages:
     sv,
     th,
     tr,
+    vi,
     zh-CN,
     zh-TW,
   ]


### PR DESCRIPTION
### WHY are these changes introduced?

The file has not been updated with the rollout of Vietnamese (`vi`) in other repositories. This omission is causing mixed-language issues in multiple places in the admin.

### WHAT is this pull request doing?

Updating our `translation.yml` with the latest list of supported languages so that the translation platform keeps our locales in sync with what the product supports.