### PR TITLE
[Collapsible] Fix collapsible transition behaviour

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -27,6 +27,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed accessibility issue on `Tabs` disclosure popover on close ([#3994](https://github.com/Shopify/polaris-react/pull/3994))
 - Fixed accessibility issue when tabbing into `IndexTable` ([#4004](https://github.com/Shopify/polaris-react/pull/4004))
 - Fixed an issue where inline code would be hard to select ([#4005](https://github.com/Shopify/polaris-react/pull/4005))
+- Fixed `Collapsible` bug where animation complete logic was being prematurely triggered by transitions in the children ([#4000](https://github.com/Shopify/polaris-react/pull/4000))
 
 ### Documentation
 

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -36,7 +36,7 @@ export function Collapsible({
   const [height, setHeight] = useState(0);
   const [isOpen, setIsOpen] = useState(open);
   const [animationState, setAnimationState] = useState<AnimationState>('idle');
-  const collapisbleContainer = useRef<HTMLDivElement>(null);
+  const collapsibleContainer = useRef<HTMLDivElement>(null);
 
   const isFullyOpen = animationState === 'idle' && open && isOpen;
   const isFullyClosed = animationState === 'idle' && !open && !isOpen;
@@ -59,10 +59,15 @@ export function Collapsible({
     },
   };
 
-  const handleCompleteAnimation = useCallback(() => {
-    setAnimationState('idle');
-    setIsOpen(open);
-  }, [open]);
+  const handleCompleteAnimation = useCallback(
+    ({target}: React.TransitionEvent<HTMLDivElement>) => {
+      if (target === collapsibleContainer.current) {
+        setAnimationState('idle');
+        setIsOpen(open);
+      }
+    },
+    [open],
+  );
 
   useEffect(() => {
     if (open !== isOpen) {
@@ -71,24 +76,24 @@ export function Collapsible({
   }, [open, isOpen]);
 
   useEffect(() => {
-    if (!open || !collapisbleContainer.current) return;
+    if (!open || !collapsibleContainer.current) return;
     // If collapsible defaults to open, set an initial height
-    setHeight(collapisbleContainer.current.scrollHeight);
+    setHeight(collapsibleContainer.current.scrollHeight);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
-    if (!collapisbleContainer.current) return;
+    if (!collapsibleContainer.current) return;
 
     switch (animationState) {
       case 'idle':
         break;
       case 'measuring':
-        setHeight(collapisbleContainer.current.scrollHeight);
+        setHeight(collapsibleContainer.current.scrollHeight);
         setAnimationState('animating');
         break;
       case 'animating':
-        setHeight(open ? collapisbleContainer.current.scrollHeight : 0);
+        setHeight(open ? collapsibleContainer.current.scrollHeight : 0);
     }
   }, [animationState, open, isOpen]);
 
@@ -96,7 +101,7 @@ export function Collapsible({
     <div
       id={id}
       style={collapsibleStyles}
-      ref={collapisbleContainer}
+      ref={collapsibleContainer}
       className={wrapperClassName}
       onTransitionEnd={handleCompleteAnimation}
       aria-expanded={open}


### PR DESCRIPTION
### WHY are these changes introduced?
* Fix a bug where transitions of elements inside the collapsible would trigger the component's transition end event logic ([codesandbox example](https://6ke03.csb.app/))

![collapsible-bug](https://user-images.githubusercontent.com/12417232/107808710-04240e00-6d38-11eb-8787-ccf3714355a2.gif)
* In the example above, using the button outside of the collapsible opens and closes it as expected. However, if a toggle button inside the collapsible is clicked, its transition is prematurely triggering the `onTransitionEnd` logic which fully closes the collapsible 

### WHAT is this pull request doing?
* Add a check to the `onTransitionEnd` event that ensures it's coming from the container target, and not an element within it 
![collapsible-fixed](https://user-images.githubusercontent.com/12417232/107810833-4ac73780-6d3b-11eb-827d-9d7ed1b20928.gif)
* This [check](https://github.com/Shopify/polaris-react/blob/v5.12.0/src/components/Collapsible/Collapsible.tsx#L169) used to exist before `Collapsible` was converted to a functional component 

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {Button, Card, Collapsible, Page, Stack, TextContainer} from '../src';

export function Playground() {
  const [open, setOpen] = useState(true);

  const handleToggle = useCallback(() => {
    setOpen((open) => !open);
  }, []);

  return (
    <Page title="Playground">
      <div style={{height: '200px'}}>
        <Card sectioned>
          <Stack vertical>
            <Button
              onClick={handleToggle}
              ariaExpanded={open}
              ariaControls="basic-collapsible"
            >
              Toggle
            </Button>
            <Collapsible
              open={open}
              id="basic-collapsible"
              transition={{duration: '1000ms', timingFunction: 'ease-in-out'}}
            >
              <TextContainer>
                <p>
                  Your mailing list lets you contact customers or visitors who
                  have shown an interest in your store. Reach out to them with
                  exclusive offers or updates about your products.
                </p>
                <Button onClick={handleToggle}>Test button</Button>
              </TextContainer>
            </Collapsible>
          </Stack>
        </Card>
      </div>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
