### PR TITLE
[CheckableButton] 3987 - fix checkbox border issue on focus

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Made items in `ActionList` more clear in high contrast mode ([#3971](https://github.com/Shopify/polaris-react/pull/3971))
 - Fixed the MediaCard thumbnail’s corner roundness, so it wouldn’t overflow out of the parent Card ([#3974](https://github.com/Shopify/polaris-react/issues/3974))
 - Fixed `ActionList` `Item` not disabling properly when url prop is passed ([#3979](https://github.com/Shopify/polaris-react/pull/3979))
+- Fixed `CheckableButton` missing border when focused ([#3987](https://github.com/Shopify/polaris-react/issues/3987))
 
 ### Documentation
 

--- a/src/components/CheckableButton/CheckableButton.scss
+++ b/src/components/CheckableButton/CheckableButton.scss
@@ -32,7 +32,6 @@ $chekbox-label-margin: rem(20px);
   [data-buttongroup-segmented='true'] & {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
-    border-right: none;
   }
 
   &:hover {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3987

First noticed this in Admin, the right border disappears when the bulk actions checkbox is focused.

### WHAT is this pull request doing?

After investigation, the issue is with how we're dealing with overlapping borders. Subsequent buttons have a `margin-left: -1px`, so their left border overlaps the right border of the previous element so we don't have a double border:

<img width="865" alt="Screen Shot 2021-02-10 at 3 45 41 PM" src="https://user-images.githubusercontent.com/3619012/107570401-71f4fc00-6bb7-11eb-9dcc-258b8d0ae25a.png">

However, `CheckableButton` has a `border-right: none;`. This is fine when the checkbox isn't focused since the `Edit customers` button's border overlaps the rightmost 1px of `2 selected` regardless of whether there's a border underneath or not, but when the checkbox is focused it's also given an increased `z-index: 20` which is higher than that of `Edit customers`. As a result, the rightmost edge of `2 selected` now appears **above** the `Edit customers` border.

The fix is to re-introduce a `border-right` to the `CheckableButton`. When not focused, the border appears beneath the subsequent button's border. When focused, the `CheckableButton`'s border is shown.

https://user-images.githubusercontent.com/3619012/107570865-18d99800-6bb8-11eb-9bac-05309b69c82a.mp4

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
