### PR TITLE
[Link] Remove new DL and fallbacks

### DIFF
--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -8,18 +8,18 @@
   background: none;
   border: 0;
   font-size: inherit;
-  color: var(--p-interactive, color('blue'));
+  color: var(--p-interactive);
   text-decoration: none;
   cursor: pointer;
 
   &:hover {
-    color: var(--p-interactive-hovered, color('blue', 'dark'));
+    color: var(--p-interactive-hovered);
     text-decoration: underline;
   }
 
   &:focus {
     $chrome-default-outline: rgba(0, 103, 244, 0.247) auto rem(4.5px);
-    outline: var(--p-override-none, $chrome-default-outline);
+    outline: var(--p-override-none);
     text-decoration: underline;
   }
 
@@ -29,11 +29,11 @@
 
   &:active {
     position: relative;
-    color: var(--p-interactive-pressed, color('blue', 'dark'));
+    color: var(--p-interactive-pressed);
     text-decoration: underline;
 
     &::before {
-      content: var(--p-non-null-content, none);
+      content: var(--p-non-null-content);
       position: absolute;
       z-index: -1;
       // this mimics the box model of the plain button backdrop

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -33,7 +33,7 @@
     text-decoration: underline;
 
     &::before {
-      content: var(--p-non-null-content);
+      content: '';
       position: absolute;
       z-index: -1;
       // this mimics the box model of the plain button backdrop

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {ExternalSmallMinor} from '@shopify/polaris-icons';
 
-import {useFeatures} from '../../utilities/features';
 import {BannerContext} from '../../utilities/banner-context';
 import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
@@ -38,7 +37,6 @@ export function Link({
 }: LinkProps) {
   const i18n = useI18n();
   let childrenMarkup = children;
-  const {newDesignLanguage} = useFeatures();
 
   if (external && typeof children === 'string') {
     const iconLabel = i18n.translate(
@@ -65,7 +63,6 @@ export function Link({
         const className = classNames(
           styles.Link,
           shouldBeMonochrome && styles.monochrome,
-          newDesignLanguage && styles.newDesignLanguage,
         );
 
         return url ? (

--- a/src/components/Link/tests/Link.test.tsx
+++ b/src/components/Link/tests/Link.test.tsx
@@ -113,17 +113,6 @@ describe('<Link />', () => {
     });
   });
 
-  describe('newDesignLanguage', () => {
-    it('adds a newDesignLanguage class when newDesignLanguage is enabled, and sets a default color', () => {
-      const link = mountWithApp(<Link url="MyThing" />, {
-        features: {newDesignLanguage: true},
-      });
-      expect(link).toContainReactComponent('a', {
-        className: 'Link newDesignLanguage',
-      });
-    });
-  });
-
   describe('accessibilityLabel', () => {
     it('passes prop to the button url is not provided', () => {
       const mockAccessibilityLabel = 'mock accessibility label';


### PR DESCRIPTION
WHY are these changes introduced?
These changes are introduced as part of polaris-v6, where all reference to the newDesignLanguage are being removed. Fixes Shopify/polaris-ux#563.

WHAT is this pull request doing?
This pull request removes all references to the newDesignLanguage and any fallbacks in the Link component on polaris-react.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
