### PR TITLE
Fix the @-mention to be the actual team name

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 org_line: Shopify Core
 owners:
-  - Shopify/polaris
+  - Shopify/polaris-team
 classification: library
 slack_channels:
   - polaris


### PR DESCRIPTION
### WHY are these changes introduced?

`@Shopify/polaris` is not a team. The team is @Shopify/polaris-team

### WHAT is this pull request doing?

Fixing the metadata. This gets used by ServicesDB, which is then used by various tools (including the Translation Platform). 