### PR TITLE
RangeSlider - Use a non semantic element for role="slider"

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -33,6 +33,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Moved `aria-role="combobox"` in `Autocomplete` from the `div` to the `input` ([#3727](https://github.com/Shopify/polaris-react/pull/3727))
 - Removed `aria-multiline` in `Input` when false or undefined ([#3727](https://github.com/Shopify/polaris-react/pull/3727))
 - Removed `aria-multiselectable` from OptionList ([#3729](https://github.com/Shopify/polaris-react/pull/3729))
+- Replace `button` with `div` in `RangeSlider` for correct semantics when using `role="slider"` ([#3730](https://github.com/Shopify/polaris-react/pull/3730))
 
 ### Documentation
 

--- a/scripts/accessibility-check.js
+++ b/scripts/accessibility-check.js
@@ -88,8 +88,6 @@ console.log(`Running ${concurrentCount} concurrent pages at a time`);
     const expectedIssues = {
       'id=all-components-modal--modal-with-scroll-listener': 1,
       'id=all-components-modal--modal-with-scroll-listener&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
-      'id=all-components-range-slider--dual-thumb-range-slider': 1,
-      'id=all-components-range-slider--dual-thumb-range-slider&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
       'id=all-components-resource-list--resource-list-with-loading-state': 1,
       'id=all-components-resource-list--resource-list-with-loading-state&contexts=Global%20Theming=Enabled%20-%20Light%20Mode': 1,
       'id=all-components-scrollable--default-scrollable-container': 1,

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -74,8 +74,8 @@ export class DualThumb extends Component<DualThumbProps, State> {
 
   private track = createRef<HTMLDivElement>();
   private trackWrapper = createRef<HTMLDivElement>();
-  private thumbLower = createRef<HTMLButtonElement>();
-  private thumbUpper = createRef<HTMLButtonElement>();
+  private thumbLower = createRef<HTMLDivElement>();
+  private thumbUpper = createRef<HTMLDivElement>();
 
   private setTrackPosition = debounce(
     () => {
@@ -250,7 +250,7 @@ export class DualThumb extends Component<DualThumbProps, State> {
                 testID="track"
               />
               <div className={styles['Track--dashed']} />
-              <button
+              <div
                 id={idLower}
                 className={thumbLowerClassName}
                 style={{
@@ -266,14 +266,14 @@ export class DualThumb extends Component<DualThumbProps, State> {
                 aria-labelledby={labelID(id)}
                 onFocus={onFocus}
                 onBlur={onBlur}
+                tabIndex={0}
                 onKeyDown={this.handleKeypressLower}
                 onMouseDown={this.handleMouseDownThumbLower}
                 onTouchStart={this.handleTouchStartThumbLower}
                 ref={this.thumbLower}
-                disabled={disabled}
               />
               {outputMarkupLower}
-              <button
+              <div
                 id={idUpper}
                 className={thumbUpperClassName}
                 style={{
@@ -289,11 +289,11 @@ export class DualThumb extends Component<DualThumbProps, State> {
                 aria-labelledby={labelID(id)}
                 onFocus={onFocus}
                 onBlur={onBlur}
+                tabIndex={0}
                 onKeyDown={this.handleKeypressUpper}
                 onMouseDown={this.handleMouseDownThumbUpper}
                 onTouchStart={this.handleTouchStartThumbUpper}
                 ref={this.thumbUpper}
-                disabled={disabled}
               />
               {outputMarkupUpper}
             </div>
@@ -306,7 +306,7 @@ export class DualThumb extends Component<DualThumbProps, State> {
   }
 
   private handleMouseDownThumbLower = (
-    event: React.MouseEvent<HTMLButtonElement>,
+    event: React.MouseEvent<HTMLDivElement>,
   ) => {
     if (event.button !== 0 || this.props.disabled) return;
     registerMouseMoveHandler(this.handleMouseMoveThumbLower);
@@ -322,7 +322,7 @@ export class DualThumb extends Component<DualThumbProps, State> {
   };
 
   private handleTouchStartThumbLower = (
-    event: React.TouchEvent<HTMLButtonElement>,
+    event: React.TouchEvent<HTMLDivElement>,
   ) => {
     if (this.props.disabled) return;
     registerTouchMoveHandler(this.handleTouchMoveThumbLower);
@@ -339,7 +339,7 @@ export class DualThumb extends Component<DualThumbProps, State> {
   };
 
   private handleMouseDownThumbUpper = (
-    event: React.MouseEvent<HTMLButtonElement>,
+    event: React.MouseEvent<HTMLDivElement>,
   ) => {
     if (event.button !== 0 || this.props.disabled) return;
     registerMouseMoveHandler(this.handleMouseMoveThumbUpper);
@@ -355,7 +355,7 @@ export class DualThumb extends Component<DualThumbProps, State> {
   };
 
   private handleTouchStartThumbUpper = (
-    event: React.TouchEvent<HTMLButtonElement>,
+    event: React.TouchEvent<HTMLDivElement>,
   ) => {
     if (this.props.disabled) return;
     registerTouchMoveHandler(this.handleTouchMoveThumbUpper);
@@ -372,7 +372,7 @@ export class DualThumb extends Component<DualThumbProps, State> {
   };
 
   private handleKeypressLower = (
-    event: React.KeyboardEvent<HTMLButtonElement>,
+    event: React.KeyboardEvent<HTMLDivElement>,
   ) => {
     if (this.props.disabled) return;
     const {incrementValueLower, decrementValueLower} = this;
@@ -394,7 +394,7 @@ export class DualThumb extends Component<DualThumbProps, State> {
   };
 
   private handleKeypressUpper = (
-    event: React.KeyboardEvent<HTMLButtonElement>,
+    event: React.KeyboardEvent<HTMLDivElement>,
   ) => {
     if (this.props.disabled) return;
     const {incrementValueUpper, decrementValueUpper} = this;

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -106,40 +106,36 @@ describe('<DualThumb />', () => {
   });
 
   describe('disabled', () => {
-    it('sets aria-disabled and disabled to false by default on the lower thumb', () => {
+    it('sets aria-disabled to false by default on the lower thumb', () => {
       const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
 
       const thumbLower = findThumbLower(dualThumb);
       expect(thumbLower.prop('aria-disabled')).toBe(false);
-      expect(thumbLower.prop('disabled')).toBe(false);
     });
 
-    it('sets aria-disabled and disabled to false by default on the upper thumb', () => {
+    it('sets aria-disabled to false by default on the upper thumb', () => {
       const dualThumb = mountWithAppProvider(<DualThumb {...mockProps} />);
 
       const thumbUpper = findThumbUpper(dualThumb);
       expect(thumbUpper.prop('aria-disabled')).toBe(false);
-      expect(thumbUpper.prop('disabled')).toBe(false);
     });
 
-    it('sets aria-disabled and disabled to true on the lower thumb', () => {
+    it('sets aria-disabled to true on the lower thumb', () => {
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} disabled />,
       );
 
       const thumbLower = findThumbLower(dualThumb);
       expect(thumbLower.prop('aria-disabled')).toBe(true);
-      expect(thumbLower.prop('disabled')).toBe(true);
     });
 
-    it('sets aria-disabled and disabled to true on the upper thumb', () => {
+    it('sets aria-disabled to true on the upper thumb', () => {
       const dualThumb = mountWithAppProvider(
         <DualThumb {...mockProps} disabled />,
       );
 
       const thumbUpper = findThumbUpper(dualThumb);
       expect(thumbUpper.prop('aria-disabled')).toBe(true);
-      expect(thumbUpper.prop('disabled')).toBe(true);
     });
   });
 
@@ -1044,11 +1040,11 @@ describe('<DualThumb />', () => {
 function noop() {}
 
 function findThumbLower(containerComponent: ReactWrapper) {
-  return containerComponent.find('button').first();
+  return containerComponent.find('[role="slider"]').first();
 }
 
 function findThumbUpper(containerComponent: ReactWrapper) {
-  return containerComponent.find('button').last();
+  return containerComponent.find('[role="slider"]').last();
 }
 
 function findTrack(containerComponent: ReactWrapper) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes accessibility issue `ARIA role slider is not allowed for given element`

### WHAT is this pull request doing?

Replacing `button` with `div`. When using `role="slider"` it should not be applied to a `button` element. [Following the examples on MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_slider_role#Example_2_Text_Values) we replace `button` with `div` update the types and add a `tab-index` for focus management. 

### 🎩 checklist

* [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [x] Updated the component's `README.md` with documentation changes
* [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
