### PR TITLE
Remove deprecated features

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,9 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed `NewDesignLanguage`, `Color`, `AnimationProps` exported types ([#3868](https://github.com/Shopify/polaris-react/pull/3868))
 - Replaced `BaseAction` with `Action` type ([#3868](https://github.com/Shopify/polaris-react/pull/3868))
 - Changed the `frameOffset` prop to accept a string in `ThemeProvider` ([#3883](https://github.com/Shopify/polaris-react/pull/3883))
+- Removed `Button` and `UnstyledButton`'s `ariaPressed` prop. Consumers should use the `pressed` prop instead
+- Removed `Button`'s `stretchContent` prop. Consumers should combine the `fullWidth` and `textAlign="left"` props instead
+- Removed `Popover`/`PopoverOverlay`'s `preventAutoFocus` prop. Consumers should use `autofocusTarget="none"` instead
 
 ### Enhancements
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,9 +10,9 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed `NewDesignLanguage`, `Color`, `AnimationProps` exported types ([#3868](https://github.com/Shopify/polaris-react/pull/3868))
 - Replaced `BaseAction` with `Action` type ([#3868](https://github.com/Shopify/polaris-react/pull/3868))
 - Changed the `frameOffset` prop to accept a string in `ThemeProvider` ([#3883](https://github.com/Shopify/polaris-react/pull/3883))
-- Removed `Button` and `UnstyledButton`'s `ariaPressed` prop. Consumers should use the `pressed` prop instead
-- Removed `Button`'s `stretchContent` prop. Consumers should combine the `fullWidth` and `textAlign="left"` props instead
-- Removed `Popover`/`PopoverOverlay`'s `preventAutoFocus` prop. Consumers should use `autofocusTarget="none"` instead
+- Removed `Button` and `UnstyledButton`'s `ariaPressed` prop. Consumers should use the `pressed` prop instead ([#3884](https://github.com/Shopify/polaris-react/pull/3884))
+- Removed `Button`'s `stretchContent` prop. Consumers should combine the `fullWidth` and `textAlign="left"` props instead ([#3884](https://github.com/Shopify/polaris-react/pull/3884))
+- Removed `Popover`/`PopoverOverlay`'s `preventAutoFocus` prop. Consumers should use `autofocusTarget="none"` instead ([#3884](https://github.com/Shopify/polaris-react/pull/3884))
 
 ### Enhancements
 

--- a/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
+++ b/src/components/Autocomplete/components/ComboBox/ComboBox.tsx
@@ -336,7 +336,7 @@ export function ComboBox({
           onClose={forcePopoverActiveFalse}
           preferredPosition={preferredPosition}
           fullWidth
-          preventAutofocus
+          autofocusTarget="none"
         >
           <Popover.Pane onScrolledToBottom={onEndReached}>
             <div id={id} role="listbox" aria-multiselectable={allowMultiple}>

--- a/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
+++ b/src/components/Autocomplete/components/ComboBox/tests/ComboBox.test.tsx
@@ -313,7 +313,7 @@ describe('<ComboBox/>', () => {
     });
 
     it('prevents autofocus on Popover', () => {
-      expect(comboBox.find(Popover).prop('preventAutofocus')).toBe(true);
+      expect(comboBox.find(Popover).prop('autofocusTarget')).toBe('none');
     });
 
     it('passes the preferredPosition to Popover', () => {

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -127,10 +127,6 @@ $stacking-order: (
   }
 }
 
-.stretchContent > .Content {
-  justify-content: space-between;
-}
-
 .Icon {
   // This compensates for the typical icon used in buttons being
   // inset within its bounding box.

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -82,7 +82,7 @@ type ActionButtonProps = Pick<
   | 'loading'
   | 'ariaControls'
   | 'ariaExpanded'
-  | 'ariaPressed'
+  | 'pressed'
   | 'onKeyDown'
   | 'onKeyUp'
   | 'onKeyPress'
@@ -105,7 +105,6 @@ export function Button({
   ariaControls,
   ariaExpanded,
   ariaDescribedBy,
-  ariaPressed,
   onClick,
   onFocus,
   onBlur,
@@ -198,8 +197,6 @@ export function Button({
     </span>
   ) : null;
 
-  const ariaPressedStatus = pressed !== undefined ? pressed : ariaPressed;
-
   const [disclosureActive, setDisclosureActive] = useState(false);
   const toggleDisclosureActive = useCallback(() => {
     setDisclosureActive((disclosureActive) => !disclosureActive);
@@ -286,7 +283,7 @@ export function Button({
     loading,
     ariaControls,
     ariaExpanded,
-    ariaPressed: ariaPressedStatus,
+    pressed,
     onKeyDown,
     onKeyUp,
     onKeyPress,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useRef, useState} from 'react';
+import React, {useCallback, useState} from 'react';
 import {
   CaretDownMinor,
   CaretUpMinor,
@@ -49,11 +49,6 @@ export interface ButtonProps extends BaseButton {
   icon?: React.ReactElement | IconSource;
   /** Disclosure button connected right of the button. Toggles a popover action list. */
   connectedDisclosure?: ConnectedDisclosure;
-  /**
-   * @deprecated As of release 5.13.0, replaced by {@link https://polaris.shopify.com/components/actions/button/textAlign}
-   * Stretch the content (text + icon) from side to side
-   */
-  stretchContent?: boolean;
 }
 
 interface CommonButtonProps
@@ -124,19 +119,9 @@ export function Button({
   textAlign,
   fullWidth,
   connectedDisclosure,
-  stretchContent,
 }: ButtonProps) {
   const {newDesignLanguage} = useFeatures();
   const i18n = useI18n();
-  const hasGivenDeprecationWarning = useRef(false);
-
-  if (stretchContent && !hasGivenDeprecationWarning.current) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: The `stretchContent` prop has been replaced with `textAlign="left"`',
-    );
-    hasGivenDeprecationWarning.current = true;
-  }
 
   const isDisabled = disabled || loading;
 
@@ -156,7 +141,6 @@ export function Button({
     fullWidth && styles.fullWidth,
     icon && children == null && styles.iconOnly,
     connectedDisclosure && styles.connectedDisclosure,
-    stretchContent && styles.stretchContent,
   );
 
   const disclosureMarkup = disclosure ? (

--- a/src/components/Button/README.md
+++ b/src/components/Button/README.md
@@ -461,7 +461,7 @@ Buttons can have different states that are visually and programmatically conveye
 - Use the `ariaControls` prop to add an `aria-controls` attribute to the button. Use the attribute to point to the unique `id` of the content that the button manages.
 - If a button expands or collapses adjacent content, then use the `ariaExpanded` prop to add the `aria-expanded` attribute to the button. Set the value to convey the current expanded (`true`) or collapsed (`false`) state of the content.
 - Use the `disabled` prop to set the `disabled` state of the button. This prevents merchants from being able to interact with the button, and conveys its inactive state to assistive technologies.
-- Use the `ariaPressed` prop to add an `aria-pressed` attribute to the button.
+- Use the `pressed` prop to add an `aria-pressed` attribute to the button.
 
 #### Navigation
 

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -176,13 +176,6 @@ describe('<Button />', () => {
     });
   });
 
-  describe('ariaPressed', () => {
-    it('passes prop', () => {
-      const button = mountWithAppProvider(<Button ariaPressed />);
-      expect(button.find(UnstyledButton).prop('ariaPressed')).toBeTruthy();
-    });
-  });
-
   describe('connectedDisclosure', () => {
     it('connects a disclosure icon button to the button', () => {
       const disclosure = {

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -440,13 +440,4 @@ describe('<Button />', () => {
       });
     });
   });
-
-  describe('stretchContent', () => {
-    it('sets variant class', () => {
-      const button = mountWithApp(<Button stretchContent />);
-      expect(button).toContainReactComponent(UnstyledButton, {
-        className: 'Button stretchContent',
-      });
-    });
-  });
 });

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -50,11 +50,6 @@ export interface PopoverProps {
    * @default 'div'
    */
   activatorWrapper?: string;
-  /**
-   * Prevent automatic focus of the popover on activation
-   * @deprecated Use autofocusTarget: 'none' instead.
-   * */
-  preventAutofocus?: boolean;
   /** Prevents focusing the activator or the next focusable element when the popover is deactivated */
   preventFocusOnClose?: boolean;
   /** Automatically add wrap content in a section */

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -46,7 +46,6 @@ export interface PopoverOverlayProps {
   id: string;
   activator: HTMLElement;
   preferInputActivator?: PositionedOverlayProps['preferInputActivator'];
-  preventAutofocus?: boolean;
   sectioned?: boolean;
   fixed?: boolean;
   hideOnPrint?: boolean;
@@ -161,20 +160,9 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
   }
 
   private focusContent() {
-    const {autofocusTarget = 'container', preventAutofocus} = this.props;
+    const {autofocusTarget = 'container'} = this.props;
 
-    if (preventAutofocus) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Deprecation: The preventAutofocus prop has been deprecated. Use autofocusTarget: "none" instead. Read more at [https://github.com/Shopify/polaris-react/issues/3602]',
-      );
-    }
-
-    if (
-      preventAutofocus ||
-      autofocusTarget === 'none' ||
-      this.contentNode == null
-    ) {
+    if (autofocusTarget === 'none' || this.contentNode == null) {
       return;
     }
 
@@ -212,7 +200,6 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
       fluidContent,
       hideOnPrint,
       colorScheme,
-      preventAutofocus,
       autofocusTarget,
     } = this.props;
 
@@ -235,9 +222,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
     const content = (
       <div
         id={id}
-        tabIndex={
-          preventAutofocus || autofocusTarget === 'none' ? undefined : -1
-        }
+        tabIndex={autofocusTarget === 'none' ? undefined : -1}
         className={contentClassNames}
         style={contentStyles}
         ref={this.contentNode}

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -170,7 +170,7 @@ describe('<PopoverOverlay />', () => {
     ).toBe(false);
   });
 
-  it("doesn't include a tabindex prop when preventAutofocus is true", () => {
+  it("doesn't include a tabindex prop when autofocusTarget is 'none'", () => {
     const popoverOverlay = mountWithAppProvider(
       <PopoverOverlay
         active
@@ -178,7 +178,7 @@ describe('<PopoverOverlay />', () => {
         activator={activator}
         onClose={noop}
         fixed
-        preventAutofocus
+        autofocusTarget="none"
         preferInputActivator={false}
       >
         {children}

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -162,18 +162,18 @@ describe('<Popover />', () => {
     expect(popover.children[0].type).toBe('span');
   });
 
-  it('passes preventAutofocus to PopoverOverlay', () => {
+  it('passes autofocusTarget to PopoverOverlay', () => {
     const popover = mountWithApp(
       <Popover
         active={false}
-        preventAutofocus
+        autofocusTarget="none"
         activator={<div>Activator</div>}
         onClose={spy}
       />,
     );
 
     expect(popover).toContainReactComponent(PopoverOverlay, {
-      preventAutofocus: true,
+      autofocusTarget: 'none',
     });
   });
 

--- a/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/src/components/UnstyledButton/UnstyledButton.tsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React from 'react';
 
 import type {BaseButton} from '../../types';
 import {handleMouseUpByBlurring} from '../../utilities/focus';
@@ -28,7 +28,6 @@ export function UnstyledButton({
   ariaControls,
   ariaExpanded,
   ariaDescribedBy,
-  ariaPressed,
   onClick,
   onFocus,
   onBlur,
@@ -39,18 +38,6 @@ export function UnstyledButton({
   onTouchStart,
   ...rest
 }: UnstyledButtonProps) {
-  const hasGivenDeprecationWarning = useRef(false);
-
-  if (ariaPressed && !hasGivenDeprecationWarning.current) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Deprecation: The ariaPressed prop has been replaced with pressed',
-    );
-    hasGivenDeprecationWarning.current = true;
-  }
-
-  const ariaPressedStatus = pressed !== undefined ? pressed : ariaPressed;
-
   let buttonMarkup;
 
   const commonProps = {
@@ -95,7 +82,7 @@ export function UnstyledButton({
         aria-controls={ariaControls}
         aria-expanded={ariaExpanded}
         aria-describedby={ariaDescribedBy}
-        aria-pressed={ariaPressedStatus}
+        aria-pressed={pressed}
         onKeyDown={onKeyDown}
         onKeyUp={onKeyUp}
         onKeyPress={onKeyPress}

--- a/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
+++ b/src/components/UnstyledButton/tests/UnstyledButton.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
-import {mountWithApp} from 'test-utilities';
 import {UnstyledLink} from 'components';
 
 import {UnstyledButton} from '../UnstyledButton';
@@ -295,13 +294,13 @@ describe('<Button />', () => {
     });
   });
 
-  describe('ariaPressed', () => {
+  describe('pressed', () => {
     it('sets an aria-pressed on the button', () => {
       const warningSpy = jest
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
 
-      const button = mountWithAppProvider(<UnstyledButton ariaPressed />);
+      const button = mountWithAppProvider(<UnstyledButton pressed />);
       expect(button.find('button').prop('aria-pressed')).toBeTruthy();
 
       warningSpy.mockRestore();
@@ -445,20 +444,6 @@ describe('<Button />', () => {
       ).find('button');
       trigger(button, 'onKeyDown');
       expect(spy).toHaveBeenCalled();
-    });
-  });
-
-  describe('deprecations', () => {
-    it('warns the ariaPressed prop has been replaced', () => {
-      const warningSpy = jest
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
-      mountWithApp(<UnstyledButton ariaPressed />);
-
-      expect(warningSpy).toHaveBeenCalledWith(
-        'Deprecation: The ariaPressed prop has been replaced with pressed',
-      );
-      warningSpy.mockRestore();
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,11 +37,6 @@ export interface BaseButton {
   ariaExpanded?: boolean;
   /** Indicates the ID of the element that describes the button */
   ariaDescribedBy?: string;
-  /**
-   * @deprecated As of release 4.7.0, replaced by {@link https://polaris.shopify.com/components/actions/button#prop-pressed}
-   * Tells screen reader the element is pressed
-   */
-  ariaPressed?: boolean;
   /** Callback when clicked */
   onClick?(): void;
   /** Callback when button becomes focussed */


### PR DESCRIPTION
### WHY are these changes introduced?

Removing deprecated features in a major version

### WHAT is this pull request doing?

- Remove Button/UnstyledButton ariaPressed - This was replaced by the `pressed` prop in Polaris v4.7.0
- Remove Button stretchContent prop: This was replaced by combining using `fullWidth` and `textAlign=left` in Polaris v5.13.0
- Remove Popover/PopoverOverlay preventAutofocus prop:This was replaced by `autofocusTarget="none"` in 5.13.0

---

The FilterControl component remains deprecated but present as web never prioritized ripping out its one remaining but knotty usage in web.
