### PR TITLE
[Modal, Frame(Nav), Sheet] Trapped virtual cursor inside dialogs

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,8 +9,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed virtual cursor leaving dialog in `Modal`, `Navigation` and `Sheet` ([#3931](https://github.com/Shopify/polaris-react/pull/3931))
-- Fixed an accessibility issue where high contrast styles wouldn’t be applied to the `Tag` component ([#3810](https://github.com/Shopify/polaris-react/pull/3810))
-- Fixed `ColorPicker` checker background to remain visible on a white background ([#3812](https://github.com/Shopify/polaris-react/pull/3812))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,10 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed virtual cursor leaving dialog in `Modal`, `Navigation` and `Sheet` ([#3931](https://github.com/Shopify/polaris-react/pull/3931))
+- Fixed an accessibility issue where high contrast styles wouldn’t be applied to the `Tag` component ([#3810](https://github.com/Shopify/polaris-react/pull/3810))
+- Fixed `ColorPicker` checker background to remain visible on a white background ([#3812](https://github.com/Shopify/polaris-react/pull/3812))
+
 ### Documentation
 
 ### Development workflow

--- a/locales/en.json
+++ b/locales/en.json
@@ -113,6 +113,7 @@
     },
     "Frame": {
       "skipToContent": "Skip to content",
+      "navigationLabel": "Navigation",
       "Navigation": {
         "closeMobileNavigationLabel": "Close navigation"
       }

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -135,6 +135,8 @@ class FrameInner extends PureComponent<CombinedProps, State> {
           classNames={navTransitionClasses}
         >
           <div
+            aria-modal
+            role="dialog"
             ref={this.navigationNode}
             className={navClassName}
             onKeyDown={this.handleNavKeydown}

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -124,6 +124,13 @@ class FrameInner extends PureComponent<CombinedProps, State> {
     const mobileNavShowing = isNavigationCollapsed && showMobileNavigation;
     const tabIndex = mobileNavShowing ? 0 : -1;
 
+    const mobileNavAttributes = {
+      ...(mobileNavShowing && {
+        'aria-modal': true,
+        role: 'dialog',
+      }),
+    };
+
     const navigationMarkup = navigation ? (
       <TrapFocus trapping={mobileNavShowing}>
         <CSSTransition
@@ -135,8 +142,7 @@ class FrameInner extends PureComponent<CombinedProps, State> {
           classNames={navTransitionClasses}
         >
           <div
-            aria-modal
-            role="dialog"
+            {...mobileNavAttributes}
             aria-label={i18n.translate('Polaris.Frame.navigationLabel')}
             ref={this.navigationNode}
             className={navClassName}

--- a/src/components/Frame/Frame.tsx
+++ b/src/components/Frame/Frame.tsx
@@ -137,6 +137,7 @@ class FrameInner extends PureComponent<CombinedProps, State> {
           <div
             aria-modal
             role="dialog"
+            aria-label={i18n.translate('Polaris.Frame.navigationLabel')}
             ref={this.navigationNode}
             className={navClassName}
             onKeyDown={this.handleNavKeydown}

--- a/src/components/Frame/README.md
+++ b/src/components/Frame/README.md
@@ -346,6 +346,7 @@ function FrameExample() {
             },
             Frame: {
               skipToContent: 'Skip to content',
+              navigationLabel: 'Navigation',
               Navigation: {
                 closeMobileNavigationLabel: 'Close navigation',
               },
@@ -680,6 +681,7 @@ function FrameExample() {
             },
             Frame: {
               skipToContent: 'Skip to content',
+              navigationLabel: 'Navigation',
               Navigation: {
                 closeMobileNavigationLabel: 'Close navigation',
               },

--- a/src/components/Frame/tests/Frame.test.tsx
+++ b/src/components/Frame/tests/Frame.test.tsx
@@ -224,6 +224,32 @@ describe('<Frame />', () => {
 
       expect(spy).toHaveBeenCalledTimes(1);
     });
+
+    it('renders mobile accessibility attributes on small screens', () => {
+      const navigation = <div />;
+      const frame = mountWithApp(
+        <Frame showMobileNavigation navigation={navigation} />,
+        {mediaQuery: {isNavigationCollapsed: true}},
+      );
+
+      expect(frame).toContainReactComponent('div', {
+        'aria-modal': true,
+        role: 'dialog',
+      });
+    });
+
+    it('does not render mobile accessibility attributes on large screens', () => {
+      const navigation = <div />;
+      const frame = mountWithApp(
+        <Frame showMobileNavigation navigation={navigation} />,
+        {mediaQuery: {isNavigationCollapsed: false}},
+      );
+
+      expect(frame).not.toContainReactComponent('div', {
+        'aria-modal': true,
+        role: 'dialog',
+      });
+    });
   });
 
   describe('globalRibbon', () => {

--- a/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/src/components/Modal/components/Dialog/Dialog.tsx
@@ -66,6 +66,7 @@ export function Dialog({
         <TrapFocus>
           <div
             role="dialog"
+            aria-modal
             aria-labelledby={labelledBy}
             tabIndex={-1}
             className={styles.Dialog}

--- a/src/components/Sheet/Sheet.tsx
+++ b/src/components/Sheet/Sheet.tsx
@@ -76,6 +76,7 @@ export function Sheet({
           <TrapFocus trapping={open}>
             <div
               role="dialog"
+              aria-modal
               tabIndex={-1}
               className={styles.Sheet}
               aria-label={accessibilityLabel}


### PR DESCRIPTION
### WHY are these changes introduced?

Keyboard focus is trapped whoever virtual cursors are not

### Current keyboard trapping

|Modal|Sheet|Nav|
|-|-|-|
|![key-modal](https://user-images.githubusercontent.com/24610840/106061999-270dbb80-60c4-11eb-8828-d920f92b1e85.gif)|![key-sheet](https://user-images.githubusercontent.com/24610840/106062018-2ecd6000-60c4-11eb-91e0-60e1b9873222.gif)|![key-nav](https://user-images.githubusercontent.com/24610840/106062035-37259b00-60c4-11eb-8e5b-e1e79eede5e2.gif)|

### Before/After virtual cursor navigation

||Before|After|
|-|-|-|
|<b>Modal</b>|![vc-modal-old](https://user-images.githubusercontent.com/24610840/106062455-ce8aee00-60c4-11eb-9178-93e93e1ac26e.gif)|![key-modal](https://user-images.githubusercontent.com/24610840/106062489-d77bbf80-60c4-11eb-801f-34189bb8b93e.gif)|
|<b>Sheet</b>|![vc-sheet-old](https://user-images.githubusercontent.com/24610840/106062517-e19dbe00-60c4-11eb-8bb5-602cf063c013.gif)|![vc-sheet](https://user-images.githubusercontent.com/24610840/106062548-ebbfbc80-60c4-11eb-9f28-cbb21d0d8c1f.gif)|
|<b>Nav</b>|![vc-nav-old](https://user-images.githubusercontent.com/24610840/106062563-f37f6100-60c4-11eb-9b47-ce0693c4b70c.gif)|![vc-nav](https://user-images.githubusercontent.com/24610840/106062587-f8441500-60c4-11eb-8081-8ed43bd7f38f.gif)|

### WHAT is this pull request doing?

* Make using of the aria-modal & role attribute to trap virtual cursors in dialogs

### How to 🎩

* Loading storybook and play around modal/nav/sheet with a virtual cursor
