### PR TITLE
Remove some mentions of new DL in tests

### DIFF
--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -626,31 +626,6 @@ describe('<Filters />', () => {
       expect(helpTextMarkup).toHaveLength(0);
     });
   });
-
-  describe('newDesignLanguage', () => {
-    it('adds a newDesignLanguage class when newDesignLanguage is enabled', () => {
-      const resourceFilters = mountWithAppProvider(<Filters {...mockProps} />, {
-        features: {newDesignLanguage: true},
-      });
-
-      trigger(findByTestID(resourceFilters, 'SheetToggleButton'), 'onClick');
-      expect(
-        findById(resourceFilters, 'filterOneToggleButton').exists(),
-      ).toBeTruthy();
-    });
-
-    it('does not add a newDesignLanguage class when newDesignLanguage is disabled', () => {
-      const filters = mountWithApp(<Filters {...mockProps} disabled />, {
-        features: {newDesignLanguage: false},
-      });
-
-      filters.find('button', {disabled: true})!.trigger('onClick');
-
-      expect(filters).not.toContainReactComponent('button', {
-        className: 'FilterTrigger newDesignLanguage',
-      });
-    });
-  });
 });
 
 function noop() {}

--- a/src/components/OptionList/components/Checkbox/tests/Checkbox.test.tsx
+++ b/src/components/OptionList/components/Checkbox/tests/Checkbox.test.tsx
@@ -41,9 +41,7 @@ describe('<Checkbox />', () => {
 
   describe('Focus className', () => {
     it('on keyUp adds a keyFocused class to the input', () => {
-      const checkbox = mountWithApp(<Checkbox onChange={noop} />, {
-        features: {newDesignLanguage: true},
-      });
+      const checkbox = mountWithApp(<Checkbox onChange={noop} />);
 
       const event: KeyboardEventInit & {keyCode: Key} = {
         keyCode: Key.Space,

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -156,9 +156,7 @@ describe('<Page />', () => {
         );
       }
 
-      const wrapper = mountWithApp(<PageWithSecondaryActionsToggle />, {
-        features: {newDesignLanguage: true},
-      });
+      const wrapper = mountWithApp(<PageWithSecondaryActionsToggle />);
 
       wrapper.find('button')!.trigger('onClick');
       expect(wrapper).toContainReactComponent(Page, {
@@ -187,9 +185,7 @@ describe('<Page />', () => {
         );
       }
 
-      const wrapper = mountWithApp(<PageWithActionsGroupsToggle />, {
-        features: {newDesignLanguage: true},
-      });
+      const wrapper = mountWithApp(<PageWithActionsGroupsToggle />);
 
       wrapper.find('button')!.trigger('onClick');
       expect(wrapper).toContainReactComponent(Page, {


### PR DESCRIPTION
### WHY are these changes introduced?

Removing mentions of newDesignLanguage

### WHAT is this pull request doing?

Deleting mentions of newDesignLanguage in tests for components that no longer use the new DL