### PR TITLE
[ToolTip] Clean up and fixes for a11y test

### DIFF
--- a/src/components/Tooltip/Tooltip.scss
+++ b/src/components/Tooltip/Tooltip.scss
@@ -25,21 +25,12 @@ $content-max-width: rem(200px);
   margin: spacing() spacing() $offset-from-activator;
 }
 
-.Wrapper {
-  position: relative;
-  display: flex;
-  background-color: var(--p-surface);
-  border-radius: var(--p-border-radius-base);
-  color: var(--p-text);
-}
-
 .Content {
   position: relative;
   border-radius: border-radius();
+  background-color: var(--p-surface);
+  color: var(--p-text);
   max-width: $content-max-width;
-}
-
-.Label {
   padding: spacing(extra-tight) spacing(tight);
   word-break: break-word;
 }

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -7,7 +7,6 @@ import {useToggle} from '../../utilities/use-toggle';
 import {Key} from '../../types';
 
 import {TooltipOverlay, TooltipOverlayProps} from './components';
-import styles from './Tooltip.scss';
 
 export interface TooltipProps {
   /** The element that will activate to tooltip */
@@ -82,9 +81,7 @@ export function Tooltip({
         onClose={noop}
         preventInteraction={dismissOnMouseOut}
       >
-        <div className={styles.Label} testID="TooltipOverlayLabel">
-          {content}
-        </div>
+        {content}
       </TooltipOverlay>
     </Portal>
   ) : null;

--- a/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
+++ b/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
@@ -3,7 +3,7 @@
 $offset-from-activator: rem(4px);
 $content-max-width: rem(200px);
 
-.Tooltip {
+.TooltipOverlay {
   margin: $offset-from-activator spacing() spacing();
   opacity: 1;
   box-shadow: var(--p-popover-shadow);

--- a/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
+++ b/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
@@ -1,4 +1,4 @@
-@import '../../styles/common';
+@import '../../../../styles/common';
 
 $offset-from-activator: rem(4px);
 $content-max-width: rem(200px);

--- a/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -12,7 +12,6 @@ import styles from '../../Tooltip.scss';
 export interface TooltipOverlayProps {
   id: string;
   active: boolean;
-  light?: boolean;
   preventInteraction?: PositionedOverlayProps['preventInteraction'];
   preferredPosition?: PositionedOverlayProps['preferredPosition'];
   children?: React.ReactNode;

--- a/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -28,7 +28,6 @@ export function TooltipOverlay({
   preventInteraction,
   id,
   children,
-  light,
   accessibilityLabel,
 }: TooltipOverlayProps) {
   const i18n = useI18n();
@@ -51,7 +50,6 @@ export function TooltipOverlay({
 
     const containerClassName = classNames(
       styles.Tooltip,
-      light && styles.light,
       measuring && styles.measuring,
       positioning === 'above' && styles.positionedAbove,
     );
@@ -60,22 +58,20 @@ export function TooltipOverlay({
 
     return (
       <div className={containerClassName} {...layer.props}>
-        <div className={styles.Wrapper}>
-          <div
-            id={id}
-            role="tooltip"
-            className={styles.Content}
-            style={contentStyles}
-            aria-label={
-              accessibilityLabel
-                ? i18n.translate('Polaris.TooltipOverlay.accessibilityLabel', {
-                    label: accessibilityLabel,
-                  })
-                : undefined
-            }
-          >
-            {children}
-          </div>
+        <div
+          id={id}
+          role="tooltip"
+          className={styles.Content}
+          style={contentStyles}
+          aria-label={
+            accessibilityLabel
+              ? i18n.translate('Polaris.TooltipOverlay.accessibilityLabel', {
+                  label: accessibilityLabel,
+                })
+              : undefined
+          }
+        >
+          {children}
         </div>
       </div>
     );

--- a/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -7,7 +7,8 @@ import {
   PositionedOverlay,
 } from '../../../PositionedOverlay';
 import {useI18n} from '../../../../utilities/i18n';
-import styles from '../../Tooltip.scss';
+
+import styles from './TooltipOverlay.scss';
 
 export interface TooltipOverlayProps {
   id: string;
@@ -48,7 +49,7 @@ export function TooltipOverlay({
     const {measuring, desiredHeight, positioning} = overlayDetails;
 
     const containerClassName = classNames(
-      styles.Tooltip,
+      styles.TooltipOverlay,
       measuring && styles.measuring,
       positioning === 'above' && styles.positionedAbove,
     );

--- a/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -22,7 +22,8 @@ describe('<Tooltip />', () => {
   });
 
   it('does not render initially', () => {
-    expect(findByTestID(tooltip, 'TooltipOverlayLabel').exists()).toBe(false);
+    const overlayContent = tooltip.find(TooltipOverlay).find('div');
+    expect(overlayContent.exists()).toBe(false);
   });
 
   it('renders initially when active is true', () => {
@@ -31,9 +32,8 @@ describe('<Tooltip />', () => {
         <Link>link content</Link>
       </Tooltip>,
     );
-    expect(findByTestID(tooltipActive, 'TooltipOverlayLabel').exists()).toBe(
-      true,
-    );
+    const overlayContent = tooltipActive.find(TooltipOverlay).find('div');
+    expect(overlayContent.exists()).toBe(true);
   });
 
   it('passes preventInteraction to TooltipOverlay when dismissOnMouseOut is true', () => {
@@ -49,22 +49,26 @@ describe('<Tooltip />', () => {
 
   it('renders on mouseOver', () => {
     wrapperComponent.simulate('mouseOver');
-    expect(findByTestID(tooltip, 'TooltipOverlayLabel').exists()).toBe(true);
+    const overlayContent = tooltip.find(TooltipOverlay).find('div');
+    expect(overlayContent.exists()).toBe(true);
   });
 
   it('renders on focus', () => {
     wrapperComponent.simulate('focus');
-    expect(findByTestID(tooltip, 'TooltipOverlayLabel').exists()).toBe(true);
+    const overlayContent = tooltip.find(TooltipOverlay).find('div');
+    expect(overlayContent.exists()).toBe(true);
   });
 
   it('unrenders its children on blur', () => {
     wrapperComponent.simulate('blur');
-    expect(findByTestID(tooltip, 'TooltipOverlayLabel').exists()).toBe(false);
+    const overlayContent = tooltip.find(TooltipOverlay).find('div');
+    expect(overlayContent.exists()).toBe(false);
   });
 
   it('unrenders its children on mouseLeave', () => {
     wrapperComponent.simulate('mouseLeave');
-    expect(findByTestID(tooltip, 'TooltipOverlayLabel').exists()).toBe(false);
+    const overlayContent = tooltip.find(TooltipOverlay).find('div');
+    expect(overlayContent.exists()).toBe(false);
   });
 
   it('closes itself when escape is pressed on keyup', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

This removes the light prop which was causing the a11y issue originally and some unnecessary wrapping components


### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
