### PR TITLE
Update tokens to v2.21.1

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,6 +1,6 @@
 import {addons} from '@storybook/addons';
 import {create} from '@storybook/theming';
-import tokens from '@shopify/polaris-tokens';
+import {colorSkyLight, colorInk} from '@shopify/polaris-tokens';
 
 addons.setConfig({
   panelPosition: 'bottom',
@@ -10,9 +10,9 @@ addons.setConfig({
     brandUrl: '/',
     brandImage: null,
     appBorderRadius: 0,
-    appBg: tokens.colorSkyLight,
-    contentBg: tokens.colorSkyLight,
-    textColor: tokens.colorInk,
+    appBg: colorSkyLight,
+    contentBg: colorSkyLight,
+    textColor: colorInk,
     // TODO more pretty brand colors?
     // SEE https://github.com/storybooks/storybook/blob/next/docs/src/pages/configurations/theming/index.md
   }),

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -19,6 +19,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Dependency upgrades
 
+- Update `@shopify/polaris-tokens to v2.21.0 ([#4030](https://github.com/Shopify/polaris-react/pull/4030))
+
 ### Code quality
 
 ### Deprecations

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "@shopify/polaris-icons": "^4.1.0",
-    "@shopify/polaris-tokens": "^2.16.0",
+    "@shopify/polaris-tokens": "^2.21.0",
     "@types/react": "^16.9.12",
     "@types/react-dom": "^16.9.4",
     "@types/react-transition-group": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "@shopify/polaris-icons": "^4.1.0",
-    "@shopify/polaris-tokens": "^2.21.0",
+    "@shopify/polaris-tokens": "^2.21.1",
     "@types/react": "^16.9.12",
     "@types/react-dom": "^16.9.4",
     "@types/react-transition-group": "^4.4.0",

--- a/src/utilities/theme/types.ts
+++ b/src/utilities/theme/types.ts
@@ -1,4 +1,4 @@
-import type {Config} from '@shopify/polaris-tokens/dist-modern/types';
+import type {Config} from '@shopify/polaris-tokens/dist-modern';
 
 export interface ThemeLogo {
   /** Provides a path for a logo used on a dark background */

--- a/src/utilities/theme/utils.ts
+++ b/src/utilities/theme/utils.ts
@@ -1,5 +1,4 @@
-import {colorFactory} from '@shopify/polaris-tokens/dist-modern';
-import {mergeConfigs} from '@shopify/polaris-tokens/dist-modern/utils';
+import {colorFactory, mergeConfigs} from '@shopify/polaris-tokens/dist-modern';
 import {config as base} from '@shopify/polaris-tokens/dist-modern/configs/base';
 
 import type {HSLAColor} from '../color-types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2486,13 +2486,13 @@
   resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-4.1.0.tgz#296ff47d22b52cb1592e2fa81a609f8f3c912eb0"
   integrity sha512-U5ODhOJtfYHJskYUknceIjpF+EhHdMQJ54HSWsjuHAapCWbmA8ROVonAnDEM+cWeEVinpPZzQd2nE/DVJUmKkw==
 
-"@shopify/polaris-tokens@^2.16.0":
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.16.0.tgz#217574a37e7dcc3249fd03509508538286571596"
-  integrity sha512-uhwu//NpS9OEBIVvX04TMHwsePpRb+KmvDvTUDYpqafK0PqBvldWjyrDEs+/lZCcCBNQMZhnwX27DgQkywkW0Q==
+"@shopify/polaris-tokens@^2.21.0":
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.21.0.tgz#9f410939225df456b1cd2d8d2372eb0f4d31d8b8"
+  integrity sha512-uwdsQjCb79sPXc7HYI2SGmiPu6kOkm2sN59gZ6OGSqxFsDpFky/5HRq4b9iONIWBgG3WdHeU+dUi0wjU5bhZIA==
   dependencies:
     hsluv "^0.1.0"
-    tslib "^1.10.0"
+    tslib "^1.14.1"
 
 "@shopify/polyfills@^1.1.8":
   version "1.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2486,10 +2486,10 @@
   resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-4.1.0.tgz#296ff47d22b52cb1592e2fa81a609f8f3c912eb0"
   integrity sha512-U5ODhOJtfYHJskYUknceIjpF+EhHdMQJ54HSWsjuHAapCWbmA8ROVonAnDEM+cWeEVinpPZzQd2nE/DVJUmKkw==
 
-"@shopify/polaris-tokens@^2.21.0":
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.21.0.tgz#9f410939225df456b1cd2d8d2372eb0f4d31d8b8"
-  integrity sha512-uwdsQjCb79sPXc7HYI2SGmiPu6kOkm2sN59gZ6OGSqxFsDpFky/5HRq4b9iONIWBgG3WdHeU+dUi0wjU5bhZIA==
+"@shopify/polaris-tokens@^2.21.1":
+  version "2.21.1"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-tokens/-/polaris-tokens-2.21.1.tgz#d4f2a53edac57505b5ebcaf46b3e278653e10b19"
+  integrity sha512-v4gQQashbv+3bUZ14wPVyomUhdmDDhhyx0BJKagQUC6vu1KWWnrXKC3Li2VgPHYTN5v+B+/0vAfNvSIxR+FArw==
   dependencies:
     hsluv "^0.1.0"
     tslib "^1.14.1"


### PR DESCRIPTION
### WHY are these changes introduced?

Gives us esm support for legacy tokens, and lets us remove some deep
imports inside dist-modern.

### WHAT is this pull request doing?

- Update `@shopify/polaris-tokens` to v2.21.0
- Import from `@shopify/polaris-tokens/dist-modern` where possible
- Use named imports in storybook manager config (the default export still works but is deprecated)
