### PR TITLE
[ActionList/Item] Fix disabling ActionList Item when url prop is passed

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed click propagation that was preventing the `Tooltip` to open when used as suffix on a `TextField` ([#3956](https://github.com/Shopify/polaris-react/issues/3956))
 - Made items in `ActionList` more clear in high contrast mode ([#3971](https://github.com/Shopify/polaris-react/pull/3971))
 - Fixed the MediaCard thumbnail’s corner roundness, so it wouldn’t overflow out of the parent Card ([#3974](https://github.com/Shopify/polaris-react/issues/3974))
+- Fixed `ActionList` `Item` not disabling properly when url prop is passed ([#3979](https://github.com/Shopify/polaris-react/pull/3979))
 
 ### Documentation
 

--- a/src/components/ActionList/components/Item/Item.tsx
+++ b/src/components/ActionList/components/Item/Item.tsx
@@ -94,11 +94,11 @@ export function Item({
   const control = url ? (
     <UnstyledLink
       id={id}
-      url={url}
+      url={disabled ? undefined : url}
       className={className}
       external={external}
       aria-label={accessibilityLabel}
-      onClick={onAction}
+      onClick={disabled ? () => false : onAction}
     >
       {contentElement}
     </UnstyledLink>

--- a/src/components/ActionList/components/Item/Item.tsx
+++ b/src/components/ActionList/components/Item/Item.tsx
@@ -94,11 +94,11 @@ export function Item({
   const control = url ? (
     <UnstyledLink
       id={id}
-      url={disabled ? undefined : url}
+      url={disabled ? null : url}
       className={className}
       external={external}
       aria-label={accessibilityLabel}
-      onClick={disabled ? () => false : onAction}
+      onClick={disabled ? null : onAction}
     >
       {contentElement}
     </UnstyledLink>

--- a/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -80,6 +80,20 @@ describe('<Item />', () => {
       mockAccessibilityLabel,
     );
   });
+
+  it('passes `url` as null to `<UnstyledLink />` when disabled', () => {
+    const item = mountWithApp(<Item url="https://shopify.com" disabled />);
+
+    expect(item.find(UnstyledLink)!.prop('url')).toBeNull();
+  });
+
+  it('passes `onClick` as null to `<UnstyledLink />` when disabled', () => {
+    const item = mountWithApp(
+      <Item onAction={noop} disabled url="https://shopify.com" />,
+    );
+
+    expect(item.find(UnstyledLink)!.prop('onClick')).toBeNull();
+  });
 });
 
 function noop() {}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes an issue where ActionList Items will disable visually but not functionally when the url prop is passed. 

### WHAT is this pull request doing?

Sets the Item url and onClick to null if a url is passed and disabled is passed as true.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page} from '../src';

export function Playground() {
  return (
    <Page
      title="Playground"
      actionGroups={[
        {
          title: 'Promote',
          actions: [
            {
              content: 'Share on Facebook',
              onAction: () => {
                // eslint-disable-next-line no-console
                console.log('test');
              },
              disabled: true,
              url: 'https://shopify.com',
            },
          ],
        },
      ]}
    >
      <p>Page content</p>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit