### PR TITLE
[IndexTable] Remove `in your store` from IndexTable bulk selection

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -34,6 +34,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `CheckableButton` missing border when focused ([#3987](https://github.com/Shopify/polaris-react/issues/3987))
 - Removed all `outline` and `border`instances of `-ms-high-contrast` as it is non-standard ([#3962](https://github.com/Shopify/polaris-react/pull/3962)).
 - Fixed `Autocomplete` popover height not being calculated correctly ([#4015](https://github.com/Shopify/polaris-react/pull/4015)).
+- `IndexTable` Remove parent resource name from bulk select action ([#4013](https://github.com/Shopify/polaris-react/pull/4013))
 
 ### Documentation
 

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -306,7 +306,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Položka",
       "defaultItemPlural": "Položky",
-      "allItemsSelected": "V obchodě bylo vybráno veškeré zboží typu {resourceNamePlural} ({itemsLength}+).",
+      "allItemsSelected": "Bylo vybráno veškeré zboží typu {resourceNamePlural} ({itemsLength} a více).",
       "selected": "Vybráno: {selectedItemsCount}",
       "a11yCheckboxDeselectAllSingle": "Zrušit výběr: {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Vybrat: {resourceNameSingular}",
@@ -321,7 +321,7 @@
       "selectAllLabel": "Vybrat vše: {resourceNamePlural}",
       "selected": "Vybráno: {selectedItemsCount}",
       "undo": "Vrátit zpět",
-      "selectAllItems": "Vybrat v obchodě všechno zboží typu {resourceNamePlural} ({itemsLength}+)",
+      "selectAllItems": "Vybrat všechno zboží typu {resourceNamePlural} ({itemsLength} a více)",
       "selectItem": "Vybrat: {resourceName}",
       "selectButtonText": "Vybrat"
     }

--- a/locales/da.json
+++ b/locales/da.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Vare",
       "defaultItemPlural": "Varer",
-      "allItemsSelected": "Al {itemsLength} + {resourceNamePlural} i din butik er valgt.",
+      "allItemsSelected": "Alle {itemsLength}+ {resourceNamePlural} er valgt.",
       "selected": "{selectedItemsCount} valgt",
       "a11yCheckboxDeselectAllSingle": "Fravælg {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Vælg {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "Vælg alle {resourceNamePlural}",
       "selected": "{selectedItemsCount} valgt",
       "undo": "Fortryd",
-      "selectAllItems": "Vælg alle {itemsLength} + {resourceNamePlural} i butikken",
+      "selectAllItems": "Vælg alle {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Vælg {resourceName}",
       "selectButtonText": "Vælg"
     }

--- a/locales/de.json
+++ b/locales/de.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Artikel",
       "defaultItemPlural": "Artikel",
-      "allItemsSelected": "Alle {itemsLength}+ {resourceNamePlural} in deinem Shop sind ausgewählt.",
+      "allItemsSelected": "Alle {itemsLength}+ {resourceNamePlural} wurden ausgewählt.",
       "selected": "{selectedItemsCount} ausgewählt",
       "a11yCheckboxDeselectAllSingle": "Auswahl für {resourceNameSingular} aufheben",
       "a11yCheckboxSelectAllSingle": "{resourceNameSingular} auswählen",
@@ -319,7 +319,7 @@
       "selectAllLabel": "Alle {resourceNamePlural} auswählen",
       "selected": "{selectedItemsCount} ausgewählt",
       "undo": "Rückgängig machen",
-      "selectAllItems": "Alle {itemsLength}+ {resourceNamePlural} in deinem Shop auswählen",
+      "selectAllItems": "Alle {itemsLength}+ {resourceNamePlural} auswählen",
       "selectItem": "{resourceName} auswählen",
       "selectButtonText": "Auswählen"
     }

--- a/locales/en.json
+++ b/locales/en.json
@@ -137,7 +137,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Item",
       "defaultItemPlural": "Items",
-      "allItemsSelected": "All {itemsLength}+ {resourceNamePlural} in your store are selected.",
+      "allItemsSelected": "All {itemsLength}+ {resourceNamePlural} are selected.",
       "selected": "{selectedItemsCount} selected",
       "a11yCheckboxDeselectAllSingle": "Deselect {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Select {resourceNameSingular}",
@@ -152,7 +152,7 @@
       "selectAllLabel": "Select all {resourceNamePlural}",
       "selected": "{selectedItemsCount} selected",
       "undo": "Undo",
-      "selectAllItems": "Select all {itemsLength}+ {resourceNamePlural} in your store",
+      "selectAllItems": "Select all {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Select {resourceName}",
       "selectButtonText": "Select"
     },

--- a/locales/es.json
+++ b/locales/es.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Artículo",
       "defaultItemPlural": "Artículos",
-      "allItemsSelected": "Todos los {itemsLength}+ {resourceNamePlural} en tu tienda están seleccionados.",
+      "allItemsSelected": "Todos los {itemsLength}+ {resourceNamePlural} están seleccionados.",
       "selected": "{selectedItemsCount} seleccionados",
       "a11yCheckboxDeselectAllSingle": "Deseleccionar {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Seleccionar {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "Seleccionar todos los {resourceNamePlural}",
       "selected": "{selectedItemsCount} seleccionados",
       "undo": "Deshacer",
-      "selectAllItems": "Seleccionar todos los {itemsLength}+ {resourceNamePlural} en tu tienda",
+      "selectAllItems": "Seleccionar todos los {itemsLength}+{resourceNamePlural}",
       "selectItem": "Seleccionar {resourceName}",
       "selectButtonText": "Seleccionar"
     }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Tuote",
       "defaultItemPlural": "Tuotteet",
-      "allItemsSelected": "Kaikki {itemsLength}+ {resourceNamePlural} kaupassasi on valittu.",
+      "allItemsSelected": "Kaikki {itemsLength} ja {resourceNamePlural} on valittu.",
       "selected": "{selectedItemsCount} valittu",
       "a11yCheckboxDeselectAllSingle": "Poista valinta {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Valitse {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "Valitse kaikki {resourceNamePlural}",
       "selected": "{selectedItemsCount} valittu",
       "undo": "Peru",
-      "selectAllItems": "Valitse kaikki {itemsLength}+ {resourceNamePlural} kaupassasi",
+      "selectAllItems": "Valitse kaikki {itemsLength} ja {resourceNamePlural}",
       "selectItem": "Valitse {resourceName}",
       "selectButtonText": "Valitse"
     }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Article",
       "defaultItemPlural": "Articles",
-      "allItemsSelected": "La totalité des {itemsLength}+ {resourceNamePlural} de votre boutique sont sélectionnés.",
+      "allItemsSelected": "La totalité des {itemsLength}+ {resourceNamePlural} est sélectionnée.",
       "selected": "{selectedItemsCount} sélectionné(s)",
       "a11yCheckboxDeselectAllSingle": "Désélectionner {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Sélectionner {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "Sélectionner la totalité des {resourceNamePlural}",
       "selected": "{selectedItemsCount} sélectionné(s)",
       "undo": "Annuler",
-      "selectAllItems": "Sélectionner la totalité des {itemsLength}+ {resourceNamePlural} de votre boutique",
+      "selectAllItems": "Sélectionner la totalité des {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Sélectionner {resourceName}",
       "selectButtonText": "Sélectionner"
     }

--- a/locales/it.json
+++ b/locales/it.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Articolo",
       "defaultItemPlural": "Articoli",
-      "allItemsSelected": "Tutti i {itemsLength}+ {resourceNamePlural} nel tuo negozio sono selezionati.",
+      "allItemsSelected": "Tutti i {itemsLength}+ {resourceNamePlural} sono selezionati.",
       "selected": "{selectedItemsCount} selezionati",
       "a11yCheckboxDeselectAllSingle": "Deseleziona {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Seleziona {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "Seleziona tutti gli {resourceNamePlural}",
       "selected": "{selectedItemsCount} selezionati",
       "undo": "Annulla",
-      "selectAllItems": "Seleziona tutti i {itemsLength}+ {resourceNamePlural} nel tuo negozio",
+      "selectAllItems": "Seleziona tutti i {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Seleziona {resourceName}",
       "selectButtonText": "Seleziona"
     }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "アイテム",
       "defaultItemPlural": "アイテム",
