### PR TITLE
[Layout ] Remove new design language fallbacks

### DIFF
--- a/src/components/Layout/Layout.scss
+++ b/src/components/Layout/Layout.scss
@@ -11,12 +11,8 @@ $relative-size: $primary-basis / $secondary-basis;
   flex-wrap: wrap;
   justify-content: center;
   align-items: flex-start;
-  margin-top: -1 * spacing(loose);
+  margin-top: -1 * spacing();
   margin-left: -1 * spacing(loose);
-
-  &.newDesignLanguage {
-    margin-top: -1 * spacing();
-  }
 }
 
 .Section {
@@ -51,21 +47,13 @@ $relative-size: $primary-basis / $secondary-basis;
 .Section,
 .AnnotatedSection {
   max-width: calc(100% - #{spacing(loose)});
-  margin-top: spacing(loose);
+  margin-top: spacing();
   margin-left: spacing(loose);
-
-  .newDesignLanguage & {
-    margin-top: spacing();
-  }
 
   + .AnnotatedSection {
     @include page-content-when-not-fully-condensed {
-      padding-top: spacing(loose);
+      padding-top: spacing();
       border-top: border('divider');
-      // stylelint-disable-next-line selector-max-combinators, selector-max-class
-      .newDesignLanguage & {
-        padding-top: spacing();
-      }
     }
   }
 }
@@ -73,12 +61,8 @@ $relative-size: $primary-basis / $secondary-basis;
 .AnnotationWrapper {
   display: flex;
   flex-wrap: wrap;
-  margin-top: -1 * spacing(loose);
+  margin-top: -1 * spacing();
   margin-left: -1 * spacing(loose);
-
-  .newDesignLanguage & {
-    margin-top: -1 * spacing();
-  }
 }
 
 .AnnotationContent {
@@ -102,12 +86,8 @@ $relative-size: $primary-basis / $secondary-basis;
 .AnnotationContent {
   min-width: 0;
   max-width: calc(100% - #{spacing(loose)});
-  margin-top: spacing(loose);
+  margin-top: spacing();
   margin-left: spacing(loose);
-
-  .newDesignLanguage & {
-    margin-top: spacing();
-  }
 }
 
 .AnnotationDescription {

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
 
-import {useFeatures} from '../../utilities/features';
-import {classNames} from '../../utilities/css';
-
 import {AnnotatedSection, Section} from './components';
 import styles from './Layout.scss';
 
@@ -17,14 +14,8 @@ export const Layout: React.FunctionComponent<LayoutProps> & {
   AnnotatedSection: typeof AnnotatedSection;
   Section: typeof Section;
 } = function Layout({sectioned, children}: LayoutProps) {
-  const {newDesignLanguage} = useFeatures();
   const content = sectioned ? <Section>{children}</Section> : children;
-  const className = classNames(
-    styles.Layout,
-    newDesignLanguage && styles.newDesignLanguage,
-  );
-
-  return <div className={className}>{content}</div>;
+  return <div className={styles.Layout}>{content}</div>;
 };
 
 Layout.AnnotatedSection = AnnotatedSection;


### PR DESCRIPTION
### WHAT is this pull request doing?
This is the React portion of this issue: https://github.com/Shopify/polaris-ux/issues/564
Removes the new design language fallbacks from the Layout component

### How to 🎩

To tophat this, please compare your local version and http://polaris-react.herokuapp.com/

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
