### PR TITLE
Rename Modal hideTitle prop to titleHidden

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,7 +6,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - `Link` is underlined by default, added `removeUnderline` prop to remove underline ([#3705](https://github.com/Shopify/polaris-react/pull/3705))
 - Remove `light` property from `Tooltip` as it now defaults to a light background ([#3846](https://github.com/Shopify/polaris-react/pull/3846))
-- Made `title` property required in `Modal` for accessibility label, added `hideTitle` property ([#3803](https://github.com/Shopify/polaris-react/pull/3803))
+- Made `title` property required in `Modal` for accessibility label ([#3803](https://github.com/Shopify/polaris-react/pull/3803))
 - Added required `ariaLabel` property in `Sheet` ([#3852](https://github.com/Shopify/polaris-react/pull/3852))
 - Removed `NewDesignLanguage`, `Color`, `AnimationProps` exported types ([#3868](https://github.com/Shopify/polaris-react/pull/3868))
 - Replaced `BaseAction` with `Action` type ([#3868](https://github.com/Shopify/polaris-react/pull/3868))

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -30,7 +30,7 @@ export interface ModalProps extends FooterProps {
    * Hide the title in the modal
    * @default false
    */
-  hideTitle?: boolean;
+  titleHidden?: boolean;
   /** The content to display inside modal */
   children?: React.ReactNode;
   /** Inner content of the footer */
@@ -62,7 +62,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
 } = function Modal({
   children,
   title,
-  hideTitle = false,
+  titleHidden = false,
   src,
   iFrameName,
   open,
@@ -179,7 +179,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
         large={large}
         limitHeight={limitHeight}
       >
-        <Header hideTitle={hideTitle} id={headerId} onClose={onClose}>
+        <Header titleHidden={titleHidden} id={headerId} onClose={onClose}>
           {title}
         </Header>
         <div className={styles.BodyWrapper}>{bodyMarkup}</div>

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -575,7 +575,7 @@ function ModalWithoutTitleExample() {
     <div style={{height: '500px'}}>
       <Modal
         title="Reach more shoppers with Instagram product tags"
-        hideTitle
+        titleHidden
         activator={activator}
         open={active}
         onClose={handleChange}

--- a/src/components/Modal/components/Header/Header.tsx
+++ b/src/components/Modal/components/Header/Header.tsx
@@ -7,14 +7,14 @@ import styles from './Header.scss';
 
 export interface HeaderProps {
   id: string;
-  hideTitle: boolean;
+  titleHidden: boolean;
   children?: React.ReactNode;
   onClose(): void;
 }
 
-export function Header({id, hideTitle, children, onClose}: HeaderProps) {
+export function Header({id, titleHidden, children, onClose}: HeaderProps) {
   return (
-    <div className={hideTitle ? styles.withoutTitle : styles.Header}>
+    <div className={titleHidden ? styles.withoutTitle : styles.Header}>
       <div id={id} className={styles.Title}>
         <DisplayText element="h2" size="small">
           {children}

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -261,9 +261,9 @@ describe('<Modal>', () => {
       });
     });
 
-    it('only renders a close button when hideTitle is present', () => {
+    it('only renders a close button when titleHidden is present', () => {
       const modal = mountWithApp(
-        <Modal title="foo" hideTitle onClose={jest.fn()} open />,
+        <Modal title="foo" titleHidden onClose={jest.fn()} open />,
       );
 
       expect(modal.find(Header)).toContainReactComponent('div', {


### PR DESCRIPTION
### WHY are these changes introduced?

Keeping naming consistent.

Modal's hideTitle prop differs from Page and ChoiceList's naming of titleHidden

### WHAT is this pull request doing?

Rename's modal's `hideTitle` prop to `titleHidden`

We've already applied this change to the v5 branch, but doing this here will make the merge a little easier.