### PR TITLE
🏷️ [OptionList] Export types

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Update `OptionList` selected styles ([#3633](https://github.com/Shopify/polaris-react/pull/3633))
 - Added the ability to hide the clear filter button on the filter component ([#3049](https://github.com/Shopify/polaris-react/pull/3049))
+- **`OptionList`:** Export `OptionListOptionDescriptor` and `OptionListSectionDescriptor` ([#3741](https://github.com/Shopify/polaris-react/pull/3741))
 - **`Popover`:** New `autofocusTarget` prop to enhance autofocus options ([#3600](https://github.com/Shopify/polaris-react/pull/3600))
 - Added ability to hide query text field in `Filters` component using `hideQueryField` prop ([#3674](https://github.com/Shopify/polaris-react/pull/3674))
 

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -27,7 +27,7 @@ export interface OptionDescriptor {
   media?: React.ReactElement<IconProps | ThumbnailProps | AvatarProps>;
 }
 
-interface SectionDescriptor {
+export interface SectionDescriptor {
   /** Collection of options within the section */
   options: OptionDescriptor[];
   /** Section title */

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -181,7 +181,11 @@ export type {
 } from './Navigation';
 
 export {OptionList} from './OptionList';
-export type {OptionListProps} from './OptionList';
+export type {
+  OptionListProps,
+  OptionDescriptor as OptionListOptionDescriptor,
+  SectionDescriptor as OptionListSectionDescriptor,
+} from './OptionList';
 
 export {Page} from './Page';
 export type {PageProps} from './Page';


### PR DESCRIPTION
We have a need for the `OptionDescriptor` and `SectionDescriptor` in `online-store-web`, so I am exporting both of these types for consumption.

Since both of these type names are somewhat generic... I've renamed their exports. Please let me know if this is following convention!