### PR TITLE
fix: image url in mediacard and thumbnail example

### DIFF
--- a/src/components/MediaCard/README.md
+++ b/src/components/MediaCard/README.md
@@ -150,7 +150,7 @@ Use to surface educational information about a feature or opportunity.
       objectFit: 'cover',
       objectPosition: 'center',
     }}
-    src="https://burst.shopifycdn.com/photos/smiling-businesswoman-in-office.jpg?width=1850"
+    src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
   />
 </MediaCard>
 ```
@@ -178,7 +178,7 @@ Use when there are limited vertical space, or when the card should be less promi
       objectFit: 'cover',
       objectPosition: 'center',
     }}
-    src="https://burst.shopifycdn.com/photos/smiling-businesswoman-in-office.jpg?width=1850"
+    src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
   />
 </MediaCard>
 ```
@@ -206,7 +206,7 @@ Use when there are two distinct actions merchants can take on the information in
     width="100%"
     height="100%"
     style={{objectFit: 'cover', objectPosition: 'center'}}
-    src="https://burst.shopifycdn.com/photos/smiling-businesswoman-in-office.jpg?width=1850"
+    src="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
   />
 </MediaCard>
 ```
@@ -227,7 +227,7 @@ Use to provide a consistent layout for contextual learning content. Use to wrap 
 >
   <VideoThumbnail
     videoLength={80}
-    thumbnailUrl="https://burst.shopifycdn.com/photos/smiling-businesswoman-in-office.jpg?width=1850"
+    thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
   />
 </MediaCard>
 ```
@@ -249,7 +249,7 @@ Use when vertical screen space is not limited or when the video card is the page
 >
   <VideoThumbnail
     videoLength={80}
-    thumbnailUrl="https://burst.shopifycdn.com/photos/smiling-businesswoman-in-office.jpg?width=1850"
+    thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
   />
 </MediaCard>
 ```

--- a/src/components/VideoThumbnail/README.md
+++ b/src/components/VideoThumbnail/README.md
@@ -49,7 +49,7 @@ Use as a play button for a video player within a media card.
 >
   <VideoThumbnail
     videoLength={80}
-    thumbnailUrl="https://burst.shopifycdn.com/photos/smiling-businesswoman-in-office.jpg?width=1850"
+    thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
   />
 </MediaCard>
 ```
@@ -72,7 +72,7 @@ Use to indicate the video’s play progress in relation to its duration.
     videoLength={80}
     videoProgress={45}
     showVideoProgress
-    thumbnailUrl="https://burst.shopifycdn.com/photos/smiling-businesswoman-in-office.jpg?width=1850"
+    thumbnailUrl="https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850"
   />
 </MediaCard>
 ```


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #3712 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

This PR fixes the URL of some images that are used for the examples of the [MediaCard](https://polaris.shopify.com/components/structure/media-card) and [VideoThumbnail](https://polaris.shopify.com/components/images-and-icons/video-thumbnail) components. 

### WHAT is this pull request doing?

Replaces this URL:

- https://burst.shopifycdn.com/photos/smiling-businesswoman-in-office.jpg?width=1850

by this one:

- https://burst.shopifycdn.com/photos/business-woman-smiling-in-office.jpg?width=1850