### PR TITLE
[IndexTable] Fix UX / jank when resizing

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Ensured `@charset` declaration is the first thing in our styles.css file ([#4019](https://github.com/Shopify/polaris-react/pull/4019))
 - Fix `Modal.Section` divider color to match header and footer divider ([#4021](https://github.com/Shopify/polaris-react/pull/4021))
+- Fix `IndexTable` sticky header alignment and jank ([#4033](https://github.com/Shopify/polaris-react/pull4033)
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Replaced mentions of "invalid" with not "valid" ([#4025](https://github.com/Shopify/polaris-react/pull/4025))
+
 ### Development workflow
 
 ### Dependency upgrades

--- a/src/components/IndexTable/IndexTable.tsx
+++ b/src/components/IndexTable/IndexTable.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState, useEffect, useCallback, useMemo} from 'react';
+import React, {useRef, useState, useEffect, useCallback} from 'react';
 import {EnableSelectionMinor} from '@shopify/polaris-icons';
 import debounce from 'lodash/debounce';
 import throttle from 'lodash/throttle';

--- a/src/components/IndexTable/IndexTable.tsx
+++ b/src/components/IndexTable/IndexTable.tsx
@@ -55,6 +55,7 @@ export interface TableHeadingRect {
 const SCROLL_BAR_PADDING = 4;
 const SIXTY_FPS = 1000 / 60;
 const SCROLL_BAR_DEBOUNCE_PERIOD = 300;
+const SMALL_SCREEN_WIDTH = 458;
 
 function IndexTableBase({
   headings,
@@ -169,7 +170,7 @@ function IndexTableBase({
           // update sticky header min-widths
           stickyTableHeadings.current.forEach((heading, index) => {
             let minWidth = 0;
-            if (index === 0) {
+            if (index === 0 && !isSmallScreen()) {
               minWidth = calculateFirstHeaderOffset();
             } else if (tableHeadingRects.current.length > index) {
               minWidth = tableHeadingRects.current[index].offsetWidth;
@@ -690,6 +691,12 @@ function IndexTableBase({
     setIsSmallScreenSelectable(val);
   }
 }
+
+const isSmallScreen = () => {
+  return typeof window === 'undefined'
+    ? false
+    : window.innerWidth < SMALL_SCREEN_WIDTH;
+};
 
 export interface IndexTableProps
   extends IndexTableBaseProps,

--- a/src/components/IndexTable/IndexTable.tsx
+++ b/src/components/IndexTable/IndexTable.tsx
@@ -27,8 +27,8 @@ import {
 import {AfterInitialMount} from '../AfterInitialMount';
 import {IndexProvider} from '../IndexProvider';
 import type {NonEmptyArray} from '../../types';
-import {getTableHeadingsBySelector} from './utilities';
 
+import {getTableHeadingsBySelector} from './utilities';
 import {ScrollContainer, Cell, Row} from './components';
 import styles from './IndexTable.scss';
 

--- a/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -4,8 +4,8 @@ import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {Sticky} from 'components/Sticky';
 import {EventListener} from 'components/EventListener';
-import {getTableHeadingsBySelector} from '../utilities';
 
+import {getTableHeadingsBySelector} from '../utilities';
 import {EmptySearchResult} from '../../EmptySearchResult';
 import {Spinner} from '../../Spinner';
 import {Button} from '../../Button';

--- a/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -19,7 +19,7 @@ import {SelectionType} from '../../../utilities/index-provider';
 import {AfterInitialMount} from '../../AfterInitialMount';
 
 jest.mock('../utilities', () => ({
-  ...(jest.requireActual('../utilities') as any),
+  ...jest.requireActual('../utilities'),
   getTableHeadingsBySelector: jest.fn(),
 }));
 

--- a/src/components/IndexTable/utilities/index.ts
+++ b/src/components/IndexTable/utilities/index.ts
@@ -1,0 +1,1 @@
+export {getTableHeadingsBySelector} from './utilities';

--- a/src/components/IndexTable/utilities/tests/utilities.test.ts
+++ b/src/components/IndexTable/utilities/tests/utilities.test.ts
@@ -1,16 +1,16 @@
-import {getTableHeadingsBySelector} from "../utilities";
+import {getTableHeadingsBySelector} from '../utilities';
 
 describe('#getTableHeadingsBySelector', function () {
-  it('returns empty array when no wrapper is passed', async () => {
-    expect(getTableHeadingsBySelector(null, '')).toStrictEqual([])
+  it('returns empty array when no wrapper is passed', () => {
+    expect(getTableHeadingsBySelector(null, '')).toStrictEqual([]);
   });
 
-  it('returns array when wrapper is passed', async () => {
+  it('returns array when wrapper is passed', () => {
     const response = [{id: 'test'}];
-    const fakeElement = (({
+    const fakeElement = ({
       querySelectorAll: () => response,
-    }) as unknown) as HTMLElement;
+    } as unknown) as HTMLElement;
 
-    expect(getTableHeadingsBySelector(fakeElement, '')).toStrictEqual(response)
+    expect(getTableHeadingsBySelector(fakeElement, '')).toStrictEqual(response);
   });
 });

--- a/src/components/IndexTable/utilities/tests/utilities.test.ts
+++ b/src/components/IndexTable/utilities/tests/utilities.test.ts
@@ -1,0 +1,16 @@
+import {getTableHeadingsBySelector} from "../utilities";
+
+describe('#getTableHeadingsBySelector', function () {
+  it('returns empty array when no wrapper is passed', async () => {
+    expect(getTableHeadingsBySelector(null, '')).toStrictEqual([])
+  });
+
+  it('returns array when wrapper is passed', async () => {
+    const response = [{id: 'test'}];
+    const fakeElement = (({
+      querySelectorAll: () => response,
+    }) as unknown) as HTMLElement;
+
+    expect(getTableHeadingsBySelector(fakeElement, '')).toStrictEqual(response)
+  });
+});

--- a/src/components/IndexTable/utilities/utilities.ts
+++ b/src/components/IndexTable/utilities/utilities.ts
@@ -1,0 +1,8 @@
+export function getTableHeadingsBySelector(
+  wrapperElement: HTMLElement | null,
+  selector: string,
+) {
+  return wrapperElement
+    ? Array.from(wrapperElement.querySelectorAll<HTMLElement>(selector))
+    : [];
+}

--- a/src/components/InlineError/README.md
+++ b/src/components/InlineError/README.md
@@ -15,7 +15,7 @@ keywords:
 
 # Inline error
 
-Inline errors are brief, in-context messages that tell merchants something went wrong with a single or group of inputs in a form. Use inline errors to help merchants understand why a form input may be invalid and how to fix it.
+Inline errors are brief, in-context messages that tell merchants something went wrong with a single or group of inputs in a form. Use inline errors to help merchants understand why a form input may not be valid and how to fix it.
 
 ---
 
@@ -25,7 +25,7 @@ Inline errors should:
 
 - Be brief
 - Be written in sentence case
-- Be visible immediately upon the invalid form input
+- Be visible immediately upon a form input that is not valid
 - Be removed as soon as the input is valid so merchants can immediately tell they fixed the issue
 - Describe specific solutions so merchants can successfully complete their task in the form
 - Not be placed out of context of the input or group of inputs they describe
@@ -64,7 +64,7 @@ Inline error messages should:
 
 ### Basic inline error
 
-Use when the merchant has entered invalid information into multiple fields inside of a form, or needs to be displayed in a non-standard position in the form layout.
+Use when the merchant has entered information that is not valid into multiple fields inside of a form, or needs to be displayed in a non-standard position in the form layout.
 
 ```jsx
 <InlineError message="Store name is required" fieldID="myFieldID" />

--- a/src/utilities/sticky-manager/sticky-manager.ts
+++ b/src/utilities/sticky-manager/sticky-manager.ts
@@ -1,4 +1,4 @@
-import throttle from 'lodash/throttle';
+import debounce from 'lodash/debounce';
 import {spacingLoose} from '@shopify/polaris-tokens';
 
 import {dataPolarisTopBar, scrollable} from '../../components/shared';
@@ -33,20 +33,20 @@ export class StickyManager {
   private container: Document | HTMLElement | null = null;
   private topBarOffset = 0;
 
-  private handleResize = throttle(
+  private handleResize = debounce(
     () => {
       this.manageStickyItems();
     },
     SIXTY_FPS,
-    {leading: true, trailing: true},
+    {leading: true, trailing: true, maxWait: SIXTY_FPS},
   );
 
-  private handleScroll = throttle(
+  private handleScroll = debounce(
     () => {
       this.manageStickyItems();
     },
     SIXTY_FPS,
-    {leading: true, trailing: true},
+    {leading: true, trailing: true, maxWait: SIXTY_FPS},
   );
 
   constructor(container?: Document | HTMLElement) {

--- a/src/utilities/sticky-manager/sticky-manager.ts
+++ b/src/utilities/sticky-manager/sticky-manager.ts
@@ -1,4 +1,4 @@
-import debounce from 'lodash/debounce';
+import throttle from 'lodash/throttle';
 import {spacingLoose} from '@shopify/polaris-tokens';
 
 import {dataPolarisTopBar, scrollable} from '../../components/shared';
@@ -25,26 +25,28 @@ interface StickyItem {
   ): void;
 }
 
+const SIXTY_FPS = 1000 / 60;
+
 export class StickyManager {
   private stickyItems: StickyItem[] = [];
   private stuckItems: StickyItem[] = [];
   private container: Document | HTMLElement | null = null;
   private topBarOffset = 0;
 
-  private handleResize = debounce(
+  private handleResize = throttle(
     () => {
       this.manageStickyItems();
     },
-    40,
-    {leading: true, trailing: true, maxWait: 40},
+    SIXTY_FPS,
+    {leading: true, trailing: true},
   );
 
-  private handleScroll = debounce(
+  private handleScroll = throttle(
     () => {
       this.manageStickyItems();
     },
-    40,
-    {leading: true, trailing: true, maxWait: 40},
+    SIXTY_FPS,
+    {leading: true, trailing: true},
   );
 
   constructor(container?: Document | HTMLElement) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Resolves #3991.

The IndexTable currently has some UX, jank, and performance issues when resizing. This PR aims to address a lot of these by making UX and performance fixes to make this resize buttery-smooth.

### WHAT is this pull request doing?
**1) Fixed sticky header alignment issues**
All the sticky headers are sized on load and not resized when the window width changes.

👀 _before (watch the Location column)_ 👀 

https://user-images.githubusercontent.com/3619012/109985851-31c6fc00-7cd3-11eb-9f50-962d805a235e.mp4

👀 _after (watch the Location column)_ 👀 

https://user-images.githubusercontent.com/3619012/109988962-0b569000-7cd6-11eb-8954-89f70faf2d5c.mp4


**2) Fixed first (non-sticky) column alignment issues when resizing browser**
First column header doesn't resize when window does.

👀 _before_ 👀 

https://user-images.githubusercontent.com/3619012/109986360-a7cb6300-7cd3-11eb-9041-1be1628149eb.mp4


👀 _after_ 👀 

https://user-images.githubusercontent.com/3619012/109989074-26c19b00-7cd6-11eb-8dd7-18b5990b2015.mp4


**3) Fixed first sticky header misalignment **
First column is out of place when you load the page and scroll down

👀 _before (watch the Name column)_ 👀 

https://user-images.githubusercontent.com/3619012/109985568-e44a8f00-7cd2-11eb-9a77-af1e8cd65cf2.mp4

👀 _after_ 👀 

https://user-images.githubusercontent.com/3619012/109989399-7607cb80-7cd6-11eb-9247-1d9e6112de1e.mp4


**4)  Fix flickering scrollbar **
Scrollbar flickers when resizing window large->small. The issue here was that the width of `.ScrollBarContent` was set by `--p-scroll-bar-content-width`, so when you resize smaller unless `--p-scroll-bar-content-width` is set on a bare-metal resize event (i.e. not by a throttled/debounced function), the scrollbar will be larger than the content when you size the window down and will flicker. Fixed this by setting this width to 0 when resizing and only actually setting `--p-scroll-bar-content-width` once resizing completes.

👀 _before_ 👀 

https://user-images.githubusercontent.com/3619012/109987181-67201980-7cd4-11eb-9cf2-5c1e0108be86.mp4

👀 _after_ 👀 

https://user-images.githubusercontent.com/3619012/109989526-93d53080-7cd6-11eb-8d69-ef8af87d4597.mp4


**5)  Fix sticky header not resizing smoothly **
Watch the upper right corner of the sticky header. As you resize, the width of the header goes out of shape with the rest of the card, this happens because the debounce period is at a slower framerate than it should be. Fix was to update to 60FPS (and converted to use `throttle` instead of `debounce` with `maxWait` for clarity).

👀 _before (watch upper right corner of sticky header)_ 👀 

https://user-images.githubusercontent.com/3619012/109987935-0ba25b80-7cd5-11eb-8081-29f2217fde36.mp4

👀 _after_ 👀 


https://user-images.githubusercontent.com/3619012/109989890-e9114200-7cd6-11eb-95d4-789d305ce41f.mp4



**6)  Performance stuff **
- converted the resize handler to use `useCallback` instead of `useMemo`, we really don't need to memoize anything for this
- cache the column header / sticky column header DOM lookups instead of performing them on every resize event
- increased the debounce period on the scrollbar resize event so it fires ~600% less frequently


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```

import React from 'react';

import {Card, IndexTable, Page, TextStyle, useIndexResourceState} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}

      <div style={{ marginBottom: 1000 }}>
        <SimpleIndexTableExample />
      </div>
    </Page>
  );
}


function SimpleIndexTableExample() {
  const customers = [
    {
      id: '3411',
      url: 'customers/341',
      name: 'Mae Jemison',
      location: 'Decatur, USA',
      orders: 20,
      amountSpent: '$2,400',
    },
    {
      id: '2561',
      url: 'customers/256',
      name: 'Ellen Ochoa',
      location: 'Los Angeles, USA',
      orders: 30,
      amountSpent: '$140',
    },
  ];
  const resourceName = {
    singular: 'customer',
    plural: 'customers',
  };

  const {
    selectedResources,
    allResourcesSelected,
    handleSelectionChange,
  } = useIndexResourceState(customers);

  const rowMarkup = customers.map(
    ({id, name, location, orders, amountSpent}, index) => (
      <IndexTable.Row
        id={id}
        key={id}
        selected={selectedResources.includes(id)}
        position={index}
      >
        <IndexTable.Cell>
          <TextStyle variation="strong">{name}</TextStyle>
        </IndexTable.Cell>
        <IndexTable.Cell>{location}</IndexTable.Cell>
        <IndexTable.Cell>{orders}</IndexTable.Cell>
        <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
      </IndexTable.Row>
    ),
  );

  return (
    <Card>
      <IndexTable
        resourceName={resourceName}
        itemCount={customers.length}
        selectedItemsCount={
          allResourcesSelected ? 'All' : selectedResources.length
        }
        onSelectionChange={handleSelectionChange}
        headings={[
          {title: 'Name'},
          {title: 'Location'},
          {title: 'Order count'},
          {title: 'Amount spent'},
        ]}
      >
        {rowMarkup}
      </IndexTable>
    </Card>
  );
}


```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