-      "allItemsSelected": "ストアにあるすべての{itemsLength}以上の{resourceNamePlural}が選択されています。",
+      "allItemsSelected": "すべての{itemsLength}+{resourceNamePlural}が選択されています。",
       "selected": "{selectedItemsCount}を選択済み",
       "a11yCheckboxDeselectAllSingle": "{resourceNameSingular}の選択を解除する",
       "a11yCheckboxSelectAllSingle": "{resourceNameSingular}を選択する",
@@ -319,7 +319,7 @@
       "selectAllLabel": "すべての{resourceNamePlural}を選択する",
       "selected": "{selectedItemsCount}を選択済み",
       "undo": "元に戻す",
-      "selectAllItems": "ストアにあるすべての{itemsLength}以上の{resourceNamePlural}を選択する",
+      "selectAllItems": "すべての{itemsLength}+{resourceNamePlural}を選択する",
       "selectItem": "{resourceName}を選択する",
       "selectButtonText": "選択"
     }

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "품목",
       "defaultItemPlural": "품목",
-      "allItemsSelected": "스토어에서 길이가 {itemsLength}보다 긴 {resourceNamePlural}을(를) 모두 선택했습니다.",
+      "allItemsSelected": "길이가 {itemsLength} 이상인 모든 {resourceNamePlural}이(가) 선택되었습니다.",
       "selected": "{selectedItemsCount}개 선택됨",
       "a11yCheckboxDeselectAllSingle": "{resourceNameSingular} 선택 취소",
       "a11yCheckboxSelectAllSingle": "{resourceNameSingular} 선택",
