### PR TITLE
Make `utilities/focus` helpers available to consumers

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added the ability to hide the clear filter button on the filter component ([#3049](https://github.com/Shopify/polaris-react/pull/3049))
 - **`Popover`:** New `autofocusTarget` prop to enhance autofocus options ([#3600](https://github.com/Shopify/polaris-react/pull/3600))
 - Added ability to hide query text field in `Filters` component using `hideQueryField` prop ([#3674](https://github.com/Shopify/polaris-react/pull/3674))
+- Export helpers from `utilities/focus.ts` to be publicly available to consumers ([#3737](https://github.com/Shopify/polaris-react/pull/3737))
 
 ### Bug fixes
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,3 +33,15 @@ export {
   toCssCustomPropertySyntax as UNSTABLE_toCssCustomPropertySyntax,
   Tokens as UNSTABLE_Tokens,
 } from './utilities/theme';
+
+export {
+  findFirstFocusableNode,
+  findFirstFocusableNodeIncludingDisabled,
+  findFirstKeyboardFocusableNode,
+  findLastKeyboardFocusableNode,
+  focusFirstFocusableNode,
+  focusFirstKeyboardFocusableNode,
+  focusLastKeyboardFocusableNode,
+  focusNextFocusableNode,
+  nextFocusableNode,
+} from './utilities/focus';


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3738 

This PR makes the helpers in `utilities/focus.ts` publicly available to consumers. 

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


### 🎩 checklist

* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
* [ ] Updated the component's `README.md` with documentation changes
* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
