### PR TITLE
[ThemeProvider] Change frameOffset to accept a string

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added required `ariaLabel` property in `Sheet` ([#3852](https://github.com/Shopify/polaris-react/pull/3852))
 - Removed `NewDesignLanguage`, `Color`, `AnimationProps` exported types ([#3868](https://github.com/Shopify/polaris-react/pull/3868))
 - Replaced `BaseAction` with `Action` type ([#3868](https://github.com/Shopify/polaris-react/pull/3868))
+- Changed the `frameOffset` prop to accept a string in `ThemeProvider` ([#3883](https://github.com/Shopify/polaris-react/pull/3883))
 
 ### Enhancements
 

--- a/src/components/Frame/README.md
+++ b/src/components/Frame/README.md
@@ -648,7 +648,7 @@ function FrameExample() {
         background: '#225062',
       },
     },
-    frameOffset: 60,
+    frameOffset: '60px',
     logo: {
       width: 124,
       topBarSource:

--- a/src/utilities/theme/tests/utils.test.ts
+++ b/src/utilities/theme/tests/utils.test.ts
@@ -122,7 +122,7 @@ describe('buildCustomProperties', () => {
     expect(colors).not.toContain('--top-bar-background');
   });
 
-  it('creates default custom property of 0px for frameOffset when frameOffset is undefined and newDesignLanguage is false', () => {
+  it('creates default custom property of 0px for frameOffset when frameOffset is undefined', () => {
     const theme = {
       colors: {topBar: {background: '#eeeeee'}, surface: '#ffffff'},
       colorScheme: DefaultColorScheme,
@@ -132,19 +132,9 @@ describe('buildCustomProperties', () => {
     expect(colors).toMatchObject({'--p-frame-offset': '0px'});
   });
 
-  it('creates default custom property of 0px for frameOffset when frameOffset is undefined and newDesignLanguage is true', () => {
-    const theme = {
-      colors: {topBar: {background: '#eeeeee'}, surface: '#ffffff'},
-      colorScheme: DefaultColorScheme,
-    };
-
-    const colors = buildCustomProperties(theme, true);
-    expect(colors).toMatchObject({'--p-frame-offset': '0px'});
-  });
-
   it('creates custom property with value for frameOffset when frameOffset is provided and newDesignLanguage is false', () => {
     const theme = {
-      frameOffset: 60,
+      frameOffset: '60px',
       colors: {topBar: {background: '#eeeeee'}, surface: '#ffffff'},
       colorScheme: DefaultColorScheme,
     };
@@ -155,7 +145,7 @@ describe('buildCustomProperties', () => {
 
   it('creates custom property with value for frameOffset when frameOffset is provided and newDesignLanguage is true', () => {
     const theme = {
-      frameOffset: 80,
+      frameOffset: '80px',
       colors: {topBar: {background: '#eeeeee'}, surface: '#ffffff'},
       colorScheme: DefaultColorScheme,
     };

--- a/src/utilities/theme/types.ts
+++ b/src/utilities/theme/types.ts
@@ -52,7 +52,7 @@ export interface ThemeConfig {
   colors?: Partial<RoleColors> & LegacyColors;
   colorScheme?: ColorScheme;
   config?: Config;
-  frameOffset?: number;
+  frameOffset?: string;
 }
 
 export type CustomPropertiesLike = Record<string, string>;

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -26,18 +26,18 @@ export function buildCustomPropertiesNoMemo(
   newDesignLanguage: boolean,
   tokens?: Record<string, string>,
 ): CustomPropertiesLike {
-  const {colors = {}, colorScheme, config, frameOffset = 0} = themeConfig;
+  const {colors = {}, colorScheme, config, frameOffset = '0px'} = themeConfig;
   const mergedConfig = mergeConfigs(base, config || {});
 
   return newDesignLanguage
     ? customPropertyTransformer({
         ...colorFactory(colors, colorScheme, mergedConfig),
         ...tokens,
-        frameOffset: `${frameOffset}px`,
+        frameOffset,
       })
     : {
         ...buildLegacyColors(themeConfig),
-        ...customPropertyTransformer({frameOffset: `${frameOffset}px`}),
+        ...customPropertyTransformer({frameOffset}),
       };
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/global-nav/issues/843

### WHAT is this pull request doing?

Some consumers need relative units for the frame offset. This takes into account for font-size and matching up breakpoints.

This PR allows for any string to be passed in i.e. `12em` and still defaults to `0px`.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Check out the frame example and try different units

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
