### PR TITLE
Remove Icon backdrop warning message

### DIFF
--- a/locales/cs.json
+++ b/locales/cs.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Zavřít navigaci"
       }
     },
-    "Icon": {
-      "backdropWarning": "Ikona {color} nepoužívá pozadí. Barvy ikon, které mají pozadí: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Akce"

--- a/locales/da.json
+++ b/locales/da.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Luk navigation"
       }
     },
-    "Icon": {
-      "backdropWarning": "{color}-ikonet accepterer ikke baggrunde. De ikonfarver, der har baggrunde, er: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Handlinger"

--- a/locales/de.json
+++ b/locales/de.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Navigation schließen"
       }
     },
-    "Icon": {
-      "backdropWarning": "Das {color}-Symbol akzeptiert keine Hintergründe. Die Symbolfarben, die Hintergründe haben, sind: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Aktionen"

--- a/locales/en.json
+++ b/locales/en.json
@@ -117,9 +117,6 @@
         "closeMobileNavigationLabel": "Close navigation"
       }
     },
-    "Icon": {
-      "backdropWarning": "The {color} icon doesn’t accept backdrops. The icon colors that have backdrops are: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Actions"

--- a/locales/es.json
+++ b/locales/es.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Cerrar la navegación"
       }
     },
-    "Icon": {
-      "backdropWarning": "El ícono {color} no acepta fondos. Los colores de los íconos que tienen fondos son: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Acciones"

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Sulje navigointi"
       }
     },
-    "Icon": {
-      "backdropWarning": "{color} kuvake ei hyväksy taustoja. Kuvakevärit, joissa on tausta, ovat seuraavat: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Toiminnat"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Fermer la navigation"
       }
     },
-    "Icon": {
-      "backdropWarning": "L'icône {color} n'accepte pas les fonds. Les couleurs des icônes qui possèdent un fond sont : {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Actions"

--- a/locales/hi.json
+++ b/locales/hi.json
@@ -102,9 +102,6 @@
         "closeMobileNavigationLabel": "नेविगेशन बंद करें"
       }
     },
-    "Icon": {
-      "backdropWarning": "{color} आइकन बैकड्रॉप स्वीकार नहीं करता है. आइकन के वे रंग जिनमें बैकड्रॉप होते हैं: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "कार्रवाई"

--- a/locales/it.json
+++ b/locales/it.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Chiudi la navigazione"
       }
     },
-    "Icon": {
-      "backdropWarning": "L'icona {color} non accetta gli sfondi. I colori dell'icona con sfondi sono i seguenti: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Azioni"

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "メニューを閉じる"
       }
     },
-    "Icon": {
-      "backdropWarning": "{color}のアイコンは、背景を受け付けません。背景を持つアイコンの色は次のとおりです: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "アクション"

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "탐색 닫기"
       }
     },
-    "Icon": {
-      "backdropWarning": "{color} 아이콘에는 투명 무늬를 사용할 수 없습니다. 투명 무늬가 있는 아이콘 색상: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "작업"

--- a/locales/ms.json
+++ b/locales/ms.json
@@ -101,9 +101,6 @@
         "closeMobileNavigationLabel": "Tutup navigasi"
       }
     },
-    "Icon": {
-      "backdropWarning": "Ikon {color} tidak menerima latar belakang. Warna ikon yang mempunyai latar belakang adalah: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Tindakan"

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Lukk navigering"
       }
     },
-    "Icon": {
-      "backdropWarning": "{color}-ikonet godtar ikke bakgrunnsstiler. Ikonfargene som har bakgrunnsstiler, er: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Handlinger"

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Navigatie sluiten"
       }
     },
-    "Icon": {
-      "backdropWarning": "Het pictogram {color} accepteert geen achtergronden. De pictogramkleuren met achtergronden zijn: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Acties"

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Zamknij nawigację"
       }
     },
-    "Icon": {
-      "backdropWarning": "Ikona {color} nie akceptuje teł. Kolory ikon, które mają tło, są: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Czynności"

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Fechar a navegação"
       }
     },
-    "Icon": {
-      "backdropWarning": "O ícone {color} não aceita fundo. As cores dos ícones que têm fundos são: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Ações"

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Fechar a navegação"
       }
     },
-    "Icon": {
-      "backdropWarning": "O ícone {color} não aceita fundos. As cores dos ícones com fundos são: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Ações"

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Stäng navigering"
       }
     },
-    "Icon": {
-      "backdropWarning": "Ikonen {color} accepterar inte bakgrunder. Ikonfärgerna som har bakgrunder är: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Åtgärder"

--- a/locales/th.json
+++ b/locales/th.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "ปิดการนำทาง"
       }
     },
-    "Icon": {
-      "backdropWarning": "ไม่สามารถใช้ฉากหลังกับไอคอน {color} ได้ สีไอคอนที่มีฉากหลังคือ: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "การดำเนินการ"

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "Gezinmeyi kapat"
       }
     },
-    "Icon": {
-      "backdropWarning": "{color} renkli simgeye fon eklenmez. Fonu olan simge renkleri şunlardır: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "İşlemler"

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -117,9 +117,6 @@
         "closeMobileNavigationLabel": "Đóng menu điều hướng"
       }
     },
-    "Icon": {
-      "backdropWarning": "Biểu tượng {color} không chấp nhận phông nền. Màu biểu tượng có phông nền là: {colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "Thao tác"

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "关闭网站地图"
       }
     },
-    "Icon": {
-      "backdropWarning": "{color} 图标不能用于背景。可用于背景的图标颜色：{colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "编辑"

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -114,9 +114,6 @@
         "closeMobileNavigationLabel": "關閉導覽"
       }
     },
-    "Icon": {
-      "backdropWarning": "{color} 圖示不適用背景。有背景的圖示顏色為：{colorsWithBackDrops}"
-    },
     "ActionMenu": {
       "RollupActions": {
         "rollupButton": "動作"

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -14,14 +14,6 @@ type Color =
   | 'success'
   | 'primary';
 
-const COLORS_WITH_BACKDROPS = [
-  'base',
-  'critical',
-  'warning',
-  'highlight',
-  'success',
-];
-
 export interface IconProps {
   /** The SVG contents to display in the icon (icons should fit in a 20 × 20 pixel viewBox) */
   source: IconSource;
@@ -41,16 +33,6 @@ export function Icon({source, color, backdrop, accessibilityLabel}: IconProps) {
     sourceType = 'placeholder';
   } else {
     sourceType = 'external';
-  }
-
-  if (color && backdrop && !COLORS_WITH_BACKDROPS.includes(color)) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      i18n.translate('Polaris.Icon.backdropWarning', {
-        color,
-        colorsWithBackDrops: COLORS_WITH_BACKDROPS.join(', '),
-      }),
-    );
   }
 
   if (color && sourceType === 'external') {


### PR DESCRIPTION


### WHY are these changes introduced?

This got removed in v6, then a merge from main brought it back. Now I'm getting rid of it again


### WHAT is this pull request doing?
Removing Icon Backdrop warning message