@@ -319,7 +319,7 @@
       "selectAllLabel": "{resourceNamePlural} 모두 선택",
       "selected": "{selectedItemsCount}개 선택됨",
       "undo": "실행 취소",
-      "selectAllItems": "스토어에서 길이가 {itemsLength}보다 긴 모든 {resourceNamePlural} 선택",
+      "selectAllItems": "길이가 {itemsLength} 이상인 모든 {resourceNamePlural} 선택",
       "selectItem": "{resourceName} 선택",
       "selectButtonText": "선택"
     }

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Vare",
       "defaultItemPlural": "Varer",
-      "allItemsSelected": "Alle {itemsLength}+ {resourceNamePlural} i butikken din er valgt.",
+      "allItemsSelected": "Alle {itemsLength} + {resourceNamePlural} er valgt.",
       "selected": "{selectedItemsCount} valgt",
       "a11yCheckboxDeselectAllSingle": "Opphev valg av {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Velg {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "Velg alle {resourceNamePlural}",
       "selected": "{selectedItemsCount} valgt",
       "undo": "Angre",
-      "selectAllItems": "Velg alle {itemsLength}+ {resourceNamePlural} i butikken din",
+      "selectAllItems": "Velg alle {itemsLength} {resourceNamePlural}",
       "selectItem": "Velg {resourceName}",
       "selectButtonText": "Velg"
     }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Artikel",
       "defaultItemPlural": "Artikelen",
-      "allItemsSelected": "Alle {itemsLength}+ {resourceNamePlural} in je winkel zijn geselecteerd.",
+      "allItemsSelected": "Alle {itemsLength}+ {resourceNamePlural} zijn geselecteerd.",
       "selected": "{selectedItemsCount} geselecteerd",
       "a11yCheckboxDeselectAllSingle": "Selectie {resourceNameSingular} opheffen",
       "a11yCheckboxSelectAllSingle": "Selecteer {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "Selecteer alle {resourceNamePlural}",
       "selected": "{selectedItemsCount} geselecteerd",
       "undo": "Ongedaan maken",
-      "selectAllItems": "Selecteer alle {itemsLength}+ {resourceNamePlural} in je winkel",
+      "selectAllItems": "Selecteer alle {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Selecteer {resourceName}",
       "selectButtonText": "Selecteren"
     }

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -306,7 +306,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Pozycja",
       "defaultItemPlural": "Pozycje",
-      "allItemsSelected": "Wszystkie {itemsLength}+ {resourceNamePlural} w Twoim sklepie są zaznaczone.",
+      "allItemsSelected": "Wybrano wszystkie {itemsLength}+ {resourceNamePlural}.",
       "selected": "Wybrano {selectedItemsCount}",
       "a11yCheckboxDeselectAllSingle": "Usuń wybór {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Wybierz {resourceNameSingular}",
@@ -321,7 +321,7 @@
       "selectAllLabel": "Wybierz wszystkie {resourceNamePlural}",
       "selected": "Wybrano {selectedItemsCount}",
       "undo": "Cofnij",
