### PR TITLE
[Badge] Add customAccessibilityLabel prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added `customAccessibilityLabel` prop to `Badge` ([#4028](https://github.com/Shopify/polaris-react/pull/4028))
+
 ### Bug fixes
 
 - Ensured `@charset` declaration is the first thing in our styles.css file ([#4019](https://github.com/Shopify/polaris-react/pull/4019))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,7 +6,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-- Added `customAccessibilityLabel` prop to `Badge` ([#4028](https://github.com/Shopify/polaris-react/pull/4028))
+- Added `statusAndProgressLabelOverride` prop to `Badge` ([#4028](https://github.com/Shopify/polaris-react/pull/4028))
 
 ### Bug fixes
 

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -23,6 +23,8 @@ export interface BadgeProps {
    * @default 'medium'
    */
   size?: Size;
+  /** Pass a custom accessibilityLabel (overrides status and progress labels) */
+  customAccessibilityLabel?: string;
 }
 
 const PROGRESS_LABELS: {[key in Progress]: Progress} = {
@@ -47,6 +49,7 @@ export function Badge({
   status,
   progress,
   size = DEFAULT_SIZE,
+  customAccessibilityLabel,
 }: BadgeProps) {
   const i18n = useI18n();
   const withinFilter = useContext(WithinFilterContext);
@@ -98,12 +101,17 @@ export function Badge({
       break;
   }
 
-  const accessibilityLabel = i18n.translate('Polaris.Badge.progressAndStatus', {
-    progressLabel,
-    statusLabel,
-  });
+  const accessibilityLabel = customAccessibilityLabel
+    ? customAccessibilityLabel
+    : i18n.translate('Polaris.Badge.progressAndStatus', {
+        progressLabel,
+        statusLabel,
+      });
 
-  let accessibilityMarkup = (progressLabel || statusLabel) && (
+  const hasAccessibilityLabel =
+    progressLabel || statusLabel || customAccessibilityLabel;
+
+  let accessibilityMarkup = hasAccessibilityLabel && (
     <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>
   );
 

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -23,8 +23,8 @@ export interface BadgeProps {
    * @default 'medium'
    */
   size?: Size;
-  /** Pass a custom accessibilityLabel (overrides status and progress labels) */
-  customAccessibilityLabel?: string;
+  /** Pass a custom accessibilityLabel */
+  statusAndProgressLabelOverride?: string;
 }
 
 const PROGRESS_LABELS: {[key in Progress]: Progress} = {
@@ -49,7 +49,7 @@ export function Badge({
   status,
   progress,
   size = DEFAULT_SIZE,
-  customAccessibilityLabel,
+  statusAndProgressLabelOverride,
 }: BadgeProps) {
   const i18n = useI18n();
   const withinFilter = useContext(WithinFilterContext);
@@ -101,15 +101,15 @@ export function Badge({
       break;
   }
 
-  const accessibilityLabel = customAccessibilityLabel
-    ? customAccessibilityLabel
+  const accessibilityLabel = statusAndProgressLabelOverride
+    ? statusAndProgressLabelOverride
     : i18n.translate('Polaris.Badge.progressAndStatus', {
         progressLabel,
         statusLabel,
       });
 
   const hasAccessibilityLabel =
-    progressLabel || statusLabel || customAccessibilityLabel;
+    progressLabel || statusLabel || statusAndProgressLabelOverride;
 
   let accessibilityMarkup = hasAccessibilityLabel && (
     <VisuallyHidden>{accessibilityLabel}</VisuallyHidden>

--- a/src/components/Badge/README.md
+++ b/src/components/Badge/README.md
@@ -251,7 +251,7 @@ Use to indicate when a given task has been completed. For example, when merchant
 <Badge progress="complete">Fulfilled</Badge>
 ```
 
-### Badge with customAccessibilityLabel
+### Badge with statusAndProgressLabelOverride
 
 Use when the status and progress accessibilityLabels are not appropriate to a given context.
 
@@ -259,7 +259,7 @@ Use when the status and progress accessibilityLabels are not appropriate to a gi
 <Badge
   status="success"
   progress="complete"
-  customAccessibilityLabel="Status: Published. Your online store is visible."
+  statusAndProgressLabelOverride="Status: Published. Your online store is visible."
 >
   Published
 </Badge>

--- a/src/components/Badge/README.md
+++ b/src/components/Badge/README.md
@@ -251,6 +251,20 @@ Use to indicate when a given task has been completed. For example, when merchant
 <Badge progress="complete">Fulfilled</Badge>
 ```
 
+### Badge with customAccessibilityLabel
+
+Use when the status and progress accessibilityLabels are not appropriate to a given context.
+
+```jsx
+<Badge
+  status="success"
+  progress="complete"
+  customAccessibilityLabel="Status: Published. Your online store is visible."
+>
+  Published
+</Badge>
+```
+
 <!-- content-for: android -->
 
 ![Complete badge. Default badge with complete status](/public_images/components/Badge/android/complete@2x.png)

--- a/src/components/Badge/tests/Badge.test.tsx
+++ b/src/components/Badge/tests/Badge.test.tsx
@@ -61,9 +61,6 @@ describe('<Badge />', () => {
     expect(badge).toContainReactComponent(VisuallyHidden, {
       children: mockAccessibilityLabel,
     });
-    expect(badge).not.toContainReactComponent(VisuallyHidden, {
-      children: 'Attention Incomplete',
-    });
   });
 
   it('does not render progress or status accessibility labels when a `customAccessibilityLabel` is provided', () => {

--- a/src/components/Badge/tests/Badge.test.tsx
+++ b/src/components/Badge/tests/Badge.test.tsx
@@ -48,13 +48,13 @@ describe('<Badge />', () => {
     });
   });
 
-  it('renders with a customAccessibilityLabel when provided', () => {
+  it('renders with a custom accessibilityLabel when a `statusAndProgressLabelOverride` is provided', () => {
     const mockAccessibilityLabel = 'mock accessibilityLabel';
     const badge = mountWithApp(
       <Badge
         status="attention"
         progress="incomplete"
-        customAccessibilityLabel={mockAccessibilityLabel}
+        statusAndProgressLabelOverride={mockAccessibilityLabel}
       />,
     );
 
@@ -63,13 +63,13 @@ describe('<Badge />', () => {
     });
   });
 
-  it('does not render progress or status accessibility labels when a `customAccessibilityLabel` is provided', () => {
+  it('does not render progress or status accessibility labels when a `statusAndProgressLabelOverride` is provided', () => {
     const mockAccessibilityLabel = 'mock accessibilityLabel';
     const badge = mountWithApp(
       <Badge
         status="attention"
         progress="incomplete"
-        customAccessibilityLabel={mockAccessibilityLabel}
+        statusAndProgressLabelOverride={mockAccessibilityLabel}
       />,
     );
 

--- a/src/components/Badge/tests/Badge.test.tsx
+++ b/src/components/Badge/tests/Badge.test.tsx
@@ -47,4 +47,37 @@ describe('<Badge />', () => {
       className: 'Pip',
     });
   });
+
+  it('renders with a customAccessibilityLabel when provided', () => {
+    const mockAccessibilityLabel = 'mock accessibilityLabel';
+    const badge = mountWithApp(
+      <Badge
+        status="attention"
+        progress="incomplete"
+        customAccessibilityLabel={mockAccessibilityLabel}
+      />,
+    );
+
+    expect(badge).toContainReactComponent(VisuallyHidden, {
+      children: mockAccessibilityLabel,
+    });
+    expect(badge).not.toContainReactComponent(VisuallyHidden, {
+      children: 'Attention Incomplete',
+    });
+  });
+
+  it('does not render progress or status accessibility labels when a `customAccessibilityLabel` is provided', () => {
+    const mockAccessibilityLabel = 'mock accessibilityLabel';
+    const badge = mountWithApp(
+      <Badge
+        status="attention"
+        progress="incomplete"
+        customAccessibilityLabel={mockAccessibilityLabel}
+      />,
+    );
+
+    expect(badge).not.toContainReactComponent(VisuallyHidden, {
+      children: 'Attention Incomplete',
+    });
+  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

Experimenting with a proposed feature request #4027 

### WHAT is this pull request doing?

- Adds a `customAccessibilityLabel` for consumer's who need to pass more specific labels.

### How to 🎩

- Access  `Badge with customAccessibilityLabel` story 
- Enable Voiceover 


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes

