### PR TITLE
[Filters] Fix loss of focus after clicking clear all filters

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Updated ToastManager to use aria-live 'assertive' for accessibility ([#3837](https://github.com/Shopify/polaris-react/pull/3837))
 - Fixed responsiveness of empty search state in `ResourceList` to support user text zoom settings ([#2983](https://github.com/Shopify/polaris-react/pull/2983))
 - Fixed `ActionList` not rendering `.active` indicator ([#3854](https://github.com/Shopify/polaris-react/pull/3854))
+- Prevent loss of focus when clicking clear all filters in `Filters` ([#3754](https://github.com/Shopify/polaris-react/pull/3754))
 
 ### Documentation
 

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -122,6 +122,7 @@ class FiltersInner extends Component<CombinedProps, State> {
   };
 
   private moreFiltersButtonContainer = createRef<HTMLDivElement>();
+  private moreFiltersDoneButtonContainer = createRef<HTMLDivElement>();
   private focusNode = createRef<HTMLDivElement>();
 
   render() {
@@ -339,12 +340,17 @@ class FiltersInner extends Component<CombinedProps, State> {
 
     const filtersDesktopFooterMarkup = (
       <div className={filtersDesktopFooterClassname}>
-        <Button onClick={onClearAll} disabled={!this.hasAppliedFilters()}>
+        <Button
+          onClick={this.handleClearAll}
+          disabled={!this.hasAppliedFilters()}
+        >
           {i18n.translate('Polaris.Filters.clearAllFilters')}
         </Button>
-        <Button onClick={this.closeFilters} primary>
-          {i18n.translate('Polaris.Filters.done')}
-        </Button>
+        <div ref={this.moreFiltersDoneButtonContainer}>
+          <Button onClick={this.closeFilters} primary>
+            {i18n.translate('Polaris.Filters.done')}
+          </Button>
+        </div>
       </div>
     );
 
@@ -589,6 +595,16 @@ class FiltersInner extends Component<CombinedProps, State> {
       </div>
     );
   }
+
+  private handleClearAll = () => {
+    this.props.onClearAll();
+
+    this.moreFiltersDoneButtonContainer.current &&
+      focusFirstFocusableNode(
+        this.moreFiltersDoneButtonContainer.current,
+        false,
+      );
+  };
 }
 
 function getShortcutFilters(filters: FilterInterface[]) {

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -13,6 +13,7 @@ import {mountWithApp} from 'test-utilities';
 import {WithinFilterContext} from '../../../utilities/within-filter-context';
 import {Filters, FiltersProps} from '../Filters';
 import {ConnectedFilterControl, TagsWrapper} from '../components';
+import * as focusUtils from '../../../utilities/focus';
 
 const MockFilter = (props: {id: string}) => <div id={props.id} />;
 const MockChild = () => <div />;
@@ -463,6 +464,40 @@ describe('<Filters />', () => {
         'SheetToggleButton',
       );
       expect(rightActionButton.text()).toBe('More filters (2)');
+    });
+
+    it('calls clear all callback and shifts focus when clear all filters is clicked to prevent visual loss of focus', () => {
+      const focusSpy = jest.spyOn(focusUtils, 'focusFirstFocusableNode');
+      const spy = jest.fn();
+      const appliedFilters = [{key: 'filterOne', label: 'foo', onRemove: spy}];
+
+      const resourceFilters = mountWithAppProvider(
+        <Filters {...mockProps} appliedFilters={appliedFilters} />,
+      );
+      resourceFilters.setProps({
+        onClearAll: () => {
+          resourceFilters.setProps({
+            appliedFilters: [],
+          });
+        },
+      });
+
+      trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
+
+      let clearAllButton = resourceFilters
+        .findWhere((node) => node.prop('children') === 'Clear all filters')
+        .first();
+
+      expect(clearAllButton.prop('disabled')).toBeFalsy();
+
+      trigger(clearAllButton, 'onClick');
+
+      clearAllButton = resourceFilters
+        .findWhere((node) => node.prop('children') === 'Clear all filters')
+        .first();
+
+      expect(clearAllButton.prop('disabled')).toBeTruthy();
+      expect(focusSpy).toHaveBeenCalled();
     });
   });
 

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -498,6 +498,7 @@ describe('<Filters />', () => {
 
       expect(clearAllButton.prop('disabled')).toBeTruthy();
       expect(focusSpy).toHaveBeenCalled();
+      focusSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/34673

AODA Compliance: The clear all filters button becomes disabled after being clicked but retains focus, resulting in a visual loss of focus. This change focuses the next focusable node.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR focuses the next node in the MoreFilters footer, the Done button.

Before:
![Loss of focus when clicking clear all button](https://user-images.githubusercontent.com/3300102/98872605-db446200-2444-11eb-951e-f51e96e84b29.gif)

After:
![No loss of focus when clicking clear all button](https://user-images.githubusercontent.com/3300102/102922302-d4edd080-445b-11eb-9b1d-ddc49e2835c7.gif)


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
