### PR TITLE
[Tags] Fix invalid ms-high-contrast media query css without selector in Tags

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,6 +26,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed `Tags` invalid css to work with ms-high-contrast media active ([#3810](https://github.com/Shopify/polaris-react/pull/3810))
 - `plain` variant `children` no longer remain visible while `loading` for `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
 - No longer spin `disclosure` 180deg when toggling between `up` and `down` on `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
 - Prevent layout shift when toggling “filled” variants on `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,7 +26,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
-- Fixed `Tags` invalid css to work with ms-high-contrast media active ([#3810](https://github.com/Shopify/polaris-react/pull/3810))
+- Fixed an accessibility issue where high contrast styles wouldn’t be applied to the `Tag` component ([#3810](https://github.com/Shopify/polaris-react/pull/3810))
 - `plain` variant `children` no longer remain visible while `loading` for `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
 - No longer spin `disclosure` 180deg when toggling between `up` and `down` on `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))
 - Prevent layout shift when toggling “filled” variants on `Button` ([#3709](https://github.com/Shopify/polaris-react/pull/3709))

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -70,6 +70,10 @@ $icon-size: rem(16px);
       // stylelint-enable
     }
   }
+
+  @media (-ms-high-contrast: active) {
+    outline: 1px solid ms-high-contrast-color('text');
+  }
 }
 
 .TagText {
@@ -77,10 +81,6 @@ $icon-size: rem(16px);
   text-overflow: ellipsis;
   white-space: nowrap;
   vertical-align: middle;
-}
-
-@media (-ms-high-contrast: active) {
-  outline: 1px solid ms-high-contrast-color('text');
 }
 
 .Button {


### PR DESCRIPTION
### WHY are these changes introduced?
Found in `Tags.scss` a media query for `ms-high-contrast` without a selector. This is invalid css which prevents `dart-sass` compilation and possibly generate other issues.

### WHAT is this pull request doing?
Put the media query back to the `Tags` class selector as it was before https://github.com/Shopify/polaris-react/pull/2774 which introduced the bug.

**Before with `ms-high-contrast` active**
<img src="https://user-images.githubusercontent.com/1143424/104241576-318e4b00-545e-11eb-8196-621acc098715.png" width="200" />

**After with `ms-high-contrast` active**
<img src="https://user-images.githubusercontent.com/1143424/104241206-96957100-545d-11eb-8ea4-f51b1323ec14.png" width="200" />

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Tag} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Tag>Polaris</Tag>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)