### PR TITLE
[Label, Labelled] Change `label` prop type to `React.ReactNode`

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,24 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Updated `OptionList` selected styles ([#3633](https://github.com/Shopify/polaris-react/pull/3633))
+- Added the ability to hide the clear filter button on the filter component ([#3049](https://github.com/Shopify/polaris-react/pull/3049))
+- Right-align `disclosure` when using `textAlignLeft` for `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
+- Remove all transitions from `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
+- New `select` option for `disclosure` in `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
+- Conveyed `DatePicker` more clearly to screen readers ([#3660](https://github.com/Shopify/polaris-react/pull/3660))
+- Added `accessibilityLabels` prop to `Pagination` ([#3667](https://github.com/Shopify/polaris-react/pull/3667))
+- New `autofocusTarget` prop to enhance autofocus options on `Popover` ([#3600](https://github.com/Shopify/polaris-react/pull/3600))
+- Added ability to hide query text field in `Filters` component using `hideQueryField` prop ([#3674](https://github.com/Shopify/polaris-react/pull/3674))
+- Added `tabIndex` to `Scrollable` for keyboard focus ([#3744](https://github.com/Shopify/polaris-react/pull/3744))
+- Added accessibility label prop to `UserMenu` and `Menu` subcomponents in `TopBar` ([#3659](https://github.com/Shopify/polaris-react/pull/3659))
+- Add `aria-label` to the `Loading` bar in `Frame` ([#3770](https://github.com/Shopify/polaris-react/pull/3770))
+- Updated `Collapsible` to be a functional component ([#3779](https://github.com/Shopify/polaris-react/pull/3779))
+- Coverted `TooltipOverlay` to a functional component ([#3631](https://github.com/Shopify/polaris-react/pull/3631))
+- New `ariaDescribedBy` prop for `Button` ([#3664](https://github.com/Shopify/polaris-react/pull/3686))
+- Changed the way sub navigation menus are rendered for improved accessibility ([#3661](https://github.com/Shopify/polaris-react/pull/3661))
+- Changed `Label` and `Labelled`’s `label` prop type to `React.ReactNode` instead of `string` ([#3787](https://github.com/Shopify/polaris-react/pull/3787))
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -35,7 +35,7 @@ type Type = 'file' | 'image';
 
 export interface DropZoneProps {
   /** Label for the file input */
-  label?: string;
+  label?: React.ReactNode;
   /** Adds an action to the label */
   labelAction?: LabelledProps['action'];
   /** Visually hide the label */

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -6,7 +6,7 @@ import styles from './Label.scss';
 
 export interface LabelProps {
   /** Label content */
-  children?: string;
+  children?: React.ReactNode;
   /** A unique identifier for the label */
   id: string;
   /** Visually hide the label */

--- a/src/components/Labelled/Labelled.tsx
+++ b/src/components/Labelled/Labelled.tsx
@@ -14,7 +14,7 @@ export interface LabelledProps {
   /** A unique identifier for the label */
   id: LabelProps['id'];
   /** Text for the label */
-  label: string;
+  label: React.ReactNode;
   /** Error to display beneath the label */
   error?: Error | boolean;
   /** An action */

--- a/src/components/RangeSlider/types.ts
+++ b/src/components/RangeSlider/types.ts
@@ -7,7 +7,7 @@ export type RangeSliderValue = number | DualValue;
 
 export interface RangeSliderProps {
   /** Label for the range input */
-  label: string;
+  label: React.ReactNode;
   /** Adds an action to the label */
   labelAction?: LabelledProps['action'];
   /** Visually hide the label */

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -43,7 +43,7 @@ export interface SelectProps {
   /** List of options or option groups to choose from */
   options?: (SelectOption | SelectGroup)[];
   /** Label for the select */
-  label: string;
+  label: React.ReactNode;
   /** Adds an action to the label */
   labelAction?: LabelledProps['action'];
   /** Visually hide the label */

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -60,7 +60,7 @@ interface NonMutuallyExclusiveProps {
   /** Additional hint text to display */
   helpText?: React.ReactNode;
   /** Label for the input */
-  label: string;
+  label: React.ReactNode;
   /** Adds an action to the label */
   labelAction?: LabelledProps['action'];
   /** Visually hide the label */


### PR DESCRIPTION
### WHY are these changes introduced?

The current type for `label` is `string`, which doesn’t allow us to add anything else than unstyled text to a label. This would have greatly improved https://github.com/Shopify/web/pull/35964, we currently workaround it by passing an empty label and re-implementing fields’ labels, which is not ideal… I added some examples of what a `React.ReactNode` `label` enables in the tophatting section below.

### WHAT is this pull request doing?

This PR updates the `Label` and `Labelled`’s `label` prop types to `React.ReactNode` and makes the necessary change anywhere that prop is drilled down (which most form fields seem to do). I think I changed every occurence, I checked and I couldn’t find any code manipulating the label and expecting it to be a string, there isn’t any TypeScript error. 😌

The `helpText` prop is already typed with `React.ReactNode`, I don’t see any reason not to use it for the `label` as well, except that block elements cannot be children of `label` tags, which polaris consumers may not realize; I expected React to log an error for invalid DOM nesting but I couldn’t have it show up 🤔 

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {QuestionMarkMajor} from '@shopify/polaris-icons';

import {Page, TextField, Icon} from '../src';

function Marker() {
  return <span style={{color: 'red'}}>*</span>;
}

function noop() {}

export function Playground() {
  return (
    <Page title="Playground">
      <TextField onChange={noop} label="Regular label" />
      <TextField
        onChange={noop}
        label={
          <>
            Label as Fragment <Marker />
          </>
        }
      />
      <TextField
        onChange={noop}
        label={['Label as array', ' ', <Marker key="marker" />]}
      />
      <TextField
        onChange={noop}
        label={
          <span style={{display: 'flex'}}>
            Label with icon &nbsp;
            <Icon source={QuestionMarkMajor} />
          </span>
        }
      />
    </Page>
  );
}

```

</details>

Every field should render its label as expected:
![Screenshot 2021-01-07 at 11 58 32](https://user-images.githubusercontent.com/9154236/103885011-b0daf200-50df-11eb-81a6-44a6275e315a.png)

### 🎩 &nbsp;checklist

None of these are applicable.

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing) 
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
