### PR TITLE
[Tooltip] Change accessibility label translation key

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed an incorrect translation key for `accessibilityLabel` in `Tooltip`([#3843](https://github.com/Shopify/polaris-react/pull/3843))
+
 ### Documentation
 
 ### Development workflow

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -303,7 +303,7 @@
       "label": "Panel načítání stránky"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Tip s vysvětlením: {label}"
+      "accessibilityLabel": "Tip s vysvětlením: {label}"
     }
   }
 }

--- a/locales/da.json
+++ b/locales/da.json
@@ -301,7 +301,7 @@
       "label": "Statuslinje for sideindlæsning"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Værktøjstip: {label}"
+      "accessibilityLabel": "Værktøjstip: {label}"
     }
   }
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -301,7 +301,7 @@
       "label": "Seiten-Ladeleiste"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Tooltip: {label}"
+      "accessibilityLabel": "Tooltip: {label}"
     }
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -243,7 +243,7 @@
       "characterCountWithMaxLength": "{count} of {limit} characters used"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Tooltip: {label}"
+      "accessibilityLabel": "Tooltip: {label}"
     },
     "TopBar": {
       "toggleMenuLabel": "Toggle menu",

--- a/locales/es.json
+++ b/locales/es.json
@@ -301,7 +301,7 @@
       "label": "Barra de \"cargando página\""
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Descripción emergente: {label}"
+      "accessibilityLabel": "Descripción emergente: {label}"
     }
   }
 }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -301,7 +301,7 @@
       "label": "Sivun latautumisen palkki"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Työkaluvihje: {label}"
+      "accessibilityLabel": "Työkaluvihje: {label}"
     }
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -301,7 +301,7 @@
       "label": "Barre de chargement de la page"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Info-bulle : {label}"
+      "accessibilityLabel": "Info-bulle : {label}"
     }
   }
 }

--- a/locales/it.json
+++ b/locales/it.json
@@ -301,7 +301,7 @@
       "label": "Barra di caricamento della pagina"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Suggerimento: {label}"
+      "accessibilityLabel": "Suggerimento: {label}"
     }
   }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -301,7 +301,7 @@
       "label": "ページの読み込み表示バー"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "ツールチップ: {label}"
+      "accessibilityLabel": "ツールチップ: {label}"
     }
   }
 }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -301,7 +301,7 @@
       "label": "페이지 로딩 표시줄"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "툴팁: {label}"
+      "accessibilityLabel": "툴팁: {label}"
     }
   }
 }

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -301,7 +301,7 @@
       "label": "Sidelastingslinje"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Verktøytips: {label}"
+      "accessibilityLabel": "Verktøytips: {label}"
     }
   }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -301,7 +301,7 @@
       "label": "Pagina laadbalk"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Knopinfo: {label}"
+      "accessibilityLabel": "Knopinfo: {label}"
     }
   }
 }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -303,7 +303,7 @@
       "label": "Pasek ładowania strony"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Etykietka narzędzia: {label}"
+      "accessibilityLabel": "Etykietka narzędzia: {label}"
     }
   }
 }

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -301,7 +301,7 @@
       "label": "Barra de carregamento de página"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Dica de ferramenta: {label}"
+      "accessibilityLabel": "Dica de ferramenta: {label}"
     }
   }
 }

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -301,7 +301,7 @@
       "label": "Barra de carregamento da página"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Descrição: {label}"
+      "accessibilityLabel": "Descrição: {label}"
     }
   }
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -301,7 +301,7 @@
       "label": "Fält för att ladda sida"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Verktygstips: {label}"
+      "accessibilityLabel": "Verktygstips: {label}"
     }
   }
 }

--- a/locales/th.json
+++ b/locales/th.json
@@ -301,7 +301,7 @@
       "label": "แถบแสดงการโหลดหน้า"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "เคล็ดลับเกี่ยวกับเครื่องมือ: {label}"
+      "accessibilityLabel": "เคล็ดลับเกี่ยวกับเครื่องมือ: {label}"
     }
   }
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -301,7 +301,7 @@
       "label": "Sayfa yüklenme çubuğu"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "İpucu: {label}"
+      "accessibilityLabel": "İpucu: {label}"
     }
   }
 }

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -301,7 +301,7 @@
       "label": "Thanh tải trang"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "Chú giải công cụ: {label}"
+      "accessibilityLabel": "Chú giải công cụ: {label}"
     }
   }
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -301,7 +301,7 @@
       "label": "页面加载条"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "工具提示：{label}"
+      "accessibilityLabel": "工具提示：{label}"
     }
   }
 }

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -301,7 +301,7 @@
       "label": "頁面載入進度條"
     },
     "TooltipOverlay": {
-      "accessibilitylabel": "工具提示：{label}"
+      "accessibilityLabel": "工具提示：{label}"
     }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The translation key is incorrect

### WHAT is this pull request doing?

Using camel case on the translation key

### Screeny

![Screen Shot 2021-01-14 at 2 29 50 PM](https://user-images.githubusercontent.com/24610840/104639124-09c50000-5675-11eb-8271-feef7ca7faf3.png)

### How to 🎩

* Add an accessibility label to tooltip & use a voice assistance tool

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
