### PR TITLE
[Popover] Add zIndexOverride prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added `statusAndProgressLabelOverride` prop to `Badge` ([#4028](https://github.com/Shopify/polaris-react/pull/4028))
+- Added `zIndexOverride` prop to `Popover` ([#3937](https://github.com/Shopify/polaris-react/pull/3937))
 
 ### Bug fixes
 

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -49,6 +49,8 @@ export interface PopoverProps {
    * @default 'div'
    */
   activatorWrapper?: string;
+  /** Override on the default z-index of 400 */
+  zIndexOverride?: number;
   /** Prevents focusing the activator or the next focusable element when the popover is deactivated */
   preventFocusOnClose?: boolean;
   /** Automatically add wrap content in a section */
@@ -95,6 +97,7 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
   ariaHaspopup,
   preferInputActivator = true,
   colorScheme,
+  zIndexOverride,
   ...rest
 }: PopoverProps) {
   const [activatorNode, setActivatorNode] = useState<HTMLElement>();
@@ -182,6 +185,7 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
         active={active}
         fixed={fixed}
         colorScheme={colorScheme}
+        zIndexOverride={zIndexOverride}
         {...rest}
       >
         {children}

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -44,6 +44,7 @@ export interface PopoverOverlayProps {
   preferredAlignment?: PositionedOverlayProps['preferredAlignment'];
   active: boolean;
   id: string;
+  zIndexOverride?: number;
   activator: HTMLElement;
   preferInputActivator?: PositionedOverlayProps['preferInputActivator'];
   sectioned?: boolean;
@@ -118,6 +119,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
       preferredAlignment = 'center',
       preferInputActivator = true,
       fixed,
+      zIndexOverride,
     } = this.props;
     const {transitionStatus} = this.state;
     if (transitionStatus === TransitionStatus.Exited && !active) return null;
@@ -145,6 +147,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
         fixed={fixed}
         onScrollOut={this.handleScrollOut}
         classNames={className}
+        zIndexOverride={zIndexOverride}
       />
     );
   }

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -170,6 +170,24 @@ describe('<PopoverOverlay />', () => {
     ).toBe(false);
   });
 
+  it('passes zIndexOverride to PositionedOverlay', () => {
+    const popoverOverlay = mountWithApp(
+      <PopoverOverlay
+        active
+        zIndexOverride={100}
+        id="PopoverOverlay-1"
+        activator={activator}
+        onClose={noop}
+      >
+        {children}
+      </PopoverOverlay>,
+    );
+
+    expect(popoverOverlay).toContainReactComponent(PositionedOverlay, {
+      zIndexOverride: 100,
+    });
+  });
+
   it("doesn't include a tabindex prop when autofocusTarget is 'none'", () => {
     const popoverOverlay = mountWithAppProvider(
       <PopoverOverlay

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -46,7 +46,6 @@ describe('<Popover />', () => {
         onClose={spy}
       />,
     );
-
     expect(setActivatorAttributesSpy).toHaveBeenLastCalledWith(
       expect.any(Object),
       {
@@ -218,6 +217,21 @@ describe('<Popover />', () => {
     );
     expect(popover).toContainReactComponent(PopoverOverlay, {
       fluidContent: true,
+    });
+  });
+
+  it("passes 'zIndexOverride' to PopoverOverlay", () => {
+    const popover = mountWithApp(
+      <Popover
+        active={false}
+        zIndexOverride={100}
+        activator={<div>Activator</div>}
+        onClose={spy}
+      />,
+    );
+
+    expect(popover).toContainReactComponent(PopoverOverlay, {
+      zIndexOverride: 100,
     });
   });
 

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -38,6 +38,7 @@ export interface PositionedOverlayProps {
   fixed?: boolean;
   preventInteraction?: boolean;
   classNames?: string;
+  zIndexOverride?: number;
   render(overlayDetails: OverlayDetails): React.ReactNode;
   onScrollOut?(): void;
 }
@@ -127,6 +128,7 @@ export class PositionedOverlay extends PureComponent<
       fixed,
       preventInteraction,
       classNames: propClassNames,
+      zIndexOverride,
     } = this.props;
 
     const style = {
@@ -134,7 +136,10 @@ export class PositionedOverlay extends PureComponent<
       left: left == null || isNaN(left) ? undefined : left,
       right: right == null || isNaN(right) ? undefined : right,
       width: width == null || isNaN(width) ? undefined : width,
-      zIndex: zIndex == null || isNaN(zIndex) ? undefined : zIndex,
+      zIndex:
+        !zIndexOverride && (zIndex == null || isNaN(zIndex))
+          ? undefined
+          : zIndexOverride || zIndex,
     };
 
     const className = classNames(

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -136,10 +136,7 @@ export class PositionedOverlay extends PureComponent<
       left: left == null || isNaN(left) ? undefined : left,
       right: right == null || isNaN(right) ? undefined : right,
       width: width == null || isNaN(width) ? undefined : width,
-      zIndex:
-        !zIndexOverride && (zIndex == null || isNaN(zIndex))
-          ? undefined
-          : zIndexOverride || zIndex,
+      zIndex: zIndexOverride || zIndex || undefined,
     };
 
     const className = classNames(

--- a/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -114,6 +114,37 @@ describe('<PositionedOverlay />', () => {
     });
   });
 
+  describe('zIndex', () => {
+    it('is undefined if no state or prop override exist', () => {
+      const positionedOverlay = mountWithAppProvider(
+        <PositionedOverlay {...mockProps} />,
+      );
+      expect(
+        (positionedOverlay.find('div').prop('style') as any).zIndex,
+      ).toBeUndefined();
+    });
+
+    it('is set to state calculated value if no override prop is given', () => {
+      const positionedOverlay = mountWithAppProvider(
+        <PositionedOverlay {...mockProps} />,
+      );
+      positionedOverlay.setState({zIndex: 200});
+      expect((positionedOverlay.find('div').prop('style') as any).zIndex).toBe(
+        200,
+      );
+    });
+
+    it('is set to value of zIndexOverride prop if given', () => {
+      const positionedOverlay = mountWithAppProvider(
+        <PositionedOverlay {...mockProps} zIndexOverride={100} />,
+      );
+      positionedOverlay.setState({zIndex: 200});
+      expect((positionedOverlay.find('div').prop('style') as any).zIndex).toBe(
+        100,
+      );
+    });
+  });
+
   describe('preventInteraction', () => {
     it('passes preventInteraction to PositionedOverlay when preventInteraction is true', () => {
       const positionedOverlay = mountWithAppProvider(


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-ux/issues/602

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Popover} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Popover
        active
        activator={<div>asdf</div>}
        onClose={() => {}}
        zIndexOverride={402}
      >
        <ul>
          <li>one</li>
          <li>two</li>
        </ul>
      </Popover>
      <div style={{background: 'red', zIndex: 401, position: 'relative'}}>
        some content
      </div>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
