### PR TITLE
[Avatar] Expose `onError` hook

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added `statusAndProgressLabelOverride` prop to `Badge` ([#4028](https://github.com/Shopify/polaris-react/pull/4028))
+- Added an `onError` hook to the `Avatar` component
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,7 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added `statusAndProgressLabelOverride` prop to `Badge` ([#4028](https://github.com/Shopify/polaris-react/pull/4028))
-- Added an `onError` hook to the `Avatar` component
+- Added an `onError` hook to the `Avatar` component ([#4052](https://github.com/Shopify/polaris-react/pull/4052))
 
 ### Bug fixes
 

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -31,6 +31,8 @@ export interface AvatarProps {
   customer?: boolean;
   /** URL of the avatar image which falls back to initials if the image fails to load */
   source?: string;
+  /** Callback fired when the image fails to load  */
+  onError?(): void;
   /** Accessible label for the avatar image */
   accessibilityLabel?: string;
 }
@@ -38,6 +40,7 @@ export interface AvatarProps {
 export function Avatar({
   name,
   source,
+  onError,
   initials,
   customer,
   size = 'medium',
@@ -61,7 +64,10 @@ export function Avatar({
 
   const handleError = useCallback(() => {
     setStatus(Status.Errored);
-  }, []);
+    if (onError) {
+      onError();
+    }
+  }, [onError]);
   const handleLoad = useCallback(() => {
     setStatus(Status.Loaded);
   }, []);

--- a/src/components/Avatar/tests/Avatar.test.tsx
+++ b/src/components/Avatar/tests/Avatar.test.tsx
@@ -67,6 +67,23 @@ describe('<Avatar />', () => {
     });
   });
 
+  describe('consumer-specified "onError" hook', () => {
+    it('gets invoked in the event of an error', () => {
+      const spy = jest.fn();
+      const avatar = mountWithApp(
+        <Avatar
+          size="large"
+          initials="DL"
+          source="image/path/"
+          onError={spy}
+        />,
+      );
+
+      avatar.find(Image)!.trigger('onError');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('on Error with changed props', () => {
     it('re-renders the image if a the source prop is changed after an error', () => {
       const workingSrc = 'image/goodPath/';


### PR DESCRIPTION
### WHY are these changes introduced?

Due to surface area constraints, in our app, we use custom a user menu — the activator is a standalone avatar within a button which toggles a `Popover`. The popover includes an avatar and the full name of the user in question, as opposed to displaying the full name alongside the avatar directly on the top bar.

For Identity users that haven't uploaded an avatar, we attempt to grab an image from gravatar based on their `uuid` which eventually resolves to their email — that request can either return the image or `404` if the account doesn't exist.

The problem with that is each time the user menu activator is clicked, the popover is re-rendered which results in extraneous requests to the same url that previously failed in an attempt to retrieve the gravatar.

### WHAT is this pull request doing?

This adds an `onError` hook to the `Avatar` component, which provides consumers with an avenue to make decisions when the HTTP request for an avatar fails. In our case, we'll simply prevent subsequent requests to the same url.


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page, Avatar} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Avatar source="invalidUrl" onError={() => console.log('bummer')} />
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
