### PR TITLE
[Modal.Section]: Fix in Modal.Section divider color

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -35,6 +35,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed all `outline` and `border`instances of `-ms-high-contrast` as it is non-standard ([#3962](https://github.com/Shopify/polaris-react/pull/3962)).
 - Fixed `Autocomplete` popover height not being calculated correctly ([#4015](https://github.com/Shopify/polaris-react/pull/4015)).
 - Ensured `@charset` declaration is the first thing in our styles.css file ([#4019](https://github.com/Shopify/polaris-react/pull/4019))
+- Fix `Modal.Section` divider color to match header and footer divider ([#4021](https://github.com/Shopify/polaris-react/pull/4021))
 
 ### Documentation
 

--- a/src/components/Modal/components/Section/Section.scss
+++ b/src/components/Modal/components/Section/Section.scss
@@ -5,7 +5,7 @@
   padding: spacing(loose);
 
   &:not(:last-of-type) {
-    border-bottom: border();
+    border-bottom: border('divider');
   }
 
   &.subdued {


### PR DESCRIPTION
### WHY are these changes introduced?

I was creating a Modal component with different sections and I noticed that the color of the divider line between the section was darker than the line that divides the footer and header of the modal. I went to Polaris channel and I was told that the color was not the correct one, so I change to use the border('divider').

### WHAT is this pull request doing?

This is before:

<img width="649" alt="Screen Shot 2021-02-25 at 9 34 24 AM" src="https://user-images.githubusercontent.com/45268098/109168294-a8e91700-774c-11eb-9df1-a4e8dbf239f6.png">

This is After: 

<img width="651" alt="Screen Shot 2021-02-25 at 9 33 45 AM" src="https://user-images.githubusercontent.com/45268098/109168243-9c64be80-774c-11eb-97c7-97ff14ea40ac.png">

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
