### PR TITLE
[ToastManager] Change aria-live to assertive for accessibility

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed an incorrect translation key for `accessibilityLabel` in `Tooltip`([#3843](https://github.com/Shopify/polaris-react/pull/3843))
 - Fix shadows on filled `Button`s not touching the bottom edge ([#3841](https://github.com/Shopify/polaris-react/pull/3841))
 - Adjust `Thumbnail` icon color to be subdued ([#3846](https://github.com/Shopify/polaris-react/pull/3846))
+- Updated ToastManager to use aria-live 'assertive' for accessibility ([#3837](https://github.com/Shopify/polaris-react/pull/3837))
 
 ### Documentation
 

--- a/src/components/Frame/components/ToastManager/ToastManager.tsx
+++ b/src/components/Frame/components/ToastManager/ToastManager.tsx
@@ -62,7 +62,7 @@ export const ToastManager = memo(function ToastManager({
   return (
     <Portal>
       <EventListener event="resize" handler={updateToasts} />
-      <div className={styles.ToastManager} aria-live="polite">
+      <div className={styles.ToastManager} aria-live="assertive">
         <TransitionGroup component={null}>{toastsMarkup}</TransitionGroup>
       </div>
     </Portal>

--- a/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
+++ b/src/components/Frame/components/ToastManager/tests/ToastManager.test.tsx
@@ -32,13 +32,15 @@ describe('<ToastManager />', () => {
     }).not.toThrow();
   });
 
-  it('has and aria-live attribute of polite', () => {
+  it('has and aria-live attribute of assertive', () => {
     const toastManager = mountWithAppProvider(
       <ToastManager
         toastMessages={[{id: '1', content: 'Hello', onDismiss: noop}]}
       />,
     );
-    expect(toastManager.find('[aria-live]').prop('aria-live')).toBe('polite');
+    expect(toastManager.find('[aria-live]').prop('aria-live')).toBe(
+      'assertive',
+    );
   });
 });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/34584 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

Toast messages using aria-live set to 'polite' are ignored by screen reader. There is discussion in the linked PR as for the decision made to choose this solution over extending the time a toast spends on screen. 

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [X] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
