### PR TITLE
DropZone - show plural message when allowMultiple is true

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,7 +7,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added `hideOnPrint` prop to `Card` and `CardSection` ([#4071](https://github.com/Shopify/polaris-react/pull/4071))
-- Added `statusAndProgressLabelOverride` prop to `Badge` ([#4028](https://github.com/Shopify/polaris-react/pull/4028))
 - `DropZone` now has plural sentences when `allowMultiple` is true [#4037](https://github.com/Shopify/polaris-react/pull/4037)
 
 ### Bug fixes

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added `hideOnPrint` prop to `Card` and `CardSection` ([#4071](https://github.com/Shopify/polaris-react/pull/4071))
+- Added `statusAndProgressLabelOverride` prop to `Badge` ([#4028](https://github.com/Shopify/polaris-react/pull/4028))
+- `DropZone` now has plural sentences when `allowMultiple` is true [#4037](https://github.com/Shopify/polaris-react/pull/4037)
 
 ### Bug fixes
 

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Pokračovat v úpravách"
     },
     "DropZone": {
-      "overlayTextFile": "Soubor nahrajete přetáhnutím",
-      "overlayTextImage": "Obrázek nahrajete přetáhnutím",
       "errorOverlayTextFile": "Typ souboru není platný",
       "errorOverlayTextImage": "Typ obrázku není platný",
-      "FileUpload": {
-        "actionTitleFile": "Přidat soubor",
-        "actionTitleImage": "Přidat obrázek",
-        "actionHintFile": "nebo nahrajte soubor přetáhnutím",
-        "actionHintImage": "nebo nahrajte obrázek přetáhnutím",
-        "label": "Nahrát soubor"
+      "single": {
+        "overlayTextFile": "Soubor nahrajete přetažením",
+        "overlayTextImage": "Obrázek nahrajete přetažením",
+        "actionTitleFile": "Přidejte soubor",
+        "actionTitleImage": "Přidejte obrázek",
+        "actionHintFile": "nebo ho nahrajte přetažením",
+        "actionHintImage": "nebo ho nahrajte přetažením",
+        "labelFile": "Nahrát soubor",
+        "labelImage": "Nahrát obrázek"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Soubory nahrajete přetažením",
+        "overlayTextImage": "Obrázky nahrajete přetažením",
+        "actionTitleFile": "Přidejte soubory",
+        "actionTitleImage": "Přidejte obrázky",
+        "actionHintFile": "nebo je nahrajte přetažením",
+        "actionHintImage": "nebo je nahrajte přetažením",
+        "labelFile": "Nahrát soubory",
+        "labelImage": "Nahrát obrázky"
       }
     },
     "EmptySearchResult": {

--- a/locales/da.json
+++ b/locales/da.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Fortsæt redigering"
     },
     "DropZone": {
-      "overlayTextFile": "Slip fil for at uploade",
-      "overlayTextImage": "Slip billede for at uploade",
       "errorOverlayTextFile": "Filtype er ikke gyldig",
       "errorOverlayTextImage": "Billedtype er ikke gyldig",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Slip fil for at uploade",
+        "overlayTextImage": "Slip billede for at uploade",
         "actionTitleFile": "Tilføj fil",
         "actionTitleImage": "Tilføj billede",
+        "actionHintFile": "eller slip filen for at uploade",
+        "actionHintImage": "eller slip billedet for at uploade",
+        "labelFile": "Upload fil",
+        "labelImage": "Upload billede"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Slip filer for at uploade",
+        "overlayTextImage": "Slip billeder for at uploade",
+        "actionTitleFile": "Tilføj filer",
+        "actionTitleImage": "Tilføj billeder",
         "actionHintFile": "eller slip filer for at uploade",
         "actionHintImage": "eller slip billeder for at uploade",
-        "label": "Upload fil"
+        "labelFile": "Upload filer",
+        "labelImage": "Upload billeder"
       }
     },
     "EmptySearchResult": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Weiter bearbeiten"
     },
     "DropZone": {
-      "overlayTextFile": "Datei zum Hochladen ablegen",
-      "overlayTextImage": "Bild zum Hochladen ablegen",
       "errorOverlayTextFile": "Der Dateityp ist nicht gültig",
       "errorOverlayTextImage": "Der Bildtyp ist nicht gültig",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Datei zum Hochladen ablegen",
+        "overlayTextImage": "Bild zum Hochladen ablegen",
         "actionTitleFile": "Datei hinzufügen",
         "actionTitleImage": "Bild hinzufügen",
+        "actionHintFile": "oder Datei zum Hochladen ablegen",
+        "actionHintImage": "oder Bild zum Hochladen ablegen",
+        "labelFile": "Datei hochladen",
+        "labelImage": "Bild hochladen"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Dateien zum Hochladen ablegen",
+        "overlayTextImage": "Bilder zum Hochladen ablegen",
+        "actionTitleFile": "Dateien hinzufügen",
+        "actionTitleImage": "Bilder hinzufügen",
         "actionHintFile": "oder Dateien zum Hochladen ablegen",
         "actionHintImage": "oder Bilder zum Hochladen ablegen",
-        "label": "Datei hochladen"
+        "labelFile": "Dateien hochladen",
+        "labelImage": "Bilder hochladen"
       }
     },
     "EmptySearchResult": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -96,17 +96,28 @@
       "secondaryAction": "Continue editing"
     },
     "DropZone": {
-      "overlayTextFile": "Drop file to upload",
-      "overlayTextImage": "Drop image to upload",
-      "errorOverlayTextFile": "File type is not valid",
-      "errorOverlayTextImage": "Image type is not valid",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Drop file to upload",
+        "overlayTextImage": "Drop image to upload",
         "actionTitleFile": "Add file",
         "actionTitleImage": "Add image",
+        "actionHintFile": "or drop file to upload",
+        "actionHintImage": "or drop image to upload",
+        "labelFile": "Upload file",
+        "labelImage": "Upload image"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Drop files to upload",
+        "overlayTextImage": "Drop images to upload",
+        "actionTitleFile": "Add files",
+        "actionTitleImage": "Add images",
         "actionHintFile": "or drop files to upload",
         "actionHintImage": "or drop images to upload",
-        "label": "Upload file"
-      }
+        "labelFile": "Upload files",
+        "labelImage": "Upload images"
+      },
+      "errorOverlayTextFile": "File type is not valid",
+      "errorOverlayTextImage": "Image type is not valid"
     },
     "EmptySearchResult": {
       "altText": "Empty search results"

--- a/locales/es.json
+++ b/locales/es.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Continuar editando"
     },
     "DropZone": {
-      "overlayTextFile": "Arrastra y suelta el archivo que deseas subir",
-      "overlayTextImage": "Arrastra y suelta la imagen que deseas subir",
       "errorOverlayTextFile": "El tipo de archivo no es válido",
       "errorOverlayTextImage": "El tipo de imagen no es válida",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Arrastra y suelta el archivo que deseas subir",
+        "overlayTextImage": "Arrastra y suelta la imagen que deseas subir",
         "actionTitleFile": "Agregar archivo",
         "actionTitleImage": "Agregar imagen",
+        "actionHintFile": "o suelta el archivo que deseas subir",
+        "actionHintImage": "o arrastra y suelta la imagen que deseas subir",
+        "labelFile": "Subir archivo",
+        "labelImage": "Subir imagen"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Arrastra y suelta los archivos que deseas subir",
+        "overlayTextImage": "Arrastra y suelta las imágenes que deseas subir",
+        "actionTitleFile": "Agregar archivos",
+        "actionTitleImage": "Agregar imágenes",
         "actionHintFile": "o arrastra y suelta los archivos que deseas subir",
         "actionHintImage": "o arrastra y suelta las imágenes que deseas subir",
-        "label": "Subir archivo"
+        "labelFile": "Subir archivos",
+        "labelImage": "Subir imágenes"
       }
     },
     "EmptySearchResult": {

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Jatka muokkausta"
     },
     "DropZone": {
-      "overlayTextFile": "Pudota ladattava tiedosto",
-      "overlayTextImage": "Pudota lähetettävä kuva",
       "errorOverlayTextFile": "Tiedostotyyppi ei kelpaa",
       "errorOverlayTextImage": "Kuvan tyyppi ei kelpaa",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Pudota tiedosto ladattavaksi",
+        "overlayTextImage": "Pudota kuva ladattavaksi",
         "actionTitleFile": "Lisää tiedosto",
         "actionTitleImage": "Lisää kuva",
-        "actionHintFile": "tai pudota lähetettävät tiedostot",
-        "actionHintImage": "tai pudota lähetettävät kuvat",
-        "label": "Lataa tiedosto"
+        "actionHintFile": "tai pudota tiedosto ladattavaksi",
+        "actionHintImage": "tai pudota kuva ladattavaksi",
+        "labelFile": "Lataa tiedosto",
+        "labelImage": "Lataa kuva"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Pudota ladattavat tiedostot",
+        "overlayTextImage": "Pudota ladattavat kuvat",
+        "actionTitleFile": "Lisää tiedostoja",
+        "actionTitleImage": "Lisää kuvia",
+        "actionHintFile": "tai pudota ladattavat tiedostot",
+        "actionHintImage": "tai pudota ladattavat kuvat",
+        "labelFile": "Lataa tiedostoja",
+        "labelImage": "Lataa kuvia"
       }
     },
     "EmptySearchResult": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Poursuivre les corrections"
     },
     "DropZone": {
-      "overlayTextFile": "Déposer le fichier à mettre en ligne",
-      "overlayTextImage": "Déposer l'image à mettre en ligne",
       "errorOverlayTextFile": "Le type de fichier n'est pas valide",
       "errorOverlayTextImage": "Le type d'image n'est pas valide",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Déposer le fichier à mettre en ligne",
+        "overlayTextImage": "Déposer l'image à mettre en ligne",
         "actionTitleFile": "Ajouter un fichier",
         "actionTitleImage": "Ajouter une image",
-        "actionHintFile": "ou déposer les fichiers à mettre en ligne",
-        "actionHintImage": "ou déposer les images à mettre en ligne",
-        "label": "Télécharger un fichier"
+        "actionHintFile": "ou déposer le fichier à mettre en ligne",
+        "actionHintImage": "ou déposer l'image à mettre en ligne",
+        "labelFile": "Mettre en ligne un fichier",
+        "labelImage": "Mettre en ligne une image"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Déposer les fichiers à mettre en ligne",
+        "overlayTextImage": "Déposer les images à mettre en ligne",
+        "actionTitleFile": "Ajouter des fichiers",
+        "actionTitleImage": "Ajouter des images",
+        "actionHintFile": "ou déposer des fichiers à mettre en ligne",
+        "actionHintImage": "ou déposer des images à mettre en ligne",
+        "labelFile": "Mettre en ligne des fichiers",
+        "labelImage": "Mettre en ligne des images"
       }
     },
     "EmptySearchResult": {

--- a/locales/it.json
+++ b/locales/it.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Continua a modificare"
     },
     "DropZone": {
-      "overlayTextFile": "Rilascia il file per caricarlo",
-      "overlayTextImage": "Rilascia l'immagine per caricarla",
       "errorOverlayTextFile": "Il tipo di file non è valido",
       "errorOverlayTextImage": "Il tipo di immagine non è valido",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Rilascia il file per caricarlo",
+        "overlayTextImage": "Rilascia l'immagine per caricarla",
         "actionTitleFile": "Aggiungi file",
         "actionTitleImage": "Aggiungi immagine",
+        "actionHintFile": "o rilascia il file per caricarlo",
+        "actionHintImage": "o rilascia l'immagine per caricarla",
+        "labelFile": "Carica file",
+        "labelImage": "Carica immagine"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Rilascia i file per caricarli",
+        "overlayTextImage": "Rilascia le immagini per caricarle",
+        "actionTitleFile": "Aggiungi file",
+        "actionTitleImage": "Aggiungi immagini",
         "actionHintFile": "o rilascia i file per caricarli",
         "actionHintImage": "o rilascia le immagini per caricarle",
-        "label": "Carica file"
+        "labelFile": "Carica file",
+        "labelImage": "Carica delle immagini"
       }
     },
     "EmptySearchResult": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -93,16 +93,27 @@
       "secondaryAction": "編集を続ける"
     },
     "DropZone": {
-      "overlayTextFile": "ファイルをドロップしてアップロード",
-      "overlayTextImage": "画像をドロップしてアップロードする",
       "errorOverlayTextFile": "ファイルタイプが有効ではありません",
       "errorOverlayTextImage": "画像タイプが有効ではありません",
-      "FileUpload": {
-        "actionTitleFile": "ファイルを追加する",
-        "actionTitleImage": "画像を追加する",
+      "single": {
+        "overlayTextFile": "ファイルをドロップしてアップロード",
+        "overlayTextImage": "画像をドロップしてアップロード",
+        "actionTitleFile": "ファイルを追加",
+        "actionTitleImage": "画像を追加",
+        "actionHintFile": "またはファイルをドロップしてアップロード",
+        "actionHintImage": "または、画像をドロップしてアップロード",
+        "labelFile": "ファイルをアップロード",
+        "labelImage": "画像をアップロード"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "ファイルをドロップしてアップロード",
+        "overlayTextImage": "画像をドロップしてアップロード",
+        "actionTitleFile": "ファイルを追加",
+        "actionTitleImage": "画像を追加",
         "actionHintFile": "または、ファイルをドロップしてアップロード",
-        "actionHintImage": "または、画像をドロップしてアップロードする",
-        "label": "ファイルをアップロード"
+        "actionHintImage": "または、画像をドロップしてアップロード",
+        "labelFile": "ファイルをアップロード",
+        "labelImage": "画像をアップロード"
       }
     },
     "EmptySearchResult": {

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -93,16 +93,27 @@
       "secondaryAction": "계속 편집"
     },
     "DropZone": {
-      "overlayTextFile": "업로드할 파일 놓기",
-      "overlayTextImage": "업로드할 이미지 놓기",
       "errorOverlayTextFile": "파일 형식이 유효하지 않습니다.",
       "errorOverlayTextImage": "이미지 형식이 유효하지 않습니다.",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "업로드할 파일 놓기",
+        "overlayTextImage": "업로드할 이미지 놓기",
         "actionTitleFile": "파일 추가",
         "actionTitleImage": "이미지 추가",
         "actionHintFile": "또는 업로드할 파일 놓기",
         "actionHintImage": "또는 업로드할 이미지 놓기",
-        "label": "파일 업로드"
+        "labelFile": "파일 업로드",
+        "labelImage": "이미지 업로드"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "업로드할 파일 놓기",
+        "overlayTextImage": "업로드할 이미지 놓기",
+        "actionTitleFile": "파일 추가",
+        "actionTitleImage": "이미지 추가",
+        "actionHintFile": "또는 업로드할 파일 놓기",
+        "actionHintImage": "또는 업로드할 이미지 놓기",
+        "labelFile": "파일 업로드",
+        "labelImage": "이미지 업로드"
       }
     },
     "EmptySearchResult": {

--- a/locales/nb.json
+++ b/locales/nb.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Fortsett å redigere"
     },
     "DropZone": {
-      "overlayTextFile": "Slipp fil for å laste opp",
-      "overlayTextImage": "Slipp bilde for å laste opp",
       "errorOverlayTextFile": "Filtypen er ikke gyldig",
       "errorOverlayTextImage": "Bildetypen er ikke gyldig",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Slipp fil for å laste opp",
+        "overlayTextImage": "Slipp bilde for å laste opp",
         "actionTitleFile": "Legg til en fil",
-        "actionTitleImage": "Legg til et bilde",
+        "actionTitleImage": "Legg til bilde",
+        "actionHintFile": "eller slipp filen for å laste den opp",
+        "actionHintImage": "eller slipp bildet for å laste opp",
+        "labelFile": "Last opp fil",
+        "labelImage": "Last opp bilde"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Slipp filer for å laste opp",
+        "overlayTextImage": "Slipp bilder for å laste opp",
+        "actionTitleFile": "Legg til filer",
+        "actionTitleImage": "Legg til bilder",
         "actionHintFile": "eller slipp filer for å laste opp",
         "actionHintImage": "eller slipp bilder for å laste opp",
-        "label": "Last opp fil"
+        "labelFile": "Last opp filer",
+        "labelImage": "Laste opp bilder"
       }
     },
     "EmptySearchResult": {

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Doorgaan met bewerken"
     },
     "DropZone": {
-      "overlayTextFile": "Sleep bestand om te uploaden",
-      "overlayTextImage": "Sleep afbeelding om te uploaden",
       "errorOverlayTextFile": "Ongeldig bestandstype",
       "errorOverlayTextImage": "Ongeldig afbeeldingsbestand",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Sleep bestand om te uploaden",
+        "overlayTextImage": "Sleep afbeelding om te uploaden",
         "actionTitleFile": "Bestand toevoegen",
         "actionTitleImage": "Afbeelding toevoegen",
+        "actionHintFile": "of sleep bestand om te uploaden",
+        "actionHintImage": "of sleep afbeelding om te uploaden",
+        "labelFile": "Bestand uploaden",
+        "labelImage": "Afbeelding uploaden"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Zet bestanden neer om te uploaden",
+        "overlayTextImage": "Sleep afbeeldingen om te uploaden",
+        "actionTitleFile": "Bestanden toevoegen",
+        "actionTitleImage": "Afbeeldingen toevoegen",
         "actionHintFile": "of sleep bestanden om te uploaden",
         "actionHintImage": "of sleep afbeeldingen om te uploaden",
-        "label": "Bestand uploaden"
+        "labelFile": "Bestanden uploaden",
+        "labelImage": "Afbeeldingen uploaden"
       }
     },
     "EmptySearchResult": {

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Kontynuuj edycję"
     },
     "DropZone": {
-      "overlayTextFile": "Upuść plik, aby załadować",
-      "overlayTextImage": "Upuść obraz , aby załadować",
       "errorOverlayTextFile": "Nieprawidłowy typ pliku",
       "errorOverlayTextImage": "Nieprawidłowy typ obrazu",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Upuść plik do załadowania",
+        "overlayTextImage": "Upuść obraz do załadowania",
         "actionTitleFile": "Dodaj plik",
         "actionTitleImage": "Dodaj obraz",
-        "actionHintFile": "lub upuść pliki, aby załadować",
-        "actionHintImage": "lub upuść obrazy, aby załadować",
-        "label": "Przekaż plik"
+        "actionHintFile": "lub upuść plik do załadowania",
+        "actionHintImage": "lub upuść zdjęcie do załadowania",
+        "labelFile": "Załaduj plik",
+        "labelImage": "Załaduj obraz"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Upuść pliki do załadowania",
+        "overlayTextImage": "Upuść obrazy do załadowania",
+        "actionTitleFile": "Dodaj pliki",
+        "actionTitleImage": "Dodaj zdjęcia",
+        "actionHintFile": "lub upuść pliki do załadowania",
+        "actionHintImage": "lub upuść zdjęcia do załadowania",
+        "labelFile": "Załaduj pliki",
+        "labelImage": "Załaduj zdjęcia"
       }
     },
     "EmptySearchResult": {

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Continuar editando"
     },
     "DropZone": {
-      "overlayTextFile": "Solte o arquivo para carregar",
-      "overlayTextImage": "Solte a imagem para carregar",
       "errorOverlayTextFile": "O tipo de arquivo é inválido.",
       "errorOverlayTextImage": "O tipo de imagem é inválido.",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Soltar arquivo para carregar",
+        "overlayTextImage": "Soltar imagem para carregar",
         "actionTitleFile": "Adicionar arquivo",
         "actionTitleImage": "Adicionar imagem",
-        "actionHintFile": "ou soltar os arquivos para carregar",
+        "actionHintFile": "ou soltar arquivo para carregar",
+        "actionHintImage": "ou soltar imagem para carregar",
+        "labelFile": "Carregar arquivo",
+        "labelImage": "Carregar imagem"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Soltar arquivos para carregar",
+        "overlayTextImage": "Soltar imagens para carregar",
+        "actionTitleFile": "Adicionar arquivos",
+        "actionTitleImage": "Adicionar imagens",
+        "actionHintFile": "ou soltar arquivos para carregar",
         "actionHintImage": "ou soltar imagens para carregar",
-        "label": "Carregar arquivo"
+        "labelFile": "Carregar arquivos",
+        "labelImage": "Carregar imagens"
       }
     },
     "EmptySearchResult": {

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Continuar a editar"
     },
     "DropZone": {
-      "overlayTextFile": "Solte o ficheiro para carregar",
-      "overlayTextImage": "Solte a imagem para carregar",
       "errorOverlayTextFile": "O tipo de ficheiro não é válido",
       "errorOverlayTextImage": "O tipo de imagem é inválido",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Solte o ficheiro para carregar",
+        "overlayTextImage": "Solte a imagem para carregar",
         "actionTitleFile": "Adicionar ficheiro",
         "actionTitleImage": "Adicionar imagem",
         "actionHintFile": "ou solte os ficheiros para carregar",
         "actionHintImage": "ou solte as imagens para carregar",
-        "label": "Carregar ficheiro"
+        "labelFile": "Carregar ficheiro",
+        "labelImage": "Carregar imagem"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Solte os ficheiros para carregar",
+        "overlayTextImage": "Solte a imagem para carregar",
+        "actionTitleFile": "Adicionar ficheiros",
+        "actionTitleImage": "Adicionar imagens",
+        "actionHintFile": "ou solte os ficheiros para carregar",
+        "actionHintImage": "ou solte as imagens para carregar",
+        "labelFile": "Carregar ficheiros",
+        "labelImage": "Carregar imagens"
       }
     },
     "EmptySearchResult": {

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Fortsätt redigera"
     },
     "DropZone": {
-      "overlayTextFile": "Släpp fil för uppladdning",
-      "overlayTextImage": "Släpp bild för uppladdning",
       "errorOverlayTextFile": "Filtypen är inte giltig",
       "errorOverlayTextImage": "Bildtypen är inte giltig",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Släpp fil för uppladdning",
+        "overlayTextImage": "Släpp bild för uppladdning",
         "actionTitleFile": "Lägg till fil",
         "actionTitleImage": "Lägg till bild",
+        "actionHintFile": "eller släpp fil för uppladdning",
+        "actionHintImage": "eller släpp bild för att ladda upp",
+        "labelFile": "Ladda upp fil",
+        "labelImage": "Ladda upp bild"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Släpp filer för uppladdning",
+        "overlayTextImage": "Släpp bilder för uppladdning",
+        "actionTitleFile": "Lägg till filer",
+        "actionTitleImage": "Lägg till bilder",
         "actionHintFile": "eller släpp filer för uppladdning",
         "actionHintImage": "eller släpp bilder för uppladdning",
-        "label": "Ladda upp fil"
+        "labelFile": "Ladda upp fil",
+        "labelImage": "Ladda upp bilder"
       }
     },
     "EmptySearchResult": {

--- a/locales/th.json
+++ b/locales/th.json
@@ -93,16 +93,27 @@
       "secondaryAction": "แก้ไขต่อ"
     },
     "DropZone": {
-      "overlayTextFile": "วางไฟล์เพื่ออัพโหลด",
-      "overlayTextImage": "วางรูปภาพเพื่ออัพโหลด",
       "errorOverlayTextFile": "ประเภทของไฟล์ไม่ถูกต้อง",
       "errorOverlayTextImage": "ประเภทของรูปภาพไม่ถูกต้อง",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "วางไฟล์เพื่ออัปโหลด",
+        "overlayTextImage": "วางรูปภาพเพื่ออัปโหลด",
         "actionTitleFile": "เพิ่มไฟล์",
         "actionTitleImage": "เพิ่มรูปภาพ",
-        "actionHintFile": "หรือวางไฟล์เพื่ออัพโหลด",
-        "actionHintImage": "หรือวางรูปภาพเพื่ออัพโหลด",
-        "label": "อัปโหลดไฟล์"
+        "actionHintFile": "หรือวางไฟล์เพื่ออัปโหลด",
+        "actionHintImage": "หรือวางรูปภาพเพื่ออัปโหลด",
+        "labelFile": "อัปโหลดไฟล์",
+        "labelImage": "อัปโหลดรูปภาพ"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "วางไฟล์เพื่ออัปโหลด",
+        "overlayTextImage": "วางรูปภาพเพื่ออัปโหลด",
+        "actionTitleFile": "เพิ่มไฟล์",
+        "actionTitleImage": "เพิ่มรูปภาพ",
+        "actionHintFile": "หรือวางไฟล์เพื่ออัปโหลด",
+        "actionHintImage": "หรือวางรูปภาพเพื่ออัปโหลด",
+        "labelFile": "อัปโหลดไฟล์",
+        "labelImage": "อัปโหลดรูปภาพ"
       }
     },
     "EmptySearchResult": {

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -93,16 +93,27 @@
       "secondaryAction": "Düzenlemeye devam et"
     },
     "DropZone": {
-      "overlayTextFile": "Yüklenecek dosyayı bırakın",
-      "overlayTextImage": "Yüklenecek görseli bırakın",
       "errorOverlayTextFile": "Dosya türü geçerli değil",
       "errorOverlayTextImage": "Görsel türü geçerli değil",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Yüklenecek dosyayı bırakın",
+        "overlayTextImage": "Yüklenecek görseli bırakın",
         "actionTitleFile": "Dosya ekleyin",
         "actionTitleImage": "Görsel ekleyin",
+        "actionHintFile": "veya yüklenecek dosyayı bırakın",
+        "actionHintImage": "veya yüklenecek görseli bırakın",
+        "labelFile": "Dosya yükle",
+        "labelImage": "Görsel yükle"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Yüklemek için dosyaları bırakın",
+        "overlayTextImage": "Yüklenecek görselleri bırakın",
+        "actionTitleFile": "Dosyaları ekleyin",
+        "actionTitleImage": "Görsel ekle",
         "actionHintFile": "veya yüklenecek dosyaları bırakın",
         "actionHintImage": "veya yüklenecek görselleri bırakın",
-        "label": "Dosya yükle"
+        "labelFile": "Dosyaları yükle",
+        "labelImage": "Görsel yükle"
       }
     },
     "EmptySearchResult": {

--- a/locales/vi.json
+++ b/locales/vi.json
@@ -96,16 +96,27 @@
       "secondaryAction": "Tiếp tục chỉnh sửa"
     },
     "DropZone": {
-      "overlayTextFile": "Thả tệp để tải lên",
-      "overlayTextImage": "Thả ảnh để tải lên",
       "errorOverlayTextFile": "Loại tệp không hợp lệ",
       "errorOverlayTextImage": "Loại hình ảnh không hợp lệ",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "Thả tệp để tải lên",
+        "overlayTextImage": "Thả ảnh để tải lên",
         "actionTitleFile": "Thêm tệp",
         "actionTitleImage": "Thêm hình ảnh",
         "actionHintFile": "hoặc thả tệp để tải lên",
         "actionHintImage": "hoặc thả ảnh để tải lên",
-        "label": "Tải tệp lên"
+        "labelFile": "Tải lên tệp",
+        "labelImage": "Tải lên hình ảnh"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "Thả tệp để tải lên",
+        "overlayTextImage": "Thả ảnh để tải lên",
+        "actionTitleFile": "Thêm tệp",
+        "actionTitleImage": "Thêm hình ảnh",
+        "actionHintFile": "hoặc thả tệp để tải lên",
+        "actionHintImage": "hoặc thả ảnh để tải lên",
+        "labelFile": "Tải lên tệp",
+        "labelImage": "Tải lên hình ảnh"
       }
     },
     "EmptySearchResult": {

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -93,16 +93,27 @@
       "secondaryAction": "继续编辑"
     },
     "DropZone": {
-      "overlayTextFile": "拖放文件以上传",
-      "overlayTextImage": "拖放图片以上传",
       "errorOverlayTextFile": "文件类型无效",
       "errorOverlayTextImage": "图片类型无效",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "拖放上传文件",
+        "overlayTextImage": "拖放上传图片",
         "actionTitleFile": "添加文件",
         "actionTitleImage": "添加图片",
-        "actionHintFile": "或拖放上传",
-        "actionHintImage": "或拖放上传",
-        "label": "上传文件"
+        "actionHintFile": "或拖放上传文件",
+        "actionHintImage": "或拖放上传图片",
+        "labelFile": "上传文件",
+        "labelImage": "上传图片"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "拖放上传文件",
+        "overlayTextImage": "拖放上传图片",
+        "actionTitleFile": "添加文件",
+        "actionTitleImage": "添加图片",
+        "actionHintFile": "或拖放上传文件",
+        "actionHintImage": "或拖放上传图片",
+        "labelFile": "上传文件",
+        "labelImage": "上传图片"
       }
     },
     "EmptySearchResult": {

--- a/locales/zh-TW.json
+++ b/locales/zh-TW.json
@@ -93,16 +93,27 @@
       "secondaryAction": "繼續編輯"
     },
     "DropZone": {
-      "overlayTextFile": "拖入檔案以上傳",
-      "overlayTextImage": "拖入圖片以上傳",
       "errorOverlayTextFile": "檔案類型無效",
       "errorOverlayTextImage": "圖片類型無效",
-      "FileUpload": {
+      "single": {
+        "overlayTextFile": "拖放檔案以上傳",
+        "overlayTextImage": "拖放圖片以上傳",
         "actionTitleFile": "新增檔案",
         "actionTitleImage": "新增圖片",
-        "actionHintFile": "或將檔案拖入即可上傳",
-        "actionHintImage": "或將圖片拖入即可上傳",
-        "label": "上傳檔案"
+        "actionHintFile": "或拖放檔案即可上傳",
+        "actionHintImage": "或拖放圖像即可上傳",
+        "labelFile": "上傳檔案",
+        "labelImage": "上傳圖片"
+      },
+      "allowMultiple": {
+        "overlayTextFile": "拖放檔案以上傳",
+        "overlayTextImage": "拖放圖片以上傳",
+        "actionTitleFile": "新增檔案",
+        "actionTitleImage": "新增圖片",
+        "actionHintFile": "或拖放檔案以上傳",
+        "actionHintImage": "或拖放圖像即可上傳",
+        "labelFile": "上傳檔案",
+        "labelImage": "上傳圖片"
       }
     },
     "EmptySearchResult": {

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -35,7 +35,7 @@ import {
 } from './utils';
 import styles from './DropZone.scss';
 
-export type Type = 'file' | 'image';
+export type DropZoneFileType = 'file' | 'image';
 
 export interface DropZoneProps {
   /** Label for the file input */
@@ -52,7 +52,7 @@ export interface DropZoneProps {
    * Whether is a file or an image
    * @default 'file'
    */
-  type?: Type;
+  type?: DropZoneFileType;
   /** Sets an active state */
   active?: boolean;
   /** Sets an error state */
@@ -453,7 +453,7 @@ interface DropZoneInputProps {
   id: string;
   accept?: string;
   disabled: boolean;
-  type: Type;
+  type: DropZoneFileType;
   multiple: boolean;
   openFileDialog?: boolean;
   onChange(event: DragEvent | React.ChangeEvent<HTMLInputElement>): void;

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -27,10 +27,15 @@ import {useToggle} from '../../utilities/use-toggle';
 
 import {FileUpload} from './components';
 import {DropZoneContext} from './context';
-import {fileAccepted, getDataTransferFiles} from './utils';
+import {
+  fileAccepted,
+  getDataTransferFiles,
+  defaultAllowMultiple,
+  createAllowMultipleKey,
+} from './utils';
 import styles from './DropZone.scss';
 
-type Type = 'file' | 'image';
+export type Type = 'file' | 'image';
 
 export interface DropZoneProps {
   /** Label for the file input */
@@ -117,7 +122,7 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
   accept,
   active,
   overlay = true,
-  allowMultiple = true,
+  allowMultiple = defaultAllowMultiple,
   overlayText,
   errorOverlayText,
   id: idProp,
@@ -308,15 +313,25 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
   });
 
   const id = useUniqueId('DropZone', idProp);
-  const suffix = capitalize(type);
+  const typeSuffix = capitalize(type);
+  const allowMultipleKey = createAllowMultipleKey(allowMultiple);
+
   const overlayTextWithDefault =
     overlayText === undefined
-      ? i18n.translate(`Polaris.DropZone.overlayText${suffix}`)
+      ? i18n.translate(
+          `Polaris.DropZone.${allowMultipleKey}.overlayText${typeSuffix}`,
+        )
       : overlayText;
+
   const errorOverlayTextWithDefault =
     errorOverlayText === undefined
-      ? i18n.translate(`Polaris.DropZone.errorOverlayText${suffix}`)
+      ? i18n.translate(`Polaris.DropZone.errorOverlayText${typeSuffix}`)
       : errorOverlayText;
+
+  const labelValue =
+    label ||
+    i18n.translate(`Polaris.DropZone.${allowMultipleKey}.label${typeSuffix}`);
+  const labelHiddenValue = label ? labelHidden : true;
 
   const inputAttributes = {
     id,
@@ -351,10 +366,6 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
     (internalError || error) &&
     overlayMarkup(CircleAlertMajor, 'critical', errorOverlayTextWithDefault);
 
-  const labelValue =
-    label || i18n.translate('Polaris.DropZone.FileUpload.label');
-  const labelHiddenValue = label ? labelHidden : true;
-
   const context = useMemo(
     () => ({
       disabled,
@@ -362,8 +373,9 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
       size,
       type: type || 'file',
       measuring,
+      allowMultiple,
     }),
-    [disabled, focused, measuring, size, type],
+    [disabled, focused, measuring, size, type, allowMultiple],
   );
 
   return (

--- a/src/components/DropZone/components/FileUpload/FileUpload.tsx
+++ b/src/components/DropZone/components/FileUpload/FileUpload.tsx
@@ -8,6 +8,7 @@ import {TextStyle} from '../../../TextStyle';
 import {uploadArrow} from '../../images';
 import {DropZoneContext} from '../../context';
 import {useI18n} from '../../../../utilities/i18n';
+import {createAllowMultipleKey} from '../../utils';
 
 import styles from './FileUpload.scss';
 
@@ -18,16 +19,19 @@ export interface FileUploadProps {
 
 export function FileUpload(props: FileUploadProps) {
   const i18n = useI18n();
-  const {size, measuring, type, focused, disabled} = useContext(
+  const {size, measuring, type, focused, disabled, allowMultiple} = useContext(
     DropZoneContext,
   );
-  const suffix = capitalize(type);
+
+  const typeSuffix = capitalize(type);
+  const allowMultipleKey = createAllowMultipleKey(allowMultiple);
+
   const {
     actionTitle = i18n.translate(
-      `Polaris.DropZone.FileUpload.actionTitle${suffix}`,
+      `Polaris.DropZone.${allowMultipleKey}.actionTitle${typeSuffix}`,
     ),
     actionHint = i18n.translate(
-      `Polaris.DropZone.FileUpload.actionHint${suffix}`,
+      `Polaris.DropZone.${allowMultipleKey}.actionHint${typeSuffix}`,
     ),
   } = props;
 

--- a/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
+++ b/src/components/DropZone/components/FileUpload/tests/FileUpload.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Caption, TextStyle} from 'components';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {DropZoneContext} from '../../../context';
 import {FileUpload} from '../FileUpload';
@@ -13,6 +14,7 @@ describe('<FileUpload />', () => {
     focused: false,
     disabled: false,
     measuring: false,
+    allowMultiple: true,
   };
   describe('measuring', () => {
     it('hides the FileUpload while measuring is true', () => {
@@ -118,7 +120,7 @@ describe('<FileUpload />', () => {
     );
 
     fileUpload.setProps({children: <FileUpload />});
-    expect(findByTestID(fileUpload, 'Button').text()).toBe('Add file');
+    expect(findByTestID(fileUpload, 'Button').text()).toBe('Add files');
   });
 
   it('sets a default actionHint if the prop is provided then removed', () => {
@@ -133,4 +135,29 @@ describe('<FileUpload />', () => {
     fileUpload.setProps({children: <FileUpload />});
     expect(fileUpload.find(TextStyle).text()).toBe('or drop files to upload');
   });
+
+  it.each([
+    [false, 'image', 'Add image', 'or drop image to upload'],
+    [true, 'image', 'Add images', 'or drop images to upload'],
+    [false, 'file', 'Add file', 'or drop file to upload'],
+    [true, 'file', 'Add files', 'or drop files to upload'],
+  ])(
+    'renders texts when allowMultiple is %s and type is %s',
+    (allowMultiple, type, expectedButtonText, expectedTextStyleText) => {
+      const fileUpload = mountWithApp(
+        <DropZoneContext.Provider
+          value={{size: 'large', ...defaultStates, allowMultiple, type}}
+        >
+          <FileUpload />
+        </DropZoneContext.Provider>,
+      );
+
+      expect(fileUpload).toContainReactComponent('div', {
+        children: expectedButtonText,
+      });
+      expect(fileUpload).toContainReactComponent(TextStyle, {
+        children: expectedTextStyleText,
+      });
+    },
+  );
 });

--- a/src/components/DropZone/context.tsx
+++ b/src/components/DropZone/context.tsx
@@ -1,9 +1,12 @@
 import {createContext} from 'react';
 
+import {defaultAllowMultiple} from './utils';
+
 interface DropZoneContextType {
   disabled: boolean;
   focused: boolean;
   measuring: boolean;
+  allowMultiple: boolean;
   size: string;
   type: string;
 }
@@ -14,4 +17,5 @@ export const DropZoneContext = createContext<DropZoneContextType>({
   size: 'extraLarge',
   type: 'file',
   measuring: false,
+  allowMultiple: defaultAllowMultiple,
 });

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -6,7 +6,7 @@ import {Label, Labelled, DisplayText, Caption} from 'components';
 import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 
-import {DropZone} from '../DropZone';
+import {DropZone, Type} from '../DropZone';
 import {DropZoneContext} from '../context';
 
 const files = [
@@ -205,6 +205,36 @@ describe('<DropZone />', () => {
     const dropZone = mountWithAppProvider(<DropZone disabled />);
     expect(dropZone.find('input[type="file"]').prop('disabled')).toBe(true);
   });
+
+  it.each([
+    [false, 'image', 'Drop image to upload', 'Upload image'],
+    [true, 'image', 'Drop images to upload', 'Upload images'],
+    [false, 'file', 'Drop file to upload', 'Upload file'],
+    [true, 'file', 'Drop files to upload', 'Upload files'],
+  ])(
+    'renders texts when allowMultiple is %s and type is %s',
+    (allowMultiple, type, expectedDisplayText, expectedLabelText) => {
+      const dropZone = mountWithApp(
+        <DropZone overlay allowMultiple={allowMultiple} type={type as Type} />,
+      );
+
+      act(() => {
+        dropZone
+          .find('div', {'aria-disabled': false})!
+          .domNode!.dispatchEvent(new Event('dragenter'));
+      });
+
+      dropZone.forceUpdate();
+
+      expect(dropZone).toContainReactComponent(DisplayText, {
+        children: expectedDisplayText,
+      });
+
+      expect(dropZone).toContainReactComponent(Labelled, {
+        label: expectedLabelText,
+      });
+    },
+  );
 
   describe('onClick', () => {
     it('calls the onClick when clicking the dropzone if one is provided', () => {

--- a/src/components/DropZone/tests/DropZone.test.tsx
+++ b/src/components/DropZone/tests/DropZone.test.tsx
@@ -6,7 +6,7 @@ import {Label, Labelled, DisplayText, Caption} from 'components';
 import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 
-import {DropZone, Type} from '../DropZone';
+import {DropZone, DropZoneFileType} from '../DropZone';
 import {DropZoneContext} from '../context';
 
 const files = [
@@ -215,7 +215,11 @@ describe('<DropZone />', () => {
     'renders texts when allowMultiple is %s and type is %s',
     (allowMultiple, type, expectedDisplayText, expectedLabelText) => {
       const dropZone = mountWithApp(
-        <DropZone overlay allowMultiple={allowMultiple} type={type as Type} />,
+        <DropZone
+          overlay
+          allowMultiple={allowMultiple}
+          type={type as DropZoneFileType}
+        />,
       );
 
       act(() => {

--- a/src/components/DropZone/utils/index.ts
+++ b/src/components/DropZone/utils/index.ts
@@ -57,3 +57,9 @@ function isChangeEvent(
 ): event is React.ChangeEvent<HTMLInputElement> {
   return Object.prototype.hasOwnProperty.call(event, 'target');
 }
+
+export const defaultAllowMultiple = true;
+
+export function createAllowMultipleKey(allowMultiple: boolean) {
+  return allowMultiple ? 'allowMultiple' : 'single';
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/3586

### WHAT is this pull request doing?

I have created a singular and a plural sentence for each call to action in DropZone.
I have based my changes on [this thread in Slack](https://shopify.slack.com/archives/C7TJQLVC7/p1614733227142400).
TLDR: We don't know how many files should be upload, so we don't have any `count` value. Using a random `count` value would be problematic in languages that have several plural rules. So we hope each translator will find a general sentence in both cases.

Also I could not use [scope](https://github.com/Shopify/quilt/tree/main/packages/react-i18n#dynamic-translation-keys), it seems not available in Polaris 🤔 

### How to 🎩

Run `yarn dev` and browse DropZone stories.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit