### PR TITLE
Make pagination labels required in v6

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -4,6 +4,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Breaking changes
 
+- Pagination accessibility labels are now required ([#3633](https://github.com/Shopify/polaris-react/pull/3633))
+
 ### Enhancements
 
 - Updated `OptionList` selected styles ([#3633](https://github.com/Shopify/polaris-react/pull/3633))

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -48,7 +48,7 @@ export interface PaginationDescriptor {
   /** Accessible label for the pagination */
   accessibilityLabel?: string;
   /** Accessible labels for the buttons and UnstyledLinks */
-  accessibilityLabels?: AccessibilityLabels;
+  accessibilityLabels: AccessibilityLabels;
   /** Callback when next button is clicked */
   onNext?(): void;
   /** Callback when previous button is clicked */
@@ -87,11 +87,11 @@ export function Pagination({
     accessibilityLabel || i18n.translate('Polaris.Pagination.pagination');
 
   const previousLabel =
-    accessibilityLabels?.previous ||
+    accessibilityLabels.previous ||
     i18n.translate('Polaris.Pagination.previous');
 
   const nextLabel =
-    accessibilityLabels?.next || i18n.translate('Polaris.Pagination.next');
+    accessibilityLabels.next || i18n.translate('Polaris.Pagination.next');
 
   const className = classNames(styles.Pagination, plain && styles.plain);
 


### PR DESCRIPTION
### WHY are these changes introduced?

Make accessibility required for version 6.

### WHAT is this pull request doing?

Removing the ability to not add pagination.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
