### PR TITLE
Updated Peer Dependencies to accept React 17.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,8 +89,8 @@
     "react-transition-group": "^4.4.1"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "react": "^16.9.0 || ^17.0.0",
+    "react-dom": "^16.9.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.0",


### PR DESCRIPTION
React 17 is out and it there's no API change between 16 and 17

In my environment it seems to work as before