### PR TITLE
[TrapFocus] Fixed focus being stolen from internal elements

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed virtual cursor leaving dialog in `Modal`, `Navigation` and `Sheet` ([#3931](https://github.com/Shopify/polaris-react/pull/3931))
+- Fixed `Modal` removing focus from internal elements ([#3964](https://github.com/Shopify/polaris-react/pull/3964))
 - Simplified output of `Badge`'s css ([#3950](https://github.com/Shopify/polaris-react/pull/3950))
 
 ### Documentation

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -7,7 +7,6 @@ import {Badge, Button, Spinner, Portal, Scrollable} from 'components';
 
 import {Footer, Dialog, Header} from '../components';
 import {Modal} from '../Modal';
-import * as focusUtils from '../../../utilities/focus';
 import {WithinContentContext} from '../../../utilities/within-content-context';
 
 jest.mock('react-transition-group', () => {
@@ -427,16 +426,20 @@ describe('<Modal>', () => {
     });
 
     it('focuses the activator when the activator is an element on close', () => {
-      const focusSpy = jest.spyOn(focusUtils, 'focusFirstFocusableNode');
-
+      const id = 'activator-id';
       const modal = mountWithApp(
-        <Modal title="foo" onClose={noop} open activator={<Button />} />,
+        <Modal
+          title="foo"
+          onClose={noop}
+          open
+          activator={<Button id={id} />}
+        />,
       );
 
       modal.find(Dialog)!.trigger('onExited');
+      const activator = modal.find('button', {id})!.domNode;
 
-      expect(document.activeElement).toBe(modal.find('button')!.domNode);
-      expect(focusSpy).toHaveBeenCalledTimes(3);
+      expect(document.activeElement).toBe(activator);
     });
 
     it('focuses the activator when the activator a ref on close', () => {

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useRef, useEffect} from 'react';
+import React, {useRef} from 'react';
 
 import {Key} from '../../types';
 import {EventListener} from '../EventListener';
@@ -13,6 +13,7 @@ import {
 } from '../../utilities/focus';
 import {useFocusManager} from '../../utilities/focus-manager';
 import {portal} from '../shared';
+import {useIsAfterInitialMount} from '../../utilities/use-is-after-initial-mount';
 
 export interface TrapFocusProps {
   trapping?: boolean;
@@ -20,29 +21,19 @@ export interface TrapFocusProps {
 }
 
 export function TrapFocus({trapping = true, children}: TrapFocusProps) {
-  const [shouldFocusSelf, setFocusSelf] = useState<boolean | undefined>(
-    undefined,
-  );
   const {canSafelyFocus} = useFocusManager({trapping});
   const focusTrapWrapper = useRef<HTMLDivElement>(null);
+  const isMounted = useIsAfterInitialMount();
 
-  useEffect(() => {
-    setFocusSelf(
-      !(
-        canSafelyFocus &&
-        focusTrapWrapper.current &&
-        focusTrapWrapper.current.contains(document.activeElement)
-      ),
-    );
-  }, [canSafelyFocus]);
-
-  const shouldDisableFirstElementFocus = () => {
-    if (shouldFocusSelf === undefined || !canSafelyFocus) {
-      return true;
-    }
-
-    return shouldFocusSelf ? !trapping : !shouldFocusSelf;
-  };
+  const disableFocus =
+    isMounted &&
+    canSafelyFocus &&
+    !(
+      focusTrapWrapper.current &&
+      focusTrapWrapper.current.contains(document.activeElement)
+    )
+      ? !trapping
+      : true;
 
   const handleFocusIn = (event: FocusEvent) => {
     const containerContentsHaveFocus =
@@ -93,10 +84,7 @@ export function TrapFocus({trapping = true, children}: TrapFocusProps) {
   };
 
   return (
-    <Focus
-      disabled={shouldDisableFirstElementFocus()}
-      root={focusTrapWrapper.current}
-    >
+    <Focus disabled={disableFocus} root={focusTrapWrapper.current}>
       <div ref={focusTrapWrapper}>
         <EventListener event="focusin" handler={handleFocusIn} />
         <KeypressListener

--- a/src/components/TrapFocus/tests/TrapFocus.test.tsx
+++ b/src/components/TrapFocus/tests/TrapFocus.test.tsx
@@ -112,6 +112,7 @@ describe('<TrapFocus />', () => {
   it('keeps focus on nodes contained inside trap focus during mount', () => {
     const trapFocus = mountWithApp(
       <TrapFocus>
+        <button>First node</button>
         <TextField label="" value="" onChange={noop} autoFocus />
       </TrapFocus>,
     );


### PR DESCRIPTION
### WHY are these changes introduced?

`TrapFocus` was stealing focus from `autoFocus` text fields.

### WHAT is this pull request doing?

* simplifying & adjusting the disable logic

### Gifs

#### Focus not being stolen
![Screen Recording 2021-02-03 at 11 16 02 AM](https://user-images.githubusercontent.com/24610840/106778297-d17d6580-6613-11eb-839d-6a13fa0d9119.gif)


#### Focus not being stolen from the original trap focus
![Screen Recording 2021-02-03 at 11 16 27 AM](https://user-images.githubusercontent.com/24610840/106778300-d3472900-6613-11eb-8a35-4c812fbf182e.gif)

#### From web - TrapFocus still works

![Screen Recording 2021-02-08 at 01 53 04 PM](https://user-images.githubusercontent.com/24610840/107267711-4803d400-6a15-11eb-8efd-651f874b8470.gif)
![Screen Recording 2021-02-08 at 01 52 04 PM](https://user-images.githubusercontent.com/24610840/107267743-505c0f00-6a15-11eb-9f49-ebd713e0a85a.gif)
![Screen Recording 2021-02-08 at 01 36 50 PM](https://user-images.githubusercontent.com/24610840/107267765-5520c300-6a15-11eb-9eef-c07c19dad976.gif)
![Screen Recording 2021-02-08 at 01 34 20 PM](https://user-images.githubusercontent.com/24610840/107267793-5c47d100-6a15-11eb-8674-c84c1749fd98.gif)


##### Notes

* (issue unrelated to this change) It seems focus can be moved out of trap focus from clicks and be contained in secondary trap focuses. Do we consider this a bug?

### How to 🎩

Play around with the playground code!

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useRef, useCallback} from 'react';

import {
  Page,
  Button,
  Modal,
  Stack,
  TextContainer,
  TextField,
  TrapFocus,
  Heading,
} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <ModalWithPrimaryActionExample />
    </Page>
  );
}

function ModalWithPrimaryActionExample() {
  const DISCOUNT_LINK = 'https://polaris.shopify.com/';
  const [trappingActive, setTrappingActive] = useState(false);
  const [active, setActive] = useState(true);
  const node = useRef(null);

  const handleClick = useCallback(() => {
    node.current && node.current.input.focus();
  }, []);

  const handleFocus = useCallback(() => {
    console.log('focused');

    if (node.current == null) {
      return;
    }
    node.current.input.select();
    document.execCommand('copy');
  }, []);

  const toggleModal = useCallback(() => setActive((active) => !active), []);

  const activator = <Button onClick={toggleModal}>Open</Button>;

  return (
    <>
      <TrapFocus trapping={trappingActive}>
        <Heading>{trappingActive ? 'Active' : 'Inactive'}</Heading>
        <Button
          onClick={() =>
            setTrappingActive((currentTrappingActive) => !currentTrappingActive)
          }
        >
          Toggle additional trap focus
        </Button>
      </TrapFocus>
      <div style={{height: '500px'}}>
        <Modal
          activator={activator}
          open={active}
          onClose={toggleModal}
          title="Get a shareable link"
          primaryAction={{
            content: 'Close',
            onAction: toggleModal,
          }}
        >
          <Modal.Section>
            <Stack vertical>
              <Stack.Item>
                <TextContainer>
                  <p>
                    You can share this discount link with your customers via
                    email or social media. Your discount will be automatically
                    applied at checkout.
                  </p>
                </TextContainer>
              </Stack.Item>
              <Stack.Item fill>
                <TextField
                  ref={node}
                  autoFocus
                  label="Discount link"
                  onFocus={handleFocus}
                  value={DISCOUNT_LINK}
                  onChange={() => {}}
                  connectedRight={
                    <Button primary onClick={handleClick}>
                      Copy link
                    </Button>
                  }
                />
              </Stack.Item>
            </Stack>
          </Modal.Section>
        </Modal>
      </div>
    </>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
