### PR TITLE
[Tabs] Fix aria-controls related a11y error

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,7 +2,7 @@
 
 Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to format new entries. 💜
 
-- Update `Tabs` to prevent `aria-valid-attr-value` a11y error ([#3777](https://github.com/Shopify/polaris-react/pull/3777))
+- Updated `Tabs` to prevent `aria-valid-attr-value` a11y error ([#3777](https://github.com/Shopify/polaris-react/pull/3777))
 
 ### Breaking changes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,8 @@
 
 Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to format new entries. 💜
 
+- Update `Tabs` to prevent `aria-valid-attr-value` a11y error ([#3777](https://github.com/Shopify/polaris-react/pull/3777))
+
 ### Breaking changes
 
 ### Enhancements

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -107,7 +107,9 @@ class TabsInner extends PureComponent<CombinedProps, State> {
 
     const tabsMarkup = visibleTabs
       .sort((tabA, tabB) => tabA - tabB)
-      .map((tabIndex) => this.renderTabMarkup(tabs[tabIndex], tabIndex));
+      .map((tabIndex) =>
+        this.renderTabMarkup(tabs[tabIndex], tabIndex, children),
+      );
 
     const disclosureActivatorVisible = visibleTabs.length < tabs.length;
     const hasCustomDisclosure = Boolean(disclosureText);
@@ -245,9 +247,14 @@ class TabsInner extends PureComponent<CombinedProps, State> {
   };
 
   // eslint-disable-next-line @shopify/react-no-multiple-render-methods
-  private renderTabMarkup = (tab: TabDescriptor, index: number) => {
+  private renderTabMarkup = (
+    tab: TabDescriptor,
+    index: number,
+    children: React.ReactNode,
+  ) => {
     const {selected} = this.props;
     const {tabToFocus} = this.state;
+    const tabPanelID = tab.panelID || `${tab.id}-panel`;
 
     return (
       <Tab
@@ -257,7 +264,7 @@ class TabsInner extends PureComponent<CombinedProps, State> {
         focused={index === tabToFocus}
         selected={index === selected}
         onClick={this.handleTabClick}
-        panelID={tab.panelID || `${tab.id}-panel`}
+        panelID={children ? tabPanelID : undefined}
         accessibilityLabel={tab.accessibilityLabel}
         url={tab.url}
       >

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -107,9 +107,7 @@ class TabsInner extends PureComponent<CombinedProps, State> {
 
     const tabsMarkup = visibleTabs
       .sort((tabA, tabB) => tabA - tabB)
-      .map((tabIndex) =>
-        this.renderTabMarkup(tabs[tabIndex], tabIndex, children),
-      );
+      .map((tabIndex) => this.renderTabMarkup(tabs[tabIndex], tabIndex));
 
     const disclosureActivatorVisible = visibleTabs.length < tabs.length;
     const hasCustomDisclosure = Boolean(disclosureText);
@@ -247,12 +245,8 @@ class TabsInner extends PureComponent<CombinedProps, State> {
   };
 
   // eslint-disable-next-line @shopify/react-no-multiple-render-methods
-  private renderTabMarkup = (
-    tab: TabDescriptor,
-    index: number,
-    children: React.ReactNode,
-  ) => {
-    const {selected} = this.props;
+  private renderTabMarkup = (tab: TabDescriptor, index: number) => {
+    const {selected, children} = this.props;
     const {tabToFocus} = this.state;
     const tabPanelID = tab.panelID || `${tab.id}-panel`;
 

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -134,8 +134,11 @@ describe('<Tabs />', () => {
         {...tabs[0], panelID: 'panel-1'},
         {...tabs[1], panelID: 'panel-2'},
       ];
+      const content = <p>Panel contents</p>;
       const wrapper = mountWithAppProvider(
-        <Tabs {...mockProps} tabs={panelIDedTabs} />,
+        <Tabs {...mockProps} tabs={panelIDedTabs}>
+          {content}
+        </Tabs>,
       );
 
       panelIDedTabs.forEach((tab, index) => {
@@ -144,12 +147,24 @@ describe('<Tabs />', () => {
     });
 
     it('uses an auto-generated panelID if none is provided', () => {
-      const wrapper = mountWithAppProvider(<Tabs {...mockProps} />);
+      const content = <p>Panel contents</p>;
+      const wrapper = mountWithAppProvider(
+        <Tabs {...mockProps}>{content}</Tabs>,
+      );
 
       tabs.forEach((_, index) => {
         const panelID = wrapper.find(Tab).at(index).prop('panelID');
         expect(typeof panelID).toBe('string');
         expect(panelID).not.toBe('');
+      });
+    });
+
+    it('sets the panelID to undefined when the tab does not have an associated panel (child)', () => {
+      const wrapper = mountWithAppProvider(<Tabs {...mockProps} />);
+
+      tabs.forEach((_, index) => {
+        const panelID = wrapper.find(Tab).at(index).prop('panelID');
+        expect(panelID).toBeUndefined();
       });
     });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/34637

The way the Tabs component was build allows users to (unknowingly) introduce an a11y error (`aria-valid-attr-value`). This happens when the Tab component is used without children (tab panel). The component sets an `aria-controls` value, even if there is no associated panel with the same `id`. This then throws the a11y error because the aria controls value needs to match the id of the associated panel. 

[Here are more details about why this happens and a look at the code.](https://github.com/Shopify/polaris-react/issues/3692) 

### WHAT is this pull request doing?

This PR implements [Solution 1](https://github.com/Shopify/polaris-react/issues/3692) outlined in an issue where I describe the problem. I have updated the component to conditionally assign the aria-controls id based on if there is an associated tab panel or not. If an id is not provided, a unique one is generated and used if there is an associated tab panel (current behaviour). 

No UI changes. 

I am open to discussing the other 2 possible solutions [I outlined in this issue](https://github.com/Shopify/polaris-react/issues/3692), but I think this is the best way forward.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Paste the code below into your local `Playground.tsx`. Run the server and launch the Playground in the browser.
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {Page, Tabs, Card} from '../src';

export function Playground() {
  const [selected, setSelected] = useState(0);
  const [selected2, setSelected2] = useState(0);

  const tabs = [
    {
      id: 'all-customers',
      content: 'All',
      accessibilityLabel: 'All customers',
      panelID: 'all-customers-content',
    },
    {
      id: 'accepts-marketing',
      content: 'Accepts marketing',
      panelID: 'accepts-marketing-content',
    },
    {
      id: 'repeat-customers',
      content: 'Repeat customers',
      panelID: 'repeat-customers-content',
    },
    {
      id: 'prospects',
      content: 'Prospects',
      panelID: 'prospects-content',
    },
  ];

  const tabs2 = [
    {
      id: 'all-customers2',
      content: 'All',
      accessibilityLabel: 'All customers',
      panelID: 'all-customers-content2',
    },
    {
      id: 'accepts-marketing2',
      content: 'Accepts marketing',
      panelID: 'accepts-marketing-content2',
    },
    {
      id: 'repeat-customers2',
      content: 'Repeat customers',
      panelID: 'repeat-customers-content2',
    },
    {
      id: 'prospects2',
      content: 'Prospects',
      panelID: 'prospects-content2',
    },
  ];

  const handleTabChange = useCallback(
    (selectedTabIndex) => setSelected(selectedTabIndex),
    [],
  );

  const handleTabChange2 = useCallback(
    (selectedTabIndex2) => setSelected2(selectedTabIndex2),
    [],
  );

  return (
    <Page title="Playground">
      <Card>
      {<Tabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
        <Card.Section title={tabs[selected].content}>
          <p>Tab {selected} selected</p>
        </Card.Section>
      </Tabs>}
    </Card>

    <Tabs tabs={tabs2} selected={selected2} onSelect={handleTabChange2} />
    </Page>
  );
}
```
</details>


This Playground has two examples: tabs with associated tab panels and tabs without tab panels. 
1. Run the [Accessibility Insights](https://chrome.google.com/webstore/detail/accessibility-insights-fo/pbjjkligggfmakdaogkfomddhfmpjeni?hl=en) chrome extension to ensure the `aria-valid-attr-value` does not appear
2. Inspect the HTML for the tab link or button in each example:
a. Ensure the tabs with panels have an aria-controls value that matches the id of the panel
b. Ensure the tabs without panels does not have an aria-controls value


### Tabs with panels
![image](https://user-images.githubusercontent.com/12052693/103709636-3cce0c00-4f70-11eb-9c50-7b845e1306b2.png)

### Tabs without panels
![image](https://user-images.githubusercontent.com/12052693/103709494-e19c1980-4f6f-11eb-9b5e-cbe99e99d1c2.png)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes **[No change]**
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide **[No change]**
- [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit **[No change]**

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