-      "selectAllItems": "Zaznacz wszystkie {itemsLength}+ {resourceNamePlural} w Twoim sklepie",
+      "selectAllItems": "Wybierz wszystkie {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Wybierz {resourceName}",
       "selectButtonText": "Wybierz"
     }

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Item",
       "defaultItemPlural": "Itens",
-      "allItemsSelected": "Todos os mais de {itemsLength} {resourceNamePlural} da loja estão selecionados.",
+      "allItemsSelected": "Todos os {itemsLength}+ {resourceNamePlural} estão selecionados.",
       "selected": "{selectedItemsCount} selecionados",
       "a11yCheckboxDeselectAllSingle": "Desmarcar {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Selecionar {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "Selecione todos os {resourceNamePlural}",
       "selected": "{selectedItemsCount} selecionados",
       "undo": "Desfazer",
-      "selectAllItems": "Selecionar todos os mais de {itemsLength} {resourceNamePlural} da loja",
+      "selectAllItems": "Selecionar todos os {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Selecionar {resourceName}",
       "selectButtonText": "Selecionar"
     }

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Item",
       "defaultItemPlural": "Itens",
-      "allItemsSelected": "Todos os {itemsLength}+ {resourceNamePlural} da sua loja estão selecionados.",
+      "allItemsSelected": "Todos os itens de {resourceNamePlural} de {itemsLength}+ foram selecionados.",
       "selected": "{selectedItemsCount} selecionado",
       "a11yCheckboxDeselectAllSingle": "Anular seleção {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Selecionar {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "Selecionar tudo em {resourceNamePlural}",
       "selected": "{selectedItemsCount} selecionado",
       "undo": "Anular",
-      "selectAllItems": "Selecionar tudo em {itemsLength}+ {resourceNamePlural} da sua loja",
+      "selectAllItems": "Selecionar todos os itens de {resourceNamePlural} de {itemsLength}+",
       "selectItem": "Selecionar {resourceName}",
       "selectButtonText": "Selecionar"
     }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Artikel",
       "defaultItemPlural": "Artiklar",
-      "allItemsSelected": "Alla {itemsLength}+ {resourceNamePlural} i din butik har valts.",
+      "allItemsSelected": "Alla {itemsLength}+ {resourceNamePlural} har valts.",
       "selected": "{selectedItemsCount} har valts",
       "a11yCheckboxDeselectAllSingle": "Avmarkera {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Välj {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "Välj alla {resourceNamePlural}",
       "selected": "{selectedItemsCount} har valts",
       "undo": "Ångra",
-      "selectAllItems": "Välj alla {itemsLength}+ {resourceNamePlural} i din butik",
+      "selectAllItems": "Välj alla {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Välj {resourceName}",
       "selectButtonText": "Välj"
     }

--- a/locales/th.json
+++ b/locales/th.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "รายการ",
       "defaultItemPlural": "รายการ",
-      "allItemsSelected": "เลือก {itemsLength}+ {resourceNamePlural} ทั้งหมดในร้านค้าของคุณแล้ว",
+      "allItemsSelected": "{itemsLength}+ {resourceNamePlural} ที่เลือกทั้งหมด",
       "selected": "เลือกแล้ว {selectedItemsCount} รายการ",
       "a11yCheckboxDeselectAllSingle": "ยกเลิกการเลือก {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "เลือก {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "เลือก {resourceNamePlural} ทั้งหมด",
       "selected": "เลือกแล้ว {selectedItemsCount} รายการ",
       "undo": "เลิกทำ",
-      "selectAllItems": "เลือก {itemsLength}+ {resourceNamePlural} ทั้งหมดในร้านค้าของคุณ",
+      "selectAllItems": "เลือก {itemsLength}+ {resourceNamePlural} ทั้งหมด",
       "selectItem": "เลือก {resourceName}",
       "selectButtonText": "เลือก"
     }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Ürün",
       "defaultItemPlural": "Ürünler",
-      "allItemsSelected": "Mağazanızdaki tüm {itemsLength}+ {resourceNamePlural} kaynağı seçildi.",
+      "allItemsSelected": "Tüm {itemsLength}+ {resourceNamePlural} seçildi.",
       "selected": "{selectedItemsCount} adet seçildi",
       "a11yCheckboxDeselectAllSingle": "{resourceNameSingular} seçimini kaldır",
       "a11yCheckboxSelectAllSingle": "Seç: {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "Şunların tümünü seç: {resourceNamePlural}",
       "selected": "{selectedItemsCount} adet seçildi",
       "undo": "Geri al",
