### PR TITLE
Remove Page separator prop as pages never have a separator

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed `button-filled-disabled` and `plain-button-background` SASS mixins ([#3817](https://github.com/Shopify/polaris-react/pull/3817))
 - Removed `text-emphasis-placeholder` SASS mixin ([#3889](https://github.com/Shopify/polaris-react/pull/3889))
 - Removed `plain` property in `Pagination` as it no longer has any effect. ([#3833](https://github.com/Shopify/polaris-react/pull/3833))
+- Removed `separator` property in `Page` as it no longer has any effect. ([#3918](https://github.com/Shopify/polaris-react/pull/3918))
 
 ### Enhancements
 

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -19,7 +19,6 @@ keywords:
   - full-width page
   - narrow-width page
   - page with action groups
-  - page with separator
   - outer wrapper
   - page actions
   - page layouts
@@ -174,7 +173,6 @@ Use for detail pages, which should have pagination and breadcrumbs, and also oft
     hasNext: true,
   }}
   additionalNavigation={<Avatar size="small" initials="CD" customer={false} />}
-  separator
 >
   <p>Page content</p>
 </Page>
@@ -427,22 +425,6 @@ Use action groups for sets of actions that relate to one another, particularly w
   ]}
 >
   <p>Page content</p>
-</Page>
-```
-
-### Page with separator
-
-<!-- example-for: web -->
-
-Use a separator for pages that have an [empty state](https://polaris.shopify.com/components/structure/empty-state) as their only content, or that have an [annotated section](https://polaris.shopify.com/components/structure/layout) as the first component on the page.
-
-```jsx
-<Page title="Settings" separator>
-  <Layout>
-    <Layout.AnnotatedSection title="Store details">
-      <p>Annotated section content</p>
-    </Layout.AnnotatedSection>
-  </Layout>
 </Page>
 ```
 

--- a/src/components/Page/components/Header/Header.scss
+++ b/src/components/Page/components/Header/Header.scss
@@ -12,11 +12,6 @@ $action-menu-rollup-computed-width: rem(40px);
   position: relative;
 }
 
-.separator {
-  padding-bottom: spacing();
-  border-bottom: var(--p-override-none);
-}
-
 .titleHidden {
   @include visually-hidden;
 }

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -37,8 +37,6 @@ interface PrimaryAction
 export interface HeaderProps extends TitleProps {
   /** Visually hide the title */
   titleHidden?: boolean;
-  /** Adds a border to the bottom of the page header */
-  separator?: boolean;
   /** Primary page-level action */
   primaryAction?: PrimaryAction | React.ReactNode;
   /** Page-level pagination */
@@ -72,7 +70,6 @@ export function Header({
   additionalMetaData,
   thumbnail,
   titleHidden = false,
-  separator,
   primaryAction,
   pagination,
   additionalNavigation,
@@ -148,7 +145,6 @@ export function Header({
 
   const headerClassNames = classNames(
     styles.Header,
-    separator && styles.separator,
     isSingleRow && styles.isSingleRow,
     titleHidden && styles.titleHidden,
     navigationMarkup && styles.hasNavigation,


### PR DESCRIPTION
### WHY are these changes introduced?

In the new DL Pages never have separators.

This also fixes a spacing regression between main and version-6.0.0

### WHAT is this pull request doing?

Remove the spacing prop on Page