### PR TITLE
[Banner] Remove NDL fallbacks

### DIFF
--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -117,7 +117,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
   position: relative;
   display: flex;
 
-  // stylelint-disable selector-max-class, selector-max-combinators
+  // stylelint-disable selector-max-class, selector-max-combinators, selector-max-specificity
   &.statusCritical .PrimaryAction .Button {
     border-color: var(--p-border-critical-subdued);
     background: var(--p-surface-critical-subdued);
@@ -197,6 +197,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
       background: var(--p-surface-success-subdued);
     }
   }
+  // stylelint-enable selector-max-class, selector-max-combinators, selector-max-specificity
 }
 
 .ContentWrapper {

--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -116,177 +116,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
   --p-rgb-text: 33, 43, 54;
   position: relative;
   display: flex;
-}
 
-.ContentWrapper {
-  flex: 1 1 auto;
-}
-
-.withinContentContainer {
-  padding: spacing(tight) $intermediate-spacing;
-
-  // stylelint-disable selector-max-class
-  &.newDesignLanguage {
-    $newDesignLanguageSpacing: rem(14px);
-    $newDesignLanguageOffset: $newDesignLanguageSpacing - spacing();
-    padding: spacing() spacing() $newDesignLanguageSpacing;
-
-    .ContentWrapper {
-      margin-top: $newDesignLanguageOffset;
-    }
-
-    .Dismiss {
-      top: spacing();
-    }
-
-    .Ribbon {
-      padding-right: spacing();
-    }
-  }
-  // stylelint-enable selector-max-class
-
-  @include banner-variants;
-
-  + .Banner {
-    margin-top: spacing(tight);
-  }
-
-  .Ribbon {
-    padding-right: $intermediate-spacing;
-  }
-
-  .Actions {
-    padding: $intermediate-spacing 0 spacing(extra-tight) 0;
-  }
-
-  .Dismiss {
-    right: $intermediate-spacing;
-    top: $intermediate-spacing;
-    position: absolute;
-  }
-}
-
-.withinPage {
-  border-radius: 0 0 border-radius() border-radius();
-  padding: spacing();
-
-  &.newDesignLanguage {
-    $newDesignLanguageSpacing: rem(18px);
-    $newDesignLanguageOffset: $newDesignLanguageSpacing - spacing(loose);
-    padding: spacing(loose) spacing(loose) $newDesignLanguageSpacing;
-
-    // stylelint-disable-next-line selector-max-class
-    .ContentWrapper {
-      margin-top: $newDesignLanguageOffset;
-    }
-  }
-
-  @include banner-variants(true);
-
-  + .Banner {
-    margin-top: spacing(loose);
-  }
-
-  .Ribbon {
-    padding-right: spacing();
-
-    // stylelint-disable-next-line selector-max-combinators, selector-max-class
-    .newDesignLanguage & {
-      padding-right: spacing(loose);
-    }
-  }
-
-  .Actions {
-    padding-top: spacing();
-  }
-
-  .Dismiss {
-    right: spacing();
-    top: spacing(loose);
-    position: absolute;
-  }
-}
-
-.hasDismiss {
-  padding-right: spacing() + spacing(extra-tight) + control-height();
-
-  &.newDesignLanguage {
-    padding-right: calc(#{2 * spacing()} + var(--p-icon-size));
-  }
-}
-
-.Heading {
-  padding-top: var(--p-override-none, $heading-offset);
-  word-break: break-word;
-}
-
-.Content {
-  @include text-breakword;
-  padding: spacing(extra-tight) 0;
-
-  .newDesignLanguage & {
-    padding: rem(2px) 0;
-  }
-}
-
-.Ribbon {
-  flex: 0 0 $ribbon-flex-basis;
-}
-
-.PrimaryAction {
-  margin-right: rem(6px);
-}
-
-// We need pretty high specificity to do the descendant selectors
-// onto the text, which needs to be the relative positioned wrapper
-// so that the borders/ backgrounds do not extend outside of it.
-// stylelint-disable selector-max-specificity
-
-.SecondaryAction {
-  @include unstyled-button;
-  @include unstyled-link;
-  display: inline-block;
-  text-align: left;
-  margin: (-1 * $secondary-action-vertical-padding)
-    (-0.5 * $secondary-action-horizontal-padding);
-  padding: $secondary-action-vertical-padding
-    $secondary-action-horizontal-padding;
-  color: var(--p-text, color('ink'));
-  padding-left: rem(6px);
-
-  &:hover > .Text {
-    box-shadow: 0 -2px 0 0 rgba(var(--p-rgb-text), 0.75) inset;
-  }
-
-  &:active > .Text {
-    box-shadow: 0 -2px 0 0 rgba(var(--p-rgb-text), 0) inset;
-  }
-
-  &:focus > .Text {
-    @include plain-button-backdrop;
-    @include high-contrast-button-outline;
-    box-shadow: none;
-  }
-}
-
-.Text {
-  box-shadow: 0 -2px 0 0 rgba(var(--p-rgb-text), 0.25) inset;
-  will-change: box-shadow;
-  transition: box-shadow duration() easing();
-}
-
-.Button {
-  @include button-base;
-  @include text-style-button;
-  @include focus-ring($border-width: rem(2px));
-  color: var(--p-text);
-
-  &:focus {
-    @include focus-ring($style: 'focused');
-  }
-}
-
-.newDesignLanguage {
   // stylelint-disable selector-max-class, selector-max-combinators
   &.statusCritical .PrimaryAction .Button {
     border-color: var(--p-border-critical-subdued);
@@ -366,5 +196,140 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
       border-color: var(--p-border-success-subdued);
       background: var(--p-surface-success-subdued);
     }
+  }
+}
+
+.ContentWrapper {
+  flex: 1 1 auto;
+}
+
+.withinContentContainer {
+  $bannerSpacing: rem(14px);
+  $bannerOffset: $bannerSpacing - spacing();
+  padding: spacing() spacing() $bannerSpacing;
+
+  .ContentWrapper {
+    margin-top: $bannerOffset;
+  }
+
+  .Dismiss {
+    top: spacing();
+  }
+
+  .Ribbon {
+    padding-right: spacing();
+  }
+
+  @include banner-variants;
+
+  + .Banner {
+    margin-top: spacing(tight);
+  }
+
+  .Actions {
+    padding: $intermediate-spacing 0 spacing(extra-tight) 0;
+  }
+}
+
+.withinPage {
+  border-radius: 0 0 border-radius() border-radius();
+
+  $bannerSpacing: rem(18px);
+  $bannerOffset: $bannerSpacing - spacing(loose);
+  padding: spacing(loose) spacing(loose) $bannerSpacing;
+
+  .ContentWrapper {
+    margin-top: $bannerOffset;
+  }
+
+  @include banner-variants(true);
+
+  + .Banner {
+    margin-top: spacing(loose);
+  }
+
+  .Ribbon {
+    padding-right: spacing(loose);
+  }
+
+  .Actions {
+    padding-top: spacing();
+  }
+
+  .Dismiss {
+    right: spacing();
+    top: spacing(loose);
+    position: absolute;
+  }
+}
+
+.hasDismiss {
+  padding-right: calc(#{2 * spacing()} + var(--p-icon-size));
+}
+
+.Heading {
+  padding-top: var(--p-override-none, $heading-offset);
+  word-break: break-word;
+}
+
+.Content {
+  @include text-breakword;
+  padding: rem(2px) 0;
+}
+
+.Ribbon {
+  flex: 0 0 $ribbon-flex-basis;
+}
+
+.PrimaryAction {
+  margin-right: rem(6px);
+}
+
+// We need pretty high specificity to do the descendant selectors
+// onto the text, which needs to be the relative positioned wrapper
+// so that the borders/ backgrounds do not extend outside of it.
+// stylelint-disable selector-max-specificity
+
+.SecondaryAction {
+  @include unstyled-button;
+  @include unstyled-link;
+  display: inline-block;
+  text-align: left;
+  margin: (-1 * $secondary-action-vertical-padding)
+    (-0.5 * $secondary-action-horizontal-padding);
+  padding: $secondary-action-vertical-padding
+    $secondary-action-horizontal-padding;
+  color: var(--p-text, color('ink'));
+  padding-left: rem(6px);
+
+  &:hover > .Text {
+    box-shadow: 0 -2px 0 0 rgba(var(--p-rgb-text), 0.75) inset;
+  }
+
+  &:active > .Text {
+    box-shadow: 0 -2px 0 0 rgba(var(--p-rgb-text), 0) inset;
+  }
+
+  &:focus > .Text {
+    @include plain-button-backdrop;
+    @include high-contrast-button-outline;
+    box-shadow: none;
+  }
+}
+
+.Text {
+  box-shadow: 0 -2px 0 0 rgba(var(--p-rgb-text), 0.25) inset;
+  will-change: box-shadow;
+  transition: box-shadow duration() easing();
+}
+
+.Button {
+  @include button-base;
+  @include text-style-button;
+  @include focus-ring($border-width: rem(2px));
+  color: var(--p-text);
+
+  &:focus {
+    @include focus-ring($style: 'focused');
   }
 }

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -7,7 +7,6 @@ import React, {
 } from 'react';
 import {
   CancelSmallMinor,
-  FlagMajor,
   CircleTickMajor,
   CircleInformationMajor,
   CircleAlertMajor,
@@ -16,7 +15,6 @@ import {
 
 import {classNames, variationName} from '../../utilities/css';
 import {BannerContext} from '../../utilities/banner-context';
-import {useFeatures} from '../../utilities/features';
 import {useUniqueId} from '../../utilities/unique-id';
 import type {
   Action,
@@ -24,7 +22,7 @@ import type {
   LoadableAction,
   IconProps,
 } from '../../types';
-import {Button, buttonFrom} from '../Button';
+import {Button} from '../Button';
 import {Heading} from '../Heading';
 import {ButtonGroup} from '../ButtonGroup';
 import {UnstyledButton, unstyledButtonFrom} from '../UnstyledButton';
@@ -68,7 +66,6 @@ export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
   }: BannerProps,
   bannerRef,
 ) {
-  const {newDesignLanguage} = useFeatures();
   const withinContentContainer = useContext(WithinContentContext);
   const buttonSizeValue = withinContentContainer ? 'slim' : undefined;
   const id = useUniqueId('Banner');
@@ -79,10 +76,7 @@ export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
     handleMouseUp,
     shouldShowFocus,
   } = useBannerFocus(bannerRef);
-  const {defaultIcon, iconColor, ariaRoleType} = useBannerAttributes(
-    status,
-    newDesignLanguage,
-  );
+  const {defaultIcon, iconColor, ariaRoleType} = useBannerAttributes(status);
   const iconName = icon || defaultIcon;
   const className = classNames(
     styles.Banner,
@@ -90,7 +84,6 @@ export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
     onDismiss && styles.hasDismiss,
     shouldShowFocus && styles.keyFocused,
     withinContentContainer ? styles.withinContentContainer : styles.withinPage,
-    newDesignLanguage && styles.newDesignLanguage,
   );
 
   let headingMarkup: React.ReactNode = null;
@@ -107,11 +100,9 @@ export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
 
   const primaryActionMarkup = action ? (
     <div className={styles.PrimaryAction}>
-      {newDesignLanguage
-        ? unstyledButtonFrom(action, {
-            className: styles.Button,
-          })
-        : buttonFrom(action, {outline: true, size: buttonSizeValue})}
+      {unstyledButtonFrom(action, {
+        className: styles.Button,
+      })}
     </div>
   ) : null;
 
@@ -171,11 +162,7 @@ export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
         {dismissButton}
 
         <div className={styles.Ribbon}>
-          <Icon
-            source={iconName}
-            color={iconColor}
-            backdrop={!newDesignLanguage}
-          />
+          <Icon source={iconName} color={iconColor} />
         </div>
 
         <div className={styles.ContentWrapper}>
@@ -216,43 +203,40 @@ interface BannerAttributes {
   ariaRoleType: 'status' | 'alert';
 }
 
-function useBannerAttributes(
-  status: BannerProps['status'],
-  newDesignLanguage: boolean,
-): BannerAttributes {
+function useBannerAttributes(status: BannerProps['status']): BannerAttributes {
   switch (status) {
     case 'success':
       return {
         defaultIcon: CircleTickMajor,
-        iconColor: newDesignLanguage ? 'success' : 'greenDark',
+        iconColor: 'success',
         ariaRoleType: 'status',
       };
 
     case 'info':
       return {
         defaultIcon: CircleInformationMajor,
-        iconColor: newDesignLanguage ? 'highlight' : 'tealDark',
+        iconColor: 'highlight',
         ariaRoleType: 'status',
       };
 
     case 'warning':
       return {
         defaultIcon: CircleAlertMajor,
-        iconColor: newDesignLanguage ? 'warning' : 'yellowDark',
+        iconColor: 'warning',
         ariaRoleType: 'alert',
       };
 
     case 'critical':
       return {
         defaultIcon: DiamondAlertMajor,
-        iconColor: newDesignLanguage ? 'critical' : 'redDark',
+        iconColor: 'critical',
         ariaRoleType: 'alert',
       };
 
     default:
       return {
-        defaultIcon: newDesignLanguage ? CircleInformationMajor : FlagMajor,
-        iconColor: newDesignLanguage ? 'base' : 'inkLighter',
+        defaultIcon: CircleInformationMajor,
+        iconColor: 'base',
         ariaRoleType: 'status',
       };
   }

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -67,7 +67,6 @@ export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
   bannerRef,
 ) {
   const withinContentContainer = useContext(WithinContentContext);
-  const buttonSizeValue = withinContentContainer ? 'slim' : undefined;
   const id = useUniqueId('Banner');
   const {
     wrapperRef,

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -1,6 +1,5 @@
 import React, {useEffect, useRef} from 'react';
 import {
-  FlagMajor,
   CirclePlusMinor,
   CircleTickMajor,
   CircleInformationMajor,

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -32,38 +32,38 @@ describe('<Banner />', () => {
     expect(banner.find(Icon).prop('source')).toBe(CirclePlusMinor);
   });
 
-  it('uses a greenDark circleCheckMark if status is success and sets a status aria role', () => {
+  it('uses a success circleCheckMark if status is success and sets a status aria role', () => {
     const banner = mountWithAppProvider(<Banner status="success" />);
     expect(banner.find(Icon).prop('source')).toBe(CircleTickMajor);
-    expect(banner.find(Icon).prop('color')).toBe('greenDark');
+    expect(banner.find(Icon).prop('color')).toBe('success');
     expect(banner.find('div').first().prop('role')).toBe('status');
   });
 
-  it('uses a tealDark circleInformation if status is info and sets a status aria role', () => {
+  it('uses a highlight circleInformation if status is info and sets a status aria role', () => {
     const banner = mountWithAppProvider(<Banner status="info" />);
     expect(banner.find(Icon).prop('source')).toBe(CircleInformationMajor);
-    expect(banner.find(Icon).prop('color')).toBe('tealDark');
+    expect(banner.find(Icon).prop('color')).toBe('highlight');
     expect(banner.find('div').first().prop('role')).toBe('status');
   });
 
-  it('uses a yellowDark circleAlert if status is warning and sets an alert aria role', () => {
+  it('uses a warning circleAlert if status is warning and sets an alert aria role', () => {
     const banner = mountWithAppProvider(<Banner status="warning" />);
     expect(banner.find(Icon).prop('source')).toBe(CircleAlertMajor);
-    expect(banner.find(Icon).prop('color')).toBe('yellowDark');
+    expect(banner.find(Icon).prop('color')).toBe('warning');
     expect(banner.find('div').first().prop('role')).toBe('alert');
   });
 
-  it('uses a redDark circleBarred if status is critical and sets an alert aria role', () => {
+  it('uses a critical circleBarred if status is critical and sets an alert aria role', () => {
     const banner = mountWithAppProvider(<Banner status="critical" />);
     expect(banner.find(Icon).prop('source')).toBe(DiamondAlertMajor);
-    expect(banner.find(Icon).prop('color')).toBe('redDark');
+    expect(banner.find(Icon).prop('color')).toBe('critical');
     expect(banner.find('div').first().prop('role')).toBe('alert');
   });
 
   it('uses a default icon and aria role', () => {
     const banner = mountWithAppProvider(<Banner />);
-    expect(banner.find(Icon).prop('source')).toBe(FlagMajor);
-    expect(banner.find(Icon).prop('color')).toBe('inkLighter');
+    expect(banner.find(Icon).prop('source')).toBe(CircleInformationMajor);
+    expect(banner.find(Icon).prop('color')).toBe('base');
     expect(banner.find('div').first().prop('role')).toBe('status');
   });
 
@@ -80,7 +80,7 @@ describe('<Banner />', () => {
   });
 
   describe('action', () => {
-    it('renders an outline button', () => {
+    it('renders an unstyled button', () => {
       const bannerWithAction = mountWithAppProvider(
         <Banner
           title="Test"
@@ -90,27 +90,6 @@ describe('<Banner />', () => {
         >
           Hello World
         </Banner>,
-      );
-
-      const bannerAction = bannerWithAction.find(Button);
-
-      expect(bannerAction.exists()).toBeTruthy();
-      expect(bannerAction.text()).toBe('Primary action');
-    });
-
-    it('renders an unstyled button when newDesignLanguage is true', () => {
-      const bannerWithAction = mountWithAppProvider(
-        <Banner
-          title="Test"
-          action={{
-            content: 'Primary action',
-          }}
-        >
-          Hello World
-        </Banner>,
-        {
-          features: {newDesignLanguage: true},
-        },
       );
 
       const bannerAction = bannerWithAction.find(UnstyledButton);
@@ -212,9 +191,9 @@ describe('<Banner />', () => {
     </WithinContentContext.Provider>,
   );
 
-  it('renders a slim button with contentContext', () => {
-    const button = bannerWithContentContext.find(Button);
-    expect(button.prop('size')).toBe('slim');
+  it('renders an unstyled button with contentContext', () => {
+    const button = bannerWithContentContext.find(UnstyledButton);
+    expect(button.exists()).toBeTruthy();
   });
 
   describe('focus', () => {
@@ -238,12 +217,10 @@ describe('<Banner />', () => {
 
     describe('Focus className', () => {
       it('adds a keyFocused class to the banner on keyUp', () => {
-        const banner = mountWithApp(<Banner />, {
-          features: {newDesignLanguage: true},
-        });
+        const banner = mountWithApp(<Banner />);
 
         const bannerDiv = banner.find('div', {
-          className: 'Banner withinPage newDesignLanguage',
+          className: 'Banner withinPage',
         });
 
         bannerDiv!.trigger('onKeyUp', {
@@ -251,17 +228,15 @@ describe('<Banner />', () => {
         });
 
         expect(banner).toContainReactComponent('div', {
-          className: 'Banner keyFocused withinPage newDesignLanguage',
+          className: 'Banner keyFocused withinPage',
         });
       });
 
       it('does not add a keyFocused class onMouseUp', () => {
-        const banner = mountWithApp(<Banner />, {
-          features: {newDesignLanguage: true},
-        });
+        const banner = mountWithApp(<Banner />);
 
         const bannerDiv = banner.find('div', {
-          className: 'Banner withinPage newDesignLanguage',
+          className: 'Banner withinPage',
         });
 
         bannerDiv!.trigger('onMouseUp', {
@@ -269,7 +244,7 @@ describe('<Banner />', () => {
         });
 
         expect(banner).toContainReactComponent('div', {
-          className: 'Banner withinPage newDesignLanguage',
+          className: 'Banner withinPage',
         });
       });
     });
@@ -319,12 +294,9 @@ describe('<Banner />', () => {
     ])(
       'Sets Icon props when: %s',
       (_: any, status: any, color: any, iconSource: any) => {
-        const banner = mountWithApp(<Banner status={status} />, {
-          features: {newDesignLanguage: true},
-        });
+        const banner = mountWithApp(<Banner status={status} />);
 
         expect(banner.find(Icon)!.props).toStrictEqual({
-          backdrop: false,
           color,
           source: iconSource,
         });


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves Shopify/polaris-ux#590

### WHAT is this pull request doing?

Removes references to newDesignLanguage in the Banner component

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Banner component with new design language should look identical

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
