### PR TITLE
[Range Slider] Add test comments

### DIFF
--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -1030,7 +1030,8 @@ function findTrack(containerComponent: ReactWrapper) {
 function mockGetBoundingClientRect(): ReturnType<
   Element['getBoundingClientRect']
 > {
-  const thumbSize = 16; // Match thumbSize set in DualThumb.tsx
+  // Match thumbSize set in DualThumb.tsx
+  const thumbSize = 16;
 
   return {
     width: 100 + thumbSize,

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -1030,11 +1030,13 @@ function findTrack(containerComponent: ReactWrapper) {
 function mockGetBoundingClientRect(): ReturnType<
   Element['getBoundingClientRect']
 > {
+  const thumbSize = 16; // Match thumbSize set in DualThumb.tsx
+
   return {
-    width: 116,
+    width: 100 + thumbSize,
     height: 0,
     top: 0,
-    left: -8,
+    left: -(thumbSize / 2),
     bottom: 0,
     right: 0,
     x: 0,


### PR DESCRIPTION
### WHY are these changes introduced?

`DualThumb` relies on `thumbSize` being set to match the design and also for the tests to pass.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Add comment to make the `DualThumb` tests to make them more clear.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
