### PR TITLE
[Portal] Don’t use isMounted in useEffect

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Update `IndexTable` to select row when clicked ([#4062](https://github.com/Shopify/polaris-react/issues/4062))
+- Removed the `isMounted` check from `Portal` to only rely on the useEffect for calling `onPortalCreated` ([#4066](https://github.com/Shopify/polaris-react/pull/4066))
 
 ### Documentation
 

--- a/src/components/Portal/Portal.tsx
+++ b/src/components/Portal/Portal.tsx
@@ -3,7 +3,6 @@ import {createPortal} from 'react-dom';
 
 import {usePortalsManager} from '../../utilities/portals';
 import {useUniqueId} from '../../utilities/unique-id';
-import {useIsMountedRef} from '../../utilities/use-is-mounted-ref';
 
 export interface PortalProps {
   children?: React.ReactNode;
@@ -16,17 +15,14 @@ export function Portal({
   idPrefix = '',
   onPortalCreated = noop,
 }: PortalProps) {
-  const isMounted = useIsMountedRef();
   const {container} = usePortalsManager();
 
   const uniqueId = useUniqueId('portal');
   const portalId = idPrefix !== '' ? `${idPrefix}-${uniqueId}` : uniqueId;
 
   useEffect(() => {
-    if (isMounted) {
-      onPortalCreated();
-    }
-  }, [onPortalCreated, isMounted]);
+    onPortalCreated();
+  }, [onPortalCreated]);
 
   return container
     ? createPortal(<div data-portal-id={portalId}>{children}</div>, container)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4064

### WHAT is this pull request doing?

We shouldn't need the `isMounted` check at all in this so updating to only call the `onPortalCreated` within the `useEffect` instead.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Try some of the examples that use a portal in storybook and make sure they still work as expected.

### 🎩 checklist

- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
