### PR TITLE
Add prop docs to generated storybook docs pages

### DIFF
--- a/.storybook/polaris-readme-loader.js
+++ b/.storybook/polaris-readme-loader.js
@@ -3,6 +3,7 @@ const chalk = require('chalk');
 const grayMatter = require('gray-matter');
 const MdParser = require('./md-parser');
 const React = require('react');
+const lodash = require('lodash');
 
 const HOOK_PREFIX = 'use';
 
@@ -250,7 +251,10 @@ import {
   ViewMinor,
 } from '@shopify/polaris-icons';
 
-export default { title: ${JSON.stringify(`All Components/${readme.name}`)} };
+export default {
+  title: ${JSON.stringify(`All Components/${readme.name}`)},
+  component: ${readme.component},
+};
 
 ${csfExports.join('\n\n')}
 `;
@@ -283,11 +287,13 @@ function isExampleForPlatform(exampleMarkdown, platform) {
 
 function parseCodeExamples(data) {
   const matter = grayMatter(data);
+  const examples = generateExamples(matter);
 
   return {
     name: matter.data.name,
     category: matter.data.category,
-    examples: generateExamples(matter),
+    component: examples.length ? toPascalCase(matter.data.name) : undefined,
+    examples,
     omitAppProvider: matter.data.omitAppProvider || false,
   };
 }
@@ -429,4 +435,8 @@ function wrapExample(code) {
     return JsxOnlyExample;
   }`;
   }
+}
+
+function toPascalCase(str) {
+  return lodash.startCase(lodash.camelCase(str)).replace(/ /g, '');
 }

--- a/scripts/accessibility-check.js
+++ b/scripts/accessibility-check.js
@@ -14,15 +14,15 @@ const getUrls = async (browser) => {
   // Get the URLS from storybook
   const page = await browser.newPage();
   await page.goto(iframePath);
-  const stories = await page.evaluate(() =>
-    window.__STORYBOOK_CLIENT_API__.raw(),
+  const storyIds = await page.evaluate(() =>
+    window.__STORYBOOK_CLIENT_API__.raw().map((story) => story.id),
   );
   await page.close();
 
-  const urls = stories.reduce((memo, story) => {
+  const urls = storyIds.reduce((memo, storyId) => {
     // If it is a story id that is not in excludedStoryIds
-    if (skippedStoryIds.every((id) => !story.id.includes(id))) {
-      const url = `${iframePath}?id=${story.id}`;
+    if (skippedStoryIds.every((id) => !storyId.includes(id))) {
+      const url = `${iframePath}?id=${storyId}`;
       memo.push(
         url,
         // Dark mode has lots of errors. It is still very WIP so ignore for now


### PR DESCRIPTION
### WHY are these changes introduced?

Storybook generates docs pages for us. Let's teach it about where to pull component docs from.

Splitting off part of the functionality of #2888 which is general investigative PR

### WHAT is this pull request doing?

Teaching storybook what what component corresponds to each README file.

### How to 🎩

- open storybook
- Load docs page for any story generated by a README file (which is everything but the playground)
- See that a props table is generated and displayed.