### PR TITLE
[IndexTable] migrate select by row from polaris next

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Update `IndexTable` to select row when clicked ([#4062](https://github.com/Shopify/polaris-react/issues/4062))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/IndexTable/components/Row/Row.tsx
+++ b/src/components/IndexTable/components/Row/Row.tsx
@@ -81,9 +81,8 @@ export const Row = memo(function Row({
       '[data-primary-link]',
     );
 
-    isNavigating.current = true;
-
     if (primaryLinkElement && !selectMode) {
+      isNavigating.current = true;
       const {ctrlKey, metaKey} = event.nativeEvent;
 
       if (onNavigation) {
@@ -102,7 +101,7 @@ export const Row = memo(function Row({
       primaryLinkElement.dispatchEvent(
         new MouseEvent(event.type, event.nativeEvent),
       );
-    } else if (selectMode) {
+    } else {
       isNavigating.current = false;
       handleInteraction(event);
     }

--- a/src/components/IndexTable/components/Row/tests/Row.test.tsx
+++ b/src/components/IndexTable/components/Row/tests/Row.test.tsx
@@ -186,6 +186,28 @@ describe('<Row />', () => {
 
     expect(onNavigationSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('calls handleInteraction when clicked and no primary link child present', () => {
+    const onSelectionChangeSpy = jest.fn();
+    const row = mountWithTable(
+      <Row {...defaultProps}>
+        <th>
+          <a href="/">Child without data-primary-link</a>
+        </th>
+      </Row>,
+      {
+        indexTableProps: {
+          itemCount: 50,
+          selectedItemsCount: 0,
+          onSelectionChange: onSelectionChangeSpy,
+        },
+      },
+    );
+
+    triggerOnClick(row, 1, defaultEvent);
+
+    expect(onSelectionChangeSpy).toHaveBeenCalledTimes(1);
+  });
 });
 
 function triggerOnClick(


### PR DESCRIPTION
### WHY are these changes introduced?

This PR migrates changes made to the polaris-next version of IndexTable in [this pr](https://github.com/Shopify/web/pull/35506/files)

### WHAT is this pull request doing?

This PR enables the consumer to select an indextable row by clicking on the row itself

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
