### PR TITLE
[MediaCard] Fix the thumbnail’s corner roundness, so it won’t overflow out of the parent Card

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Simplified output of `Badge`'s css ([#3950](https://github.com/Shopify/polaris-react/pull/3950))
 - Fixed click propagation that was preventing the `Tooltip` to open when used as suffix on a `TextField` ([#3956](https://github.com/Shopify/polaris-react/issues/3956))
 - Made items in `ActionList` more clear in high contrast mode ([#3971](https://github.com/Shopify/polaris-react/pull/3971))
+- Fixed the MediaCard thumbnail’s corner roundness, so it wouldn’t overflow out of the parent Card ([#3974](https://github.com/Shopify/polaris-react/issues/3974))
 
 ### Documentation
 

--- a/src/components/MediaCard/MediaCard.scss
+++ b/src/components/MediaCard/MediaCard.scss
@@ -18,6 +18,10 @@ $portrait-breakpoint: 804px;
 }
 
 .MediaContainer {
+  overflow: hidden;
+  border-top-left-radius: var(--p-border-radius-wide);
+  border-top-right-radius: var(--p-border-radius-wide);
+
   &:not(.portrait) {
     flex-basis: 40%;
 
@@ -27,16 +31,10 @@ $portrait-breakpoint: 804px;
   }
 
   @include breakpoint-after($portrait-breakpoint, inclusive) {
-    overflow: hidden;
-
-    &.portrait {
-      border-top-left-radius: border-radius();
-      border-top-right-radius: border-radius();
-    }
-
     &:not(.portrait) {
-      border-top-left-radius: border-radius();
-      border-bottom-left-radius: border-radius();
+      border-top-right-radius: 0;
+      border-top-left-radius: var(--p-border-radius-wide);
+      border-bottom-left-radius: var(--p-border-radius-wide);
     }
   }
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes an issue in MediaCard where the thumbnail would overflow outside of the parent card on small screens at the top, as well as on larger screens, to the left, as in these screenshots:

![Screen_Shot_2021-02-04_at_11_12_11_AM](https://user-images.githubusercontent.com/85783/106955205-c563d780-66e9-11eb-974f-b1e603a1938d.png)

![Screen Shot 2021-02-04 at 11 31 10 AM](https://user-images.githubusercontent.com/85783/106945362-8b400900-66dc-11eb-975d-a5ca86be294b.png)

### WHAT is this pull request doing?

Uses the new design language custom properties instead of the Sass functions when applying border radius values.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Compare new and old versions on Chromatic, at various viewport sizes.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
