### PR TITLE
[Select] Remove new DL fallbacks

### DIFF
--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -25,7 +25,6 @@ $stacking-order: (
   }
 
   .Icon {
-    opacity: var(--p-override-one);
     @include recolor-icon(var(--p-icon-disabled));
   }
 

--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -17,7 +17,7 @@ $stacking-order: (
 
 .disabled {
   .Content {
-    color: var(--p-text-disabled, color('ink', 'lightest'));
+    color: var(--p-text-disabled);
   }
 
   .InlineLabel {
@@ -25,22 +25,19 @@ $stacking-order: (
   }
 
   .Icon {
-    opacity: var(--p-override-one, 0.4);
-    @include recolor-icon(var(--p-icon-disabled, color('ink', 'lighter')));
+    opacity: var(--p-override-one);
+    @include recolor-icon(var(--p-icon-disabled));
   }
 
-  &.newDesignLanguage {
-    // stylelint-disable-next-line selector-max-class
-    .Backdrop {
-      border-color: var(--p-border-disabled);
-      // stylelint-disable-next-line selector-max-class, selector-max-specificity
-      &::before {
-        background-color: var(--p-action-secondary-disabled);
-      }
-      // stylelint-disable-next-line selector-max-class, selector-max-specificity
-      &:hover {
-        cursor: default;
-      }
+  .Backdrop {
+    border-color: var(--p-border-disabled);
+
+    &::before {
+      background-color: var(--p-action-secondary-disabled);
+    }
+
+    &:hover {
+      cursor: default;
     }
   }
 }
@@ -56,7 +53,7 @@ $stacking-order: (
   // stylelint-disable-next-line selector-max-class, selector-max-specificity
   &.error .Input:-moz-focusring {
     color: transparent;
-    text-shadow: var(--p-override-none, 0 0 0 color('ink', 'base'));
+    text-shadow: var(--p-override-none);
   }
 }
 
@@ -91,7 +88,7 @@ $stacking-order: (
 }
 
 .Icon {
-  @include recolor-icon(var(--p-icon, color('ink', 'lighter')));
+  @include recolor-icon(var(--p-icon));
 }
 
 .Input {
@@ -111,91 +108,46 @@ $stacking-order: (
   appearance: none;
 }
 
-.Select:not(.newDesignLanguage) {
+.Backdrop {
+  z-index: z-index(backdrop, $stacking-order);
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  border: border-width() solid var(--p-border-subdued);
+  border-bottom-color: var(--p-border-shadow-subdued);
+  border-radius: var(--p-border-radius-base);
+  background-color: var(--p-surface);
+  box-shadow: var(--p-button-drop-shadow);
+  @include focus-ring($border-width: rem(1px));
+  // 'position' needs to sit below focus-ring since it will be overwritten
+  // with relative when the focus ring style is 'base'
+  // stylelint-disable-next-line order/properties-order
+  position: absolute;
+}
+
+.error {
   .Backdrop {
-    @include control-backdrop;
-    position: absolute;
-    z-index: z-index(backdrop, $stacking-order);
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-  }
-
-  &.error {
-    // stylelint-disable-next-line selector-max-specificity, selector-max-class
-    .Backdrop {
-      @include control-backdrop(error);
-    }
-
-    // Need to override the higher specificity of the sibling selector
-    // so that errors still have red borders.
-    // stylelint-disable-next-line selector-max-combinators, selector-max-specificity, selector-max-class
-    .Input:focus ~ .Backdrop {
-      @include control-backdrop(focused-error);
+    border-color: var(--p-border-critical);
+    background-color: var(--p-surface-critical);
+    // stylelint-disable-next-line selector-max-class, selector-max-specificity
+    &.hover,
+    &:hover {
+      border-color: var(--p-border-critical);
     }
   }
 
-  &.disabled {
-    // stylelint-disable-next-line selector-max-specificity, selector-max-class
-    .Backdrop {
-      @include control-backdrop(disabled);
-    }
-  }
-
-  // stylelint-disable-next-line selector-max-specificity
-  .Input:focus {
-    // stylelint-disable-next-line selector-max-specificity, selector-max-combinators, selector-max-class
-    ~ .Backdrop {
-      @include control-backdrop(focused);
-    }
+  // Need to override the higher specificity of the sibling selector
+  // so that errors still have red borders.
+  // stylelint-disable-next-line selector-max-combinators, selector-max-specificity, selector-max-class
+  .Input:focus ~ .Backdrop {
+    @include focus-ring($style: 'focused');
   }
 }
 
-.newDesignLanguage {
-  .Backdrop {
-    z-index: z-index(backdrop, $stacking-order);
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    border: border-width() solid var(--p-border-subdued);
-    border-bottom-color: var(--p-border-shadow-subdued);
-    border-radius: var(--p-border-radius-base);
-    background-color: var(--p-surface);
-    box-shadow: var(--p-button-drop-shadow);
-    @include focus-ring($border-width: rem(1px));
-    // 'position' needs to sit below focus-ring since it will be overwritten
-    // with relative when the focus ring style is 'base'
-    // stylelint-disable-next-line order/properties-order
-    position: absolute;
-  }
-
-  &.error {
-    // stylelint-disable-next-line selector-max-class
-    .Backdrop {
-      border-color: var(--p-border-critical);
-      background-color: var(--p-surface-critical);
-      // stylelint-disable-next-line selector-max-class, selector-max-specificity
-      &.hover,
-      &:hover {
-        border-color: var(--p-border-critical);
-      }
-    }
-
-    // Need to override the higher specificity of the sibling selector
-    // so that errors still have red borders.
-    // stylelint-disable-next-line selector-max-combinators, selector-max-specificity, selector-max-class
-    .Input:focus ~ .Backdrop {
-      @include focus-ring($style: 'focused');
-    }
-  }
-
-  .Input:focus {
-    // stylelint-disable-next-line selector-max-specificity, selector-max-combinators, selector-max-class
-    ~ .Backdrop {
-      @include focus-ring($style: 'focused');
-    }
+.Input:focus {
+  ~ .Backdrop {
+    @include focus-ring($style: 'focused');
   }
 }
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {SelectMinor} from '@shopify/polaris-icons';
 
 import {classNames} from '../../utilities/css';
-import {useFeatures} from '../../utilities/features';
 import {useUniqueId} from '../../utilities/unique-id';
 import {Labelled, LabelledProps, helpTextID} from '../Labelled';
 import {Icon} from '../Icon';
@@ -93,13 +92,11 @@ export function Select({
 }: SelectProps) {
   const id = useUniqueId('Select', idProp);
   const labelHidden = labelInline ? true : labelHiddenProp;
-  const {newDesignLanguage} = useFeatures();
 
   const className = classNames(
     styles.Select,
     error && styles.error,
     disabled && styles.disabled,
-    newDesignLanguage && styles.newDesignLanguage,
   );
 
   const handleChange = onChange

--- a/src/components/Select/tests/Select.test.tsx
+++ b/src/components/Select/tests/Select.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {InlineError, Icon} from 'components';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
-import {mountWithApp} from 'test-utilities';
 import {CircleTickOutlineMinor} from '@shopify/polaris-icons';
 
 import {Select} from '../Select';
@@ -358,32 +357,6 @@ describe('<Select />', () => {
       );
 
       expect(select.find(InlineError)).toHaveLength(0);
-    });
-  });
-
-  describe('newDesignLanguage', () => {
-    it('adds a newDesignLanguage class when newDesignLanguage is enabled', () => {
-      const select = mountWithApp(
-        <Select label="Select" options={[]} onChange={noop} />,
-        {
-          features: {newDesignLanguage: true},
-        },
-      );
-      expect(select).toContainReactComponent('div', {
-        className: 'Select newDesignLanguage',
-      });
-    });
-
-    it('does not add a newDesignLanguage class when newDesignLanguage is disabled', () => {
-      const select = mountWithApp(
-        <Select label="Select" options={[]} onChange={noop} />,
-        {
-          features: {newDesignLanguage: false},
-        },
-      );
-      expect(select).not.toContainReactComponent('div', {
-        className: 'Select newDesignLanguage',
-      });
     });
   });
 });


### PR DESCRIPTION
WHY are these changes introduced?
These changes are introduced as part of polaris-v6, where all reference to the newDesignLanguages are being removed. Fixes Shopify/polaris-ux#546.

WHAT is this pull request doing?
This pull request removes all references to the newDesignLanguage and any fallbacks in the Select component on polaris-react.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
