### PR TITLE
Added ability to navigate in portals during focus trapping

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -29,6 +29,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `Banner` `secondaryAction` only rendering if `action` is set ([#2949](https://github.com/Shopify/polaris-react/pull/2949))
 - Added a `alwaysRenderCustomProperties` to `ThemeProvider` for elements that render outside of the DOM tree to their parent context ([#3652](https://github.com/Shopify/polaris-react/pull/3652))
 - Fixed keyboard interactions for the `Tab` component ([#3650](https://github.com/Shopify/polaris-react/pull/3650))
+- Fixed `TrapFocus` disallowing focus inside `Portal` ([#3790](https://github.com/Shopify/polaris-react/pull/3790))
 - Fixed keyboard interaction when selected Tab was focused and rendering the wrong `::before` colour ([#3669](https://github.com/Shopify/polaris-react/pull/3669))
 - Added focus ring to disclosure tab when tabbing with keyboard([#3675](https://github.com/Shopify/polaris-react/pull/3675))
 - Fixed windows high contrast mode on hover within disclosure menu and displaying active state upon click for `::before` ([#3675](https://github.com/Shopify/polaris-react/pull/3675))

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -12,6 +12,7 @@ import {
   focusLastKeyboardFocusableNode,
 } from '../../utilities/focus';
 import {useFocusManager} from '../../utilities/focus-manager';
+import {portal} from '../shared';
 
 export interface TrapFocusProps {
   trapping?: boolean;
@@ -51,7 +52,9 @@ export function TrapFocus({trapping = true, children}: TrapFocusProps) {
     if (
       trapping === false ||
       !focusTrapWrapper.current ||
-      containerContentsHaveFocus
+      containerContentsHaveFocus ||
+      (event.target instanceof Element &&
+        event.target.matches(`${portal.selector} *`))
     ) {
       return;
     }

--- a/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -90,7 +90,7 @@ describe('<TrapFocus />', () => {
     expect(trapFocus).toContainReactComponent(Focus, {disabled: false});
   });
 
-  it(`does not track focus while navigating inside a portal`, () => {
+  it(`does not trap focus while navigating inside a portal`, () => {
     const id = 'focusable';
     const trapFocus = mountWithApp(
       <TrapFocus>

--- a/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -6,6 +6,7 @@ import {
   TextContainer,
   TextField,
   Button,
+  Portal,
 } from 'components';
 
 import * as focusUtils from '../../../utilities/focus';
@@ -87,6 +88,25 @@ describe('<TrapFocus />', () => {
     );
 
     expect(trapFocus).toContainReactComponent(Focus, {disabled: false});
+  });
+
+  it(`does not track focus while navigating inside a portal`, () => {
+    const id = 'focusable';
+    const trapFocus = mountWithApp(
+      <TrapFocus>
+        <Portal>
+          <button id={id} />
+        </Portal>
+        <button />
+      </TrapFocus>,
+    );
+    const focusableButton = trapFocus.find('button', {id})?.domNode;
+    focusableButton?.focus();
+    trapFocus
+      .find(EventListener, {event: 'focusin'})
+      ?.trigger('handler', {target: focusableButton});
+
+    expect(document.activeElement).toBe(focusableButton);
   });
 
   it('keeps focus on nodes contained inside trap focus during mount', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

`TrapFocus` blocks focus inside of portals

### Gifs

|Before|After|
|-|-|
|![Screen Recording 2021-01-07 at 12 42 44 PM](https://user-images.githubusercontent.com/24610840/103925789-0adeb600-50e6-11eb-8f9a-63b77b5e7da0.gif)|![Screen Recording 2021-01-07 at 12 41 25 PM](https://user-images.githubusercontent.com/24610840/103925799-0dd9a680-50e6-11eb-9f06-7e63d79bdbe8.gif)|

### WHAT is this pull request doing?

Allowing focus inside of portals while trapping focus

### How to 🎩

* Playground setup with modal + popover + actionlist

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {Page, Modal, Button, TextContainer, Popover, ActionList} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <ModalExample />
    </Page>
  );
}

function ModalExample() {
  const [active, setActive] = useState(false);

  const handleChange = useCallback(() => setActive(!active), [active]);

  const activator = <Button onClick={handleChange}>Open</Button>;

  return (
    <div style={{height: '500px'}}>
      <Modal
        activator={activator}
        open={active}
        onClose={handleChange}
        title="Reach more shoppers with Instagram product tags"
        primaryAction={{
          content: 'Add Instagram',
          onAction: handleChange,
        }}
        secondaryActions={[
          {
            content: 'Learn more',
            onAction: handleChange,
          },
        ]}
      >
        <Modal.Section>
          <TextContainer>
            <p>
              Use Instagram posts to share your products with millions of
              people. Let shoppers buy from your store without leaving
              Instagram.
            </p>
          </TextContainer>
          <PopoverWithActionListExample />
        </Modal.Section>
      </Modal>
    </div>
  );
}

function PopoverWithActionListExample() {
  const [popoverActive, setPopoverActive] = useState(false);
  const [focusOnClose, setFocusOnClose] = useState(false);

  const togglePopoverActive = useCallback(
    () => setPopoverActive((popoverActive) => !popoverActive),
    [],
  );

  const activator = (
    <Button onClick={togglePopoverActive} disclosure>
      More actions
    </Button>
  );

  return (
    <div style={{height: '250px'}}>
      <Button primary onClick={() => setFocusOnClose((cv) => !cv)}>
        Focus on close: {`${focusOnClose}`}
      </Button>
      <Popover
        active={popoverActive}
        activator={activator}
        onClose={togglePopoverActive}
        preventFocusOnClose={focusOnClose}
      >
        <ActionList items={[{content: 'Import'}, {content: 'Export'}]} />
      </Popover>
    </div>
  );
}
```

</details>
