### PR TITLE
[ResourceItem] Add dataHref prop

### DIFF
--- a/src/components/ResourceItem/ResourceItem.tsx
+++ b/src/components/ResourceItem/ResourceItem.tsx
@@ -53,6 +53,8 @@ interface BaseProps {
   children?: React.ReactNode;
   /** Adjust vertical alignment of elements */
   verticalAlignment?: Alignment;
+  /** Prefetched url attribute to bind to the main element being returned */
+  dataHref?: string;
 }
 
 interface PropsWithUrl extends BaseProps {
@@ -148,6 +150,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
       context: {selectable, selectMode, loading, resourceName},
       i18n,
       verticalAlignment,
+      dataHref,
     } = this.props;
 
     const {actionsMenuVisible, focused, focusedInner, selected} = this.state;
@@ -322,7 +325,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
     );
 
     return (
-      <li className={listItemClassName}>
+      <li className={listItemClassName} data-href={dataHref}>
         <div className={styles.ItemWrapper}>
           <div
             ref={this.setNode}

--- a/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -735,7 +735,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      expect(item.find('li').prop('data-href')).toBe(undefined);
+      expect(item.find('li').prop('data-href')).toBeUndefined();
     });
   });
 });

--- a/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -708,6 +708,36 @@ describe('<ResourceItem />', () => {
       });
     });
   });
+
+  describe('dataHref', () => {
+    it('renders a data-href tag on the li when the dataHref prop is specified', () => {
+      const item = mountWithAppProvider(
+        <ResourceListContext.Provider value={mockDefaultContext}>
+          <ResourceItem
+            accessibilityLabel={accessibilityLabel}
+            id={itemId}
+            url="https://shopify.com"
+            dataHref="google.com"
+          />
+        </ResourceListContext.Provider>,
+      );
+
+      expect(item.find('li').prop('data-href')).toBe('google.com');
+    });
+    it('renders a data-href tag on the li when the dataHref prop is not specified', () => {
+      const item = mountWithAppProvider(
+        <ResourceListContext.Provider value={mockDefaultContext}>
+          <ResourceItem
+            accessibilityLabel={accessibilityLabel}
+            id={itemId}
+            url="https://shopify.com"
+          />
+        </ResourceListContext.Provider>,
+      );
+
+      expect(item.find('li').prop('data-href')).toBe(undefined);
+    });
+  });
 });
 
 function noop() {}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

To enable prefetching when a user hovers over the `ResourceItem` through a `data-href` attribute on the parent `li` tag. 

Fixes https://github.com/Shopify/marketing-technology/issues/6390. Also referenced [here](https://shopify.slack.com/archives/C4Y8N30KD/p1612387605186600) @billycai 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds the `dataHref` prop to `ResourceItem`. If a string is provided, the main `li` tag will render a `data-href` attribute. Also adds two tests to check functionality.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
