### PR TITLE
Thumbnail icon subdued

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixed an incorrect translation key for `accessibilityLabel` in `Tooltip`([#3843](https://github.com/Shopify/polaris-react/pull/3843))
 - Fix shadows on filled `Button`s not touching the bottom edge ([#3841](https://github.com/Shopify/polaris-react/pull/3841))
+- Adjust `Thumbnail` icon color to be subdued ([#3846](https://github.com/Shopify/polaris-react/pull/3846))
 
 ### Documentation
 

--- a/src/components/Thumbnail/Thumbnail.scss
+++ b/src/components/Thumbnail/Thumbnail.scss
@@ -39,5 +39,9 @@
   max-width: 100%;
   max-height: 100%;
   @include recolor-icon(currentColor);
+<<<<<<< Updated upstream
   color: var(--p-icon, color('ink', 'lighter'));
+=======
+  color: var(--p-icon-subdued);
+>>>>>>> Stashed changes
 }

--- a/src/components/Thumbnail/Thumbnail.scss
+++ b/src/components/Thumbnail/Thumbnail.scss
@@ -39,9 +39,5 @@
   max-width: 100%;
   max-height: 100%;
   @include recolor-icon(currentColor);
-<<<<<<< Updated upstream
-  color: var(--p-icon, color('ink', 'lighter'));
-=======
   color: var(--p-icon-subdued);
->>>>>>> Stashed changes
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Changes thumbnail icon color subdued, as referenced in https://github.com/Shopify/web/issues/32928

### WHAT is this pull request doing?

Makes thumbnail icon color subdued, as referenced in https://github.com/Shopify/web/issues/32928

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
