### PR TITLE
[TextStyle] Fix an issue where inline code would be hard to select

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,6 +26,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `CheckableButton` missing border when focused ([#3988](https://github.com/Shopify/polaris-react/pull/3988))
 - Fixed accessibility issue on `Tabs` disclosure popover on close ([#3994](https://github.com/Shopify/polaris-react/pull/3994))
 - Fixed accessibility issue when tabbing into `IndexTable` ([#4004](https://github.com/Shopify/polaris-react/pull/4004))
+- Fixed an issue where inline code would be hard to select ([#4005](https://github.com/Shopify/polaris-react/pull/4005))
 
 ### Documentation
 

--- a/src/components/TextStyle/TextStyle.scss
+++ b/src/components/TextStyle/TextStyle.scss
@@ -28,6 +28,7 @@ $code-font-size: 1.15em;
     width: 100%;
     height: 100%;
     border: 1px solid transparent;
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The `::after` pseudo element goes on top of the code, making it impossible to select when clicking/selecting or double clicking on it.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

It adds `pointer-events: none` to the pseudo element that covers the code, so that clicking on code isn't impacted by it.