-      "selectAllItems": "Mağazanızdaki tüm {itemsLength}+ {resourceNamePlural} kaynağını seçin.",
+      "selectAllItems": "{itemsLength}+ {resourceNamePlural} kaynağın tümünü seç",
       "selectItem": "Seç: {resourceName}",
       "selectButtonText": "Seç"
     }

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "Mặt hàng",
       "defaultItemPlural": "Các mặt hàng",
-      "allItemsSelected": "Đã chọn tất cả {itemsLength}+ {resourceNamePlural} trong cửa hàng của bạn.",
+      "allItemsSelected": "Đã chọn tất cả {itemsLength}+ {resourceNamePlural}.",
       "selected": "Đã chọn {selectedItemsCount}",
       "a11yCheckboxDeselectAllSingle": "Bỏ chọn {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "Chọn {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "Chọn tất cả {resourceNamePlural}",
       "selected": "Đã chọn {selectedItemsCount}",
       "undo": "Hoàn tác",
-      "selectAllItems": "Chọn tất cả {itemsLength}+ {resourceNamePlural} trong cửa hàng của bạn",
+      "selectAllItems": "Chọn tất cả {itemsLength}+ {resourceNamePlural}",
       "selectItem": "Chọn {resourceName}",
       "selectButtonText": "Chọn"
     }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "商品",
       "defaultItemPlural": "商品",
-      "allItemsSelected": "已选择您商店中所有的 {itemsLength}+ 件 {resourceNamePlural}。",
+      "allItemsSelected": "所有 {itemsLength}+ 的{resourceNamePlural} 均已被选中。",
       "selected": "已选择 {selectedItemsCount} 个",
       "a11yCheckboxDeselectAllSingle": "取消选择 {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "选择 {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "选择所有 {resourceNamePlural}",
       "selected": "已选择 {selectedItemsCount} 个",
       "undo": "撤销",
-      "selectAllItems": "选择您商店中所有的 {itemsLength}+ 件 {resourceNamePlural}",
+      "selectAllItems": "选择所有 {itemsLength}+ 的 {resourceNamePlural}",
       "selectItem": "选择 {resourceName}",
       "selectButtonText": "选择"
     }

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -304,7 +304,7 @@
     "IndexProvider": {
       "defaultItemSingular": "品項",
       "defaultItemPlural": "品項",
-      "allItemsSelected": "已選取您商店中所有 {itemsLength}+ {resourceNamePlural}。",
+      "allItemsSelected": "已選取全部 {itemsLength} + {resourceNamePlural}。",
       "selected": "已選取 {selectedItemsCount} 項",
       "a11yCheckboxDeselectAllSingle": "取消選取 {resourceNameSingular}",
       "a11yCheckboxSelectAllSingle": "選取 {resourceNameSingular}",
@@ -319,7 +319,7 @@
       "selectAllLabel": "選取所有 {resourceNamePlural}",
       "selected": "已選取 {selectedItemsCount} 項",
       "undo": "復原",
-      "selectAllItems": "選取您商店中所有 {itemsLength}+ {resourceNamePlural}",
+      "selectAllItems": "選取全部 {itemsLength} + {resourceNamePlural}",
       "selectItem": "選取 {resourceName}",
       "selectButtonText": "選取"
     }

--- a/src/utilities/index-provider/tests/hooks.test.tsx
+++ b/src/utilities/index-provider/tests/hooks.test.tsx
@@ -183,7 +183,7 @@ describe('useBulkSelectionData', () => {
       singular: 'order',
       plural: 'orders',
     };
-    const paginatedSelectAllText = `All ${itemCount}+ ${resourceName.plural} in your store are selected.`;
+    const paginatedSelectAllText = `All ${itemCount}+ ${resourceName.plural} are selected.`;
     const mockComponent = mountWithApp(
       <MockComponent
         selectedItemsCount="All"


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [shopify/web issue #38565](https://github.com/Shopify/web/issues/38565)

The IndexTable component assumes that the resource present in the list is a root-level resource, which means that the messaging when selecting all items in the list assumes that you're selecting all of that resource type across the entire store. This assumption may not always hold, which is what we're bumping up against in web.


### WHAT is this pull request doing?
This PR removes the `in your store` assumption from the `IndexTable` bulk action strings.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
