### PR TITLE
[Collapsible] Do not render children when fully closed

### DIFF
--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -40,6 +40,7 @@ export function Collapsible({
 
   const isFullyOpen = animationState === 'idle' && open && isOpen;
   const isFullyClosed = animationState === 'idle' && !open && !isOpen;
+  const content = expandOnPrint || !isFullyClosed ? children : null;
 
   const wrapperClassName = classNames(
     styles.Collapsible,
@@ -100,7 +101,7 @@ export function Collapsible({
       onTransitionEnd={handleCompleteAnimation}
       aria-expanded={open}
     >
-      {children}
+      {content}
     </div>
   );
 }

--- a/src/components/Collapsible/tests/Collapsible.test.tsx
+++ b/src/components/Collapsible/tests/Collapsible.test.tsx
@@ -31,6 +31,16 @@ describe('<Collapsible />', () => {
     expect(collapsible.contains('content')).toBe(true);
   });
 
+  it('does not render its children when closed', () => {
+    const collapsible = mountWithAppProvider(
+      <Collapsible id="test-collapsible" open={false}>
+        content
+      </Collapsible>,
+    );
+
+    expect(collapsible.contains('content')).toBe(false);
+  });
+
   it('renders its children when expandOnPrint is true and open is false', () => {
     const collapsible = mountWithAppProvider(
       <Collapsible id="test-collapsible" open={false} expandOnPrint>


### PR DESCRIPTION
### WHY are these changes introduced?

Display none was doing the heavy lifting before but we have too many instances in web where we don't want to render the children if collapsed. 

### WHAT is this pull request doing?

Only allow the children of collapsible to render if `expandOnPrint` or `!isFullyClosed`

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
