### PR TITLE
[Tabs] Fix Tabs focus state issue on close

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `ActionList` `Item` not disabling properly when url prop is passed ([#3979](https://github.com/Shopify/polaris-react/pull/3979))
 - Update `IndexTable`'s checkbox header to be aligned with other headers ([#3990](https://github.com/Shopify/polaris-react/issues/3990))
 - Fixed `CheckableButton` missing border when focused ([#3987](https://github.com/Shopify/polaris-react/issues/3987))
+- Fixed `CheckableButton` missing border when focused ([#3988](https://github.com/Shopify/polaris-react/pull/3988))
+- Fixed accessibility issue on `Tabs` disclosure popover on close ([#3994](https://github.com/Shopify/polaris-react/pull/3994))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,7 +21,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed the MediaCard thumbnail’s corner roundness, so it wouldn’t overflow out of the parent Card ([#3974](https://github.com/Shopify/polaris-react/issues/3974))
 - Fixed `ActionList` `Item` not disabling properly when url prop is passed ([#3979](https://github.com/Shopify/polaris-react/pull/3979))
 - Update `IndexTable`'s checkbox header to be aligned with other headers ([#3990](https://github.com/Shopify/polaris-react/issues/3990))
-- Fixed `CheckableButton` missing border when focused ([#3987](https://github.com/Shopify/polaris-react/issues/3987))
 - Fixed `CheckableButton` missing border when focused ([#3988](https://github.com/Shopify/polaris-react/pull/3988))
 - Fixed accessibility issue on `Tabs` disclosure popover on close ([#3994](https://github.com/Shopify/polaris-react/pull/3994))
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -153,6 +153,14 @@ class TabsInner extends PureComponent<CombinedProps, State> {
     return (
       <div>
         <div className={styles.Wrapper}>
+          <TabMeasurer
+            tabToFocus={tabToFocus}
+            activator={activator}
+            selected={selected}
+            tabs={tabs}
+            siblingTabHasFocus={tabToFocus > -1}
+            handleMeasurement={this.handleMeasurement}
+          />
           <ul
             role="tablist"
             className={classname}
@@ -179,14 +187,6 @@ class TabsInner extends PureComponent<CombinedProps, State> {
               </Popover>
             </li>
           </ul>
-          <TabMeasurer
-            tabToFocus={tabToFocus}
-            activator={activator}
-            selected={selected}
-            tabs={tabs}
-            siblingTabHasFocus={tabToFocus > -1}
-            handleMeasurement={this.handleMeasurement}
-          />
         </div>
         {panelMarkup}
       </div>

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -98,7 +98,7 @@ describe('<Tabs />', () => {
       const wrapper = mountWithAppProvider(<Tabs {...mockProps} tabs={tabs} />);
 
       tabs.forEach((tab, index) => {
-        expect(wrapper.find(Tab).at(index).prop('id')).toBe(tab.id);
+        expect(wrapper.find('ul').find(Tab).at(index).prop('id')).toBe(tab.id);
       });
     });
 
@@ -115,7 +115,9 @@ describe('<Tabs />', () => {
       );
 
       panelIDedTabs.forEach((tab, index) => {
-        expect(wrapper.find(Tab).at(index).prop('panelID')).toBe(tab.panelID);
+        expect(wrapper.find('ul').find(Tab).at(index).prop('panelID')).toBe(
+          tab.panelID,
+        );
       });
     });
 
@@ -126,7 +128,7 @@ describe('<Tabs />', () => {
       );
 
       tabs.forEach((_, index) => {
-        const panelID = wrapper.find(Tab).at(index).prop('panelID');
+        const panelID = wrapper.find('ul').find(Tab).at(index).prop('panelID');
         expect(typeof panelID).toBe('string');
         expect(panelID).not.toBe('');
       });
@@ -136,7 +138,7 @@ describe('<Tabs />', () => {
       const wrapper = mountWithAppProvider(<Tabs {...mockProps} />);
 
       tabs.forEach((_, index) => {
-        const panelID = wrapper.find(Tab).at(index).prop('panelID');
+        const panelID = wrapper.find('ul').find(Tab).at(index).prop('panelID');
         expect(panelID).toBeUndefined();
       });
     });
@@ -151,7 +153,9 @@ describe('<Tabs />', () => {
       );
 
       urlTabs.forEach((tab, index) => {
-        expect(wrapper.find(Tab).at(index).prop('url')).toStrictEqual(tab.url);
+        expect(
+          wrapper.find('ul').find(Tab).at(index).prop('url'),
+        ).toStrictEqual(tab.url);
       });
     });
 
@@ -166,7 +170,7 @@ describe('<Tabs />', () => {
 
       labelledTabs.forEach((tab, index) => {
         expect(
-          wrapper.find(Tab).at(index).prop('accessibilityLabel'),
+          wrapper.find('ul').find(Tab).at(index).prop('accessibilityLabel'),
         ).toStrictEqual(tab.accessibilityLabel);
       });
     });
@@ -181,9 +185,9 @@ describe('<Tabs />', () => {
       );
 
       tabsWithContent.forEach((tab, index) => {
-        expect(wrapper.find(Tab).at(index).prop('children')).toStrictEqual(
-          tab.content,
-        );
+        expect(
+          wrapper.find('ul').find(Tab).at(index).prop('children'),
+        ).toStrictEqual(tab.content);
       });
     });
 
@@ -204,9 +208,9 @@ describe('<Tabs />', () => {
       );
 
       tabsWithContent.forEach((tab, index) => {
-        expect(wrapper.find(Tab).at(index).prop('children')).toStrictEqual(
-          tab.content,
-        );
+        expect(
+          wrapper.find('ul').find(Tab).at(index).prop('children'),
+        ).toStrictEqual(tab.content);
       });
     });
   });
@@ -267,7 +271,7 @@ describe('<Tabs />', () => {
         <Tabs {...mockProps}>{content}</Tabs>,
       );
 
-      const selectedTab = wrapper.find(Tab).at(0);
+      const selectedTab = wrapper.find('ul').find(Tab).at(0);
       const panel = wrapper.find(Panel).at(0);
       expect(panel.exists()).toBe(true);
       expect(panel.contains(content)).toBe(true);
@@ -288,7 +292,7 @@ describe('<Tabs />', () => {
       );
 
       const panel = wrapper.find(Panel).at(0);
-      const selectedTab = wrapper.find(Tab).at(0);
+      const selectedTab = wrapper.find('ul').find(Tab).at(0);
       expect(panel.prop('id')).toBe(selectedTab.prop('panelID'));
     });
   });
@@ -299,7 +303,7 @@ describe('<Tabs />', () => {
       const wrapper = mountWithAppProvider(
         <Tabs {...mockProps} onSelect={spy} />,
       );
-      wrapper.find(Tab).at(1).find('button').simulate('click');
+      wrapper.find('ul').find(Tab).at(1).find('button').simulate('click');
       expect(spy).toHaveBeenCalledWith(1);
     });
   });


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3993

(also fixes shopify/web issue [#37890](https://github.com/Shopify/web/issues/37890))

When the `Popover` component is [handling the close event](https://github.com/Shopify/polaris-react/blob/main/src/components/Popover/Popover.tsx#L128), it checks for the next focuseable element and focuses that, and otherwise focuses the popover trigger. However, the "next focuseable element" is determined by the [nextFocuseableNode](https://github.com/Shopify/polaris-react/blob/main/src/utilities/focus.ts#L16) utility, which just checks based on element type and doesn't take `tabindex` values into consideration.

This breaks when used by the `Tabs` component, because `Tabs` has a set of buttons with `tabindex="-1"` that are used to determine appropriate widths when resizing (the `TabMeasurer` component). Because of this, `nextFocuseableNode` is determined to be the first of these `TabMeasurer` buttons, but since it has `tabindex="-1"` the focus is shifted to the `window`.

👀  **Before** 👀

https://user-images.githubusercontent.com/3619012/107691625-aaf5a500-6c79-11eb-8bc9-1d1b625d65e7.mp4


### WHAT is this pull request doing?

This PR moves the `TabMeasurer`'s hidden tabs before the visible tabs. **Probably the better fix would be to update the focus utility to exclude buttons with negative `tabindex` values, but given that this is a core utility that could have unintended knock-on effects. Hoping one of the PR reviewers has more insight into this 🙏 **

👀  **After** 👀

https://user-images.githubusercontent.com/3619012/107691690-c2cd2900-6c79-11eb-9af8-7dc240b37cea.mp4

https://user-images.githubusercontent.com/3619012/107691696-c5c81980-6c79-11eb-87b2-5d63848e7056.mp4


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Button, Page, Tabs} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <TabsExample />
    </Page>
  );
}

function TabsExample() {
  const tabs = [
    {
      id: 'all-customers-1',
      content: 'All',
      accessibilityLabel: 'All customers',
      panelID: 'all-customers-content-1',
    },
    {
      id: 'accepts-marketing-1',
      content: 'Accepts marketing',
      panelID: 'accepts-marketing-content-1',
    },
    {
      id: 'repeat-customers-1',
      content: 'Repeat customers',
      panelID: 'repeat-customers-content-1',
    },
    {
      id: 'prospects-1',
      content: 'Prospects',
      panelID: 'prospects-content-1',
    },
    {
      id: 'prospects-2',
      content: 'Prospects 2',
      panelID: 'prospects-content-2',
    },
    {
      id: 'prospects-3',
      content: 'Prospects 3',
      panelID: 'prospects-content-3',
    },
    {
      id: 'prospects-4',
      content: 'Prospects 4',
      panelID: 'prospects-content-4',
    },
    {
      id: 'prospects-5',
      content: 'Prospects 5',
      panelID: 'prospects-content-5',
    },
    {
      id: 'prospects-6',
      content: 'Prospects 6',
      panelID: 'prospects-content-6 ',
    },
    {
      id: 'prospects-7',
      content: 'Prospects really long name so this wraps',
      panelID: 'prospects-content-7',
    },
  ];

  return (
    <div>
      <Button>test</Button>
      <Tabs tabs={tabs} selected={0} onSelect={() => {}} />
    </div>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
