### PR TITLE
[Color picker] Refactor checker board background

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -53,6 +53,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed `-ms-high-contrast` media query from `ms-high-contrast-outline` as it is non-standard and updated the outline color from `windowText` to `transparent` ([#3775](https://github.com/Shopify/polaris-react/pull/3775)).
 - Fixed `Collapsible` expand and collapse animation ([#3779](https://github.com/Shopify/polaris-react/pull/3779))
 - Fixed a bug in `Page` where re-rendering of `secondaryActions` could cause layout jittering ([#3641](https://github.com/Shopify/polaris-react/pull/3641))
+- Fixed `ColorPicker` checker background to remain visible on a white background ([#3812](https://github.com/Shopify/polaris-react/pull/3812))
 
 ### Documentation
 

--- a/src/components/ColorPicker/ColorPicker.scss
+++ b/src/components/ColorPicker/ColorPicker.scss
@@ -13,7 +13,7 @@ $stacking-order: (
 @mixin checkers {
   background: repeating-conic-gradient(
       var(--p-surface) 0% 25%,
-      var(--p-surface-neutral) 0% 50%
+      var(--p-surface-neutral-subdued) 0% 50%
     )
     50% / #{spacing() spacing()};
 }

--- a/src/components/ColorPicker/ColorPicker.scss
+++ b/src/components/ColorPicker/ColorPicker.scss
@@ -11,17 +11,11 @@ $stacking-order: (
 );
 
 @mixin checkers {
-  background-image: linear-gradient(
-      45deg,
-      var(--p-surface) 25%,
-      transparent 25%
-    ),
-    linear-gradient(-45deg, var(--p-surface) 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, var(--p-surface) 75%),
-    linear-gradient(-45deg, transparent 75%, var(--p-surface) 75%);
-  background-size: spacing() spacing();
-  background-position: 0 0, 0 spacing(tight), spacing(tight) -1 * spacing(tight),
-    -1 * spacing(tight) 0;
+  background: repeating-conic-gradient(
+      var(--p-surface) 0% 25%,
+      var(--p-surface-neutral) 0% 50%
+    )
+    50% / #{spacing() spacing()};
 }
 
 .ColorPicker {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3789

### WHAT is this pull request doing?
Rather than compose the checker board with `var(--p-surface)` and `transparent` which causes it to not be visible on a `var(--p-surface)` background, compose it with `var(--p-surface)` and `var(--p-surface-neutral-subdued)` so it is still visible no matter the background colour.

Simplifies how the checker board is generated by using `conic-gradient` rather than `linear-gradient`.

<img width="244" alt="Screen Shot 2021-01-11 at 2 08 19 PM" src="https://user-images.githubusercontent.com/3474483/104244083-93c35d80-5416-11eb-84d9-c32ca638f96a.png"><img width="243" alt="Screen Shot 2021-01-11 at 2 08 38 PM" src="https://user-images.githubusercontent.com/3474483/104244097-9d4cc580-5416-11eb-9ce3-739cc23ff043.png"><img width="238" alt="Screen Shot 2021-01-11 at 2 16 59 PM" src="https://user-images.githubusercontent.com/3474483/104244635-b2762400-5417-11eb-8fd6-38181b10d367.png">|<img width="247" alt="Screen Shot 2021-01-11 at 2 13 51 PM" src="https://user-images.githubusercontent.com/3474483/104244466-4c899c80-5417-11eb-93b5-e17e522ccaa9.png"><img width="241" alt="Screen Shot 2021-01-11 at 2 14 06 PM" src="https://user-images.githubusercontent.com/3474483/104244474-51e6e700-5417-11eb-9553-51122d498944.png"><img width="238" alt="Screen Shot 2021-01-11 at 2 16 18 PM" src="https://user-images.githubusercontent.com/3474483/104244596-98d4dc80-5417-11eb-8d1d-71a76c5821a6.png">
:----:|:----:
Before|After

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
