### PR TITLE
🐛 + ✨ [Button] Bug fixes, small improvements, new "select" disclosure

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,19 +10,25 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Updated `OptionList` selected styles ([#3633](https://github.com/Shopify/polaris-react/pull/3633))
 - Added the ability to hide the clear filter button on the filter component ([#3049](https://github.com/Shopify/polaris-react/pull/3049))
-- **`Popover`:** New `autofocusTarget` prop to enhance autofocus options ([#3600](https://github.com/Shopify/polaris-react/pull/3600))
+- Right-align `disclosure` when using `textAlignLeft` for `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
+- Remove all transitions from `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
+- New `select` option for `disclosure` in `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
 - Conveyed `DatePicker` more clearly to screen readers ([#3660](https://github.com/Shopify/polaris-react/pull/3660))
-- Added `accessibilityLabels` prop to `Pagination` ([#3667] (https://github.com/Shopify/polaris-react/pull/3667))
+- Added `accessibilityLabels` prop to `Pagination` ([#3667](https://github.com/Shopify/polaris-react/pull/3667))
+- New `autofocusTarget` prop to enhance autofocus options on `Popover` ([#3600](https://github.com/Shopify/polaris-react/pull/3600))
 - Added ability to hide query text field in `Filters` component using `hideQueryField` prop ([#3674](https://github.com/Shopify/polaris-react/pull/3674))
 - Added `tabIndex` to `Scrollable` for keyboard focus ([#3744](https://github.com/Shopify/polaris-react/pull/3744))
 - Added accessibility label prop to `UserMenu` and `Menu` subcomponents in `TopBar` ([#3659](https://github.com/Shopify/polaris-react/pull/3659))
 - Add `aria-label` to the `Loading` bar in `Frame` ([#3770](https://github.com/Shopify/polaris-react/pull/3770))
-- **`Button`:** New `ariaDescribedBy` prop for `<button />` ([#3664](https://github.com/Shopify/polaris-react/pull/3686))
 - Updated `Collapsible` to be a functional component ([#3779](https://github.com/Shopify/polaris-react/pull/3779))
 - Coverted `TooltipOverlay` to a functional component ([#3631](https://github.com/Shopify/polaris-react/pull/3631))
+- New `ariaDescribedBy` prop for `Button` ([#3664](https://github.com/Shopify/polaris-react/pull/3686))
 
 ### Bug fixes
 
+- `plain` variant `children` no longer remain visible while `loading` for `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
+- No longer spin `disclosure` 180deg when toggling between `up` and `down` on `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
+- Prevent layout shift when toggling “filled” variants on `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
 - Fixed `FocusManager` from tracking inactive items that prevented trap focusing([#3630](https://github.com/Shopify/polaris-react/pull/3630))
 - Added escape keybind to `Tooltip` ([#3627](https://github.com/Shopify/polaris-react/pull/3627))
 - Removed extra bottom border on the `DataTable` and added curved edges to footers ([#3571](https://github.com/Shopify/polaris-react/pull/3571))
@@ -69,4 +75,5 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Deprecations
 
+- `stretchContent` has been replaced by `textAlign="left" + fullWidth` for `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
 - Deprecated `Popover`'s prop `preventAutofocus`. Use `autofocusTarget` instead ([#3602](https://github.com/Shopify/polaris-react/issues/3602))

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -97,8 +97,11 @@ $stacking-order: (
   justify-content: center;
   align-items: center;
   min-width: 1px;
-  width: 100%;
   min-height: 1px;
+
+  .Button:not(.plain) & {
+    width: 100%;
+  }
 }
 
 .textAlignLeft {

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -144,7 +144,8 @@ $stacking-order: (
     margin-left: spacing(extra-tight);
   }
 
-  .textAlignLeft &:last-child {
+  // stylelint-disable-next-line selector-max-class, selector-max-specificity
+  .fullWidth.textAlignLeft &:last-child:not(:only-child) {
     margin-left: auto;
   }
 
@@ -608,11 +609,6 @@ $stacking-order: (
   .Icon:last-child {
     margin-right: rem(-4px);
   }
-  // stylelint-disable selector-max-class, selector-max-combinators, selector-max-specificity
-  &:not(.textAlignLeft) .Icon + .Icon:last-child {
-    margin-left: 0;
-  }
-  // stylelint-enable selector-max-class, selector-max-combinators, selector-max-specificity
 
   .Icon:only-child {
     margin-right: 0;

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -50,7 +50,6 @@ $partial-button-filled-pressed-box-shadow: inset 0 0 0 0 transparent,
 
   &:focus,
   &:hover {
-    transition-duration: duration(fast);
     background: linear-gradient(to bottom, $color-light, $color-light);
     border-color: $color-dark;
     box-shadow: $partial-button-filled-pressed-box-shadow $color-dark;
@@ -130,12 +129,6 @@ $stacking-order: (
 }
 
 .Icon {
-  transition: color duration() easing();
-
-  .newDesignLanguage & {
-    transition: none;
-  }
-
   // This compensates for the typical icon used in buttons being
   // inset within its bounding box.
   margin-left: -(spacing(extra-tight));
@@ -155,6 +148,13 @@ $stacking-order: (
 
   + *:not(.Icon) {
     margin-left: spacing(extra-tight);
+  }
+
+  .newDesignLanguage & {
+    // stylelint-disable-next-line selector-max-combinators
+    svg {
+      transition: fill duration() easing();
+    }
   }
 }
 
@@ -273,7 +273,6 @@ $stacking-order: (
 .loading,
 .newDesignLanguage.loading {
   position: relative;
-  transition: border-color duration() easing();
 
   // stylelint-disable-next-line selector-max-class
   &,
@@ -294,7 +293,6 @@ $stacking-order: (
   @include pressed-box-shadow;
 
   &:hover {
-    transition-duration: duration(fast);
     background: $pressed-hover-background;
     border-color: $pressed-border-color;
     @include pressed-box-shadow;

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -141,8 +141,7 @@ $stacking-order: (
     margin-left: spacing(extra-tight);
   }
 
-  // stylelint-disable-next-line selector-max-class, selector-max-specificity
-  .fullWidth.textAlignLeft:not(.stretchContent) &:last-child {
+  .textAlignLeft &:last-child {
     margin-left: auto;
   }
 
@@ -607,7 +606,7 @@ $stacking-order: (
     margin-right: rem(-4px);
   }
   // stylelint-disable selector-max-class, selector-max-combinators, selector-max-specificity
-  .Icon + .Icon:last-child {
+  &:not(.textAlignLeft) .Icon + .Icon:last-child {
     margin-left: 0;
   }
   // stylelint-enable selector-max-class, selector-max-combinators, selector-max-specificity

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -731,16 +731,6 @@ $stacking-order: (
 }
 // stylelint-enable selector-max-specificity
 
-.DisclosureIcon {
-  transition-property: transform;
-  transition-duration: duration(slow);
-  transition-timing-function: easing(out);
-}
-
-.DisclosureIconFacingUp {
-  transform: rotate(-180deg);
-}
-
 .ConnectedDisclosureWrapper {
   display: flex;
 }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -98,12 +98,17 @@ $stacking-order: (
   justify-content: center;
   align-items: center;
   min-width: 1px;
+  width: 100%;
   min-height: 1px;
 }
 
 .textAlignLeft {
   justify-content: flex-start;
   text-align: left;
+
+  .Content {
+    justify-content: flex-start;
+  }
 }
 
 .textAlignCenter {
@@ -114,11 +119,14 @@ $stacking-order: (
 .textAlignRight {
   justify-content: flex-end;
   text-align: right;
+
+  .Content {
+    justify-content: flex-end;
+  }
 }
 
-.stretchContent:not(.loading) > .Content {
+.stretchContent > .Content {
   justify-content: space-between;
-  width: 100%;
 }
 
 .Icon {
@@ -138,6 +146,11 @@ $stacking-order: (
     // spacing on the right of the button)
     margin-right: -(spacing(tight));
     margin-left: spacing(extra-tight);
+  }
+
+  // stylelint-disable-next-line selector-max-class, selector-max-specificity
+  .fullWidth.textAlignLeft:not(.stretchContent) &:last-child {
+    margin-left: auto;
   }
 
   + *:not(.Icon) {

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -500,6 +500,10 @@ $stacking-order: (
     &.disabled {
       color: var(--p-text-disabled);
       background: none;
+
+      &.loading {
+        color: transparent;
+      }
     }
 
     &.iconOnly {

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -124,6 +124,10 @@ $stacking-order: (
 .Icon {
   transition: color duration() easing();
 
+  .newDesignLanguage & {
+    transition: none;
+  }
+
   // This compensates for the typical icon used in buttons being
   // inset within its bounding box.
   margin-left: -(spacing(extra-tight));

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -155,7 +155,7 @@ $stacking-order: (
   .newDesignLanguage & {
     // stylelint-disable-next-line selector-max-combinators
     svg {
-      transition: fill duration() easing();
+      transition: fill duration(fast) easing();
     }
   }
 }
@@ -675,7 +675,7 @@ $stacking-order: (
 
     &::before {
       content: '';
-      transition: opacity duration() easing();
+      transition: opacity duration(fast) easing();
       position: absolute;
       top: 0;
       right: 0;

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -145,7 +145,7 @@ $stacking-order: (
   }
 }
 
-.Hidden {
+.hidden {
   visibility: hidden;
 }
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -152,13 +152,6 @@ $stacking-order: (
   + *:not(.Icon) {
     margin-left: spacing(extra-tight);
   }
-
-  .newDesignLanguage & {
-    // stylelint-disable-next-line selector-max-combinators
-    svg {
-      transition: fill duration(fast) easing();
-    }
-  }
 }
 
 .hidden {
@@ -671,7 +664,6 @@ $stacking-order: (
 
     &::before {
       content: '';
-      transition: opacity duration(fast) easing();
       position: absolute;
       top: 0;
       right: 0;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import {CaretDownMinor} from '@shopify/polaris-icons';
+import {CaretDownMinor, CaretUpMinor} from '@shopify/polaris-icons';
 
 import type {BaseButton, ConnectedDisclosure, IconSource} from '../../types';
 import {classNames, variationName} from '../../utilities/css';
@@ -145,17 +145,13 @@ export function Button({
   );
 
   const disclosureIcon = (
-    <Icon source={loading ? 'placeholder' : CaretDownMinor} />
+    <Icon source={getDisclosureIconSource({loading, disclosure})} />
   );
 
   const disclosureIconMarkup = disclosure ? (
     <span className={styles.Icon}>
       <div
-        className={classNames(
-          styles.DisclosureIcon,
-          disclosure === 'up' && styles.DisclosureIconFacingUp,
-          loading && styles.Hidden,
-        )}
+        className={classNames(styles.DisclosureIcon, loading && styles.Hidden)}
       >
         {disclosureIcon}
       </div>
@@ -312,4 +308,15 @@ function isIconSource(x: any): x is IconSource {
     (typeof x === 'object' && x.body) ||
     typeof x === 'function'
   );
+}
+
+function getDisclosureIconSource({
+  loading,
+  disclosure,
+}: Pick<ButtonProps, 'loading' | 'disclosure'>) {
+  if (loading) {
+    return 'placeholder';
+  }
+
+  return disclosure === 'up' ? CaretUpMinor : CaretDownMinor;
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -162,20 +162,16 @@ export function Button({
     </span>
   ) : null;
 
-  let iconMarkup;
-
-  if (icon) {
-    const iconInner = isIconSource(icon) ? (
-      <Icon source={loading ? 'placeholder' : icon} />
-    ) : (
-      icon
-    );
-    iconMarkup = (
-      <span className={classNames(styles.Icon, loading && styles.Hidden)}>
-        {iconInner}
-      </span>
-    );
-  }
+  const iconSource = isIconSource(icon) ? (
+    <Icon source={loading ? 'placeholder' : icon} />
+  ) : (
+    icon
+  );
+  const iconMarkup = iconSource ? (
+    <span className={classNames(styles.Icon, loading && styles.Hidden)}>
+      {iconSource}
+    </span>
+  ) : null;
 
   const childMarkup = children ? (
     <span className={styles.Text}>{children}</span>
@@ -194,21 +190,6 @@ export function Button({
       />
     </span>
   ) : null;
-
-  const content =
-    iconMarkup || disclosureIconMarkup ? (
-      <span className={styles.Content}>
-        {spinnerSVGMarkup}
-        {iconMarkup}
-        {childMarkup}
-        {disclosureIconMarkup}
-      </span>
-    ) : (
-      <span className={styles.Content}>
-        {spinnerSVGMarkup}
-        {childMarkup}
-      </span>
-    );
 
   const ariaPressedStatus = pressed !== undefined ? pressed : ariaPressed;
 
@@ -306,7 +287,12 @@ export function Button({
 
   const buttonMarkup = (
     <UnstyledButton {...commonProps} {...linkProps} {...actionProps}>
-      {content}
+      <span className={styles.Content}>
+        {spinnerSVGMarkup}
+        {iconMarkup}
+        {childMarkup}
+        {disclosureIconMarkup}
+      </span>
     </UnstyledButton>
   );
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,5 +1,9 @@
 import React, {useCallback, useState} from 'react';
-import {CaretDownMinor, CaretUpMinor} from '@shopify/polaris-icons';
+import {
+  CaretDownMinor,
+  CaretUpMinor,
+  SelectMinor,
+} from '@shopify/polaris-icons';
 
 import type {BaseButton, ConnectedDisclosure, IconSource} from '../../types';
 import {classNames, variationName} from '../../utilities/css';
@@ -36,7 +40,7 @@ export interface ButtonProps extends BaseButton {
   /** Allows the button to grow to the width of its container */
   fullWidth?: boolean;
   /** Displays the button with a disclosure icon. Defaults to `down` when set to true */
-  disclosure?: 'down' | 'up' | boolean;
+  disclosure?: 'down' | 'up' | 'select' | boolean;
   /** Renders a button that looks like a link */
   plain?: boolean;
   /** Makes `plain` and `outline` Button colors (text, borders, icons) the same as the current text color. Also adds an underline to `plain` Buttons */
@@ -144,16 +148,14 @@ export function Button({
     stretchContent && styles.stretchContent,
   );
 
-  const disclosureIcon = (
-    <Icon source={getDisclosureIconSource({loading, disclosure})} />
-  );
-
-  const disclosureIconMarkup = disclosure ? (
+  const disclosureMarkup = disclosure ? (
     <span className={styles.Icon}>
       <div
         className={classNames(styles.DisclosureIcon, loading && styles.hidden)}
       >
-        {disclosureIcon}
+        <Icon
+          source={loading ? 'placeholder' : getDisclosureIconSource(disclosure)}
+        />
       </div>
     </span>
   ) : null;
@@ -287,7 +289,7 @@ export function Button({
         {spinnerSVGMarkup}
         {iconMarkup}
         {childMarkup}
-        {disclosureIconMarkup}
+        {disclosureMarkup}
       </span>
     </UnstyledButton>
   );
@@ -310,12 +312,11 @@ function isIconSource(x: any): x is IconSource {
   );
 }
 
-function getDisclosureIconSource({
-  loading,
-  disclosure,
-}: Pick<ButtonProps, 'loading' | 'disclosure'>) {
-  if (loading) {
-    return 'placeholder';
+function getDisclosureIconSource(
+  disclosure: NonNullable<ButtonProps['disclosure']>,
+) {
+  if (disclosure === 'select') {
+    return SelectMinor;
   }
 
   return disclosure === 'up' ? CaretUpMinor : CaretDownMinor;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useRef, useState} from 'react';
 import {
   CaretDownMinor,
   CaretUpMinor,
@@ -47,10 +47,13 @@ export interface ButtonProps extends BaseButton {
   monochrome?: boolean;
   /** Icon to display to the left of the button content */
   icon?: React.ReactElement | IconSource;
-  /** Stretch the content (text + icon) from side to side */
-  stretchContent?: boolean;
   /** Disclosure button connected right of the button. Toggles a popover action list. */
   connectedDisclosure?: ConnectedDisclosure;
+  /**
+   * @deprecated As of release 5.13.0, replaced by {@link https://polaris.shopify.com/components/actions/button/textAlign}
+   * Stretch the content (text + icon) from side to side
+   */
+  stretchContent?: boolean;
 }
 
 interface CommonButtonProps
@@ -126,6 +129,15 @@ export function Button({
 }: ButtonProps) {
   const {newDesignLanguage} = useFeatures();
   const i18n = useI18n();
+  const hasGivenDeprecationWarning = useRef(false);
+
+  if (stretchContent && !hasGivenDeprecationWarning.current) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Deprecation: The `stretchContent` prop has been replaced with `textAlign="left"`',
+    );
+    hasGivenDeprecationWarning.current = true;
+  }
 
   const isDisabled = disabled || loading;
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -151,7 +151,7 @@ export function Button({
   const disclosureIconMarkup = disclosure ? (
     <span className={styles.Icon}>
       <div
-        className={classNames(styles.DisclosureIcon, loading && styles.Hidden)}
+        className={classNames(styles.DisclosureIcon, loading && styles.hidden)}
       >
         {disclosureIcon}
       </div>
@@ -164,7 +164,7 @@ export function Button({
     icon
   );
   const iconMarkup = iconSource ? (
-    <span className={classNames(styles.Icon, loading && styles.Hidden)}>
+    <span className={classNames(styles.Icon, loading && styles.hidden)}>
       {iconSource}
     </span>
   ) : null;

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -314,22 +314,22 @@ function DisclosureButtion() {
 }
 ```
 
-### Stretched disclosure button
+### Right-aligned disclosure
 
 <!-- example-for: web -->
 
-Stretch disclosure button content its full width for a dropdown look
+When working with `fullWidth + textAlign="left"`, the `disclosure` will align itself to the far right.
 
 ```jsx
-function StretchedDisclosureButton() {
+function RightAlignedDisclosureButton() {
   const [expanded, setExpanded] = useState(false);
 
   return (
     <div style={{width: '200px'}}>
       <Button
-        disclosure={expanded ? 'up' : 'down'}
         fullWidth
-        stretchContent
+        textAlign="left"
+        disclosure={expanded ? 'up' : 'down'}
         onClick={() => setExpanded(!expanded)}
       >
         {expanded ? 'Show less' : 'Show more'}

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -339,6 +339,20 @@ function StretchedDisclosureButton() {
 }
 ```
 
+### Select disclosure button
+
+<!-- example-for: web -->
+
+Use to indicate that multiple options are available from this control, similar to a `<select />` HTML element.
+
+```jsx
+<div style={{height: '100px'}}>
+  <Button disclosure="select" onClick={() => console.log('Open Popover')}>
+    Select options
+  </Button>
+</div>
+```
+
 ### Split button
 
 <!-- example-for: web -->

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -14,6 +14,14 @@ import {Button} from '../Button';
 import en from '../../../../locales/en.json';
 
 describe('<Button />', () => {
+  let warnSpy: jest.SpyInstance | null = null;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => warnSpy?.mockRestore());
+
   describe('children', () => {
     it('passes prop', () => {
       const mockChildren = 'mock children';
@@ -170,14 +178,8 @@ describe('<Button />', () => {
 
   describe('ariaPressed', () => {
     it('passes prop', () => {
-      const warningSpy = jest
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
-
       const button = mountWithAppProvider(<Button ariaPressed />);
       expect(button.find(UnstyledButton).prop('ariaPressed')).toBeTruthy();
-
-      warningSpy.mockRestore();
     });
   });
 
@@ -448,16 +450,10 @@ describe('<Button />', () => {
 
   describe('stretchContent', () => {
     it('sets variant class', () => {
-      const warningSpy = jest
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
-
       const button = mountWithApp(<Button stretchContent />);
       expect(button).toContainReactComponent(UnstyledButton, {
         className: 'Button stretchContent',
       });
-
-      warningSpy.mockRestore();
     });
   });
 });

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -445,4 +445,19 @@ describe('<Button />', () => {
       });
     });
   });
+
+  describe('stretchContent', () => {
+    it('sets variant class', () => {
+      const warningSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      const button = mountWithApp(<Button stretchContent />);
+      expect(button).toContainReactComponent(UnstyledButton, {
+        className: 'Button stretchContent',
+      });
+
+      warningSpy.mockRestore();
+    });
+  });
 });

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {PlusMinor, CaretDownMinor} from '@shopify/polaris-icons';
+import {PlusMinor, CaretDownMinor, CaretUpMinor} from '@shopify/polaris-icons';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
@@ -398,20 +398,20 @@ describe('<Button />', () => {
   describe('disclosure', () => {
     it('assumes "down" if set to true', () => {
       const button = mountWithAppProvider(<Button disclosure />);
-      const disclosureIcon = button.find('.DisclosureIcon');
-      expect(disclosureIcon!.hasClass('DisclosureIconFacingUp')).toBe(false);
+      const disclosureIcon = button.find('.DisclosureIcon').find(Icon);
+      expect(disclosureIcon.props().source).toBe(CaretDownMinor);
     });
 
     it('is facing down if set to "down"', () => {
       const button = mountWithAppProvider(<Button disclosure="down" />);
-      const disclosureIcon = button.find('.DisclosureIcon');
-      expect(disclosureIcon!.hasClass('DisclosureIconFacingUp')).toBe(false);
+      const disclosureIcon = button.find('.DisclosureIcon').find(Icon);
+      expect(disclosureIcon.props().source).toBe(CaretDownMinor);
     });
 
     it('is facing up if set to "up"', () => {
       const button = mountWithAppProvider(<Button disclosure="up" />);
-      const disclosureIcon = button.find('.DisclosureIcon');
-      expect(disclosureIcon!.hasClass('DisclosureIconFacingUp')).toBe(true);
+      const disclosureIcon = button.find('.DisclosureIcon').find(Icon);
+      expect(disclosureIcon.props().source).toBe(CaretUpMinor);
     });
   });
 

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import {PlusMinor, CaretDownMinor, CaretUpMinor} from '@shopify/polaris-icons';
+import {
+  CaretDownMinor,
+  CaretUpMinor,
+  PlusMinor,
+  SelectMinor,
+} from '@shopify/polaris-icons';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
@@ -412,6 +417,12 @@ describe('<Button />', () => {
       const button = mountWithAppProvider(<Button disclosure="up" />);
       const disclosureIcon = button.find('.DisclosureIcon').find(Icon);
       expect(disclosureIcon.props().source).toBe(CaretUpMinor);
+    });
+
+    it('is double-arrow if set to "select"', () => {
+      const button = mountWithAppProvider(<Button disclosure="select" />);
+      const disclosureIcon = button.find('.DisclosureIcon').find(Icon);
+      expect(disclosureIcon.props().source).toBe(SelectMinor);
     });
   });
 

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -73,7 +73,7 @@
     border-top-color: var(--p-border-subdued);
     border-bottom-color: var(--p-border-shadow-subdued);
     transition-property: color, background, border, box-shadow;
-    transition-duration: duration();
+    transition-duration: duration(fast);
     transition-timing-function: easing();
 
     &:hover {
@@ -349,7 +349,7 @@
   margin: -2px -5px;
   background: $background-color;
   border-radius: border-radius();
-  transition: opacity duration() easing();
+  transition: opacity duration(fast) easing();
 }
 
 @mixin unstyled-button() {

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -31,9 +31,6 @@
   cursor: pointer;
   user-select: none;
   text-decoration: none;
-  transition-property: color, background, border, box-shadow;
-  transition-duration: var(--p-override-none, duration());
-  transition-timing-function: var(--p-override-none, easing());
   -webkit-tap-highlight-color: transparent;
 
   &:hover {
@@ -54,7 +51,6 @@
   }
 
   &:active {
-    // Same color gradient is necessary for background transitions
     background: linear-gradient(
       to bottom,
       color('sky', 'light'),
@@ -76,6 +72,9 @@
     border: 1px solid var(--p-border-neutral-subdued);
     border-top-color: var(--p-border-subdued);
     border-bottom-color: var(--p-border-shadow-subdued);
+    transition-property: color, background, border, box-shadow;
+    transition-duration: duration();
+    transition-timing-function: easing();
 
     &:hover {
       background: var(--p-action-secondary-hovered);
@@ -114,7 +113,6 @@
 
 @mixin base-button-disabled {
   @include recolor-icon(color('ink', 'lightest'));
-  transition: none;
   background: linear-gradient(
     to bottom,
     color('sky', 'light'),
@@ -244,8 +242,8 @@
   }
 
   &.newDesignLanguage {
-    background: transparent;
     @include focus-ring($border-width: border-width('base'));
+    background: transparent;
     border: border-width() solid var(--p-border);
     box-shadow: none;
     color: var(--p-text);

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -72,9 +72,6 @@
     border: 1px solid var(--p-border-neutral-subdued);
     border-top-color: var(--p-border-subdued);
     border-bottom-color: var(--p-border-shadow-subdued);
-    transition-property: color, background, border, box-shadow;
-    transition-duration: duration(fast);
-    transition-timing-function: easing();
 
     &:hover {
       background: var(--p-action-secondary-hovered);
@@ -349,7 +346,6 @@
   margin: -2px -5px;
   background: $background-color;
   border-radius: border-radius();
-  transition: opacity duration(fast) easing();
 }
 
 @mixin unstyled-button() {

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -31,7 +31,7 @@
   cursor: pointer;
   user-select: none;
   text-decoration: none;
-  transition-property: background, border, box-shadow;
+  transition-property: color, background, border, box-shadow;
   transition-duration: var(--p-override-none, duration());
   transition-timing-function: var(--p-override-none, easing());
   -webkit-tap-highlight-color: transparent;

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -168,7 +168,6 @@
   &.newDesignLanguage {
     @include focus-ring($border-width: 0);
     background: var(--p-button-color);
-    border-width: 0;
     border-color: transparent;
     box-shadow: var(--p-button-drop-shadow), var(--p-button-inner-shadow);
     color: var(--p-button-text);

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,7 +96,7 @@ export interface BaseButton {
   /** Indicates the ID of the element that describes the button */
   ariaDescribedBy?: string;
   /**
-   * @deprecated As of release 4.7.0, replaced by {@link https://polaris.shopify.com/components/structure/page#props-pressed}
+   * @deprecated As of release 4.7.0, replaced by {@link https://polaris.shopify.com/components/actions/button#prop-pressed}
    * Tells screen reader the element is pressed
    */
   ariaPressed?: boolean;


### PR DESCRIPTION
> **Tophat:** I recommend using the provided `Playground` snippet to more easily tophat each combination of `<Button />`

<details>
<summary><strong>Playground code:</strong></summary>

```tsx
import React, {useCallback, useState} from 'react';
import {OnlineStoreMajor} from '@shopify/polaris-icons';

import {Button, Card, ChoiceList, Layout, Page} from '../src';

const childrenOptions = {
  none: undefined,
  short: 'Short text',
  long: 'This long line of text will wrap unless truncate is true',
};
const sizeOptions = {
  none: undefined,
  slim: 'slim',
  medium: 'medium',
  large: 'large',
};
const textAlignOptions = {
  none: undefined,
  left: 'left',
  center: 'center',
  right: 'right',
};
const disclosureOptions = {
  none: undefined,
  up: 'up',
  down: 'down',
  select: 'select',
};
const toggleOptions = [
  'primary',
  'destructive',
  'outline',
  'fullWidth',
  'plain',
  'monochrome',
  'icon',
  'stretchContent',
  'connectedDisclosure',
  'url',
  'external',
  'download',
  'submit',
  'disabled',
  'loading',
  'pressed',
  'role',
  'ariaExpanded',
];

const mockConnectedDisclosure = {
  actions: [
    {
      content: 'Save and mark as ordered',
    },
  ],
};
const mockRole = 'menuitem';
const mockUrl = 'https://shopify.ca';

function mockEvent(label = '') {
  // eslint-disable-next-line no-console
  return () => console.log(label);
}

export function Playground() {
  const [children, setChildren] = useState(['none']);
  const handleChildrenChange = useCallback((value) => setChildren(value), []);

  const [size, setSize] = useState(['none']);
  const handleSizeChange = useCallback((value) => setSize(value), []);

  const [textAlign, setTextAlign] = useState(['none']);
  const handleTextAlignChange = useCallback((value) => setTextAlign(value), []);

  const [disclosure, setDisclosure] = useState(['none']);
  const handleDisclosureChange = useCallback(
    (value) => setDisclosure(value),
    [],
  );

  const [toggles, setToggles] = useState(['icon']);
  const handleToggleChange = useCallback((value) => setToggles(value), []);
  const isPropToggled = (value: string) => toggles.includes(value);

  return (
    <Page title="Button Configuration">
      <Layout>
        <Layout.Section oneThird>
          <Card title="Component">
            <Card.Section title="Result">
              <Button
                id="ButtonAllProps"
                ariaControls="ControlTarget"
                accessibilityLabel="Button a11y text"
                size={sizeOptions[size]}
                textAlign={textAlignOptions[textAlign]}
                disclosure={disclosureOptions[disclosure]}
                icon={isPropToggled('icon') ? OnlineStoreMajor : undefined}
                primary={isPropToggled('primary')}
                destructive={isPropToggled('destructive')}
                outline={isPropToggled('outline')}
                fullWidth={isPropToggled('fullWidth')}
                plain={isPropToggled('plain')}
                monochrome={isPropToggled('monochrome')}
                stretchContent={isPropToggled('stretchContent')}
                connectedDisclosure={
                  isPropToggled('connectedDisclosure')
                    ? mockConnectedDisclosure
                    : undefined
                }
                url={isPropToggled('url') ? mockUrl : undefined}
                external={isPropToggled('external')}
                download={isPropToggled('download')}
                submit={isPropToggled('submit')}
                disabled={isPropToggled('disabled')}
                loading={isPropToggled('loading')}
                pressed={isPropToggled('pressed')}
                role={isPropToggled('role') ? mockRole : undefined}
                ariaExpanded={isPropToggled('ariaExpanded')}
                onClick={mockEvent('onAction')}
                onFocus={mockEvent('onFocus')}
                onBlur={mockEvent('onBlur')}
                onKeyPress={mockEvent('onKeyPress')}
                onKeyUp={mockEvent('onKeyUp')}
                onKeyDown={mockEvent('onKeyDown')}
                onMouseEnter={mockEvent('onMouseEnter')}
                onTouchStart={mockEvent('onTouchStart')}
              >
                {childrenOptions[children]}
              </Button>
            </Card.Section>
            <Card.Section title="Output">
              <p id="ControlTarget">
                <strong>Boolean toggles:</strong> {toggles.join(', ')}
              </p>
            </Card.Section>
          </Card>
        </Layout.Section>

        <Layout.Section oneThird>
          <Card title="Children" sectioned>
            <ChoiceList
              title=""
              choices={Object.keys(childrenOptions).map((prop) => ({
                label: childrenOptions[prop] ?? 'None',
                value: prop,
              }))}
              selected={children}
              onChange={handleChildrenChange}
            />
          </Card>

          <Card title="Size" sectioned>
            <ChoiceList
              title=""
              choices={Object.keys(sizeOptions).map((prop) => ({
                label: sizeOptions[prop] ?? 'None',
                value: prop,
              }))}
              selected={size}
              onChange={handleSizeChange}
            />
          </Card>

          <Card title="Text alignment" sectioned>
            <ChoiceList
              title=""
              choices={Object.keys(textAlignOptions).map((prop) => ({
                label: textAlignOptions[prop] ?? 'None',
                value: prop,
              }))}
              selected={textAlign}
              onChange={handleTextAlignChange}
            />
          </Card>

          <Card title="Disclosure" sectioned>
            <ChoiceList
              title=""
              choices={Object.keys(disclosureOptions).map((prop) => ({
                label: disclosureOptions[prop] ?? 'None',
                value: prop,
              }))}
              selected={disclosure}
              onChange={handleDisclosureChange}
            />
          </Card>
        </Layout.Section>

        <Layout.Section oneThird>
          <Card title="Toggles" sectioned>
            <ChoiceList
              allowMultiple
              title=""
              choices={toggleOptions.map((prop) => ({
                label: prop,
                value: prop,
              }))}
              selected={toggles}
              onChange={handleToggleChange}
            />
          </Card>
        </Layout.Section>
      </Layout>
    </Page>
  );
}
```

</details>

**This PR makes a few small adjustments to the `Button` component:**
- ~Enable `color` transitions, allowing for `newDesignLanguage` "icons" to inherit `color` from their parent and transition accordingly.~
- Revise use of `transition`, as it was inconsistent.
  - Avoid `transition` for "old design language"
  - Enable `transition` for "new design language"
  - Remove use of `--p-override-none`
- Fix issue with `Button` text remaining visible when `newDesignLanguage + loading + plain`.
- No longer do a `180deg` spin on the `disclosure` when toggling between `up/down`.
- Right-align the `disclosure` arrow when working with `textAlignLeft`.
- No longer set `border-width: 0` on "filled" buttons, which was resulting in layout shift when toggling certain boolean props.
- A few minor code adjustments to improve readability.
- New `"select"` option for `disclosure`.

### Screenshots

<details>
<summary><strong>1. Revised transitions:</strong></summary>

![transitions](https://user-images.githubusercontent.com/643944/102251114-609eb480-3ed2-11eb-9117-f12593dcedcd.gif)

</details>

<details>
<summary><strong>2. `newDesignLanguage + loading + plain`</strong></summary>

![button-plain-loading](https://user-images.githubusercontent.com/643944/102251229-87f58180-3ed2-11eb-8deb-84adce77e5c2.gif)

</details>

<details>
<summary><strong>3. No longer spin `disclosure`:</strong></summary>

![disclosure-up-down](https://user-images.githubusercontent.com/643944/102251284-9b085180-3ed2-11eb-93ab-bcf0b086b9a6.gif)

</details>

<details>
<summary><strong>4. Right-align `disclosure`:</strong></summary>

![disclosure-right](https://user-images.githubusercontent.com/643944/102251326-a6f41380-3ed2-11eb-889d-a6bebac3c0f7.gif)

</details>

<details>
<summary><strong>5. Prevent layout-shift from `border-width`:</strong></summary>

![border-width-layout](https://user-images.githubusercontent.com/643944/102251370-b4a99900-3ed2-11eb-985f-0cfefd2f693c.gif)

</details>

<details>
<summary><strong>6. Select disclosure:</strong></summary>

![Screen Shot 2020-12-15 at 4 06 28 PM](https://user-images.githubusercontent.com/643944/102273225-ff85d980-3eef-11eb-8554-58c4d1a053b1.png)

</details>

---

### Questions:

**1. Should we remove the left/right margins when "only disclosure"?**
Its a low-effort fix... but maybe we want to discourage "only disclosure"?

<details>
<summary><strong>Screenshot:</strong></summary>
<img src="https://user-images.githubusercontent.com/643944/102126896-b2373880-3e19-11eb-87a7-e9cf8e770703.gif" />
</details>

**~2. Should `stretchContent` instead be a `textAlign="justified"` option?~**
~Another low-effort fix. Also... why do we need to qualify the styles with `:not(.loading)`?~
Since resolved. Marked for deprecation.

**3. Why were we using `--p-override-none`?**
This was used on `transition-duration` and `transition-timing-function`. Seems to suggest we want to disable transitions in "new design language" but enable for "old design language"? This PR reverses that behaviour while completely removing `--p-override-none` from `Button.scss`. Am I misunderstanding something? Should I revert?

**4. What is with the `.monochrome.outline > ::before` for?**
Seems like its used to provide a "background". So what I don't understand is: why not use `background-color`?

**5. Do we want to document/implement logic for "incompatible props"?**
Several prop combinations are incompatible, such as: `plain + connectedDisclosure` or `primary + destructive`.

**6. Should the deprecated `ariaPressed` not have been removed by now?**
Am I able to get rid of this prop from the `BaseButton` type?

**7. Should we swap `icon` and `disclosure` for `rtl` languages?**
My instinct is "yes". Have we received any feedback about this?

---

### Pre-existing issues (discovered while tophatting):

1. `loading` does not affect `connectedDisclosure`
2. Undesired styles when using: `outline + disabled + connectedDisclosure`
3. Undesired styles when using: `primary + outline`
4. There are surely a few more faulty prop combinations... but I ran out of time tophatting.

cc/ @emma-boardman in case you have some extra time to help tophat.
cc/ @dleroux since you have touched some of the changed code
cc/ @dfmcphee since you also have some expertise/opinions on this component