### PR TITLE
[Toast] Fix toast close button alignment for mobile

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -27,6 +27,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed accessibility issue on `Tabs` disclosure popover on close ([#3994](https://github.com/Shopify/polaris-react/pull/3994))
 - Fixed accessibility issue when tabbing into `IndexTable` ([#4004](https://github.com/Shopify/polaris-react/pull/4004))
 - Fixed an issue where inline code would be hard to select ([#4005](https://github.com/Shopify/polaris-react/pull/4005))
+- Update `Toast` close button alignment for small views ([#4006](https://github.com/Shopify/polaris-react/pull/4006))
 
 ### Documentation
 

--- a/src/components/Frame/components/Toast/Toast.scss
+++ b/src/components/Frame/components/Toast/Toast.scss
@@ -40,17 +40,23 @@ $Backdrop-opacity: 0.88;
 
 .CloseButton {
   display: flex;
-  align-self: flex-start;
+  align-self: center;
   flex-direction: column;
   justify-content: flex-start;
-  margin: (-1 * spacing(tight)) (-1 * spacing()) (-1 * spacing(tight)) 0;
-  padding: (1.5 * spacing(tight)) spacing() spacing(tight);
+  margin-right: (-1 * spacing());
+  padding: 0 spacing();
   border: none;
   appearance: none;
   background: transparent;
   color: currentColor;
   @include recolor-icon(currentColor);
   cursor: pointer;
+
+  @include breakpoint-after($breakpoint) {
+    align-self: flex-start;
+    margin: (-1 * spacing(tight)) (-1 * spacing()) (-1 * spacing(tight)) 0;
+    padding: (1.5 * spacing(tight)) spacing() spacing(tight);
+  }
 
   &:focus {
     outline: none;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes shopify/web [#38294](https://github.com/Shopify/web/issues/38294).

The close button on the Toast component isn't centered on mobile views

### WHAT is this pull request doing?

** 👀  before 👀  **
<img width="399" alt="before" src="https://user-images.githubusercontent.com/3619012/108380629-07564880-71d5-11eb-8ec7-fee98cc81bee.png">

** 👀  after 👀  **
<img width="369" alt="after" src="https://user-images.githubusercontent.com/3619012/108380649-0b826600-71d5-11eb-871c-1bc15a536f0e.png">



### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
