### PR TITLE
Fix SkeletonPage vertical padding

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed `Popover`/`PopoverOverlay`'s `preventAutoFocus` prop. Consumers should use `autofocusTarget="none"` instead ([#3884](https://github.com/Shopify/polaris-react/pull/3884))
 - Removed `button-filled-disabled` and `plain-button-background` SASS mixins ([#3817](https://github.com/Shopify/polaris-react/pull/3817))
 - Removed `text-emphasis-placeholder` SASS mixin ([#3889](https://github.com/Shopify/polaris-react/pull/3889))
+- Remove `skeleton-page-header-has-secondary-actions` Sass mixin ([#3919](https://github.com/Shopify/polaris-react/pull/3919))
 - Removed `plain` property in `Pagination` as it no longer has any effect. ([#3833](https://github.com/Shopify/polaris-react/pull/3833))
 - Removed `separator` property in `Page` as it no longer has any effect. ([#3918](https://github.com/Shopify/polaris-react/pull/3918))
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,7 +16,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed `Popover`/`PopoverOverlay`'s `preventAutoFocus` prop. Consumers should use `autofocusTarget="none"` instead ([#3884](https://github.com/Shopify/polaris-react/pull/3884))
 - Removed `button-filled-disabled` and `plain-button-background` SASS mixins ([#3817](https://github.com/Shopify/polaris-react/pull/3817))
 - Removed `text-emphasis-placeholder` SASS mixin ([#3889](https://github.com/Shopify/polaris-react/pull/3889))
-- Remove `skeleton-page-header-has-secondary-actions` Sass mixin ([#3919](https://github.com/Shopify/polaris-react/pull/3919))
+- Removed `skeleton-page-header-has-secondary-actions` Sass mixin ([#3919](https://github.com/Shopify/polaris-react/pull/3919))
 - Removed `plain` property in `Pagination` as it no longer has any effect. ([#3833](https://github.com/Shopify/polaris-react/pull/3833))
 - Removed `separator` property in `Page` as it no longer has any effect. ([#3918](https://github.com/Shopify/polaris-react/pull/3918))
 

--- a/src/components/SkeletonPage/SkeletonPage.scss
+++ b/src/components/SkeletonPage/SkeletonPage.scss
@@ -26,10 +26,6 @@ $skeleton-display-text-max-width: rem(120px);
   @include skeleton-page-header-layout;
 }
 
-.Header-hasSecondaryActions {
-  @include skeleton-page-header-has-secondary-actions;
-}
-
 .BreadcrumbAction {
   padding-top: spacing(base);
   padding-bottom: spacing(base);

--- a/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/src/components/SkeletonPage/SkeletonPage.tsx
@@ -41,12 +41,6 @@ export function SkeletonPage({
     narrowWidth && styles.narrowWidth,
   );
 
-  const headerClassName = classNames(
-    styles.Header,
-    breadcrumbs && styles['Header-hasBreadcrumbs'],
-    secondaryActions && styles['Header-hasSecondaryActions'],
-  );
-
   const titleContent = title ? (
     <h1 className={styles.Title}>{title}</h1>
   ) : (
@@ -77,7 +71,7 @@ export function SkeletonPage({
       role="status"
       aria-label={i18n.translate('Polaris.SkeletonPage.loadingLabel')}
     >
-      <div className={headerClassName}>
+      <div className={styles.Header}>
         {breadcrumbMarkup}
         <div className={styles.TitleAndPrimaryAction}>
           {titleMarkup}

--- a/src/styles/shared/_skeleton.scss
+++ b/src/styles/shared/_skeleton.scss
@@ -53,11 +53,6 @@ $thumbnail-sizes: (
   align-items: center;
 }
 
-@mixin skeleton-page-header-has-secondary-actions {
-  padding-top: rem(24px);
-  margin-top: 0;
-}
-
 @mixin skeleton-page-header-layout {
   padding-bottom: spacing(tight);
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixing regression between v6 and main.


### WHAT is this pull request doing?

- Remove SkeletonPage vertical padding
- BREAKING CHANGE: Remove skeleton-page-header-has-secondary-actions mixin as it is never
used
