### PR TITLE
[Page, Header] remove new DL

### DIFF
--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {classNames} from '../../utilities/css';
-import {useFeatures} from '../../utilities/features';
 
 import {Header, HeaderProps} from './components';
 import styles from './Page.scss';
@@ -16,12 +15,10 @@ export interface PageProps extends HeaderProps {
 }
 
 export function Page({children, fullWidth, narrowWidth, ...rest}: PageProps) {
-  const {newDesignLanguage} = useFeatures();
   const className = classNames(
     styles.Page,
     fullWidth && styles.fullWidth,
     narrowWidth && styles.narrowWidth,
-    newDesignLanguage && styles.newDesignLanguage,
   );
 
   const hasHeaderContent =

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -59,6 +59,7 @@ $action-menu-rollup-computed-width: rem(40px);
 }
 
 .PaginationWrapper {
+  flex: 0 0 auto;
   display: flex;
   justify-content: flex-end;
   margin-left: spacing(extra-tight);

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -83,12 +83,7 @@ $action-menu-rollup-computed-width: rem(40px);
 .AdditionalNavigationWrapper {
   display: flex;
   flex: 1 0 auto;
-  margin: 0 spacing(tight) 0 0;
   justify-content: flex-end;
-
-  @include page-content-when-not-fully-condensed {
-    margin: 0 spacing(extra-loose);
-  }
 
   @include print-hidden;
 }
@@ -157,10 +152,13 @@ $action-menu-rollup-computed-width: rem(40px);
 
   + .Row {
     margin-top: spacing(extra-tight);
-
     // stylelint-disable-next-line selector-max-combinators, selector-max-class
     .mobileView & {
       margin-top: spacing(tight);
+    }
+    // stylelint-disable-next-line selector-max-combinators, selector-max-class
+    .RightAlign {
+      margin-left: 0;
     }
   }
 }
@@ -222,6 +220,10 @@ $action-menu-rollup-computed-width: rem(40px);
     gap: spacing(tight) spacing();
     grid-template-columns: auto 1fr;
     grid-template-areas: 'breadcrumbs actions' 'title title';
