### PR TITLE
[IndexTable] Fix issue where bulk actions appear on mobile when no rows are selected

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -29,6 +29,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed an issue where inline code would be hard to select ([#4005](https://github.com/Shopify/polaris-react/pull/4005))
 - Update `Toast` close button alignment for small views ([#4006](https://github.com/Shopify/polaris-react/pull/4006))
 - Fixed `Collapsible` bug where animation complete logic was being prematurely triggered by transitions in the children ([#4000](https://github.com/Shopify/polaris-react/pull/4000))
+- Fixed `IndexTable` bug where bulk actions are operable when no rows are selected ([#4009](https://github.com/Shopify/polaris-react/pull/4009))
 
 ### Documentation
 

--- a/src/components/IndexTable/IndexTable.tsx
+++ b/src/components/IndexTable/IndexTable.tsx
@@ -318,6 +318,10 @@ function IndexTableBase({
             isSticky && styles['StickyTableHeader-isSticky'],
           );
 
+          const shouldShowActions = !condensed || selectedItemsCount;
+          const promotedActions = shouldShowActions ? promotedBulkActions : [];
+          const actions = shouldShowActions ? bulkActions : [];
+
           const bulkActionsMarkup = shouldShowBulkActions ? (
             <div className={bulkActionClassNames} data-condensed={condensed}>
               {loadingMarkup}
@@ -330,8 +334,8 @@ function IndexTableBase({
                 selected={bulkSelectState}
                 selectMode={selectMode || isSmallScreenSelectable}
                 onToggleAll={handleTogglePage}
-                promotedActions={promotedBulkActions}
-                actions={bulkActions}
+                promotedActions={promotedActions}
+                actions={actions}
                 paginatedSelectAllText={paginatedSelectAllText}
                 paginatedSelectAllAction={paginatedSelectAllAction}
                 onSelectModeToggle={

--- a/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {Sticky} from 'components/Sticky';
-import {EnableSelectionMinor} from '@shopify/polaris-icons';
 
 import {EmptySearchResult} from '../../EmptySearchResult';
 import {Spinner} from '../../Spinner';

--- a/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
+import {Sticky} from 'components/Sticky';
+import {EnableSelectionMinor} from '@shopify/polaris-icons';
 
 import {EmptySearchResult} from '../../EmptySearchResult';
 import {Spinner} from '../../Spinner';
@@ -280,6 +282,14 @@ describe('<IndexTable>', () => {
       onSelectionChange: () => {},
     };
 
+    const width = window.innerWidth;
+
+    afterEach(() => {
+      Object.defineProperty(window, 'innerWidth', {
+        value: width,
+      });
+    });
+
     it('renders bulk actions when selectable', () => {
       const index = mountWithApp(
         <IndexTable {...defaultIndexTableProps} condensed>
@@ -360,6 +370,44 @@ describe('<IndexTable>', () => {
       index.setProps({condensed: false});
 
       expect(index).not.toContainReactComponent(BulkActions);
+    });
+
+    it('does not render bulk actions with onSelectModeToggle unless items are selected', () => {
+      Object.defineProperty(window, 'innerWidth', {
+        value: 300,
+      });
+
+      const promotedActions = [{content: 'PromotedAction'}];
+      const bulkActions = [{content: 'Action'}];
+
+      const index = mountWithApp(
+        <IndexTable
+          {...defaultIndexTableProps}
+          condensed
+          hasMoreItems
+          bulkActions={bulkActions}
+          promotedBulkActions={promotedActions}
+        >
+          {mockTableItems.map(mockRenderCondensedRow)}
+        </IndexTable>,
+      );
+
+      expect(index).not.toContainReactComponent(BulkActions);
+
+      index.find(Sticky)!.find(Button)!.trigger('onClick');
+      expect(index).toContainReactComponent(BulkActions, {
+        actions: [],
+        promotedActions: [],
+      });
+
+      index.setProps({
+        selectedItemsCount: 2,
+      });
+
+      expect(index).toContainReactComponent(BulkActions, {
+        actions: bulkActions,
+        promotedActions,
+      });
     });
   });
 });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Found this while working [on shopify/web #38318](https://github.com/Shopify/web/issues/38318).

The `IndexTable`'s bulk actions are operations that can be performed on selected `IndexTableRow`s. The mobile responsive view shows the bulk actions even when no rows are selected though.

### WHAT is this pull request doing?

Hides bulk actions dropdown unless 1+ rows are selected.

https://user-images.githubusercontent.com/3619012/108529102-1fe06480-72a2-11eb-8fb6-923cd3091da3.mp4



<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx

import React, {useState} from 'react';

import {Page, useIndexResourceState, IndexTable, Card, TextStyle, EventListener} from '../src';

export function Playground() {
  const [condensed, setCondensed] = useState(window.innerWidth < 458);

  const handleResize = () => {
    setCondensed(window.innerWidth < 458);
  };

  return (
    <Page title="Playground">
      <EventListener event="resize" handler={handleResize} />
      <IndexTableWithBulkActionsExample condensed={condensed} />
    </Page>
  );
}

function IndexTableWithBulkActionsExample({condensed}: {condensed?: boolean}) {
  const customers = [
    {
      id: '3413',
      url: 'customers/341',
      name: 'Mae Jemison',
      location: 'Decatur, USA',
      orders: 20,
      amountSpent: '$2,400',
    },
    {
      id: '2563',
      url: 'customers/256',
      name: 'Ellen Ochoa',
      location: 'Los Angeles, USA',
      orders: 30,
      amountSpent: '$140',
    },
  ];
  const resourceName = {
    singular: 'customer',
    plural: 'customers',
  };

  const {
    selectedResources,
    allResourcesSelected,
    handleSelectionChange,
  } = useIndexResourceState(customers);

  const promotedBulkActions = [
    {
      content: 'Edit customers',
      onAction: () => console.log('Todo: implement bulk edit'),
    },
  ];
  const bulkActions = [
    {
      content: 'Add tags',
      onAction: () => console.log('Todo: implement bulk add tags'),
    },
    {
      content: 'Remove tags',
      onAction: () => console.log('Todo: implement bulk remove tags'),
    },
    {
      content: 'Delete customers',
      onAction: () => console.log('Todo: implement bulk delete'),
    },
  ];

  const rowMarkup = customers.map(
    ({id, name, location, orders, amountSpent}, index) => (
      <IndexTable.Row
        id={id}
        key={id}
        selected={selectedResources.includes(id)}
        position={index}
      >
        <IndexTable.Cell>
          <TextStyle variation="strong">{name}</TextStyle>
        </IndexTable.Cell>
        <IndexTable.Cell>{location}</IndexTable.Cell>
        <IndexTable.Cell>{orders}</IndexTable.Cell>
        <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
      </IndexTable.Row>
    ),
  );

  return (
    <Card>
      <IndexTable
        resourceName={resourceName}
        itemCount={customers.length}
        selectedItemsCount={
          allResourcesSelected ? 'All' : selectedResources.length
        }
        onSelectionChange={handleSelectionChange}
        bulkActions={bulkActions}
        promotedBulkActions={promotedBulkActions}
        headings={[
          {title: 'Name'},
          {title: 'Location'},
          {title: 'Order count'},
          {title: 'Amount spent'},
        ]}
        condensed={condensed}
      >
        {rowMarkup}
      </IndexTable>
    </Card>
  );
}


```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
