### PR TITLE
[Tooltip] Fixed the issue with tooltip not opening in iOS when used as suffix in a TextField

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Fixed virtual cursor leaving dialog in `Modal`, `Navigation` and `Sheet` ([#3931](https://github.com/Shopify/polaris-react/pull/3931))
 - Simplified output of `Badge`'s css ([#3950](https://github.com/Shopify/polaris-react/pull/3950))
+- Fixed click propagation that was preventing the `Tooltip` to open when used as suffix on a `TextField` ([#3956](https://github.com/Shopify/polaris-react/issues/3956))
 
 ### Documentation
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -93,6 +93,7 @@ export function Tooltip({
       onBlur={handleBlur}
       onMouseLeave={handleMouseLeave}
       onMouseOver={handleMouseEnterFix}
+      onClick={stopPropagation}
       ref={setActivator}
       onKeyUp={handleKeyUp}
     >
@@ -133,3 +134,7 @@ export function Tooltip({
 }
 
 function noop() {}
+
+function stopPropagation(event: React.MouseEvent<any>) {
+  event.stopPropagation();
+}

--- a/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -102,4 +102,20 @@ describe('<Tooltip />', () => {
       accessibilityLabel,
     });
   });
+
+  it('does not propagate click to wrappers', () => {
+    const spyFn = jest.fn();
+    const tooltip = mountWithAppProvider(
+      <div onClick={spyFn}>
+        <Tooltip content="Inner content">
+          <Link>link content</Link>
+        </Tooltip>
+      </div>,
+    );
+
+    const wrapperComponent = findByTestID(tooltip, 'WrapperComponent');
+    wrapperComponent.simulate('click');
+
+    expect(spyFn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3956

### WHAT is this pull request doing?

| Before        | After|
| ------------- |:-------------:|
|![](https://camo.githubusercontent.com/ab26598ecfcf3bb31aa2786c403a1111583429e0edf8504ce90a90a4efda63a6/68747470733a2f2f73637265656e73686f742e636c69636b2f30322d31372d6c36307a6e2d6a36786c6f2e676966)      | ![](https://screenshot.click/02-11-k8oxb-6ph1i.gif)|


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

In order to tophat this you can copy and paste the following code in the playground and open it with Apple Simulator to see the behaviour illustrated in the gifs above.

```jsx
function TooltipTextFieldExample() {
  const [value, setValue] = useState('');
  const handleChange = useCallback((newValue) => setValue(newValue), []);
  return (
    <div style={{padding: '75px 0', width: '300px'}}>
      <TextField
        id="atPrice"
        value={value}
        label="Compare at price"
        onChange={handleChange}
        suffix={
          <Tooltip content="To show a reduced price, move the variant's original price into Compare at price. Enter a lower value into Price.">
            <Icon source={QuestionMarkMinor} />
          </Tooltip>
        }
      />
    </div>
  );
}
```

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
