### PR TITLE
Default to new Design Language in storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -55,7 +55,7 @@ function AppProviderWithKnobs(
   );
 }
 
-const preferredTheme = process.env.STORYBOOK_NEWDESIGNLANGUAGE || 'purpler';
+const preferredTheme = process.env.STORYBOOK_NEWDESIGNLANGUAGE || 'light';
 
 const withContextsDecorator = withContexts([
   {

--- a/scripts/accessibility-check.js
+++ b/scripts/accessibility-check.js
@@ -25,7 +25,7 @@ const getUrls = async (browser) => {
       const url = `${iframePath}?id=${story.id}`;
       memo.push(
         url,
-        `${url}&contexts=New%20Design%20Language%3DEnabled%20-%20Light%20Mode`,
+        `${url}&contexts=New%20Design%20Language%3DDisabled`,
         // Dark mode has lots of errors. It is still very WIP so ignore for now
         // `${url}&contexts=New%20Design%20Language%3DEnabled%20-%20Dark%20Mode`,
       );


### PR DESCRIPTION
### WHY are these changes introduced?

Getting ready for v6. By defaulting to the new DL in storybook we get to compare the version-6.0.0 branch against main so we can check for regressions.

### WHAT is this pull request doing?

Change the default rendering in Storybook to use the new design language.

This is going to do a number on percy on this PR but accepting everything here as a new baseline, then comparing v6 against this new baseline will help us catch regressions.
