### PR TITLE
[Icon] Fix issue where currentColor defaults to black

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fix issue with currentColor in icons is black instead of white ([#3938](https://github.com/Shopify/polaris-react/pull/3938))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/Icon/Icon.scss
+++ b/src/components/Icon/Icon.scss
@@ -9,6 +9,10 @@
   margin: auto;
 }
 
+.isColored {
+  color: var(--p-surface);
+}
+
 .hasBackdrop {
   position: relative;
   display: flex;

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -45,6 +45,7 @@ export function Icon({source, color, backdrop, accessibilityLabel}: IconProps) {
   const className = classNames(
     styles.Icon,
     color && styles[variationName('color', color)],
+    color && styles.isColored,
     backdrop && styles.hasBackdrop,
   );
 

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -69,7 +69,7 @@ Specify an SVG as a string to render it in an image tag, instead of an inline SV
 <Icon source="<svg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'><path d='M10.707 17.707l5-5a.999.999 0 1 0-1.414-1.414L11 14.586V3a1 1 0 1 0-2 0v11.586l-3.293-3.293a.999.999 0 1 0-1.414 1.414l5 5a.999.999 0 0 0 1.414 0' /></svg>" />
 ```
 
-### User provided icon with currentColor
+### User provided icon with color and currentColor
 
 When using changing color of an svg and it uses currentColor, the white color is applied.
 

--- a/src/components/Icon/README.md
+++ b/src/components/Icon/README.md
@@ -31,12 +31,62 @@ Use to visually communicate core parts of the product and available actions.
 <Icon source={CirclePlusMinor} />
 ```
 
+### Colored icon
+
+Apply a color to the icon.
+
+```jsx
+<>
+  <Icon source={CirclePlusMinor} color="base" />
+  <Icon source={CirclePlusMinor} color="subdued" />
+  <Icon source={CirclePlusMinor} color="primary" />
+  <Icon source={CirclePlusMinor} color="highlight" />
+  <Icon source={CirclePlusMinor} color="success" />
+  <Icon source={CirclePlusMinor} color="warning" />
+  <Icon source={CirclePlusMinor} color="critical" />
+</>
+```
+
+### Icon with backdrop
+
+Apply a backdrop to the icon.
+
+```jsx
+<>
+  <Icon source={CirclePlusMinor} color="base" backdrop />
+  <Icon source={CirclePlusMinor} color="highlight" backdrop />
+  <Icon source={CirclePlusMinor} color="success" backdrop />
+  <Icon source={CirclePlusMinor} color="warning" backdrop />
+  <Icon source={CirclePlusMinor} color="critical" backdrop />
+</>
+```
+
 ### User provided icon
 
 Specify an SVG as a string to render it in an image tag, instead of an inline SVG to prevent script injection.
 
 ```jsx
 <Icon source="<svg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'><path d='M10.707 17.707l5-5a.999.999 0 1 0-1.414-1.414L11 14.586V3a1 1 0 1 0-2 0v11.586l-3.293-3.293a.999.999 0 1 0-1.414 1.414l5 5a.999.999 0 0 0 1.414 0' /></svg>" />
+```
+
+### User provided icon with currentColor
+
+When using changing color of an svg and it uses currentColor, the white color is applied.
+
+```jsx
+function IconWithReactChild() {
+  const iconContent = () => {
+    return (
+      <svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="10" cy="10" r="10" fill="rebeccapurple" />
+        <circle cx="10" cy="10" r="6" fill="currentColor" />
+        <circle cx="10" cy="10" r="3" />
+      </svg>
+    );
+  };
+
+  return <Icon source={iconContent} color="warning" />;
+}
 ```
 
 ---

--- a/src/components/Icon/tests/Icon.test.tsx
+++ b/src/components/Icon/tests/Icon.test.tsx
@@ -40,7 +40,7 @@ describe('<Icon />', () => {
       const element = mountWithApp(<Icon source="placeholder" color="base" />);
 
       expect(element).toContainReactComponent('span', {
-        className: 'Icon colorBase',
+        className: 'Icon colorBase isColored',
       });
     });
   });


### PR DESCRIPTION
### WHY are these changes introduced?

Icons in the admin are defaulting the currentColor to black.

![Screen Shot 2021-01-28 at 1 32 35 PM](https://user-images.githubusercontent.com/19199063/106223744-dca93f00-6196-11eb-81b5-04a72e729a61.png)

### WHAT is this pull request doing?

This adds back the `.isColored` classname and functionality back and adds visual examples.


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
