### PR TITLE
[Icon] Temporary PR to remove warning and add fallbacks

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added missing fallbacks to icons and removed warning ([#3897](https://github.com/Shopify/polaris-react/pull/3897)
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -366,49 +366,49 @@
 // New design language color styles
 
 .colorBase {
-  @include recolor-icon(color('ink'));
+  @include color-icon('ink');
   &.newDesignLanguage {
     @include recolor-icon(var(--p-icon));
   }
 }
 
 .colorSubdued {
-  @include recolor-icon(color('skyDark'));
+  @include color-icon('skyDark');
   &.newDesignLanguage {
     @include recolor-icon(var(--p-icon-subdued));
   }
 }
 
 .colorCritical {
-  @include recolor-icon(color('red'));
+  @include color-icon('red');
   &.newDesignLanguage {
     @include recolor-icon(var(--p-icon-critical));
   }
 }
 
 .colorWarning {
-  @include recolor-icon(color('yellow'));
+  @include color-icon('yellow');
   &.newDesignLanguage {
     @include recolor-icon(var(--p-icon-warning));
   }
 }
 
 .colorHighlight {
-  @include recolor-icon(color('teal'));
+  @include color-icon('teal');
   &.newDesignLanguage {
     @include recolor-icon(var(--p-icon-highlight));
   }
 }
 
 .colorSuccess {
-  @include recolor-icon(color('green'));
+  @include color-icon('green');
   &.newDesignLanguage {
     @include recolor-icon(var(--p-icon-success));
   }
 }
 
 .colorPrimary {
-  @include recolor-icon(color('indigo'));
+  @include color-icon('indigo');
   &.newDesignLanguage {
     @include recolor-icon(var(--p-action-primary));
   }

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -373,7 +373,7 @@
 }
 
 .colorSubdued {
-  @include color-icon('skyDark');
+  @include color-icon('sky', 'dark');
   &.newDesignLanguage {
     @include recolor-icon(var(--p-icon-subdued));
   }

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -366,31 +366,52 @@
 // New design language color styles
 
 .colorBase {
-  @include recolor-icon(var(--p-icon, color('ink')));
+  @include recolor-icon(color('ink'));
+  &.newDesignLanguage {
+    @include recolor-icon(var(--p-icon));
+  }
 }
 
 .colorSubdued {
-  @include recolor-icon(var(--p-icon-subdued, color('skyDark')));
+  @include recolor-icon(color('skyDark'));
+  &.newDesignLanguage {
+    @include recolor-icon(var(--p-icon-subdued));
+  }
 }
 
 .colorCritical {
-  @include recolor-icon(var(--p-icon-critical, color('red')));
+  @include recolor-icon(color('red'));
+  &.newDesignLanguage {
+    @include recolor-icon(var(--p-icon-critical));
+  }
 }
 
 .colorWarning {
-  @include recolor-icon(var(--p-icon-warning, color('yellow')));
+  @include recolor-icon(color('yellow'));
+  &.newDesignLanguage {
+    @include recolor-icon(var(--p-icon-warning));
+  }
 }
 
 .colorHighlight {
-  @include recolor-icon(var(--p-icon-highlight, color('teal')));
+  @include recolor-icon(color('teal'));
+  &.newDesignLanguage {
+    @include recolor-icon(var(--p-icon-highlight));
+  }
 }
 
 .colorSuccess {
-  @include recolor-icon(var(--p-icon-success, color('green')));
+  @include recolor-icon(color('green'));
+  &.newDesignLanguage {
+    @include recolor-icon(var(--p-icon-success));
+  }
 }
 
 .colorPrimary {
-  @include recolor-icon(var(--p-action-primary, color('indigo')));
+  @include recolor-icon(color('indigo'));
+  &.newDesignLanguage {
+    @include recolor-icon(var(--p-action-primary));
+  }
 }
 
 .Svg,

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -366,31 +366,31 @@
 // New design language color styles
 
 .colorBase {
-  @include recolor-icon(var(--p-icon));
+  @include recolor-icon(var(--p-icon, color('ink')));
 }
 
 .colorSubdued {
-  @include recolor-icon(var(--p-icon-subdued));
+  @include recolor-icon(var(--p-icon-subdued, color('skyDark')));
 }
 
 .colorCritical {
-  @include recolor-icon(var(--p-icon-critical));
+  @include recolor-icon(var(--p-icon-critical, color('red')));
 }
 
 .colorWarning {
-  @include recolor-icon(var(--p-icon-warning));
+  @include recolor-icon(var(--p-icon-warning, color('yellow')));
 }
 
 .colorHighlight {
-  @include recolor-icon(var(--p-icon-highlight));
+  @include recolor-icon(var(--p-icon-highlight, color('teal')));
 }
 
 .colorSuccess {
-  @include recolor-icon(var(--p-icon-success));
+  @include recolor-icon(var(--p-icon-success, color('green')));
 }
 
 .colorPrimary {
-  @include recolor-icon(var(--p-action-primary));
+  @include recolor-icon(var(--p-action-primary, color('indigo')));
 }
 
 .Svg,

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -46,13 +46,6 @@ export function Icon({source, color, backdrop, accessibilityLabel}: Props) {
     );
   }
 
-  if (color && !newDesignLanguage && isNewDesignLanguageColor(color)) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'You have selected a color meant to be used in the new design language but new design language is not enabled.',
-    );
-  }
-
   if (
     color &&
     sourceType === 'external' &&

--- a/src/components/Icon/tests/Icon.test.tsx
+++ b/src/components/Icon/tests/Icon.test.tsx
@@ -62,21 +62,6 @@ describe('<Icon />', () => {
       warningSpy.mockRestore();
     });
 
-    it('warns when a new design language color is used and new design language is not enabled', () => {
-      const warningSpy = jest
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {});
-
-      mountWithApp(<Icon source={PlusMinor} color="warning" />, {
-        features: {newDesignLanguage: false},
-      });
-
-      expect(warningSpy).toHaveBeenCalledWith(
-        'You have selected a color meant to be used in the new design language but new design language is not enabled.',
-      );
-      warningSpy.mockRestore();
-    });
-
     it('uses a specified color when newDesignLanguage is enabled', () => {
       const icon = mountWithApp(<Icon source={PlusMinor} color="subdued" />, {
         features: {newDesignLanguage: true},


### PR DESCRIPTION
### WHY are these changes introduced?

This is irrelevant when V6 releases. We need a way to stop the 1500+ console warns in https://github.com/Shopify/web/pull/36936 and ship the icon and spinner changes with fallbacks.

### WHAT is this pull request doing?

Removes the warnings in

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
