### PR TITLE
[Modal] Ensure dialog aria-labeled-by links to element when title hidden

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Breaking changes
 
+- Required `title` property accessibility label, added `hideTitle` property to `Modal` ([#3803](https://github.com/Shopify/polaris-react/pull/3803)) ([#3803](https://github.com/Shopify/polaris-react/pull/3803))
+
 ### Enhancements
 
 - Updated `OptionList` selected styles ([#3633](https://github.com/Shopify/polaris-react/pull/3633))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,7 +6,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Breaking changes
 
-- Required `title` property accessibility label, added `hideTitle` property to `Modal` ([#3803](https://github.com/Shopify/polaris-react/pull/3803)) ([#3803](https://github.com/Shopify/polaris-react/pull/3803))
+- Made `title` property required in `Modal` for accessibility label, added `hideTitle` property ([#3803](https://github.com/Shopify/polaris-react/pull/3803)) ([#3803](https://github.com/Shopify/polaris-react/pull/3803))
 
 ### Enhancements
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -11,14 +11,7 @@ import {Scrollable} from '../Scrollable';
 import {Spinner} from '../Spinner';
 import {Portal} from '../Portal';
 
-import {
-  CloseButton,
-  Dialog,
-  Footer,
-  FooterProps,
-  Header,
-  Section,
-} from './components';
+import {Dialog, Footer, FooterProps, Header, Section} from './components';
 import styles from './Modal.scss';
 
 const IFRAME_LOADING_HEIGHT = 200;
@@ -32,7 +25,12 @@ export interface ModalProps extends FooterProps {
   /** The name of the modal content iframe */
   iFrameName?: string;
   /** The content for the title of the modal */
-  title?: string | React.ReactNode;
+  title: string | React.ReactNode;
+  /**
+   * Hide the title in the modal
+   * @default false
+   */
+  hideTitle?: boolean;
   /** The content to display inside modal */
   children?: React.ReactNode;
   /** Inner content of the footer */
@@ -64,6 +62,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
 } = function Modal({
   children,
   title,
+  hideTitle = false,
   src,
   iFrameName,
   open,
@@ -170,27 +169,19 @@ export const Modal: React.FunctionComponent<ModalProps> & {
       </Scrollable>
     );
 
-    const headerMarkup = title ? (
-      <Header id={headerId} onClose={onClose} testID="ModalHeader">
-        {title}
-      </Header>
-    ) : (
-      <CloseButton onClick={onClose} title={false} testID="ModalCloseButton" />
-    );
-
-    const labelledBy = title ? headerId : undefined;
-
     dialog = (
       <Dialog
         instant={instant}
-        labelledBy={labelledBy}
+        labelledBy={headerId}
         onClose={onClose}
         onEntered={handleEntered}
         onExited={handleExited}
         large={large}
         limitHeight={limitHeight}
       >
-        {headerMarkup}
+        <Header hideTitle={hideTitle} id={headerId} onClose={onClose}>
+          {title}
+        </Header>
         <div className={styles.BodyWrapper}>{bodyMarkup}</div>
         {footerMarkup}
       </Dialog>

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -561,7 +561,7 @@ function LargeModalExample() {
 
 <!-- example-for: web -->
 
-We recommend you add a title to your modal, but you may leave it blank.
+A title is required for accessibility, but you may hide it.
 
 ```jsx
 function ModalWithoutTitleExample() {
@@ -574,6 +574,8 @@ function ModalWithoutTitleExample() {
   return (
     <div style={{height: '500px'}}>
       <Modal
+        title="Reach more shoppers with Instagram product tags"
+        hideTitle
         activator={activator}
         open={active}
         onClose={handleChange}

--- a/src/components/Modal/components/CloseButton/CloseButton.scss
+++ b/src/components/Modal/components/CloseButton/CloseButton.scss
@@ -25,9 +25,3 @@
     @include focus-ring($style: 'focused');
   }
 }
-
-.withoutTitle {
-  position: absolute;
-  right: spacing(tight);
-  z-index: 1;
-}

--- a/src/components/Modal/components/CloseButton/CloseButton.tsx
+++ b/src/components/Modal/components/CloseButton/CloseButton.tsx
@@ -1,29 +1,22 @@
 import React from 'react';
 import {MobileCancelMajor} from '@shopify/polaris-icons';
 
-import {classNames} from '../../../../utilities/css';
 import {useI18n} from '../../../../utilities/i18n';
 import {Icon} from '../../../Icon';
 
 import styles from './CloseButton.scss';
 
 export interface CloseButtonProps {
-  title?: boolean;
   onClick(): void;
 }
 
-export function CloseButton({title = true, onClick}: CloseButtonProps) {
+export function CloseButton({onClick}: CloseButtonProps) {
   const i18n = useI18n();
-
-  const className = classNames(
-    styles.CloseButton,
-    !title && styles.withoutTitle,
-  );
 
   return (
     <button
       onClick={onClick}
-      className={className}
+      className={styles.CloseButton}
       aria-label={i18n.translate('Polaris.Common.close')}
     >
       <Icon source={MobileCancelMajor} color="base" />

--- a/src/components/Modal/components/Header/Header.scss
+++ b/src/components/Modal/components/Header/Header.scss
@@ -8,6 +8,16 @@
   border-bottom: border('divider');
 }
 
+.withoutTitle {
+  position: absolute;
+  right: spacing(tight);
+  z-index: 1;
+
+  .Title {
+    display: none;
+  }
+}
+
 .Title {
   @include text-breakword;
   flex: 1;

--- a/src/components/Modal/components/Header/Header.tsx
+++ b/src/components/Modal/components/Header/Header.tsx
@@ -7,19 +7,19 @@ import styles from './Header.scss';
 
 export interface HeaderProps {
   id: string;
+  hideTitle: boolean;
   children?: React.ReactNode;
   onClose(): void;
 }
 
-export function Header({id, children, onClose}: HeaderProps) {
+export function Header({id, hideTitle, children, onClose}: HeaderProps) {
   return (
-    <div className={styles.Header}>
+    <div className={hideTitle ? styles.withoutTitle : styles.Header}>
       <div id={id} className={styles.Title}>
         <DisplayText element="h2" size="small">
           {children}
         </DisplayText>
       </div>
-
       <CloseButton onClick={onClose} />
     </div>
   );

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -1,15 +1,11 @@
 import React, {useRef} from 'react';
 import {animationFrame} from '@shopify/jest-dom-mocks';
 // eslint-disable-next-line no-restricted-imports
-import {
-  findByTestID,
-  mountWithAppProvider,
-  trigger,
-} from 'test-utilities/legacy';
+import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {Badge, Button, Spinner, Portal, Scrollable} from 'components';
 
-import {Footer, Dialog} from '../components';
+import {Footer, Dialog, Header} from '../components';
 import {Modal} from '../Modal';
 import * as focusUtils from '../../../utilities/focus';
 import {WithinContentContext} from '../../../utilities/within-content-context';
@@ -46,7 +42,7 @@ describe('<Modal>', () => {
     }
 
     const component = mountWithAppProvider(
-      <Modal onClose={jest.fn()} open>
+      <Modal title="foo" onClose={jest.fn()} open>
         <WithinContentContext.Consumer>
           {(withinContentContext) => {
             return (
@@ -64,7 +60,7 @@ describe('<Modal>', () => {
 
   it('focuses the dialog node on mount', () => {
     const modal = mountWithAppProvider(
-      <Modal onClose={jest.fn()} open instant />,
+      <Modal title="foo" onClose={jest.fn()} open instant />,
     );
 
     expect(document.activeElement).toBe(modal.find(Dialog).getDOMNode());
@@ -73,7 +69,13 @@ describe('<Modal>', () => {
   describe('src', () => {
     it('renders an iframe if src is provided', () => {
       const modal = mountWithAppProvider(
-        <Modal src="Source" iFrameName="Name" onClose={jest.fn()} open>
+        <Modal
+          title="foo"
+          src="Source"
+          iFrameName="Name"
+          onClose={jest.fn()}
+          open
+        >
           <Badge />
         </Modal>,
       );
@@ -89,7 +91,7 @@ describe('<Modal>', () => {
 
     it('renders Scrollable if src is not provided', () => {
       const modal = mountWithAppProvider(
-        <Modal onClose={jest.fn()} open>
+        <Modal title="foo" onClose={jest.fn()} open>
           <Badge />
         </Modal>,
       );
@@ -107,7 +109,12 @@ describe('<Modal>', () => {
     it('calls onTransitionEnd after it mounts', () => {
       const mockOnTransitionEnd = jest.fn();
       const modal = mountWithAppProvider(
-        <Modal open onClose={noop} onTransitionEnd={mockOnTransitionEnd} />,
+        <Modal
+          title="foo"
+          open
+          onClose={noop}
+          onTransitionEnd={mockOnTransitionEnd}
+        />,
       );
       trigger(modal.find(Dialog), 'onEntered');
       expect(mockOnTransitionEnd).toHaveBeenCalledTimes(1);
@@ -119,6 +126,7 @@ describe('<Modal>', () => {
       const mockOnIframeLoad = jest.fn();
       const modal = mountWithAppProvider(
         <Modal
+          title="foo"
           open
           onClose={noop}
           onIFrameLoad={mockOnIframeLoad}
@@ -133,7 +141,7 @@ describe('<Modal>', () => {
   describe('instant', () => {
     it('passes instant to Dialog if true', () => {
       const modal = mountWithAppProvider(
-        <Modal instant onClose={jest.fn()} open>
+        <Modal title="foo" instant onClose={jest.fn()} open>
           <Badge />
         </Modal>,
       );
@@ -143,7 +151,7 @@ describe('<Modal>', () => {
 
     it('does not pass instant to Dialog be default', () => {
       const modal = mountWithAppProvider(
-        <Modal onClose={jest.fn()} open>
+        <Modal title="foo" onClose={jest.fn()} open>
           <Badge />
         </Modal>,
       );
@@ -155,7 +163,7 @@ describe('<Modal>', () => {
   describe('large', () => {
     it('passes large to Dialog if true', () => {
       const modal = mountWithAppProvider(
-        <Modal large onClose={jest.fn()} open>
+        <Modal title="foo" large onClose={jest.fn()} open>
           <Badge />
         </Modal>,
       );
@@ -165,7 +173,7 @@ describe('<Modal>', () => {
 
     it('does not pass large to Dialog be default', () => {
       const modal = mountWithAppProvider(
-        <Modal onClose={jest.fn()} open>
+        <Modal title="foo" onClose={jest.fn()} open>
           <Badge />
         </Modal>,
       );
@@ -177,7 +185,7 @@ describe('<Modal>', () => {
   describe('limitHeight', () => {
     it('passes limitHeight to Dialog if true', () => {
       const modal = mountWithAppProvider(
-        <Modal limitHeight onClose={jest.fn()} open>
+        <Modal title="foo" limitHeight onClose={jest.fn()} open>
           <Badge />
         </Modal>,
       );
@@ -187,7 +195,7 @@ describe('<Modal>', () => {
 
     it('does not pass limitHeight to Dialog be default', () => {
       const modal = mountWithAppProvider(
-        <Modal onClose={jest.fn()} open>
+        <Modal title="foo" onClose={jest.fn()} open>
           <Badge />
         </Modal>,
       );
@@ -199,7 +207,7 @@ describe('<Modal>', () => {
   describe('open', () => {
     it('renders <Portal />', () => {
       const modal = mountWithAppProvider(
-        <Modal onClose={jest.fn()} open>
+        <Modal title="foo" onClose={jest.fn()} open>
           <Badge />
         </Modal>,
       );
@@ -211,7 +219,7 @@ describe('<Modal>', () => {
   describe('closed', () => {
     it('does not render children', () => {
       const modal = mountWithAppProvider(
-        <Modal open={false} onClose={jest.fn()}>
+        <Modal title="foo" open={false} onClose={jest.fn()}>
           <Badge />
         </Modal>,
       );
@@ -223,7 +231,7 @@ describe('<Modal>', () => {
   describe('opening / closing', () => {
     it('renders modal content when open = true', () => {
       const modal = mountWithAppProvider(
-        <Modal open onClose={jest.fn()}>
+        <Modal title="foo" open onClose={jest.fn()}>
           <Badge />
         </Modal>,
       );
@@ -233,7 +241,7 @@ describe('<Modal>', () => {
 
     it('does not render modal content when open = false', () => {
       const modal = mountWithAppProvider(
-        <Modal open={false} onClose={jest.fn()}>
+        <Modal title="foo" open={false} onClose={jest.fn()}>
           <Badge />
         </Modal>,
       );
@@ -244,36 +252,38 @@ describe('<Modal>', () => {
 
   describe('header', () => {
     it('renders a header when title is present', () => {
-      const modal = mountWithAppProvider(
-        <Modal onClose={jest.fn()} open title="foo" />,
+      const modal = mountWithApp(
+        <Modal title="foo" onClose={jest.fn()} open />,
       );
 
-      expect(findByTestID(modal, 'ModalHeader').exists()).toBe(true);
+      expect(modal.find(Header)).toContainReactComponent('div', {
+        className: 'Header',
+      });
     });
 
-    it('does not render a header when title is not present', () => {
-      const modal = mountWithAppProvider(<Modal onClose={jest.fn()} open />);
+    it('only renders a close button when hideTitle is present', () => {
+      const modal = mountWithApp(
+        <Modal title="foo" hideTitle onClose={jest.fn()} open />,
+      );
 
-      expect(findByTestID(modal, 'ModalHeader').exists()).toBe(false);
-    });
-
-    it('renders a close button when title is not present', () => {
-      const modal = mountWithAppProvider(<Modal onClose={jest.fn()} open />);
-
-      expect(findByTestID(modal, 'ModalCloseButton').exists()).toBe(true);
+      expect(modal.find(Header)).toContainReactComponent('div', {
+        className: 'withoutTitle',
+      });
     });
   });
 
   describe('footer', () => {
     it('does not render footer by default', () => {
-      const modal = mountWithAppProvider(<Modal onClose={jest.fn()} open />);
+      const modal = mountWithAppProvider(
+        <Modal title="foo" onClose={jest.fn()} open />,
+      );
 
       expect(modal.find(Footer).exists()).toBeFalsy();
     });
 
     it('renders if footer are passed in', () => {
       const modal = mountWithAppProvider(
-        <Modal onClose={jest.fn()} open footer="Footer content" />,
+        <Modal title="foo" onClose={jest.fn()} open footer="Footer content" />,
       );
 
       expect(modal.find(Footer).exists()).toBeTruthy();
@@ -282,6 +292,7 @@ describe('<Modal>', () => {
     it('renders if primaryAction are passed in', () => {
       const modal = mountWithAppProvider(
         <Modal
+          title="foo"
           onClose={jest.fn()}
           open
           primaryAction={{content: 'Save', onAction: jest.fn()}}
@@ -294,6 +305,7 @@ describe('<Modal>', () => {
     it('renders if secondaryActions are passed in', () => {
       const modal = mountWithAppProvider(
         <Modal
+          title="foo"
           onClose={jest.fn()}
           open
           secondaryActions={[{content: 'Discard', onAction: jest.fn()}]}
@@ -307,7 +319,7 @@ describe('<Modal>', () => {
   describe('body', () => {
     it('limits dialog height from limitHeight prop', () => {
       const modal = mountWithAppProvider(
-        <Modal onClose={jest.fn()} open loading limitHeight>
+        <Modal title="foo" onClose={jest.fn()} open loading limitHeight>
           <Badge />
         </Modal>,
       );
@@ -319,7 +331,7 @@ describe('<Modal>', () => {
   describe('loading', () => {
     it('renders a spinner', () => {
       const modal = mountWithAppProvider(
-        <Modal onClose={jest.fn()} open loading>
+        <Modal title="foo" onClose={jest.fn()} open loading>
           <Badge />
         </Modal>,
       );
@@ -329,7 +341,7 @@ describe('<Modal>', () => {
 
     it('does not render children', () => {
       const modal = mountWithAppProvider(
-        <Modal onClose={jest.fn()} open loading>
+        <Modal title="foo" onClose={jest.fn()} open loading>
           <Badge />
         </Modal>,
       );
@@ -341,7 +353,7 @@ describe('<Modal>', () => {
   describe('lifecycle', () => {
     it('unmounts safely', () => {
       const modal = mountWithAppProvider(
-        <Modal open onClose={jest.fn()}>
+        <Modal title="foo" open onClose={jest.fn()}>
           <p>Child</p>
         </Modal>,
       );
@@ -366,7 +378,12 @@ describe('<Modal>', () => {
 
     it('renders the element if an element is passed in', () => {
       const modal = mountWithAppProvider(
-        <Modal onClose={noop} open={false} activator={<Button />} />,
+        <Modal
+          title="foo"
+          onClose={noop}
+          open={false}
+          activator={<Button />}
+        />,
       );
 
       expect(modal.find(Button).exists()).toBe(true);
@@ -383,7 +400,12 @@ describe('<Modal>', () => {
 
         return (
           <div>
-            <Modal onClose={noop} open={false} activator={buttonRef} />
+            <Modal
+              title="foo"
+              onClose={noop}
+              open={false}
+              activator={buttonRef}
+            />
             {button}
           </div>
         );
@@ -395,7 +417,9 @@ describe('<Modal>', () => {
     });
 
     it('does not throw an error when no activator is passed in', () => {
-      const modal = mountWithAppProvider(<Modal onClose={noop} open />);
+      const modal = mountWithAppProvider(
+        <Modal title="foo" onClose={noop} open />,
+      );
 
       expect(() => {
         modal.setProps({open: false});
@@ -406,7 +430,7 @@ describe('<Modal>', () => {
       const focusSpy = jest.spyOn(focusUtils, 'focusFirstFocusableNode');
 
       const modal = mountWithApp(
-        <Modal onClose={noop} open activator={<Button />} />,
+        <Modal title="foo" onClose={noop} open activator={<Button />} />,
       );
 
       modal.find(Dialog)!.trigger('onExited');
@@ -428,7 +452,7 @@ describe('<Modal>', () => {
 
         return (
           <div>
-            <Modal onClose={noop} open activator={buttonRef} />
+            <Modal title="foo" onClose={noop} open activator={buttonRef} />
             {button}
           </div>
         );


### PR DESCRIPTION
Fixes missing label on `dialog` element that is blocking  https://github.com/Shopify/polaris-react/pull/3749 from being merged
> Ensures every ARIA dialog and alertdialog node has an accessible name
> ARIA dialog and alertdialog nodes must have an accessible name
> https://dequeuniversity.com/rules/axe/4.1/aria-dialog-name?application=axeAPI


Changes in this PR
- [x] Move CloseButton from Modal -> Header, move layout as well
- [x] `title` is now required
- [x] Added `hideTitle` property to Modal
- [x] Title always rendered and hidden by `display: none` so that it can be linked by `aria-described-by`