+
+    + .Row {
+      gap: 0;
+    }
   }
 }
 

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -22,15 +22,13 @@ $action-menu-rollup-computed-width: rem(40px);
 }
 
 .TitleWrapper {
-  .newDesignLanguage & {
-    grid-area: title;
-    margin-top: spacing(extra-tight);
-    align-self: center;
-    flex: 1 1 auto;
+  grid-area: title;
+  margin-top: spacing(extra-tight);
+  align-self: center;
+  flex: 1 1 auto;
 
-    @include breakpoint-after($mobile-layout) {
-      margin-top: 0;
-    }
+  @include breakpoint-after($mobile-layout) {
+    margin-top: 0;
   }
 }
 
@@ -52,37 +50,30 @@ $action-menu-rollup-computed-width: rem(40px);
 }
 
 .BreadcrumbWrapper {
-  flex: 0 1 auto;
+  flex: 0 0 auto;
+  grid-area: breadcrumbs;
   max-width: 100%;
-
-  &.newDesignLanguage {
-    grid-area: breadcrumbs;
-    flex: 0 0 auto;
-    margin-right: spacing();
-  }
+  margin-right: spacing();
 
   @include print-hidden;
 }
 
 .PaginationWrapper {
-  flex: 0 0 auto;
-  margin-left: auto;
+  display: flex;
+  justify-content: flex-end;
+  margin-left: spacing(extra-tight);
   line-height: 1;
 
-  .newDesignLanguage & {
-    display: flex;
-    justify-content: flex-end;
-    margin-left: spacing(extra-tight);
-    // stylelint-disable-next-line selector-max-combinators
-    button {
-      border: 1px solid var(--p-border-neutral-subdued);
-      box-shadow: none;
-      // stylelint-disable-next-line selector-max-combinators, selector-max-specificity
-      &:hover,
-      &:active,
-      &:focus {
-        border: 1px solid var(--p-border-neutral-subdued);
-      }
+  button {
+    // stylelint-disable declaration-no-important
+    border: 1px solid var(--p-border-neutral-subdued) !important;
+    box-shadow: none !important;
+    // stylelint-disable-next-line selector-max-combinators, selector-max-specificity
+    &:hover,
+    &:active,
+    &:focus {
+      border: 1px solid var(--p-border-neutral-subdued) !important;
+      // stylelint-enable declaration-no-important
     }
   }
 
@@ -90,17 +81,13 @@ $action-menu-rollup-computed-width: rem(40px);
 }
 
 .AdditionalNavigationWrapper {
-  flex: 1 0 auto;
-  margin: 0 spacing(tight);
   display: flex;
+  flex: 1 0 auto;
+  margin: 0 spacing(tight) 0 0;
   justify-content: flex-end;
 
   @include page-content-when-not-fully-condensed {
     margin: 0 spacing(extra-loose);
-  }
-
-  .newDesignLanguage & {
-    margin-right: 0;
   }
 
   @include print-hidden;
@@ -131,24 +118,18 @@ $action-menu-rollup-computed-width: rem(40px);
 
 .PrimaryActionWrapper {
   flex: 0 0 auto;
-  .mobileView & {
-    margin-top: spacing();
-  }
+  margin-top: 0;
+  margin-left: spacing(extra-tight);
 
-  .newDesignLanguage & {
-    margin-top: 0;
-    margin-left: spacing(extra-tight);
-
-    @include breakpoint-after($button-style-breakpoint) {
-      margin-left: spacing();
-    }
+  @include breakpoint-after($button-style-breakpoint) {
+    margin-left: spacing();
   }
 
   @include print-hidden;
 }
 
 .ActionMenuWrapper {
-  margin-top: spacing(tight);
+  margin-top: 0;
 
   // stylelint-disable-next-line selector-max-class
   .mobileView & {
@@ -168,10 +149,6 @@ $action-menu-rollup-computed-width: rem(40px);
   }
 
   @include print-hidden;
-
-  &.newDesignLanguage {
-    margin-top: 0;
-  }
 }
 
 .Row {
@@ -179,11 +156,7 @@ $action-menu-rollup-computed-width: rem(40px);
   justify-content: space-between;
 
   + .Row {
-    margin-top: spacing();
-    // stylelint-disable-next-line selector-max-combinators, selector-max-class
-    .newDesignLanguage & {
-      margin-top: spacing(extra-tight);
-    }
+    margin-top: spacing(extra-tight);
 
     // stylelint-disable-next-line selector-max-combinators, selector-max-class
     .mobileView & {
@@ -199,39 +172,30 @@ $action-menu-rollup-computed-width: rem(40px);
 }
 
 .RightAlign {
+  grid-area: actions;
   display: flex;
   align-content: flex-end;
-  align-items: center;
-  margin-left: spacing(tight);
-}
-// Single row styles for new design language
-.RowCondensed {
-  .RightAlign {
-    grid-area: actions;
-    flex: 1 1 auto;
-    align-items: flex-start;
-    justify-content: flex-end;
-    margin-left: spacing();
-    // Necessary for flex to realize this container doesn't want to wrap
-    white-space: nowrap;
+  flex: 1 1 auto;
+  align-items: flex-start;
+  justify-content: flex-end;
+  margin-left: spacing();
+  // Necessary for flex to realize this container doesn't want to wrap
+  white-space: nowrap;
 
-    // stylelint-disable-next-line selector-max-class, selector-max-combinators
-    .noBreadcrumbs & {
-      @include breakpoint-before($mobile-layout) {
-        margin-left: 0;
-      }
+  // stylelint-disable-next-line selector-max-class, selector-max-combinators
+  .noBreadcrumbs & {
+    @include breakpoint-before($mobile-layout) {
+      margin-left: 0;
     }
   }
 }
 
 .AdditionalMetaData {
-  .newDesignLanguage & {
-    @include breakpoint-after($mobile-layout) {
-      margin-left: spacing(loose) * 2 + spacing(tight) + spacing(extra-tight);
-    }
+  @include breakpoint-after($mobile-layout) {
+    margin-left: spacing(loose) * 2 + spacing(tight) + spacing(extra-tight);
   }
-  // stylelint-disable-next-line selector-max-class
-  .noBreadcrumbs.newDesignLanguage & {
+
+  .noBreadcrumbs & {
     margin-left: 0;
   }
 
@@ -253,7 +217,7 @@ $action-menu-rollup-computed-width: rem(40px);
     margin-left: 0;
   }
 
-  .RowCondensed {
+  .Row {
     display: grid;
     gap: spacing(tight) spacing();
     grid-template-columns: auto 1fr;
@@ -282,7 +246,7 @@ $action-menu-rollup-computed-width: rem(40px);
     margin-bottom: spacing(extra-tight);
   }
   // stylelint-disable-next-line selector-max-class
-  .RowCondensed {
+  .Row {
     flex-wrap: wrap-reverse;
     @include breakpoint-after(layout-width(page-with-nav)) {
       flex-wrap: nowrap;
@@ -290,6 +254,6 @@ $action-menu-rollup-computed-width: rem(40px);
   }
 }
 
-.isSingleRow .RowCondensed {
+.isSingleRow .Row {
   gap: 0;
 }

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -4,7 +4,6 @@ import {classNames} from '../../../../utilities/css';
 import {buttonsFrom} from '../../../Button';
 import {TextStyle} from '../../../TextStyle';
 import {useMediaQuery} from '../../../../utilities/media-query';
-import {useFeatures} from '../../../../utilities/features';
 import {
   ConditionalRender,
   ConditionalWrapper,
@@ -20,7 +19,6 @@ import type {
 import {Breadcrumbs, BreadcrumbsProps} from '../../../Breadcrumbs';
 import {Pagination, PaginationDescriptor} from '../../../Pagination';
 import {ActionMenu, hasGroupsWithActions} from '../../../ActionMenu';
-import {ButtonGroup} from '../../../ButtonGroup';
 
 import {Title, TitleProps} from './components';
 import styles from './Header.scss';
@@ -83,7 +81,6 @@ export function Header({
   actionGroups = [],
 }: HeaderProps) {
   const {isNavigationCollapsed} = useMediaQuery();
-  const {newDesignLanguage} = useFeatures();
   const isSingleRow =
     !primaryAction &&
     !pagination &&
@@ -92,12 +89,7 @@ export function Header({
 
   const breadcrumbMarkup =
     breadcrumbs.length > 0 ? (
-      <div
-        className={classNames(
-          styles.BreadcrumbWrapper,
-          newDesignLanguage && styles.newDesignLanguage,
-        )}
-      >
+      <div className={styles.BreadcrumbWrapper}>
         <Breadcrumbs breadcrumbs={breadcrumbs} />
       </div>
     ) : null;
@@ -141,18 +133,11 @@ export function Header({
 
   const actionMenuMarkup =
     secondaryActions.length > 0 || hasGroupsWithActions(actionGroups) ? (
-      <ConditionalWrapper
-        condition={newDesignLanguage === false}
-        wrapper={(children) => (
-          <div className={styles.ActionMenuWrapper}>{children}</div>
-        )}
-      >
-        <ActionMenu
-          actions={secondaryActions}
-          groups={actionGroups}
-          rollup={isNavigationCollapsed}
-        />
-      </ConditionalWrapper>
+      <ActionMenu
+        actions={secondaryActions}
+        groups={actionGroups}
+        rollup={isNavigationCollapsed}
+      />
     ) : null;
 
   const additionalMetaDataMarkup = additionalMetaData ? (
@@ -170,80 +155,51 @@ export function Header({
     actionMenuMarkup && styles.hasActionMenu,
     isNavigationCollapsed && styles.mobileView,
     !breadcrumbs.length && styles.noBreadcrumbs,
-    newDesignLanguage && styles.newDesignLanguage,
     title && title.length < LONG_TITLE && styles.mediumTitle,
     title && title.length > LONG_TITLE && styles.longTitle,
   );
 
-  if (newDesignLanguage) {
-    const {slot1, slot2, slot3, slot4, slot5, slot6} = determineLayout({
-      actionMenuMarkup,
-      additionalMetaDataMarkup,
-      additionalNavigationMarkup,
-      breadcrumbMarkup,
-      isNavigationCollapsed,
-      pageTitleMarkup,
-      paginationMarkup,
-      primaryActionMarkup,
-      title,
-    });
-
-    const className = classNames(
-      styles.Row,
-      newDesignLanguage && styles.RowCondensed,
-    );
-
-    return (
-      <div className={headerClassNames}>
-        <ConditionalRender
-          condition={[slot1, slot2, slot3, slot4].some(notNull)}
-        >
-          <div className={className}>
-            {slot1}
-            {slot2}
-            <ConditionalRender condition={[slot3, slot4].some(notNull)}>
-              <div className={styles.RightAlign}>
-                <ConditionalWrapper
-                  condition={[slot3, slot4].every(notNull)}
-                  wrapper={(children) =>
-                    newDesignLanguage ? (
-                      <div className={styles.Actions}>{children}</div>
-                    ) : (
-                      <ButtonGroup>{children}</ButtonGroup>
-                    )
-                  }
-                >
-                  {slot3}
-                  {slot4}
-                </ConditionalWrapper>
-              </div>
-            </ConditionalRender>
-          </div>
-        </ConditionalRender>
-        <ConditionalRender condition={[slot5, slot6].some(notNull)}>
-          <div className={styles.Row}>
-            <div className={styles.LeftAlign}>{slot5}</div>
-            <ConditionalRender condition={slot6 != null}>
-              <div className={styles.RightAlign}>{slot6}</div>
-            </ConditionalRender>
-          </div>
-        </ConditionalRender>
-      </div>
-    );
-  }
+  const {slot1, slot2, slot3, slot4, slot5, slot6} = determineLayout({
+    actionMenuMarkup,
+    additionalMetaDataMarkup,
+    additionalNavigationMarkup,
+    breadcrumbMarkup,
+    isNavigationCollapsed,
+    pageTitleMarkup,
+    paginationMarkup,
+    primaryActionMarkup,
+    title,
+  });
 
   return (
     <div className={headerClassNames}>
-      {navigationMarkup}
-
-      <div className={styles.MainContent}>
-        <div className={styles.TitleActionMenuWrapper}>
-          {pageTitleMarkup}
-          {actionMenuMarkup}
+      <ConditionalRender condition={[slot1, slot2, slot3, slot4].some(notNull)}>
+        <div className={styles.Row}>
+          {slot1}
+          {slot2}
+          <ConditionalRender condition={[slot3, slot4].some(notNull)}>
+            <div className={styles.RightAlign}>
+              <ConditionalWrapper
+                condition={[slot3, slot4].every(notNull)}
+                wrapper={(children) => (
+                  <div className={styles.Actions}>{children}</div>
+                )}
+              >
+                {slot3}
+                {slot4}
+              </ConditionalWrapper>
+            </div>
+          </ConditionalRender>
         </div>
-
-        {primaryActionMarkup}
-      </div>
+      </ConditionalRender>
+      <ConditionalRender condition={[slot5, slot6].some(notNull)}>
+        <div className={styles.Row}>
+          <div className={styles.LeftAlign}>{slot5}</div>
+          <ConditionalRender condition={slot6 != null}>
+            <div className={styles.RightAlign}>{slot6}</div>
+          </ConditionalRender>
+        </div>
+      </ConditionalRender>
     </div>
   );
 }
@@ -254,18 +210,13 @@ function PrimaryActionMarkup({
   primaryAction: PrimaryAction | React.ReactNode;
 }) {
   const {isNavigationCollapsed} = useMediaQuery();
-  const {newDesignLanguage} = useFeatures();
   let content = primaryAction;
   if (isPrimaryAction(primaryAction)) {
     const primary =
       primaryAction.primary === undefined ? true : primaryAction.primary;
 
     content = buttonsFrom(
-      shouldShowIconOnly(
-        newDesignLanguage,
-        isNavigationCollapsed,
-        primaryAction,
-      ),
+      shouldShowIconOnly(isNavigationCollapsed, primaryAction),
       {
         primary,
       },
@@ -276,12 +227,11 @@ function PrimaryActionMarkup({
 }
 
 function shouldShowIconOnly(
-  newDesignLanguage: boolean,
   isMobile: boolean,
   action: PrimaryAction,
 ): PrimaryAction {
   let {content, accessibilityLabel, icon} = action;
-  if (!newDesignLanguage || icon == null) return {...action, icon: undefined};
+  if (icon == null) return {...action, icon: undefined};
 
   if (isMobile) {
     accessibilityLabel = accessibilityLabel || content;

--- a/src/components/Page/components/Header/components/Title/Title.scss
+++ b/src/components/Page/components/Header/components/Title/Title.scss
@@ -29,6 +29,10 @@
 }
 
 .TitleWithMetadataWrapper {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+
   .Title {
     display: inline;
     margin-right: spacing(tight);
@@ -39,17 +43,6 @@
     }
   }
 
-  .TitleMetadata {
-    margin-top: 0;
-    vertical-align: bottom;
-  }
-}
-
-.newDesignLanguage.TitleWithMetadataWrapper {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  // stylelint-disable-next-line selector-max-class
   .TitleMetadata {
     margin-top: 0;
     vertical-align: bottom;

--- a/src/components/Page/components/Header/components/Title/Title.scss
+++ b/src/components/Page/components/Header/components/Title/Title.scss
@@ -2,9 +2,6 @@
 
 .Title {
   @include text-breakword;
-}
-
-.newDesignLanguageTitle {
   @include text-emphasis-strong;
   font-size: rem(24px);
   line-height: rem(28px);

--- a/src/components/Page/components/Header/components/Title/Title.scss
+++ b/src/components/Page/components/Header/components/Title/Title.scss
@@ -40,8 +40,8 @@
   }
 
   .TitleMetadata {
-    margin-top: spacing(tight);
-    display: inline-block;
+    margin-top: 0;
+    vertical-align: bottom;
   }
 }
 

--- a/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/src/components/Page/components/Header/components/Title/Title.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
-import {DisplayText} from '../../../../../DisplayText';
-import {TextStyle} from '../../../../../TextStyle';
 import type {AvatarProps} from '../../../../../Avatar';
 import type {ThumbnailProps} from '../../../../../Thumbnail';
-import {classNames} from '../../../../../../utilities/css';
-import {useFeatures} from '../../../../../../utilities/features';
 
 import styles from './Title.scss';
 
@@ -23,30 +19,14 @@ export interface TitleProps {
 }
 
 export function Title({title, subtitle, titleMetadata, thumbnail}: TitleProps) {
-  const {newDesignLanguage} = useFeatures();
-
-  const titleElement = newDesignLanguage ? (
-    <h1 className={styles.newDesignLanguageTitle}>{title}</h1>
-  ) : (
-    <DisplayText size="large" element="h1">
-      <TextStyle variation="strong">{title}</TextStyle>
-    </DisplayText>
-  );
-  const titleMarkup = title ? (
-    <div className={styles.Title}>{titleElement}</div>
-  ) : null;
+  const titleMarkup = title ? <h1 className={styles.Title}>{title}</h1> : null;
 
   const titleMetadataMarkup = titleMetadata ? (
     <div className={styles.TitleMetadata}>{titleMetadata}</div>
   ) : null;
 
   const wrappedTitleMarkup = titleMetadata ? (
-    <div
-      className={classNames(
-        styles.TitleWithMetadataWrapper,
-        newDesignLanguage && styles.newDesignLanguage,
-      )}
-    >
+    <div className={styles.TitleWithMetadataWrapper}>
       {titleMarkup}
       {titleMetadataMarkup}
     </div>
@@ -62,9 +42,7 @@ export function Title({title, subtitle, titleMetadata, thumbnail}: TitleProps) {
 
   const thumbnailMarkup = thumbnail ? <div>{thumbnail}</div> : null;
 
-  const pageTitleClassName = thumbnail
-    ? classNames(styles.hasThumbnail)
-    : undefined;
+  const pageTitleClassName = thumbnail ? styles.hasThumbnail : undefined;
 
   return (
     <div className={pageTitleClassName}>

--- a/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
+++ b/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
-import {mountWithApp} from 'test-utilities';
 import {Badge, DisplayText, Avatar} from 'components';
 
 import {Title} from '../Title';
@@ -12,9 +11,9 @@ describe('<Title />', () => {
   };
 
   describe('title', () => {
-    it('renders a DisplayText with the title', () => {
+    it('renders an h1 with the title', () => {
       const pageTitle = mountWithAppProvider(<Title {...mockProps} />);
-      expect(pageTitle.find(DisplayText).text()).toBe(mockProps.title);
+      expect(pageTitle.find('h1').text()).toBe(mockProps.title);
     });
 
     it('does not render a title when not defined', () => {
@@ -60,31 +59,6 @@ describe('<Title />', () => {
     it('renders the thumbnail when defined', () => {
       const pageTitle = mountWithAppProvider(<Title {...propsWithThumbail} />);
       expect(pageTitle.find(Avatar).exists()).toBe(true);
-    });
-  });
-
-  describe('newDesignLanguage', () => {
-    const propsWithMetadata = {
-      ...mockProps,
-      titleMetadata: <Badge>Sold</Badge>,
-    };
-
-    it('adds a newDesignLanguage class when enabled', () => {
-      const title = mountWithApp(<Title {...propsWithMetadata} />, {
-        features: {newDesignLanguage: true},
-      });
-      expect(title).toContainReactComponent('div', {
-        className: 'TitleWithMetadataWrapper newDesignLanguage',
-      });
-    });
-
-    it('does not add a newDesignLanguage class when disabled', () => {
-      const title = mountWithApp(<Title {...propsWithMetadata} />, {
-        features: {newDesignLanguage: false},
-      });
-      expect(title).toContainReactComponent('div', {
-        className: 'TitleWithMetadataWrapper',
-      });
     });
   });
 });

--- a/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/src/components/Page/components/Header/tests/Header.test.tsx
@@ -126,23 +126,6 @@ describe('<Header />', () => {
     });
   });
 
-  describe('secondaryadds a newDesignLanguage class', () => {
-    const mockSecondaryActions: HeaderProps['secondaryActions'] = [
-      {content: 'mock content 1'},
-      {content: 'mock content 2'},
-    ];
-
-    it('passes to <ActionMenu />', () => {
-      const wrapper = mountWithAppProvider(
-        <Header {...mockProps} secondaryActions={mockSecondaryActions} />,
-      );
-
-      expect(wrapper.find(ActionMenu).prop('actions')).toBe(
-        mockSecondaryActions,
-      );
-    });
-  });
-
   describe('actionGroups', () => {
     const mockSecondaryActions: HeaderProps['secondaryActions'] = [
       {content: 'mock content 1'},
@@ -248,133 +231,90 @@ describe('<Header />', () => {
     });
   });
 
-  describe('newDesignLanguage', () => {
-    const primaryAction: HeaderProps['primaryAction'] = {
-      content: 'Click me!',
-      icon: PlusMinor,
-    };
+  const primaryAction: HeaderProps['primaryAction'] = {
+    content: 'Click me!',
+    icon: PlusMinor,
+  };
 
-    const secondaryActions: HeaderProps['secondaryActions'] = [
-      {content: 'mock content 1'},
-      {content: 'mock content 2'},
-    ];
+  const secondaryActions: HeaderProps['secondaryActions'] = [
+    {content: 'mock content 1'},
+    {content: 'mock content 2'},
+  ];
 
-    const breadcrumbs: LinkAction[] = [
+  const breadcrumbs: LinkAction[] = [
+    {
+      content: 'Products',
+      url: 'https://www.google.com',
+    },
+  ];
+
+  it('does not render primary and secondary action wrapper divs', () => {
+    const header = mountWithAppProvider(
+      <Header
+        title="Hello, world!"
+        primaryAction={primaryAction}
+        secondaryActions={secondaryActions}
+      />,
+    );
+    expect(header.find('.PrimaryActionWrapper')).toHaveLength(1);
+    expect(header.find('.ActionMenuWrapper')).toHaveLength(0);
+  });
+
+  it('renders a compact mobile layout with icon-only primary action', () => {
+    const header = mountWithAppProvider(
+      <Header title="mmmmmmmm" primaryAction={primaryAction} />,
       {
-        content: 'Products',
-        url: 'https://www.google.com',
+        mediaQuery: {isNavigationCollapsed: true},
       },
-    ];
+    );
+    expect(header.find('.Row')).toHaveLength(1);
+    expect(header.find(Button).prop('icon')).toStrictEqual(PlusMinor);
+    expect(header.find(Button).text()).toStrictEqual('');
+  });
 
-    it('adds a newDesignLanguage class', () => {
-      const header = mountWithAppProvider(<Header title="Hello, world!" />, {
-        features: {newDesignLanguage: true},
-      });
-      expect(header.find('div').first().prop('className')).toBe(
-        'Header isSingleRow noBreadcrumbs newDesignLanguage mediumTitle',
-      );
-    });
+  it('renders a compact desktop layout and hides primary action icon', () => {
+    const header = mountWithAppProvider(
+      <Header title="mmmmmmmm" primaryAction={primaryAction} />,
+      {
+        mediaQuery: {isNavigationCollapsed: false},
+      },
+    );
+    expect(header.find('.Row')).toHaveLength(1);
+    expect(header.find(Button).prop('icon')).toBeUndefined();
+    expect(header.find(Button).text()).toStrictEqual('Click me!');
+  });
 
-    it('does not add a newDesignLanguage class if disabled', () => {
-      const header = mountWithAppProvider(<Header title="Hello, world!" />, {
-        features: {newDesignLanguage: false},
-      });
-      expect(header.find('div').first().prop('className')).toBe(
-        'Header isSingleRow noBreadcrumbs mediumTitle',
-      );
-    });
+  it('renders a default mobile layout', () => {
+    const header = mountWithAppProvider(
+      <Header title="mmmmmmmmm" breadcrumbs={breadcrumbs} />,
+      {
+        mediaQuery: {isNavigationCollapsed: true},
+      },
+    );
+    expect(header.find('.Row')).toHaveLength(1);
+  });
 
-    it('removes primary and secondary action wrapper divs', () => {
-      const header = mountWithAppProvider(
-        <Header
-          title="Hello, world!"
-          primaryAction={primaryAction}
-          secondaryActions={secondaryActions}
-        />,
-        {
-          features: {newDesignLanguage: true},
-        },
-      );
-      expect(header.find('.PrimaryActionWrapper')).toHaveLength(1);
-      expect(header.find('.ActionMenuWrapper')).toHaveLength(0);
-    });
+  it('renders a default desktop layout', () => {
+    const header = mountWithAppProvider(
+      <Header title="mmmmmmmmmmmmmmmmmmmmm" primaryAction={primaryAction} />,
+      {
+        mediaQuery: {isNavigationCollapsed: false},
+      },
+    );
+    expect(header.find('.Row')).toHaveLength(1);
+  });
 
-    it('adds primary and secondary action wrapper divs when disabled', () => {
-      const header = mountWithAppProvider(
-        <Header
-          title="Hello, world!"
-          primaryAction={primaryAction}
-          secondaryActions={secondaryActions}
-        />,
-        {
-          features: {newDesignLanguage: false},
-        },
-      );
-      expect(header.find('.PrimaryActionWrapper')).toHaveLength(1);
-      expect(header.find('.ActionMenuWrapper')).toHaveLength(1);
-    });
-
-    it('renders a compact mobile layout with icon-only primary action', () => {
-      const header = mountWithAppProvider(
-        <Header title="mmmmmmmm" primaryAction={primaryAction} />,
-        {
-          features: {newDesignLanguage: true},
-          mediaQuery: {isNavigationCollapsed: true},
-        },
-      );
-      expect(header.find('.Row')).toHaveLength(1);
-      expect(header.find(Button).prop('icon')).toStrictEqual(PlusMinor);
-      expect(header.find(Button).text()).toStrictEqual('');
-    });
-
-    it('renders a compact desktop layout and hides primary action icon', () => {
-      const header = mountWithAppProvider(
-        <Header title="mmmmmmmm" primaryAction={primaryAction} />,
-        {
-          features: {newDesignLanguage: true},
-          mediaQuery: {isNavigationCollapsed: false},
-        },
-      );
-      expect(header.find('.Row')).toHaveLength(1);
-      expect(header.find(Button).prop('icon')).toBeUndefined();
-      expect(header.find(Button).text()).toStrictEqual('Click me!');
-    });
-
-    it('renders a default mobile layout', () => {
-      const header = mountWithAppProvider(
-        <Header title="mmmmmmmmm" breadcrumbs={breadcrumbs} />,
-        {
-          features: {newDesignLanguage: true},
-          mediaQuery: {isNavigationCollapsed: true},
-        },
-      );
-      expect(header.find('.Row')).toHaveLength(1);
-    });
-
-    it('renders a default desktop layout', () => {
-      const header = mountWithAppProvider(
-        <Header title="mmmmmmmmmmmmmmmmmmmmm" primaryAction={primaryAction} />,
-        {
-          features: {newDesignLanguage: true},
-          mediaQuery: {isNavigationCollapsed: false},
-        },
-      );
-      expect(header.find('.Row')).toHaveLength(1);
-    });
-
-    it('wraps the secondary activator and primary buttons in a ButtonGroup', () => {
-      const header = mountWithAppProvider(
-        <Header
-          title="Hello, world!"
-          primaryAction={primaryAction}
-          secondaryActions={secondaryActions}
-        />,
-        {
-          features: {newDesignLanguage: true},
-          mediaQuery: {isNavigationCollapsed: true},
-        },
-      );
-      expect(header.find(ButtonGroup)).toHaveLength(0);
-    });
+  it('wraps the secondary activator and primary buttons in a ButtonGroup', () => {
+    const header = mountWithAppProvider(
+      <Header
+        title="Hello, world!"
+        primaryAction={primaryAction}
+        secondaryActions={secondaryActions}
+      />,
+      {
+        mediaQuery: {isNavigationCollapsed: true},
+      },
+    );
+    expect(header.find(ButtonGroup)).toHaveLength(0);
   });
 });

--- a/src/styles/shared/_page.scss
+++ b/src/styles/shared/_page.scss
@@ -23,18 +23,10 @@ $actions-vertical-spacing: spacing(tight);
 }
 
 @mixin page-content-layout {
-  margin: spacing(loose) 0;
+  margin: spacing() 0;
 
   @include page-content-when-not-partially-condensed {
-    margin-top: spacing(loose);
-  }
-
-  .newDesignLanguage & {
-    margin: spacing() 0;
-
-    @include page-content-when-not-partially-condensed {
-      margin-top: spacing();
-    }
+    margin-top: spacing();
   }
 }
 
@@ -54,38 +46,20 @@ $actions-vertical-spacing: spacing(tight);
 }
 
 @mixin page-header-layout {
-  padding: spacing(loose) spacing(loose) 0;
-
-  &.newDesignLanguage {
-    padding: spacing() spacing() 0;
-  }
+  padding: spacing() spacing() 0;
 
   @include page-content-when-not-fully-condensed {
     padding-left: 0;
     padding-right: 0;
-
-    &.newDesignLanguage {
-      padding-left: 0;
-      padding-right: 0;
-    }
   }
 
   @include page-content-when-not-partially-condensed {
-    padding-top: spacing(extra-loose);
-
-    .newDesignLanguage &,
-    &.newDesignLanguage {
-      padding-top: spacing();
-    }
+    padding-top: spacing();
   }
 }
 
 @mixin page-header-has-navigation {
-  padding-top: rem(32px);
-
-  &.newDesignLanguage {
-    padding-top: spacing();
-  }
+  padding-top: spacing();
 }
 
 @mixin page-header-without-navigation {
@@ -93,11 +67,7 @@ $actions-vertical-spacing: spacing(tight);
 }
 
 @mixin page-header-has-secondary-actions {
-  padding-top: rem(24px);
-
-  &.newDesignLanguage {
-    padding-top: spacing();
-  }
+  padding-top: spacing();
 }
 
 @mixin page-actions-layout {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/556

### WHAT is this pull request doing?

Removes new DL conditions and merges styles with legacy for Page and Header components

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Opening as a draft because I recommend considerable tophatting. 

Start with the page examples in storybook and then move to the details page
On the details page, remove / modify all page props in as many configurations you have time for. 
Test both at as many break points as possible

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
