### PR TITLE
Improve accessibility HCM mixin to work in other browsers

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -40,7 +40,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed clear button in `TextField` unintentionally closing `Popover` when clicked ([#3688](https://github.com/Shopify/polaris-react/pull/3688))
 - Added focus styles to the clear button in `TextField` ([#3688](https://github.com/Shopify/polaris-react/pull/3688))
 - Increased contrast of navigation text color ([#3742](https://github.com/Shopify/polaris-react/pull/3742))
-- Removed `-ms-high-contrast` media query from `ms-high-contrast-outline` as it is non-standard and updated the outline color from `windowText` to `tranpsarent` ([#3775](https://github.com/Shopify/polaris-react/pull/3775)).
+- Removed `-ms-high-contrast` media query from `ms-high-contrast-outline` as it is non-standard and updated the outline color from `windowText` to `transparent` ([#3775](https://github.com/Shopify/polaris-react/pull/3775)).
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -40,6 +40,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed clear button in `TextField` unintentionally closing `Popover` when clicked ([#3688](https://github.com/Shopify/polaris-react/pull/3688))
 - Added focus styles to the clear button in `TextField` ([#3688](https://github.com/Shopify/polaris-react/pull/3688))
 - Increased contrast of navigation text color ([#3742](https://github.com/Shopify/polaris-react/pull/3742))
+- Removed `-ms-high-contrast` media query from `ms-high-contrast-outline` as it is non-standard and updated the outline color from `windowText` to `tranpsarent` ([#3775](https://github.com/Shopify/polaris-react/pull/3775)).
 
 ### Documentation
 

--- a/src/styles/foundation/_accessibility.scss
+++ b/src/styles/foundation/_accessibility.scss
@@ -1,7 +1,4 @@
 @mixin ms-high-contrast-outline($border-width: border-width()) {
-  @media (-ms-high-contrast: active) {
-    outline: $border-width solid ms-high-contrast-color('text');
-
-    @content;
-  }
+  outline: $border-width solid transparent;
+  @content;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3774

The mixin `ms-high-contrast-mode` in `_accessibility.scss` uses a media query that is non-standard and only supported by Microsoft Edge (version < 18). Alternatively, `forced-colors` media query could be used, but it is not optimal since it requires a beta flag to be manually enabled in Firefox (version > 81). The current color used (windowText) seems to also be deprecated.

The use of just a transparent outline seems to be commonly recommended solution to support a wider range of browsers, without disrupting non-high-contrast environments. 

More information can be found here: 
https://drafts.csswg.org/css-color-4/#deprecated-system-colors (windowText being a deprecated system color)
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/-ms-high-contrast (non-standard media query)

Slack conversations leading up to this PR:
https://shopify.slack.com/archives/C4Y8N30KD/p1607455945447700

### Screenshots

**Non-high-contrast environment (undisturbed)**
![image](https://user-images.githubusercontent.com/59658889/103700291-448eb000-4f72-11eb-801c-0b11ebf7b0ba.png)

**Firefox without this PR's changes**
![image](https://user-images.githubusercontent.com/59658889/103700442-73a52180-4f72-11eb-9c14-eb3b06f7c711.png)

**Firefox (same with Edge and IE) with this PR's changes**
![image](https://user-images.githubusercontent.com/59658889/103700460-7bfd5c80-4f72-11eb-8f92-3e6ee38a9952.png)

### WHAT is this pull request doing?

1. Removes non-standard media query used.
2. Updates color to `transparent` instead of `windowText`, which is deprecated.


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
