### PR TITLE
[SkeletonPage] Remove new DL fallbacks

### DIFF
--- a/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -61,6 +61,19 @@ describe('<PositionedOverlay />', () => {
         positioning: 'above',
       });
     });
+
+    it('positions below if no preferredPosition is given', () => {
+      const spy = jest.fn();
+      mountWithAppProvider(<PositionedOverlay {...mockProps} render={spy} />);
+
+      expect(spy).toHaveBeenCalledWith({
+        activatorRect: {height: 0, left: 0, top: 0, width: 0},
+        desiredHeight: 0,
+        left: undefined,
+        measuring: true,
+        positioning: 'below',
+      });
+    });
   });
 
   describe('preferredAlignment', () => {

--- a/src/components/SkeletonPage/SkeletonPage.scss
+++ b/src/components/SkeletonPage/SkeletonPage.scss
@@ -45,11 +45,11 @@ $skeleton-display-text-max-width: rem(120px);
   }
 }
 
-.Title {
+.TitleWrapper {
   flex: 1 1 0%;
 }
 
-.newDesignLanguageTitle {
+.Title {
   @include text-emphasis-strong;
   font-size: rem(24px);
   line-height: rem(28px);
@@ -59,7 +59,7 @@ $skeleton-display-text-max-width: rem(120px);
   }
 }
 
-.newDesignLanguageSkeletonTitle {
+.SkeletonTitle {
   @include skeleton-shimmer;
   @include skeleton-content;
   max-width: $skeleton-display-text-max-width;

--- a/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/src/components/SkeletonPage/SkeletonPage.tsx
@@ -47,11 +47,13 @@ export function SkeletonPage({
     secondaryActions && styles['Header-hasSecondaryActions'],
   );
 
-  const titleMarkup = (
-    <div className={styles.TitleWrapper}>
-      <SkeletonPageTitle title={title} />
-    </div>
+  const titleContent = title ? (
+    <h1 className={styles.Title}>{title}</h1>
+  ) : (
+    <div className={styles.SkeletonTitle} />
   );
+
+  const titleMarkup = <div className={styles.TitleWrapper}>{titleContent}</div>;
 
   const primaryActionMarkup = primaryAction ? (
     <div className={styles.PrimaryAction}>
@@ -99,12 +101,4 @@ function renderSecondaryActions(actionCount: number) {
     );
   }
   return <div className={styles.Actions}>{actions}</div>;
-}
-
-function SkeletonPageTitle({title = ''}) {
-  if (title) {
-    return <h1 className={styles.Title}>{title}</h1>;
-  }
-
-  return <div className={styles.SkeletonTitle} />;
 }

--- a/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/src/components/SkeletonPage/SkeletonPage.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 
 import {classNames} from '../../utilities/css';
-import {useFeatures} from '../../utilities/features';
 import {useI18n} from '../../utilities/i18n';
-import {DisplayText} from '../DisplayText';
-import {TextStyle} from '../TextStyle';
 import {SkeletonDisplayText} from '../SkeletonDisplayText';
 import {SkeletonBodyText} from '../SkeletonBodyText';
 
@@ -37,13 +34,11 @@ export function SkeletonPage({
   breadcrumbs,
 }: SkeletonPageProps) {
   const i18n = useI18n();
-  const {newDesignLanguage} = useFeatures();
 
   const className = classNames(
     styles.Page,
     fullWidth && styles.fullWidth,
     narrowWidth && styles.narrowWidth,
-    newDesignLanguage && styles.newDesignLanguage,
   );
 
   const headerClassName = classNames(
@@ -53,8 +48,8 @@ export function SkeletonPage({
   );
 
   const titleMarkup = (
-    <div className={styles.Title}>
-      <SkeletonPageTitle title={title} newDesignLanguage={newDesignLanguage} />
+    <div className={styles.TitleWrapper}>
+      <SkeletonPageTitle title={title} />
     </div>
   );
 
@@ -106,26 +101,10 @@ function renderSecondaryActions(actionCount: number) {
   return <div className={styles.Actions}>{actions}</div>;
 }
 
-function SkeletonPageTitle({
-  title = '',
-  newDesignLanguage = false,
-}: {
-  title?: string;
-  newDesignLanguage?: boolean;
-}) {
+function SkeletonPageTitle({title = ''}) {
   if (title) {
-    return newDesignLanguage ? (
-      <h1 className={styles.newDesignLanguageTitle}>{title}</h1>
-    ) : (
-      <DisplayText size="large" element="h1">
-        <TextStyle variation="strong">{title}</TextStyle>
-      </DisplayText>
-    );
+    return <h1 className={styles.Title}>{title}</h1>;
   }
 
-  if (newDesignLanguage) {
-    return <div className={styles.newDesignLanguageSkeletonTitle} />;
-  }
-
-  return <SkeletonDisplayText size="large" />;
+  return <div className={styles.SkeletonTitle} />;
 }

--- a/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
+++ b/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
@@ -33,84 +33,27 @@ describe('<SkeletonPage />', () => {
   });
 
   describe('title', () => {
-    it('renders title as DisplayText instead of SkeletonDisplayText when a title is provided', () => {
-      const skeletonPage = mountWithAppProvider(
-        <SkeletonPage title="Products" narrowWidth />,
-      );
-      const displayText = skeletonPage.find(DisplayText);
-      expect(displayText).toHaveLength(1);
-      expect(displayText.text()).toBe('Products');
-      expect(skeletonPage.find(SkeletonDisplayText)).toHaveLength(0);
-    });
-
-    it('renders SkeletonDisplayText instead of DisplayText when a title is not provided', () => {
-      const skeletonPage = mountWithAppProvider(<SkeletonPage fullWidth />);
-      expect(skeletonPage.find(DisplayText)).toHaveLength(0);
-      expect(skeletonPage.find(SkeletonDisplayText)).toHaveLength(1);
-    });
-
-    it('passes large to the size prop of DisplayText by default', () => {
+    it('renders an h1 with the Title class when title is defined', () => {
       const skeletonPage = mountWithAppProvider(
         <SkeletonPage title="Products" />,
       );
-      const displayText = skeletonPage.find(DisplayText);
-      expect(displayText.prop('size')).toBe('large');
-    });
 
-    it('passes h1 to the element prop of DisplayText', () => {
-      const skeletonPage = mountWithAppProvider(
-        <SkeletonPage title="Products" />,
-      );
-      const displayText = skeletonPage.find(DisplayText);
-      expect(displayText.prop('element')).toBe('h1');
-    });
-
-    it('renders a SkeletonDisplayText instead of DisplayText when the title is an empty string', () => {
-      const skeletonPage = mountWithAppProvider(<SkeletonPage title="" />);
-      expect(skeletonPage.find(SkeletonDisplayText)).toHaveLength(1);
+      expect(skeletonPage.find('h1.Title')).toHaveLength(1);
       expect(skeletonPage.find(DisplayText)).toHaveLength(0);
     });
 
-    it('passes large to the size prop of SkeletonDisplayText by default', () => {
-      const skeletonPage = mountWithAppProvider(<SkeletonPage title="" />);
-      const skeletonDisplayText = skeletonPage.find(SkeletonDisplayText);
-      expect(skeletonDisplayText.prop('size')).toBe('large');
+    it('renders SkeletonTitle when a title not defined', () => {
+      const skeletonPage = mountWithAppProvider(<SkeletonPage />);
+
+      expect(skeletonPage.find('h1.Title')).toHaveLength(0);
+      expect(skeletonPage.find('.SkeletonTitle')).toHaveLength(1);
     });
 
-    describe('when the new design language is enabled', () => {
-      it('renders an h1 with the newDesignLanguageTitle class instead of DisplayText when a title is defined', () => {
-        const skeletonPage = mountWithAppProvider(
-          <SkeletonPage title="Products" />,
-          {
-            features: {newDesignLanguage: true},
-          },
-        );
+    it('renders SkeletonTitle when title is an empty string', () => {
+      const skeletonPage = mountWithAppProvider(<SkeletonPage title="" />);
 
-        expect(skeletonPage.find('h1.newDesignLanguageTitle')).toHaveLength(1);
-        expect(skeletonPage.find(DisplayText)).toHaveLength(0);
-      });
-
-      it('renders newDesignLanguageSkeletonTitle when a title not defined', () => {
-        const skeletonPage = mountWithAppProvider(<SkeletonPage />, {
-          features: {newDesignLanguage: true},
-        });
-
-        expect(skeletonPage.find('h1.newDesignLanguageTitle')).toHaveLength(0);
-        expect(
-          skeletonPage.find('.newDesignLanguageSkeletonTitle'),
-        ).toHaveLength(1);
-      });
-
-      it('renders newDesignLanguageSkeletonTitle when title is an empty string', () => {
-        const skeletonPage = mountWithAppProvider(<SkeletonPage title="" />, {
-          features: {newDesignLanguage: true},
-        });
-
-        expect(skeletonPage.find('h1.newDesignLanguageTitle')).toHaveLength(0);
-        expect(
-          skeletonPage.find('.newDesignLanguageSkeletonTitle'),
-        ).toHaveLength(1);
-      });
+      expect(skeletonPage.find('h1.Title')).toHaveLength(0);
+      expect(skeletonPage.find('.SkeletonTitle')).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/541

### WHAT is this pull request doing?

Removes new design language fallbacks
Keep in mind that changes still need to be made to page and card so there will be a few margins that are off when comparing to what's in heroku

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
