### PR TITLE
[OptionList] remove ndl fallbacks

### DIFF
--- a/src/components/OptionList/OptionList.scss
+++ b/src/components/OptionList/OptionList.scss
@@ -2,10 +2,7 @@
 
 .OptionList {
   @include unstyled-list;
-
-  &.newDesignLanguage {
-    padding: spacing(tight);
-  }
+  padding: spacing(tight);
 }
 
 .Options {
@@ -14,11 +11,6 @@
 
 .Title {
   @include text-style-subheading;
-  padding: spacing(tight) spacing();
-  border-bottom: var(--p-override-none, border());
-
-  .newDesignLanguage & {
-    padding: spacing(tight);
-    color: var(--p-text-subdued);
-  }
+  padding: spacing(tight);
+  color: var(--p-text-subdued);
 }

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -1,7 +1,6 @@
 import React, {useState, useCallback} from 'react';
 
 import {arraysAreEqual} from '../../utilities/arrays';
-import {useFeatures} from '../../utilities/features';
 import {classNames} from '../../utilities/css';
 import type {IconProps} from '../Icon';
 import type {AvatarProps} from '../Avatar';
@@ -72,7 +71,6 @@ export function OptionList({
     createNormalizedOptions(options, sections, title),
   );
   const id = useUniqueId('OptionList', idProp);
-  const {newDesignLanguage} = useFeatures();
 
   useDeepEffect(
     () => {
@@ -149,13 +147,8 @@ export function OptionList({
       })
     : null;
 
-  const optionListClassName = classNames(
-    styles.OptionList,
-    newDesignLanguage && styles.newDesignLanguage,
-  );
-
   return (
-    <ul className={optionListClassName} role={role}>
+    <ul className={styles.OptionList} role={role}>
       {optionsMarkup}
     </ul>
   );

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -1,7 +1,6 @@
 import React, {useState, useCallback} from 'react';
 
 import {arraysAreEqual} from '../../utilities/arrays';
-import {classNames} from '../../utilities/css';
 import type {IconProps} from '../Icon';
 import type {AvatarProps} from '../Avatar';
 import type {ThumbnailProps} from '../Thumbnail';

--- a/src/components/OptionList/tests/OptionList.test.tsx
+++ b/src/components/OptionList/tests/OptionList.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
-import {mountWithApp} from 'test-utilities';
 
 import {Option} from '../components';
 import {OptionList, OptionListProps, OptionDescriptor} from '../OptionList';
@@ -521,28 +520,6 @@ describe('<OptionList />', () => {
 
         expect(spy).toHaveBeenCalledTimes(1);
         expect(spy).toHaveBeenCalledWith(newSelected);
-      });
-    });
-  });
-
-  describe('newDesignLanguage', () => {
-    it('adds a `newDesignLanguage` class to the `OptionList` when `newDesignLanguage` is enabled', () => {
-      const option = mountWithApp(<OptionList {...defaultProps} />, {
-        features: {newDesignLanguage: true},
-      });
-
-      expect(option).toContainReactComponent('ul', {
-        className: 'OptionList newDesignLanguage',
-      });
-    });
-
-    it('does not add a `newDesignLanguage` class to the `OptionList` when `newDesignLanguage` is disabled', () => {
-      const checkBox = mountWithApp(<OptionList {...defaultProps} />, {
-        features: {newDesignLanguage: false},
-      });
-
-      expect(checkBox).not.toContainReactComponent('ul', {
-        className: 'OptionList newDesignLanguage',
       });
     });
   });


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
