### PR TITLE
Change disclosure icon color with prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -23,6 +23,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Removed duplicate color definition from disclosure `Icon` in `Tabs` ([#3926](https://github.com/Shopify/polaris-react/pull/3926))
+
 ### Bug fixes
 
 - Fixed an accessibility issue where high contrast styles wouldn’t be applied to the `Tag` component ([#3810](https://github.com/Shopify/polaris-react/pull/3810))

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -201,10 +201,8 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 }
 
 .DisclosureActivator {
-  @include recolor-icon(var(--p-icon-subdued));
   @include focus-ring;
   height: 100%;
-  background-color: transparent;
   cursor: pointer;
   border: none;
   outline: none;

--- a/src/components/Tabs/Tabs.scss
+++ b/src/components/Tabs/Tabs.scss
@@ -203,6 +203,7 @@ $focus-state-box-shadow-color: rgba(0, 0, 0, 0.8);
 .DisclosureActivator {
   @include focus-ring;
   height: 100%;
+  background-color: transparent;
   cursor: pointer;
   border: none;
   outline: none;

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -125,7 +125,7 @@ class TabsInner extends PureComponent<CombinedProps, State> {
     const disclosureButtonContent = hasCustomDisclosure ? (
       <>
         {disclosureText}
-        <Icon source={CaretDownMinor} color="base" />
+        <Icon source={CaretDownMinor} color="subdued" />
       </>
     ) : (
       <Icon source={HorizontalDotsMinor} />

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -128,7 +128,7 @@ class TabsInner extends PureComponent<CombinedProps, State> {
         <Icon source={CaretDownMinor} color="subdued" />
       </>
     ) : (
-      <Icon source={HorizontalDotsMinor} />
+      <Icon source={HorizontalDotsMinor} color="subdued" />
     );
 
     const disclosureButton = (


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3925

### WHAT is this pull request doing?

The icon color was set in SASS and incorrect on the icon. This removes the SASS and provides the color through the Icon component.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
