### PR TITLE
Fix up secondary action button

### DIFF
--- a/playground/DetailsPage.tsx
+++ b/playground/DetailsPage.tsx
@@ -534,6 +534,7 @@ export function DetailsPage() {
         ...actions,
         {
           content: 'View',
+          destructive: true,
           onAction: () => {
             // eslint-disable-next-line no-console
             console.log(previewValue);

--- a/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
+++ b/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.scss
@@ -9,6 +9,7 @@ $button-spacing: rem(12px);
   button {
     @include focus-ring($border-width: rem(1px));
     background: transparent !important;
+    color: var(--p-text) !important;
     box-shadow: none !important;
     border-radius: var(--p-border-radius-base) !important;
     padding-left: $button-spacing;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/520

### WHAT is this pull request doing?

Adding a text color so destructive actions are also reset.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

1. Go to the details page and the `View` button should not have white text.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

