### PR TITLE
Autocomplete remove aria-expanded

### DIFF
--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -312,7 +312,6 @@ export function ComboBox({
         onClick={activatePopover}
         onKeyDown={activatePopover}
         role="combobox"
-        aria-expanded={popoverActive}
         aria-owns={id}
         aria-controls={id}
         aria-haspopup


### PR DESCRIPTION
### WHY are these changes introduced?

We are using the `aria-expanded` role incorrectly on `AutoComplete`. The `Autocomplete component is not an accordion and the `expanded` role [should only be used on a button](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#Associated_ARIA_roles_states_and_properties).

### WHAT is this pull request doing?

Removing the `aria-expanded` value on the `Autocomplete` `input`.

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
