### PR TITLE
[IndexTable] Hide table header after scrolling past end of table body

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Hide `IndexTable` header after scrolling past table body ([#4063](https://github.com/Shopify/polaris-react/issues/4063))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/IndexTable/IndexTable.tsx
+++ b/src/components/IndexTable/IndexTable.tsx
@@ -91,9 +91,11 @@ function IndexTableBase({
 
   const scrollableContainerElement = useRef<HTMLDivElement>(null);
   const tableElement = useRef<HTMLTableElement>(null);
-  const [tableInitialized, setTableInitialized] = useState(false);
+  const condensedListElement = useRef<HTMLUListElement>(null);
 
+  const [tableInitialized, setTableInitialized] = useState(false);
   const [isSmallScreenSelectable, setIsSmallScreenSelectable] = useState(false);
+  const [stickyWrapper, setStickyWrapper] = useState<HTMLElement | null>(null);
 
   const tableHeadings = useRef<HTMLElement[]>([]);
   const stickyTableHeadings = useRef<HTMLElement[]>([]);
@@ -277,7 +279,10 @@ function IndexTableBase({
 
   useEffect(() => {
     resizeTableScrollBar();
-  }, [tableInitialized, resizeTableScrollBar]);
+    setStickyWrapper(
+      condensed ? condensedListElement.current : tableElement.current,
+    );
+  }, [tableInitialized, resizeTableScrollBar, condensed]);
 
   useEffect(() => {
     if (!condensed && isSmallScreenSelectable) {
@@ -382,7 +387,7 @@ function IndexTableBase({
 
   const stickyHeaderMarkup = (
     <div className={stickyTableClassNames} role="presentation">
-      <Sticky>
+      <Sticky boundingElement={stickyWrapper}>
         {(isSticky: boolean) => {
           const stickyHeaderClassNames = classNames(
             styles.StickyTableHeader,
@@ -521,6 +526,7 @@ function IndexTableBase({
       <ul
         data-selectmode={Boolean(selectMode || isSmallScreenSelectable)}
         className={styles.CondensedList}
+        ref={condensedListElement}
       >
         {children}
       </ul>

--- a/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -128,6 +128,26 @@ describe('<IndexTable>', () => {
     expect(onSelectionchangeSpy).toHaveBeenCalledWith(SelectionType.Page, true);
   });
 
+  it('passes a bounding element to Sticky', () => {
+    const resourceName = {
+      singular: 'Item',
+      plural: 'Items',
+    };
+    const index = mountWithApp(
+      <IndexTable
+        {...defaultProps}
+        itemCount={mockTableItems.length}
+        resourceName={resourceName}
+      >
+        {mockTableItems.map(mockRenderRow)}
+      </IndexTable>,
+    );
+
+    expect(index).toContainReactComponent(Sticky, {
+      boundingElement: index.find('table')?.domNode,
+    });
+  });
+
   describe('ScrollContainer', () => {
     it('updates sticky header scroll left on scoll', () => {
       const updatedScrollLeft = 25;

--- a/src/utilities/sticky-manager/sticky-manager.ts
+++ b/src/utilities/sticky-manager/sticky-manager.ts
@@ -149,7 +149,10 @@ export class StickyManager {
     if (boundingElement == null) {
       sticky = scrollPosition >= placeHolderNodeCurrentTop;
     } else {
-      const stickyItemHeight = stickyNode.getBoundingClientRect().height;
+      const stickyItemHeight =
+        stickyNode.getBoundingClientRect().height ||
+        stickyNode.firstElementChild?.getBoundingClientRect().height ||
+        0;
       const stickyItemBottomPosition =
         boundingElement.getBoundingClientRect().bottom -
         stickyItemHeight +


### PR DESCRIPTION
### WHY are these changes introduced?
Currently, the IndexTable header is sticky at the top of the window even after scrolling past the end of the table. This PR passes a `boundingElement` to the `<Sticky>` component to fix this.

**NOTE FOR REVIEWERS**
Hoping for opinions / insight on my change to `sticky-manager.ts`. The sticky manager calculates the sticky item height based on the `getBoundingClientRect().height` of the sticky node. The problem is, if the sticky node is positioned absolutely the height will be 0, so this calculation will be wrong. My fix is to fall back to the height of the first child (if present) if the height of the sticky node is 0. **_Does this approach make sense?_**

** 👀  Before 👀  **

https://user-images.githubusercontent.com/3619012/111670790-9a8f9780-87ee-11eb-8bc7-1570228b19de.mp4


** 👀  After 👀  **

https://user-images.githubusercontent.com/3619012/111670806-9fece200-87ee-11eb-8d17-bc32d5da13b6.mp4


### WHAT is this pull request doing?
- adds a `boundingElement` to the `IndexTable`'s `<Sticky>` usage
- updates `sticky manager` to check for the sticky node first child's height if the sticky node has no inherent height.

### How to 🎩

Tophat this by scrolling down the IndexTable playground page, notice that the header won't appear sticky after you scroll past the end of the table.

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
