### PR TITLE
[TopBar] Remove new DL and references

### DIFF
--- a/src/components/TopBar/TopBar.scss
+++ b/src/components/TopBar/TopBar.scss
@@ -9,7 +9,7 @@ $context-control-expand-after: 1400px;
   position: relative;
   display: flex;
   height: top-bar-height();
-  background-color: var(--p-surface, var(--top-bar-background));
+  background-color: var(--p-surface);
   transition: duration() background-color ease-in-out;
 
   &::after {
@@ -70,17 +70,17 @@ $context-control-expand-after: 1400px;
   margin-right: spacing(tight);
   padding: spacing(tight);
   border-radius: border-radius();
-  fill: var(--p-icon, var(--top-bar-color)); // Icon will inherit this fill
+  fill: var(--p-icon); // Icon will inherit this fill
   transition: (duration() - 33ms) fill easing() 33ms;
 
   &.focused {
-    background-color: var(--p-override-transparent, rgba(color('white'), 0.16));
+    background-color: var(--p-override-transparent);
   }
   &.focused:active {
-    background-color: var(--p-surface-pressed, rgba(color('black'), 0.28));
+    background-color: var(--p-surface-pressed);
   }
   &:hover {
-    background-color: var(--p-surface-hovered, rgba(color('white'), 0.08));
+    background-color: var(--p-surface-hovered);
   }
   // This increases hit point size.
   &::after {
@@ -124,5 +124,5 @@ $context-control-expand-after: 1400px;
 }
 
 .SecondaryMenu {
-  @include recolor-icon(var(--p-icon, var(--top-bar-color)), transparent);
+  @include recolor-icon(var(--p-icon), transparent);
 }

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -5,7 +5,6 @@ import {classNames} from '../../utilities/css';
 import {getWidth} from '../../utilities/get-width';
 import {useI18n} from '../../utilities/i18n';
 import {useTheme} from '../../utilities/theme';
-import {useFeatures} from '../../utilities/features';
 import {useToggle} from '../../utilities/use-toggle';
 import {Icon} from '../Icon';
 import {Image} from '../Image';
@@ -63,7 +62,6 @@ export const TopBar: React.FunctionComponent<TopBarProps> & {
 }: TopBarProps) {
   const i18n = useI18n();
   const {logo} = useTheme();
-  const {newDesignLanguage} = useFeatures();
 
   const {
     value: focused,
@@ -137,13 +135,8 @@ export const TopBar: React.FunctionComponent<TopBarProps> & {
     </>
   ) : null;
 
-  const className = classNames(
-    styles.TopBar,
-    newDesignLanguage && styles['TopBar-newDesignLanguage'],
-  );
-
   return (
-    <div className={className}>
+    <div className={styles.TopBar}>
       {navigationButtonMarkup}
       {contextMarkup}
       <div className={styles.Contents}>

--- a/src/components/TopBar/components/Menu/Menu.scss
+++ b/src/components/TopBar/components/Menu/Menu.scss
@@ -21,7 +21,7 @@ $activator-variables: (
 .Activator {
   @include unstyled-button;
   @include focus-ring;
-  color: var(--p-text, var(--top-bar-color));
+  color: var(--p-text);
   position: relative;
   display: flex;
   justify-content: center;
@@ -36,26 +36,17 @@ $activator-variables: (
 
   &:focus {
     @include focus-ring($style: 'focused');
-    background-color: var(
-      --top-bar-background-lighter,
-      var(--p-override-transparent, rgba(color('white'), 0.16))
-    );
+    background-color: var(--top-bar-background-lighter);
     outline: none;
   }
 
   &:hover {
-    background-color: var(
-      --top-bar-background-lighter,
-      var(--p-surface-hovered, rgba(color('white'), 0.08))
-    );
+    background-color: var(--top-bar-background-lighter);
   }
 
   &:active,
   &[aria-expanded='true'] {
-    background-color: var(
-      --top-bar-background-darker,
-      var(--p-surface-pressed, rgba(color('black'), 0.28))
-    );
+    background-color: var(--top-bar-background-darker);
     outline: none;
     transition: none;
 

--- a/src/components/TopBar/components/Search/Search.scss
+++ b/src/components/TopBar/components/Search/Search.scss
@@ -9,7 +9,7 @@
   top: top-bar-height();
   left: 0;
   right: 0;
-  box-shadow: var(--p-modal-shadow, shadow());
+  box-shadow: var(--p-modal-shadow);
   overflow: hidden;
 
   @include page-content-when-not-fully-condensed {
@@ -17,7 +17,7 @@
     top: 100%;
     max-width: $search-max-width;
     margin: spacing(extra-tight) spacing(loose) 0;
-    border-radius: var(--p-border-radius-wide, border-radius());
+    border-radius: var(--p-border-radius-wide);
 
     &.newDesignLanguage {
       max-width: $new-search-max-width;
@@ -30,7 +30,7 @@
 }
 
 .SearchContent {
-  background-color: var(--p-surface, color('white'));
+  background-color: var(--p-surface);
 }
 
 .visible {

--- a/src/components/TopBar/components/Search/Search.tsx
+++ b/src/components/TopBar/components/Search/Search.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {ThemeProvider} from '../../../ThemeProvider';
 import {classNames} from '../../../../utilities/css';
 import {SearchDismissOverlay} from '../SearchDismissOverlay';
-import {useFeatures} from '../../../../utilities/features';
 
 import styles from './Search.scss';
 
@@ -24,8 +23,6 @@ export function Search({
   onDismiss,
   overlayVisible = false,
 }: SearchProps) {
-  const {newDesignLanguage} = useFeatures();
-
   if (children == null) {
     return null;
   }
@@ -37,20 +34,9 @@ export function Search({
   return (
     <>
       {overlayMarkup}
-      <div
-        className={classNames(
-          styles.Search,
-          visible && styles.visible,
-          newDesignLanguage && styles.newDesignLanguage,
-        )}
-      >
+      <div className={classNames(styles.Search, visible && styles.visible)}>
         <ThemeProvider theme={{colorScheme: 'dark'}}>
-          <div
-            className={classNames(
-              styles.SearchContent,
-              newDesignLanguage && styles.newDesignLanguage,
-            )}
-          >
+          <div className={classNames(styles.SearchContent)}>
             <div className={styles.Results}>{children}</div>
           </div>
         </ThemeProvider>

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.scss
@@ -2,7 +2,6 @@
 @import '../../variables';
 
 $entry-iterations: 1;
-$backdrop-color: rgba(color('ink'), 0.4);
 
 .SearchDismissOverlay {
   position: fixed;
@@ -19,7 +18,7 @@ $backdrop-color: rgba(color('ink'), 0.4);
 }
 
 .visible {
-  background-color: var(--p-backdrop, $backdrop-color);
+  background-color: var(--p-backdrop);
   animation: fade-in duration() $entry-iterations forwards;
 
   &.newDesignLanguage {

--- a/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.tsx
+++ b/src/components/TopBar/components/SearchDismissOverlay/SearchDismissOverlay.tsx
@@ -2,7 +2,6 @@ import React, {useCallback, useRef} from 'react';
 
 import {ScrollLock} from '../../../ScrollLock';
 import {classNames} from '../../../../utilities/css';
-import {useFeatures} from '../../../../utilities/features';
 
 import styles from './SearchDismissOverlay.scss';
 
@@ -15,7 +14,6 @@ interface Props {
 
 export function SearchDismissOverlay({onDismiss, visible}: Props) {
   const node = useRef<HTMLDivElement>(null);
-  const {newDesignLanguage} = useFeatures();
 
   const handleDismiss = useCallback(
     ({target}: React.MouseEvent<HTMLDivElement>) => {
@@ -34,7 +32,6 @@ export function SearchDismissOverlay({onDismiss, visible}: Props) {
         className={classNames(
           styles.SearchDismissOverlay,
           visible && styles.visible,
-          newDesignLanguage && styles.newDesignLanguage,
         )}
         onClick={handleDismiss}
       />

--- a/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/src/components/TopBar/components/SearchField/SearchField.scss
@@ -47,38 +47,38 @@ $stacking-order: (
 .focused .Input,
 .Input:focus {
   border: none;
-  color: var(--p-text, color('ink'));
+  color: var(--p-text);
 
   &::placeholder {
-    color: var(--p-text-subdued, color('ink', 'lightest'));
+    color: var(--p-text-subdued);
   }
 }
 
 .Input:focus {
   ~ .Backdrop {
-    background-color: var(--p-on-surface-background, color('white'));
+    background-color: var(--p-on-surface-background);
   }
 
   ~ .BackdropShowFocusBorder {
-    border: 1px solid var(--top-bar-border, transparent);
+    border: 1px solid var(--top-bar-border);
   }
 
   ~ .Icon {
-    @include recolor-icon(var(--p-icon, color('ink', 'lightest')));
+    @include recolor-icon(var(--p-icon));
   }
 }
 
 .focused {
   .Backdrop {
-    background-color: var(--p-on-surface-background, color('white'));
+    background-color: var(--p-on-surface-background);
   }
 
   .BackdropShowFocusBorder {
-    border: 1px solid var(--top-bar-border, transparent);
+    border: 1px solid var(--top-bar-border);
   }
 
   .Icon {
-    @include recolor-icon(var(--p-icon, color('ink', 'lightest')));
+    @include recolor-icon(var(--p-icon));
   }
 }
 
@@ -91,13 +91,13 @@ $stacking-order: (
   border: none;
   background-color: transparent;
   outline: none;
-  color: var(--p-text, var(--top-bar-color));
+  color: var(--p-text);
   will-change: fill, color;
   transition: fill duration() easing(), color duration() easing();
   appearance: textfield;
 
   &::placeholder {
-    color: var(--p-text, var(--top-bar-color));
+    color: var(--p-text);
     transition: (duration() - 33ms) color easing() 33ms;
   }
 
@@ -113,7 +113,7 @@ $stacking-order: (
 }
 
 .Icon {
-  @include recolor-icon(var(--p-icon, var(--top-bar-color)));
+  @include recolor-icon(var(--p-icon));
   position: absolute;
   z-index: z-index(icon, $stacking-order);
   top: 50%;
@@ -129,7 +129,7 @@ $stacking-order: (
 }
 
 .Clear {
-  @include recolor-icon(var(--p-icon, color('ink', 'lightest')));
+  @include recolor-icon(var(--p-icon));
   @include focus-ring($size: 'wide');
   position: relative;
   z-index: z-index(action, $stacking-order);
@@ -140,7 +140,7 @@ $stacking-order: (
 
   &:focus,
   &:hover {
-    @include recolor-icon(var(--p-icon-hovered, color('ink', 'lighter')));
+    @include recolor-icon(var(--p-icon-hovered));
     outline: none;
   }
 
@@ -164,21 +164,15 @@ $stacking-order: (
   right: 0;
   bottom: 0;
   left: 0;
-  background-color: var(
-    --p-on-surface-background,
-    var(--top-bar-background-lighter)
-  );
+  background-color: var(--p-on-surface-background);
   will-change: background-color;
   transition: background-color duration() easing();
-  border-radius: var(--p-border-radius-base, border-radius());
+  border-radius: var(--p-border-radius-base);
   animation: toLightBackground 0.01ms;
 }
 
 @keyframes toLightBackground {
   to {
-    background-color: var(
-      --p-surface-neutral,
-      var(--top-bar-background-lighter)
-    );
+    background-color: var(--p-surface-neutral);
   }
 }

--- a/src/components/TopBar/components/SearchField/SearchField.tsx
+++ b/src/components/TopBar/components/SearchField/SearchField.tsx
@@ -3,7 +3,6 @@ import {CircleCancelMinor, SearchMinor} from '@shopify/polaris-icons';
 
 import {classNames} from '../../../../utilities/css';
 import {useI18n} from '../../../../utilities/i18n';
-import {useFeatures} from '../../../../utilities/features';
 import {useUniqueId} from '../../../../utilities/unique-id';
 import {Icon} from '../../../Icon';
 import {VisuallyHidden} from '../../../VisuallyHidden';
@@ -44,7 +43,6 @@ export function SearchField({
 }: SearchFieldProps) {
   const i18n = useI18n();
   const [forceActive, setForceActive] = useState(false);
-  const {newDesignLanguage} = useFeatures();
 
   const input = useRef<HTMLInputElement>(null);
   const searchId = useUniqueId('SearchField');
@@ -106,7 +104,6 @@ export function SearchField({
   const className = classNames(
     styles.SearchField,
     (focused || active || forceActive) && styles.focused,
-    newDesignLanguage && styles['SearchField-newDesignLanguage'],
   );
 
   return (

--- a/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
+++ b/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
@@ -130,29 +130,6 @@ describe('<SearchField />', () => {
       'Backdrop BackdropShowFocusBorder',
     );
   });
-
-  describe('newDesignLanguage', () => {
-    it('does not render a container with newDesignLanguage className by default', () => {
-      const textField = mountWithApp(
-        <SearchField value="hello polaris" onChange={noop} />,
-      );
-      expect(textField).not.toContainReactComponent('div', {
-        className: 'SearchField SearchField-newDesignLanguage',
-      });
-    });
-
-    it('renders a container with newDesignLanguage className when newDesignLanguage is true', () => {
-      const textField = mountWithApp(
-        <SearchField value="hello polaris" onChange={noop} />,
-        {
-          features: {newDesignLanguage: true},
-        },
-      );
-      expect(textField).toContainReactComponent('div', {
-        className: 'SearchField SearchField-newDesignLanguage',
-      });
-    });
-  });
 });
 
 function noop() {}

--- a/src/components/TopBar/components/UserMenu/UserMenu.scss
+++ b/src/components/TopBar/components/UserMenu/UserMenu.scss
@@ -14,7 +14,7 @@
   @include text-style-body;
   font-weight: 500;
   line-height: line-height(subheading);
-  color: var(--p-text, var(--top-bar-color));
+  color: var(--p-text);
   text-align: left;
 }
 
@@ -22,7 +22,7 @@
   @include text-style-caption;
   @include truncate;
   opacity: 0.7;
-  color: var(--p-text, var(--top-bar-color));
+  color: var(--p-text);
   text-align: left;
 }
 

--- a/src/components/TopBar/tests/TopBar.test.tsx
+++ b/src/components/TopBar/tests/TopBar.test.tsx
@@ -251,26 +251,6 @@ describe('<TopBar />', () => {
       expect(findByTestID(topBar, 'ContextControl').exists()).toBe(false);
     });
   });
-
-  describe('newDesignLanguage', () => {
-    it('does not render a div with newDesignLanguage className when newDesignLanguage is undefined', () => {
-      const topBar = mountWithApp(<TopBar />);
-
-      expect(topBar).not.toContainReactComponent('div', {
-        className: 'TopBar TopBar-newDesignLanguage',
-      });
-    });
-
-    it('renders a div with newDesignLanguage className when newDesignLanguage is enabled', () => {
-      const topBar = mountWithApp(<TopBar />, {
-        features: {newDesignLanguage: true},
-      });
-
-      expect(topBar).toContainReactComponent('div', {
-        className: 'TopBar TopBar-newDesignLanguage',
-      });
-    });
-  });
 });
 
 function noop() {}


### PR DESCRIPTION
WHY are these changes introduced?
These changes are introduced as part of polaris-v6, where all reference to the newDesignLanguages are being removed. Fixes Shopify/polaris-ux#526.

WHAT is this pull request doing?
This pull request removes all references to the newDesignLanguage and any fallbacks in the TopBar component on polaris-react.

### How to 🎩
In order to tophat this, please compare this locally and http://polaris-react.herokuapp.com/

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
