### PR TITLE
Ensure @charset is at the top of generated css

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -34,6 +34,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `CheckableButton` missing border when focused ([#3987](https://github.com/Shopify/polaris-react/issues/3987))
 - Removed all `outline` and `border`instances of `-ms-high-contrast` as it is non-standard ([#3962](https://github.com/Shopify/polaris-react/pull/3962)).
 - Fixed `Autocomplete` popover height not being calculated correctly ([#4015](https://github.com/Shopify/polaris-react/pull/4015)).
+- Ensured `@charset` declaration is the first thing in our styles.css file ([#4019](https://github.com/Shopify/polaris-react/pull/4019))
 
 ### Documentation
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4014 

Our generated css file was not handling the consolidation and hoisting of `@charset` declarations.


### WHAT is this pull request doing?

Pulls the `@charset` declaration up to the top of the file. Will error if there is are multiple competing charsets though that shouldn't ever happen because prettier should force all our source files to be utf-8.

### How to 🎩

- `yarn run build` and check `dist/styles.css` and note that `@charset "UTF-8";` is at the top of the file and not half way down.

If you'd like to be more thorough compare output against main:

- Create a build of main: `git checkout main && yarn clean && yarn build  && mv dist dist-orig`
- Create a build from this branch: `git checkout fix-charset && yarn clean && yarn build`
- Diff the old and new dist folders and note that the only change is the location of the charset in `dist/styles.css`: `diff -ru dist-orig dist`