### PR TITLE
Fix button focus offset

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fix the `Button` focus state offset ([#3832](https://github.com/Shopify/polaris-react/pull/3832))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -698,9 +698,9 @@ $stacking-order: (
     }
 
     &.newDesignLanguage {
-      @include focus-ring($border-width: border-width('base'));
       border-color: currentColor;
       box-shadow: 0 0 0 border-width('base') currentColor;
+      @include focus-ring($border-width: rem(2px));
 
       &:focus {
         @include focus-ring($style: 'focused');

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -163,7 +163,6 @@
   }
 
   &.newDesignLanguage {
-    @include focus-ring($border-width: 0);
     background: var(--p-button-color);
     border-color: transparent;
     box-shadow: var(--p-button-drop-shadow), var(--p-button-inner-shadow);
@@ -238,7 +237,6 @@
   }
 
   &.newDesignLanguage {
-    @include focus-ring($border-width: border-width('base'));
     background: transparent;
     border: border-width() solid var(--p-border);
     box-shadow: none;
@@ -295,7 +293,6 @@
       &:focus {
         border: border-width('base') solid var(--p-border-critical);
         box-shadow: none;
-        @include focus-ring($style: 'focused');
       }
 
       &:active {


### PR DESCRIPTION
### WHY are these changes introduced?

The latest release has a regression for filled button focus styles brought up by @whizkydee

### WHAT is this pull request doing?

This PR adds back the offset and removes some duplicated code.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

1. Open the button examples and focus through them

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit