### PR TITLE
[IndexTable] Align IndexTable checkbox header with other headers

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Made items in `ActionList` more clear in high contrast mode ([#3971](https://github.com/Shopify/polaris-react/pull/3971))
 - Fixed the MediaCard thumbnail’s corner roundness, so it wouldn’t overflow out of the parent Card ([#3974](https://github.com/Shopify/polaris-react/issues/3974))
 - Fixed `ActionList` `Item` not disabling properly when url prop is passed ([#3979](https://github.com/Shopify/polaris-react/pull/3979))
+- Update `IndexTable`'s checkbox header to be aligned with other headers ([#3989](https://github.com/Shopify/polaris-react/issues/3989))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,7 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Made items in `ActionList` more clear in high contrast mode ([#3971](https://github.com/Shopify/polaris-react/pull/3971))
 - Fixed the MediaCard thumbnail’s corner roundness, so it wouldn’t overflow out of the parent Card ([#3974](https://github.com/Shopify/polaris-react/issues/3974))
 - Fixed `ActionList` `Item` not disabling properly when url prop is passed ([#3979](https://github.com/Shopify/polaris-react/pull/3979))
-- Update `IndexTable`'s checkbox header to be aligned with other headers ([#3989](https://github.com/Shopify/polaris-react/issues/3989))
+- Update `IndexTable`'s checkbox header to be aligned with other headers ([#3990](https://github.com/Shopify/polaris-react/issues/3990))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,7 +21,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Update `IndexTable`'s checkbox header to be aligned with other headers ([#3990](https://github.com/Shopify/polaris-react/issues/3990))
 - Fixed `CheckableButton` missing border when focused ([#3987](https://github.com/Shopify/polaris-react/issues/3987))
 
-
 ### Documentation
 
 - Added an example for the `onRemove` prop to `Tag` and clarified that no remove button is rendered when `onClick` is set ([#2987](https://github.com/Shopify/polaris-react/pull/2987))

--- a/src/components/IndexTable/IndexTable.scss
+++ b/src/components/IndexTable/IndexTable.scss
@@ -158,6 +158,10 @@ $loading-panel-height: rem(53px);
   padding-right: $checkbox-offset-right;
 }
 
+.ColumnHeaderCheckboxWrapper {
+  display: flex;
+}
+
 .StickyColumnHeaderCheckbox {
   margin-left: #{-1 * $small-checkbox-offset};
   padding-right: $small-checkbox-offset;

--- a/src/components/IndexTable/IndexTable.tsx
+++ b/src/components/IndexTable/IndexTable.tsx
@@ -521,14 +521,16 @@ function IndexTableBase({
 
   function renderCheckboxContent() {
     return (
-      <PolarisCheckbox
-        label={i18n.translate('Polaris.IndexTable.selectAllLabel', {
-          resourceNamePlural: resourceName.plural,
-        })}
-        labelHidden
-        onChange={handleSelectPage}
-        checked={bulkSelectState}
-      />
+      <div className={styles.ColumnHeaderCheckboxWrapper}>
+        <PolarisCheckbox
+          label={i18n.translate('Polaris.IndexTable.selectAllLabel', {
+            resourceNamePlural: resourceName.plural,
+          })}
+          labelHidden
+          onChange={handleSelectPage}
+          checked={bulkSelectState}
+        />
+      </div>
     );
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3989 

On the `IndexTable` component, the `select all` checkbox isn't vertically centered with the rest of the the table headers. This is due to the checkbox having a `display: inline-flex;`, which adds whitespace since it's an inline element. [This stackoverflow answer](https://stackoverflow.com/a/48119467/2131898) does a good job summarizing the issue.


### WHAT is this pull request doing?
This PR adds a wrapper around the checkbox header to fix the alignment.

👀 **_BEFORE_** 👀

_IndexTable / Simple Index Table example_
<img width="549" alt="Screen Shot 2021-02-10 at 5 07 51 PM" src="https://user-images.githubusercontent.com/3619012/107580419-855a9400-6bc4-11eb-83fb-c2c66e5b005e.png">

_IndexTable / Simple Index Table example w/sticky headers_
<img width="543" alt="Screen Shot 2021-02-10 at 5 14 00 PM" src="https://user-images.githubusercontent.com/3619012/107580429-88ee1b00-6bc4-11eb-839a-db60f004d335.png">

👀 **_AFTER_** 👀
_IndexTable / Simple Index Table example w/sticky headers_
<img width="557" alt="Screen Shot 2021-02-10 at 5 06 56 PM" src="https://user-images.githubusercontent.com/3619012/107581336-eafb5000-6bc5-11eb-8647-cafbef33a387.png">

_IndexTable / Simple Index Table example_
<img width="602" alt="Screen Shot 2021-02-10 at 5 13 48 PM" src="https://user-images.githubusercontent.com/3619012/107581318-e46cd880-6bc5-11eb-9fe7-f275e014d1b2.png">


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
