### PR TITLE
[ActionList] Remove ndl fallbacks

### DIFF
--- a/src/components/ActionList/components/Item/Item.tsx
+++ b/src/components/ActionList/components/Item/Item.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {classNames} from '../../../../utilities/css';
-import {useFeatures} from '../../../../utilities/features';
 import type {ActionListItemDescriptor} from '../../../../types';
 import {Scrollable} from '../../../Scrollable';
 import {Icon} from '../../../Icon';
@@ -31,13 +30,11 @@ export function Item({
   active,
   role,
 }: ItemProps) {
-  const {newDesignLanguage} = useFeatures();
   const className = classNames(
     styles.Item,
     disabled && styles.disabled,
     destructive && styles.destructive,
     active && styles.active,
-    newDesignLanguage && styles.newDesignLanguage,
   );
 
   let prefixMarkup: React.ReactNode | null = null;
@@ -46,12 +43,7 @@ export function Item({
     prefixMarkup = <div className={styles.Prefix}>{prefix}</div>;
   } else if (icon) {
     prefixMarkup = (
-      <div
-        className={classNames(
-          styles.Prefix,
-          newDesignLanguage && styles.newDesignLanguage,
-        )}
-      >
+      <div className={styles.Prefix}>
         <Icon source={icon} />
       </div>
     );
@@ -83,14 +75,7 @@ export function Item({
   );
 
   const suffixMarkup = suffix && (
-    <span
-      className={classNames(
-        styles.Suffix,
-        newDesignLanguage && styles.newDesignLanguage,
-      )}
-    >
-      {suffix}
-    </span>
+    <span className={styles.Suffix}>{suffix}</span>
   );
 
   const textMarkup = <div className={styles.Text}>{contentMarkup}</div>;

--- a/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -80,26 +80,6 @@ describe('<Item />', () => {
       mockAccessibilityLabel,
     );
   });
-
-  describe('newDesignLanguage', () => {
-    it('adds a newDesignLanguage class when newDesignLanguage is enabled', () => {
-      const item = mountWithApp(<Item />, {
-        features: {newDesignLanguage: true},
-      });
-      expect(item).toContainReactComponent('button', {
-        className: 'Item newDesignLanguage',
-      });
-    });
-
-    it('does not add a newDesignLanguage class when newDesignLanguage is disabled', () => {
-      const item = mountWithApp(<Item />, {
-        features: {newDesignLanguage: false},
-      });
-      expect(item).not.toContainReactComponent('button', {
-        className: 'Item newDesignLanguage',
-      });
-    });
-  });
 });
 
 function noop() {}

--- a/src/components/ActionList/components/Section/Section.tsx
+++ b/src/components/ActionList/components/Section/Section.tsx
@@ -6,7 +6,6 @@ import type {
   ActionListSection,
 } from '../../../../types';
 import styles from '../../ActionList.scss';
-import {useFeatures} from '../../../../utilities/features';
 import {classNames} from '../../../../utilities/css';
 
 export interface SectionProps {
@@ -53,12 +52,6 @@ export function Section({
 
   const className = section.title ? undefined : styles['Section-withoutTitle'];
 
-  const {newDesignLanguage} = useFeatures();
-  const actionsClassName = classNames(
-    styles.Actions,
-    newDesignLanguage && styles.newDesignLanguage,
-  );
-
   const titleMarkup = section.title ? (
     <p className={styles.Title}>{section.title}</p>
   ) : null;
@@ -68,7 +61,7 @@ export function Section({
   const sectionMarkup = (
     <div className={className}>
       {titleMarkup}
-      <ul className={actionsClassName} role={sectionRole}>
+      <ul className={styles.Actions} role={sectionRole}>
         {actionMarkup}
       </ul>
     </div>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
