### PR TITLE
Address accessibility issues in AutoComplete and TextField

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -30,6 +30,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added focus ring to disclosure tab when tabbing with keyboard([#3675](https://github.com/Shopify/polaris-react/pull/3675))
 - Fixed windows high contrast mode on hover within disclosure menu and displaying active state upon click for `::before` ([#3675](https://github.com/Shopify/polaris-react/pull/3675))
 - Removed `aria-selected` from `ActionList` as it is not a selectable list ([#3725](https://github.com/Shopify/polaris-react/pull/3725))
+- Moved `aria-role="combobox"` in `Autocomplete` from the `div` to the `input` ([#3727](https://github.com/Shopify/polaris-react/pull/3727))
+- Removed `aria-multiline` in `Input` when false or undefined ([#3727](https://github.com/Shopify/polaris-react/pull/3727))
 
 ### Documentation
 

--- a/scripts/accessibility-check.js
+++ b/scripts/accessibility-check.js
@@ -86,18 +86,6 @@ console.log(`Running ${concurrentCount} concurrent pages at a time`);
     // A list of urls with a count of known, expected failures
     // Ideally this shouldn't exist for long as we fix issues
     const expectedIssues = {
-      'id=all-components-autocomplete--basic-autocomplete': 1,
-      'id=all-components-autocomplete--basic-autocomplete&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
-      'id=all-components-autocomplete--multiple-tags-autocomplete': 1,
-      'id=all-components-autocomplete--multiple-tags-autocomplete&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
-      'id=all-components-autocomplete--autocomplete-with-loading': 1,
-      'id=all-components-autocomplete--autocomplete-with-loading&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
-      'id=all-components-autocomplete--autocomplete-with-lazy-loading': 1,
-      'id=all-components-autocomplete--autocomplete-with-lazy-loading&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
-      'id=all-components-autocomplete--autocomplete-with-empty-state': 1,
-      'id=all-components-autocomplete--autocomplete-with-empty-state&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
-      'id=all-components-form-layout--field-group': 1,
-      'id=all-components-form-layout--field-group&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
       'id=all-components-modal--modal-with-scroll-listener': 1,
       'id=all-components-modal--modal-with-scroll-listener&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
       'id=all-components-option-list--multiple-option-list': 1,
@@ -106,22 +94,12 @@ console.log(`Running ${concurrentCount} concurrent pages at a time`);
       'id=all-components-option-list--option-list-with-sections&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
       'id=all-components-option-list--option-list-in-a-popover': 4,
       'id=all-components-option-list--option-list-in-a-popover&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 4,
-      'id=all-components-range-slider--dual-thumb-range-slider': 2,
-      'id=all-components-range-slider--dual-thumb-range-slider&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 2,
+      'id=all-components-range-slider--dual-thumb-range-slider': 1,
+      'id=all-components-range-slider--dual-thumb-range-slider&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
       'id=all-components-resource-list--resource-list-with-loading-state': 1,
       'id=all-components-resource-list--resource-list-with-loading-state&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
       'id=all-components-scrollable--default-scrollable-container': 1,
       'id=all-components-scrollable--default-scrollable-container&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
-      'id=all-components-select--select-with-separate-validation-error': 1,
-      'id=all-components-select--select-with-separate-validation-error&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
-      'id=all-components-text-field--number-field': 1,
-      'id=all-components-text-field--number-field&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
-      'id=all-components-text-field--text-field-with-hidden-label': 1,
-      'id=all-components-text-field--text-field-with-hidden-label&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
-      'id=all-components-text-field--text-field-with-prefix-or-suffix': 1,
-      'id=all-components-text-field--text-field-with-prefix-or-suffix&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
-      'id=all-components-text-field--text-field-with-connected-fields': 1,
-      'id=all-components-text-field--text-field-with-connected-fields&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
     };
 
     const {

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -311,13 +311,13 @@ export function ComboBox({
       <div
         onClick={activatePopover}
         onKeyDown={activatePopover}
-        role="combobox"
         aria-expanded={popoverActive}
         aria-owns={id}
         aria-controls={id}
         aria-haspopup
         onFocus={forcePopoverActiveTrue}
         onBlur={handleBlur}
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={options.length === 0 ? -1 : 0}
       >
         <KeypressListener keyCode={Key.DownArrow} handler={selectNextOption} />

--- a/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
+++ b/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
@@ -61,7 +61,7 @@ describe('<ComboBox/>', () => {
         />,
       );
 
-      expect(comboBox.find('div', {role: 'combobox'})).toHaveReactProps({
+      expect(comboBox.find('div')).toHaveReactProps({
         tabIndex,
       });
     });
@@ -403,7 +403,7 @@ describe('<ComboBox/>', () => {
       );
 
       // Focus the combobox so that the popover pane is rendered
-      comboBox.find('div', {role: 'combobox'})!.trigger('onFocus');
+      comboBox.find('div')!.trigger('onFocus');
 
       comboBox.find(Popover.Pane)!.trigger('onScrolledToBottom');
       expect(spy).toHaveBeenCalledTimes(1);

--- a/src/components/Autocomplete/components/TextField/TextField.tsx
+++ b/src/components/Autocomplete/components/TextField/TextField.tsx
@@ -10,6 +10,7 @@ export function TextField(props: TextFieldProps) {
       {({selectedOptionId, comboBoxId}) => (
         <BaseTextField
           {...props}
+          role="combobox"
           autoComplete={false}
           ariaAutocomplete="list"
           ariaActiveDescendant={selectedOptionId}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -430,8 +430,8 @@ export function TextField({
     'aria-activedescendant': ariaActiveDescendant,
     'aria-autocomplete': ariaAutocomplete,
     'aria-controls': ariaControls,
-    'aria-multiline': normalizeAriaMultiline(multiline),
     'aria-expanded': ariaExpanded,
+    ...normalizeAriaMultiline(multiline),
   });
 
   const backdropClassName = classNames(
@@ -524,12 +524,9 @@ function normalizeAutoComplete(autoComplete?: boolean | string) {
 }
 
 function normalizeAriaMultiline(multiline?: boolean | number) {
-  switch (typeof multiline) {
-    case 'undefined':
-      return false;
-    case 'boolean':
-      return multiline;
-    case 'number':
-      return Boolean(multiline > 0);
-  }
+  if (!multiline) return undefined;
+
+  return Boolean(multiline) || multiline > 0
+    ? {'aria-multiline': true}
+    : undefined;
 }

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -840,12 +840,7 @@ describe('<TextField />', () => {
   describe('multiline', () => {
     it('does not render a resizer if `multiline` is false', () => {
       const textField = mountWithAppProvider(
-        <TextField
-          label="TextField"
-          id="MyField"
-          onChange={noop}
-          multiline={false}
-        />,
+        <TextField label="TextField" id="MyField" onChange={noop} />,
       );
       expect(textField.find(Resizer).exists()).toBe(false);
     });
@@ -899,7 +894,6 @@ describe('<TextField />', () => {
           label="TextField"
           id="MyField"
           onChange={noop}
-          multiline={false}
           ariaOwns="Aria owns"
           ariaExpanded
           ariaActiveDescendant="Aria active descendant"
@@ -937,7 +931,7 @@ describe('<TextField />', () => {
       expect(textField.find('textarea').prop('aria-multiline')).toBe(true);
     });
 
-    it('renders an input element with `aria-multiline` set to false if multiline is equal to 0', () => {
+    it('renders an input element without `aria-multiline` if multiline is equal to 0', () => {
       const textField = mountWithAppProvider(
         <TextField
           label="TextField"
@@ -950,10 +944,10 @@ describe('<TextField />', () => {
           ariaControls="Aria controls"
         />,
       );
-      expect(textField.find('input').prop('aria-multiline')).toBe(false);
+      expect(textField.find('input').prop('aria-multiline')).toBeUndefined();
     });
 
-    it('renders an input element with `aria-multiline` set to false if multiline is undefined', () => {
+    it('renders an input element without `aria-multiline` if multiline is undefined', () => {
       const textField = mountWithAppProvider(
         <TextField
           label="TextField"
@@ -965,7 +959,7 @@ describe('<TextField />', () => {
           ariaControls="Aria controls"
         />,
       );
-      expect(textField.find('input').prop('aria-multiline')).toBe(false);
+      expect(textField.find('input').prop('aria-multiline')).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes accessibility issues related to autocomplete
1. ARIA attribute is not allowed: aria-expanded="false"
2. ARIA attribute is not allowed: aria-multiline="false"

### WHAT is this pull request doing?

1. Fixed with moving `role="combobox"` from the `div` to the `input`
2. Fixed by removing `multiline` in `TextField` if it is undefined or false (only added when needed )

Followed these two examples:
- [WCAG example of combobox](https://www.w3.org/TR/wai-aria-1.2/#example-6) from @dleroux original PR
- [Gov UK autocomplete](https://alphagov.github.io/accessible-autocomplete/examples/) component

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
