### PR TITLE
Revert "🏷️ [OptionList] Export types"

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,7 +8,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Update `OptionList` selected styles ([#3633](https://github.com/Shopify/polaris-react/pull/3633))
 - Added the ability to hide the clear filter button on the filter component ([#3049](https://github.com/Shopify/polaris-react/pull/3049))
-- **`OptionList`:** Export `OptionListOptionDescriptor` and `OptionListSectionDescriptor` ([#3741](https://github.com/Shopify/polaris-react/pull/3741))
 - **`Popover`:** New `autofocusTarget` prop to enhance autofocus options ([#3600](https://github.com/Shopify/polaris-react/pull/3600))
 - Added ability to hide query text field in `Filters` component using `hideQueryField` prop ([#3674](https://github.com/Shopify/polaris-react/pull/3674))
 - Added `tabIndex` to `Scrollable` for keyboard focus ([#3744](https://github.com/Shopify/polaris-react/pull/3744))

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -27,7 +27,7 @@ export interface OptionDescriptor {
   media?: React.ReactElement<IconProps | ThumbnailProps | AvatarProps>;
 }
 
-export interface SectionDescriptor {
+interface SectionDescriptor {
   /** Collection of options within the section */
   options: OptionDescriptor[];
   /** Section title */

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -181,11 +181,7 @@ export type {
 } from './Navigation';
 
 export {OptionList} from './OptionList';
-export type {
-  OptionListProps,
-  OptionDescriptor as OptionListOptionDescriptor,
-  SectionDescriptor as OptionListSectionDescriptor,
-} from './OptionList';
+export type {OptionListProps} from './OptionList';
 
 export {Page} from './Page';
 export type {PageProps} from './Page';


### PR DESCRIPTION
Reverts Shopify/polaris-react#3741

Per https://github.com/Shopify/polaris-react/pull/3741#issuecomment-749130568 I'm wary of exporting internal types and think folks should slice up the SomeComponentProps type for their component instead of us exposing the constituent types directly.

So gonna revert this for now to make sure it doesn't sneak out in a release, and we can have a conversation in the new year about if my proposal works for @beefchimi (and if not we get to bust of the fabled Revert Revert commit). 