### PR TITLE
[Button] Add optional `removeUnderline` prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added `focus-visible` polyfill and default styles ([#3695](https://github.com/Shopify/polaris-react/pull/3695))
+- Added `removeUnderline` prop to `Button` to remove underline when `plain` and `monochrome` are true([#3998](https://github.com/Shopify/polaris-react/))pull/3998)
 
 ### Bug fixes
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -207,9 +207,12 @@ $stacking-order: (
   &:focus {
     @include recolor-icon(var(--p-interactive-hovered));
     color: var(--p-interactive-hovered);
-    text-decoration: underline;
     background: transparent;
     box-shadow: none;
+
+    &:not(.removeUnderline) {
+      text-decoration: underline;
+    }
   }
 
   &.pressed,
@@ -403,7 +406,7 @@ $stacking-order: (
 
   &.plain {
     // stylelint-disable selector-max-class, max-nesting-depth
-    .Text {
+    .Text:not(.removeUnderline) {
       text-decoration: underline;
     }
     // stylelint-enable selector-max-class, max-nesting-depth

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -44,6 +44,8 @@ export interface ButtonProps extends BaseButton {
   plain?: boolean;
   /** Makes `plain` and `outline` Button colors (text, borders, icons) the same as the current text color. Also adds an underline to `plain` Buttons */
   monochrome?: boolean;
+  /** Removes underline from button text (including on interaction) when `monochrome` and `plain` are true */
+  removeUnderline?: boolean;
   /** Icon to display to the left of the button content */
   icon?: React.ReactElement | IconSource;
   /** Disclosure button connected right of the button. Toggles a popover action list. */
@@ -114,6 +116,7 @@ export function Button({
   disclosure,
   plain,
   monochrome,
+  removeUnderline,
   size = DEFAULT_SIZE,
   textAlign,
   fullWidth,
@@ -138,6 +141,7 @@ export function Button({
     fullWidth && styles.fullWidth,
     icon && children == null && styles.iconOnly,
     connectedDisclosure && styles.connectedDisclosure,
+    removeUnderline && styles.removeUnderline,
   );
 
   const disclosureMarkup = disclosure ? (
@@ -164,7 +168,14 @@ export function Button({
   ) : null;
 
   const childMarkup = children ? (
-    <span className={styles.Text}>{children}</span>
+    <span
+      className={classNames(
+        styles.Text,
+        removeUnderline && styles.removeUnderline,
+      )}
+    >
+      {children}
+    </span>
   ) : null;
 
   const spinnerSVGMarkup = loading ? (

--- a/src/components/Button/tests/Button.test.tsx
+++ b/src/components/Button/tests/Button.test.tsx
@@ -420,4 +420,23 @@ describe('<Button />', () => {
       expect(disclosureIcon.props().source).toBe(SelectMinor);
     });
   });
+
+  describe('removeUnderline', () => {
+    it('passes prop to <UnstyledButton/> className', () => {
+      const button = mountWithApp(<Button removeUnderline />);
+
+      expect(button.find(UnstyledButton)!.props.className).toContain(
+        'removeUnderline',
+      );
+    });
+
+    it('passes prop to <span/> className', () => {
+      const children = 'Sample children';
+
+      const button = mountWithApp(<Button removeUnderline>{children}</Button>);
+      const childrenSpan = button.find('span', {children})!;
+
+      expect(childrenSpan.props.className).toContain('removeUnderline');
+    });
+  });
 });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

- To cover use cases for consumers who need to use a button (for interactive purposes that don't include linking to something), and want to render a truly plain, monochrome button with no underline 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Adds optional `removeUnderline` prop to `<Button/>`
- Removes underline from the button text, including on on hover/focus

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Button, Page, Stack} from '../src';

export function Playground() {
  return (
    <Page title="Compare the following two buttons">
      <Stack vertical>
        <Button monochrome plain removeUnderline>
          New plain, monochrome button with no underline
        </Button>
        <Button monochrome plain>
          Existing plain, monochrome button
        </Button>
      </Stack>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
