### PR TITLE
[Inline error] Remove ndl fallback

### DIFF
--- a/src/components/InlineError/InlineError.scss
+++ b/src/components/InlineError/InlineError.scss
@@ -4,8 +4,8 @@ $error-icon-adjustment: rem(2px);
 
 .InlineError {
   display: flex;
-  color: var(--p-text-critical, color('red', 'dark'));
-  fill: var(--p-icon-critical, color('red', 'dark'));
+  color: var(--p-text-critical);
+  fill: var(--p-icon-critical);
 }
 
 .Icon {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/566

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Removes references to newDesignLanguage in the Inline error component

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
