### PR TITLE
Run CI on push to version-6.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,8 @@ on:
       - '**'
   push:
     branches:
-      - master
+      - 'master'
+      - 'version-6.0.0'
 
 jobs:
   test:


### PR DESCRIPTION
### WHY are these changes introduced?

`version-6.0.0` is a long-running feature branch for the next version. We should run CI on it to make sure it works.

This should also help provide VRT baselines for percy on this branch.

### WHAT is this pull request doing?

Run CI on push to `version-6.0.0`