### PR TITLE
[Mixin] reset color in unstyled-button

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added `focus-visible` polyfill and default styles ([#3695](https://github.com/Shopify/polaris-react/pull/3695))
 - Added `removeUnderline` prop to `Button` to remove underline when `plain` and `monochrome` are true([#3998](https://github.com/Shopify/polaris-react/))pull/3998)
 - Removed `#AppFrameMainContent` link and updated SkipToContent link to target `#AppFrameMain` instead ([#3912](https://github.com/Shopify/polaris-react/pull/3912))
+- Reset `color` in `unstyled-button` mixin ([#4008](https://github.com/Shopify/polaris-react/pull/4008))
 
 ### Bug fixes
 

--- a/src/styles/shared/_buttons.scss
+++ b/src/styles/shared/_buttons.scss
@@ -226,6 +226,7 @@
   border: none;
   font-size: inherit;
   line-height: inherit;
+  color: inherit;
   cursor: pointer;
 
   &:focus {


### PR DESCRIPTION
### WHY are these changes introduced?

In **Safari** the buttons has a default white color when clicked via `:active`.

Demo: https://codepen.io/sylvhama/pen/ExNwarY

![button](https://user-images.githubusercontent.com/5626729/108629991-9dd27600-7430-11eb-969e-f9c4f128534c.gif)


### WHAT is this pull request doing?

Reset the `color` too based on [this tweet](https://twitter.com/bdc/status/988745695757824003).


