### PR TITLE
[ActionList] Remove child selector from .active styles

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Adjust `Thumbnail` icon color to be subdued ([#3846](https://github.com/Shopify/polaris-react/pull/3846))
 - Updated ToastManager to use aria-live 'assertive' for accessibility ([#3837](https://github.com/Shopify/polaris-react/pull/3837))
 - Fixed responsiveness of empty search state in `ResourceList` to support user text zoom settings ([#2983](https://github.com/Shopify/polaris-react/pull/2983))
+- Fixed `ActionList` not rendering `.active` indicator ([#3854](https://github.com/Shopify/polaris-react/pull/3854))
 
 ### Documentation
 

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -226,7 +226,7 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
     }
 
     // Only show when the button is selected, not active
-    &.active > &::before {
+    &.active::before {
       @include list-selected-indicator;
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

I noticed when tophatting the Online Store Editor bump to Polaris 5.13.1 that the indicator styles were missing from the `.active` `ActionList` buttons.

![image](https://user-images.githubusercontent.com/17032120/104751535-6f84bb00-574d-11eb-9d67-a60694c30178.png)

This can be resolved by removing a stray `>` child selector in `ActionList.scss`
- #3725 removed the aria-selected from  `<li>` in `ActionList`
- The `aria-selected` was used as a selector in the styles, and required the `>` child selector to target the `button` within the `li`
- The `.active` class is applied directly to the `button`, so the `>` child selector is not needed (and is preventing the indicator styles from displaying) 

**Before:**

![image](https://user-images.githubusercontent.com/17032120/104751670-9b07a580-574d-11eb-96d0-40364b1b3e1c.png)

**After**

![image](https://user-images.githubusercontent.com/17032120/104751787-c2f70900-574d-11eb-95a0-3d7b2b7baea3.png)


### WHAT is this pull request doing?

- removes  `>` child selector in `ActionList.scss`

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
