### PR TITLE
Remove border to fix button shadows

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fix shadows on filled `Button`s not touching the bottom edge ([#3841](https://github.com/Shopify/polaris-react/pull/3841))
+
 ### Documentation
 
 ### Development workflow

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -164,37 +164,32 @@
 
   &.newDesignLanguage {
     background: var(--p-button-color);
-    border-color: transparent;
     box-shadow: var(--p-button-drop-shadow), var(--p-button-inner-shadow);
     color: var(--p-button-text);
+    border: none;
 
     &:hover {
       background: var(--p-button-color-hover);
-      border-color: transparent;
       color: var(--p-button-text);
     }
 
     &:focus {
-      border-color: transparent;
       box-shadow: var(--p-button-drop-shadow), var(--p-button-inner-shadow);
     }
 
     &:active {
       background: var(--p-button-color-active);
-      border-color: transparent;
       box-shadow: var(--p-button-drop-shadow), var(--p-button-inner-shadow);
     }
 
     &.pressed {
       color: var(--p-button-text);
       background: var(--p-button-color-depressed);
-      border-color: transparent;
       box-shadow: var(--p-button-drop-shadow), var(--p-button-inner-shadow);
 
       &:hover,
       &:focus {
         background: var(--p-button-color-depressed);
-        border-color: transparent;
         box-shadow: var(--p-button-drop-shadow), var(--p-button-inner-shadow);
       }
     }

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -166,6 +166,7 @@
     background: var(--p-button-color);
     box-shadow: var(--p-button-drop-shadow), var(--p-button-inner-shadow);
     color: var(--p-button-text);
+    @include focus-ring;
     border: none;
 
     &:hover {


### PR DESCRIPTION
### WHY are these changes introduced?

Filled buttons have an extra line around around them due to the transparent border. This causes an unflush button shadow. Brought up by @dleroux 
![Screen Shot 2021-01-13 at 2 26 05 PM](https://user-images.githubusercontent.com/19199063/104517676-53e1af00-55ab-11eb-8bb2-bb97a796762e.png)

### WHAT is this pull request doing?

Fixes the button shadow
![Screen Shot 2021-01-13 at 2 26 08 PM](https://user-images.githubusercontent.com/19199063/104517721-6956d900-55ab-11eb-80b4-e021cb013db0.png)

### How to 🎩

Look at the [Percy changes](https://percy.io/Shopify/polaris-react/builds-next/8367982/changed/475920613?browser=chrome&browser_ids=9&subcategories=unreviewed%2Cchanges_requested&viewLayout=overlay&viewMode=new&width=1280&widths=375%2C1280)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
