### PR TITLE
Undo high contrast media query name change

### DIFF
--- a/src/components/DatePicker/DatePicker.scss
+++ b/src/components/DatePicker/DatePicker.scss
@@ -185,7 +185,7 @@ $range-end-border-radius: rem(30px);
     &:hover {
       background: var(--p-interactive-hovered);
       color: var(--p-text-on-interactive);
-      @include ms-high-contrast-outline;
+      @include high-contrast-outline;
     }
 
     @include focus-ring;

--- a/src/components/DropZone/DropZone.scss
+++ b/src/components/DropZone/DropZone.scss
@@ -184,7 +184,7 @@ $dropzone-stacking-order: (
     }
 
     &:hover {
-      @include ms-high-contrast-outline;
+      @include high-contrast-outline;
     }
   }
 

--- a/src/components/Filters/Filters.scss
+++ b/src/components/Filters/Filters.scss
@@ -135,7 +135,7 @@ $list-filters-footer-height: rem(70px);
     }
 
     &:hover {
-      @include ms-high-contrast-outline;
+      @include high-contrast-outline;
     }
   }
 }

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -13,7 +13,7 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 }
 
 @mixin focus-ring-override {
-  @include ms-high-contrast-outline {
+  @include high-contrast-outline {
     @include reset-before-pseudo-content;
   }
 }
@@ -130,7 +130,7 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
       border-bottom: var(--p-override-none, $underline-height) solid
         color('indigo');
 
-      @include ms-high-contrast-outline($border-width: border-width(thicker)) {
+      @include high-contrast-outline($border-width: border-width(thicker)) {
         @include reset-before-pseudo-content;
       }
     }
@@ -386,13 +386,13 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 
   .Tab-selected {
     &:hover .Title {
-      @include ms-high-contrast-outline($border-width: border-width(thicker)) {
+      @include high-contrast-outline($border-width: border-width(thicker)) {
         @include reset-before-pseudo-content;
       }
     }
 
     &:focus .Title {
-      @include ms-high-contrast-outline($border-width: border-width(thicker));
+      @include high-contrast-outline($border-width: border-width(thicker));
 
       &::before {
         background: var(--p-action-primary);
@@ -400,7 +400,7 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
     }
 
     .Title {
-      @include ms-high-contrast-outline($border-width: border-width(thicker));
+      @include high-contrast-outline($border-width: border-width(thicker));
       color: var(--p-text);
 
       &::before {

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -116,7 +116,7 @@ $icon-size: rem(16px);
 
     &:hover {
       background: var(--p-surface-neutral-hovered);
-      @include ms-high-contrast-outline;
+      @include high-contrast-outline;
     }
 
     &:focus {

--- a/src/styles/foundation/_accessibility.scss
+++ b/src/styles/foundation/_accessibility.scss
@@ -1,4 +1,4 @@
-@mixin ms-high-contrast-outline($border-width: border-width()) {
+@mixin high-contrast-outline($border-width: border-width()) {
   outline: $border-width solid transparent;
   @content;
 }

--- a/src/styles/foundation/_focus-ring.scss
+++ b/src/styles/foundation/_focus-ring.scss
@@ -37,7 +37,7 @@
   } @else if $style == 'focused' {
     &::after {
       box-shadow: 0 0 0 $stroke var(--p-focused, color('indigo'));
-      @include ms-high-contrast-outline;
+      @include high-contrast-outline;
     }
   }
 }

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -79,7 +79,7 @@
 
     &:hover {
       background: var(--p-action-secondary-hovered);
-      @include ms-high-contrast-outline;
+      @include high-contrast-outline;
     }
 
     &:focus {


### PR DESCRIPTION
### WHY are these changes introduced?

The media query name was changed in https://github.com/Shopify/polaris-react/pull/3675 Sounds like it was supposed to be changed back in https://github.com/Shopify/polaris-react/pull/3775 but may have been missed. This change would need to be included in a major version as its a breaking change.

I'm omitting a changelog entry because this change hasn't been released yet.

### WHAT is this pull request doing?

Undoing a name change
