### PR TITLE
[a11y]: Remove outline & border uses of ms-high-contrast

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -31,6 +31,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Update `Toast` close button alignment for small views ([#4006](https://github.com/Shopify/polaris-react/pull/4006))
 - Fixed `Collapsible` bug where animation complete logic was being prematurely triggered by transitions in the children ([#4000](https://github.com/Shopify/polaris-react/pull/4000))
 - Fixed `IndexTable` bug where bulk actions are operable when no rows are selected ([#4009](https://github.com/Shopify/polaris-react/pull/4009))
+- Fixed `CheckableButton` missing border when focused ([#3987](https://github.com/Shopify/polaris-react/issues/3987))
+- Removed all `outline` and `border`instances of `-ms-high-contrast` as it is non-standard and updated the outline color from `windowText` to `transparent` ([#3962](https://github.com/Shopify/polaris-react/pull/3962)).
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -32,7 +32,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `Collapsible` bug where animation complete logic was being prematurely triggered by transitions in the children ([#4000](https://github.com/Shopify/polaris-react/pull/4000))
 - Fixed `IndexTable` bug where bulk actions are operable when no rows are selected ([#4009](https://github.com/Shopify/polaris-react/pull/4009))
 - Fixed `CheckableButton` missing border when focused ([#3987](https://github.com/Shopify/polaris-react/issues/3987))
-- Removed all `outline` and `border`instances of `-ms-high-contrast` as it is non-standard and updated the outline color from `windowText` to `transparent` ([#3962](https://github.com/Shopify/polaris-react/pull/3962)).
 - Removed all `outline` and `border`instances of `-ms-high-contrast` as it is non-standard ([#3962](https://github.com/Shopify/polaris-react/pull/3962)).
 
 ### Documentation

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -33,6 +33,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `IndexTable` bug where bulk actions are operable when no rows are selected ([#4009](https://github.com/Shopify/polaris-react/pull/4009))
 - Fixed `CheckableButton` missing border when focused ([#3987](https://github.com/Shopify/polaris-react/issues/3987))
 - Removed all `outline` and `border`instances of `-ms-high-contrast` as it is non-standard and updated the outline color from `windowText` to `transparent` ([#3962](https://github.com/Shopify/polaris-react/pull/3962)).
+- Removed all `outline` and `border`instances of `-ms-high-contrast` as it is non-standard ([#3962](https://github.com/Shopify/polaris-react/pull/3962)).
 
 ### Documentation
 

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -52,15 +52,14 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   cursor: pointer;
   padding: $item-vertical-padding spacing(tight);
   border-radius: var(--p-border-radius-base);
-  border-top: 1px solid var(--p-surface); // 1px gap between elements
+  border-top: 1px solid transparent var(--p-surface); // 1px gap between elements
+  outline: 1px solid transparent;
 
   &:hover {
     background-color: var(--p-surface-hovered);
     text-decoration: none;
 
-    @media (-ms-high-contrast: active) {
-      outline: 1px solid ms-high-contrast-color('text');
-    }
+    @include high-contrast-outline($border-width: border-width(thicker));
   }
 
   &.active {
@@ -79,6 +78,7 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
 
   &:focus:not(:active) {
     @include focus-ring($style: 'focused');
+    @include high-contrast-outline($border-width: border-width(thicker));
   }
 
   &.destructive {

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -52,7 +52,6 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   cursor: pointer;
   padding: $item-vertical-padding spacing(tight);
   border-radius: var(--p-border-radius-base);
-  border-top: 1px solid transparent var(--p-surface); // 1px gap between elements
   outline: 1px solid transparent;
 
   &:hover {

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -52,14 +52,15 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   cursor: pointer;
   padding: $item-vertical-padding spacing(tight);
   border-radius: var(--p-border-radius-base);
-  border-top: 1px solid transparent var(--p-surface); // 1px gap between elements
-  outline: 1px solid transparent;
+  border-top: 1px solid var(--p-surface); // 1px gap between elements
 
   &:hover {
     background-color: var(--p-surface-hovered);
     text-decoration: none;
 
-    @include high-contrast-outline($border-width: border-width(thicker));
+    @media (-ms-high-contrast: active) {
+      outline: 1px solid ms-high-contrast-color('text');
+    }
   }
 
   &.active {
@@ -78,7 +79,6 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
 
   &:focus:not(:active) {
     @include focus-ring($style: 'focused');
-    @include high-contrast-outline($border-width: border-width(thicker));
   }
 
   &.destructive {

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -52,8 +52,7 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   cursor: pointer;
   padding: $item-vertical-padding spacing(tight);
   border-radius: var(--p-border-radius-base);
-  padding-top: 1px solid transparent;
-  outline: 1px solid transparent;
+  border: 1px solid transparent;
 
   &:hover {
     background-color: var(--p-surface-hovered);

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -52,6 +52,7 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   cursor: pointer;
   padding: $item-vertical-padding spacing(tight);
   border-radius: var(--p-border-radius-base);
+  margin-top: 1px;
   outline: 1px solid transparent;
 
   &:hover {

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -52,7 +52,7 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   cursor: pointer;
   padding: $item-vertical-padding spacing(tight);
   border-radius: var(--p-border-radius-base);
-  margin-top: 1px;
+  padding-top: 1px solid transparent;
   outline: 1px solid transparent;
 
   &:hover {

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -53,8 +53,7 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   padding: $item-vertical-padding spacing(tight);
   border-radius: var(--p-border-radius-base);
   border-top: 1px solid transparent;
-
-  @media screen and (-ms-high-contrast: active) {
+  @media (forced-colors: active) {
     @include high-contrast-border;
   }
 

--- a/src/components/ActionList/ActionList.scss
+++ b/src/components/ActionList/ActionList.scss
@@ -52,7 +52,11 @@ $item-vertical-padding: ($item-min-height - line-height(body)) / 2;
   cursor: pointer;
   padding: $item-vertical-padding spacing(tight);
   border-radius: var(--p-border-radius-base);
-  border: 1px solid transparent;
+  border-top: 1px solid transparent;
+
+  @media screen and (-ms-high-contrast: active) {
+    @include high-contrast-border;
+  }
 
   &:hover {
     background-color: var(--p-surface-hovered);

--- a/src/components/Avatar/Avatar.scss
+++ b/src/components/Avatar/Avatar.scss
@@ -15,9 +15,7 @@ $large-size: rem(60px);
   border-radius: $large-size / 2;
   user-select: none;
 
-  @media (-ms-high-contrast: active) {
-    border: 1px solid ms-high-contrast-color('text');
-  }
+  @include high-contrast-border;
 
   &::after {
     content: '';

--- a/src/components/Avatar/Avatar.scss
+++ b/src/components/Avatar/Avatar.scss
@@ -15,7 +15,9 @@ $large-size: rem(60px);
   border-radius: $large-size / 2;
   user-select: none;
 
-  @include high-contrast-border;
+  @media (forced-colors: active) {
+    @include high-contrast-border;
+  }
 
   &::after {
     content: '';

--- a/src/components/Banner/Banner.scss
+++ b/src/components/Banner/Banner.scss
@@ -23,9 +23,7 @@ $secondary-action-horizontal-padding: 1.5 * spacing(tight);
     background-color: var(--p-banner-background);
   }
 
-  @media (-ms-high-contrast: active) {
-    outline: 1px solid;
-  }
+  @include high-contrast-outline;
 
   &:focus {
     outline: none;

--- a/src/components/CheckableButton/CheckableButton.scss
+++ b/src/components/CheckableButton/CheckableButton.scss
@@ -42,10 +42,6 @@ $chekbox-label-margin: rem(20px);
     background: var(--p-action-secondary-pressed);
   }
 
-  @media (-ms-high-contrast: active) {
-    border: border-width(base) solid;
-  }
-
   &.CheckableButton-measuring {
     font-size: font-size(button);
     font-weight: 700;

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -22,9 +22,7 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     color: var(--p-text);
   }
 
-  @media (-ms-high-contrast: active) {
-    border: 1px solid ms-high-contrast-color('text');
-  }
+  @include high-contrast-border;
 }
 
 .LogoContainer {

--- a/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -22,7 +22,9 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     color: var(--p-text);
   }
 
-  @include high-contrast-border;
+  @media (forced-colors: active) {
+    @include high-contrast-border;
+  }
 }
 
 .LogoContainer {

--- a/src/components/Frame/components/Toast/Toast.scss
+++ b/src/components/Frame/components/Toast/Toast.scss
@@ -18,9 +18,7 @@ $Backdrop-opacity: 0.88;
     padding: spacing();
   }
 
-  @media (-ms-high-contrast: active) {
-    border: border-width(thick) solid ms-high-contrast-color('text');
-  }
+  @include high-contrast-border(border-width(thick));
 }
 
 .Action {

--- a/src/components/Frame/components/Toast/Toast.scss
+++ b/src/components/Frame/components/Toast/Toast.scss
@@ -18,7 +18,9 @@ $Backdrop-opacity: 0.88;
     padding: spacing();
   }
 
-  @include high-contrast-border(border-width(thick));
+  @media (forced-colors: active) {
+    @include high-contrast-border(border-width(thick));
+  }
 }
 
 .Action {

--- a/src/components/Modal/components/Dialog/Dialog.scss
+++ b/src/components/Modal/components/Dialog/Dialog.scss
@@ -38,9 +38,7 @@ $large-width: rem(980px);
   background: var(--p-surface);
   box-shadow: var(--p-modal-shadow);
 
-  @media (-ms-high-contrast: active) {
-    border: 1px solid ms-high-contrast-color('text');
-  }
+  @include high-contrast-border;
 
   @include frame-when-nav-hidden {
     bottom: 0;

--- a/src/components/Modal/components/Dialog/Dialog.scss
+++ b/src/components/Modal/components/Dialog/Dialog.scss
@@ -38,7 +38,9 @@ $large-width: rem(980px);
   background: var(--p-surface);
   box-shadow: var(--p-modal-shadow);
 
-  @include high-contrast-border;
+  @media (forced-colors: active) {
+    @include high-contrast-border;
+  }
 
   @include frame-when-nav-hidden {
     bottom: 0;

--- a/src/components/Navigation/Navigation.scss
+++ b/src/components/Navigation/Navigation.scss
@@ -103,9 +103,7 @@ $disabled-fade: 0.6;
     border-bottom-right-radius: var(--p-border-radius-base);
   }
 
-  @media (-ms-high-contrast: active) {
-    outline: 1px solid ms-high-contrast-color('text');
-  }
+  @include high-contrast-outline;
 
   @include focus-ring;
 

--- a/src/components/ProgressBar/ProgressBar.scss
+++ b/src/components/ProgressBar/ProgressBar.scss
@@ -23,9 +23,7 @@
   background-color: var(--p-surface-neutral);
   border-radius: var(--p-border-radius-base);
 
-  @media screen and (-ms-high-contrast: active) {
-    border: 1px solid ms-high-contrast-color('text');
-  }
+  @include high-contrast-border;
 }
 
 .sizeSmall {

--- a/src/components/ProgressBar/ProgressBar.scss
+++ b/src/components/ProgressBar/ProgressBar.scss
@@ -23,7 +23,9 @@
   background-color: var(--p-surface-neutral);
   border-radius: var(--p-border-radius-base);
 
-  @include high-contrast-border;
+  @media (forced-colors: active) {
+    @include high-contrast-border;
+  }
 }
 
 .sizeSmall {

--- a/src/components/RadioButton/RadioButton.scss
+++ b/src/components/RadioButton/RadioButton.scss
@@ -69,9 +69,7 @@
     transition: opacity var(--p-duration-1-0-0) var(--p-ease),
       transform var(--p-duration-1-0-0) var(--p-ease);
 
-    @media (-ms-high-contrast: active) {
-      border: rem(5px) solid ms-high-contrast-color('text');
-    }
+    @include high-contrast-border(rem(5px));
   }
 
   @include focus-ring($border-width: var(--p-control-border-width));

--- a/src/components/RadioButton/RadioButton.scss
+++ b/src/components/RadioButton/RadioButton.scss
@@ -69,7 +69,9 @@
     transition: opacity var(--p-duration-1-0-0) var(--p-ease),
       transform var(--p-duration-1-0-0) var(--p-ease);
 
-    @include high-contrast-border(rem(5px));
+    @media (forced-colors: active) {
+      @include high-contrast-border(rem(5px));
+    }
   }
 
   @include focus-ring($border-width: var(--p-control-border-width));

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -97,7 +97,6 @@ $range-thumb-border-error: rem(2px) solid color('red');
   &:focus {
     @include focus-ring($style: 'focused');
     outline: 0;
-    border-color: var(--p-override-transparent);
   }
 
   .error & {

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.scss
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.scss
@@ -98,9 +98,6 @@ $range-thumb-border-error: rem(2px) solid color('red');
     @include focus-ring($style: 'focused');
     outline: 0;
     border-color: var(--p-override-transparent);
-    @media (-ms-high-contrast: active) {
-      outline: 1px solid ms-high-contrast-color('text');
-    }
   }
 
   .error & {

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -129,6 +129,8 @@ $stacking-order: (
       border-color: var(--p-surface);
       box-shadow: 0 0 0 rem(2px) var(--p-focused);
     }
+
+    @include high-contrast-outline;
   }
 
   .error & {

--- a/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -129,10 +129,6 @@ $stacking-order: (
       border-color: var(--p-surface);
       box-shadow: 0 0 0 rem(2px) var(--p-focused);
     }
-
-    @media (-ms-high-contrast: active) {
-      outline: 1px solid ms-high-contrast-color('text');
-    }
   }
 
   .error & {
@@ -163,7 +159,6 @@ $stacking-order: (
   }
 }
 
-///
 /// Output value indicator
 $range-output-size: rem(32px);
 $range-output-translate-x: calc(
@@ -222,6 +217,7 @@ $range-output-spacing: rem(16px);
       transform: translateY(-($range-output-spacing / 2));
     }
   }
+  @include high-contrast-outline;
   // stylelint-enable selector-max-specificity, selector-max-combinators, selector-max-class
 }
 

--- a/src/components/Tag/Tag.scss
+++ b/src/components/Tag/Tag.scss
@@ -53,9 +53,7 @@ $icon-size: rem(16px);
     }
   }
 
-  @media (-ms-high-contrast: active) {
-    outline: 1px solid ms-high-contrast-color('text');
-  }
+  @include high-contrast-outline;
 }
 
 .TagText {

--- a/src/styles/foundation/_accessibility.scss
+++ b/src/styles/foundation/_accessibility.scss
@@ -2,3 +2,8 @@
   outline: $border-width solid transparent;
   @content;
 }
+
+@mixin high-contrast-border($border-width: border-width()) {
+  border: $border-width solid transparent;
+  @content;
+}

--- a/src/styles/shared/_forms.scss
+++ b/src/styles/shared/_forms.scss
@@ -16,6 +16,7 @@
 
 @mixin range-track-selectors {
   &::-ms-track {
+    @include high-contrast-outline;
     @content;
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

(partly) Fixes #3826 : it only "partly" fixes the issue since this PR only removes the `outline` and `border` uses of  `-ms-high-contrast`. 

Inspired by this [interesting article](https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/), which states that 
```CSS
@media (forced-colors: active) {
  /* Styles here only apply to Forced Colors Mode */
}
```
basically does the same thing as `-ms-high-contrast: active` HOWEVER, 😭 it doesn’t work for firefox. See [this article ](https://hacks.mozilla.org/2020/07/adding-prefers-contrast-to-firefox/)which talks about creating a custom media query called prefers-contrast, which is quite laborious. This is a temporary fix and will require thought as to how to account for firefox in high contrast mode. 

There are still many instances of `-ms-high-contrast` in the Polaris repo. 
See here: https://github.com/search?q=%22-ms-high-contrast%22+repo%3AShopify%2Fpolaris-react&type=code

According [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/-ms-high-contrast):

> This feature is non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user. There may also be large incompatibilities between implementations and the behavior may change in the future

More on the limitations of `-ms-high-contrast`, [here](https://developer.paciellogroup.com/blog/2016/12/windows-high-contrast-mode-the-limited-utility-of-ms-high-contrast/).  

### WHAT is this pull request doing?

<details>
      <summary>Summary of your gif(s)</summary>

#### **_note: the LEFT are the changes, the RIGHT is current production_**, there should be no visual changes in these, keep scrolling down for visual changes 
### Avatar 
![avatar-high-contrast](https://user-images.githubusercontent.com/43223543/107406901-f91e7300-6ad6-11eb-87e5-319e190236e6.jpg)

### Banner 
![banner-high-contrast](https://user-images.githubusercontent.com/43223543/107408922-98dd0080-6ad9-11eb-920e-c66d987bb966.jpg)

### Contextual Save Bar 
![contextualSaveBar-high-contrast](https://user-images.githubusercontent.com/43223543/107408927-9aa6c400-6ad9-11eb-920c-829a1e605737.jpg)

### ProgressBar
![progressbar-ms-high-contrast](https://user-images.githubusercontent.com/43223543/107408977-a85c4980-6ad9-11eb-9197-3616491b0fa9.jpg)

### Toast
![toast-high-contrast](https://user-images.githubusercontent.com/43223543/107409017-b0b48480-6ad9-11eb-8391-0c4e6f79cdcb.jpg)

### Tag
![tag-high-contrast](https://user-images.githubusercontent.com/43223543/107409025-b1e5b180-6ad9-11eb-88b4-46a0428045bb.jpg)

### Before & Afters (minor visual changes) 

#### SingleThumb
| Before        | After           |
| ------------- |:-------------:|
|![singlethumb-before](https://user-images.githubusercontent.com/43223543/107408996-ac886700-6ad9-11eb-89c1-1b8cf279b05d.jpg)|![singlethumb-AFTERFIX-high-contrast](https://user-images.githubusercontent.com/43223543/107409394-1e60b080-6ada-11eb-888b-822682ccadac.jpg)

#### DualThumb
(the changes are subtle, but before, there are 2 outlines, after there's only 1)

| Before        | After           |
| ------------- |:-------------:|
|![dual-thumb-BEFORE-high-contrast](https://user-images.githubusercontent.com/43223543/107408953-a0040e80-6ad9-11eb-8063-45ca9f17f26f.jpg)|![dual-thumb-AFTER-high-contrast](https://user-images.githubusercontent.com/43223543/107408943-9e3a4b00-6ad9-11eb-980f-5a7018c8b217.jpg)

</details>

### How to 🎩

1. Go to VM & set to High Contrast
2. Compare side by side with http://polaris-react.herokuapp.com/?path=/story/playground-playground--playground 
3. There should be NO visual changes except with RangeSlider (Dual & Single noted in the before and after above)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
![OUTLINE not border](https://user-images.githubusercontent.com/43223543/108753967-5d97f400-7513-11eb-8435-d47d54d02879.jpg)
