### PR TITLE
Remove /.github from .prettierignore

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -10,7 +10,6 @@ labels: Feature request
 Write a short description of the feature here ↓
 -->
 
-
 ## Rationale
 
 <!--

--- a/.github/ISSUE_TEMPLATE/ISSUE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE.md
@@ -12,13 +12,11 @@ labels: 🐛Bug
 Write a short description of the issue here ↓
 -->
 
-
 ## Expected behavior
 
 <!--
 What do you think should happen?
 -->
-
 
 ## Actual behavior
 
@@ -35,7 +33,6 @@ If you include an animated gif showing your issue, wrapping it in a details tag 
     </details>
 
 -->
-
 
 ## Steps to reproduce the problem
 
@@ -54,7 +51,6 @@ The best way to get your bug fixed is to provide a reduced test case. This [Code
 - Browser:
 - Device:
 - Operating System:
-
 
 Or run `npx envinfo --system --binaries --browsers --npmPackages react,react-dom,@shopify/polaris` to provide specifications on your environment including version numbers, browser, device, and operating system.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -56,19 +56,18 @@ export function Playground() {
     </Page>
   );
 }
-
 ```
 
 </details>
 
 ### 🎩 checklist
 
-* [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
-* [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
-* [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
-* [ ] Updated the component's `README.md` with documentation changes
-* [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
-* [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
+- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
+- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
+- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
+- [ ] Updated the component's `README.md` with documentation changes
+- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
+- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
 
 <!--
   When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).

--- a/.github/workflows/discoverability.yml
+++ b/.github/workflows/discoverability.yml
@@ -7,16 +7,16 @@ jobs:
     name: Discoverability action
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+      - uses: actions/checkout@master
 
-    - name: yarn
-      run: yarn
+      - name: yarn
+        run: yarn
 
-    - name: Add a comment with known areas to test
-      uses: shopify/discoverability-action@v0.0.13
-      with:
-        codebaseGlob: src/**/*.tsx
-        ignoreGlob: '{src/**/*.test.tsx,src/test-utilities/*}'
-        githubToken: ${{ secrets.GITHUB_TOKEN }}
-        firstQuartile: 3
-        thirdQuartile: 69
+      - name: Add a comment with known areas to test
+        uses: shopify/discoverability-action@v0.0.13
+        with:
+          codebaseGlob: src/**/*.tsx
+          ignoreGlob: '{src/**/*.test.tsx,src/test-utilities/*}'
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          firstQuartile: 3
+          thirdQuartile: 69

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,4 +4,3 @@ node_modules
 /src/styles/polaris-tokens
 
 /package.json
-/.github


### PR DESCRIPTION
Co-Authored-By: Ben Scott <227292+BPScott@users.noreply.github.com>


### WHY are these changes introduced?

Not necessary to disable Prettier in this directory.

### WHAT is this pull request doing?

Removing the disable of prettier in `/.github/`