### PR TITLE
[Card] Add hideOnPrint prop to Card and Card.Section

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,7 +6,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-- Added `hideOnPrint` prop to `Card` and `CardSection` ([#](https://github.com/Shopify/polaris-react/issues/4062))
+- Added `hideOnPrint` prop to `Card` and `CardSection` ([#4071](https://github.com/Shopify/polaris-react/pull/4071))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added `hideOnPrint` prop to `Card` and `CardSection` ([#](https://github.com/Shopify/polaris-react/issues/4062))
+
 ### Bug fixes
 
 - Update `IndexTable` to select row when clicked ([#4062](https://github.com/Shopify/polaris-react/issues/4062))

--- a/src/components/Card/Card.scss
+++ b/src/components/Card/Card.scss
@@ -18,6 +18,11 @@
   background-color: var(--p-surface-subdued);
 }
 
+.Section-hideOnPrint,
+.hideOnPrint {
+  @include hidden-when-printing;
+}
+
 .Header {
   padding: spacing() spacing() 0;
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -32,6 +32,8 @@ export interface CardProps {
   secondaryFooterActionsDisclosureText?: string;
   /** Alignment of the footer actions on the card, defaults to right */
   footerActionAlignment?: 'right' | 'left';
+  /** Allow the card to be hidden when printing */
+  hideOnPrint?: boolean;
 }
 
 // TypeScript can't generate types that correctly infer the typing of
@@ -45,6 +47,7 @@ export const Card: React.FunctionComponent<CardProps> & {
   Subsection: typeof Subsection;
 } = function Card({
   children,
+  hideOnPrint,
   title,
   subdued,
   sectioned,
@@ -60,7 +63,11 @@ export const Card: React.FunctionComponent<CardProps> & {
     toggle: toggleSecondaryActionsPopoverOpen,
   } = useToggle(false);
 
-  const className = classNames(styles.Card, subdued && styles.subdued);
+  const className = classNames(
+    styles.Card,
+    subdued && styles.subdued,
+    hideOnPrint && styles.hideOnPrint,
+  );
 
   const headerMarkup =
     title || actions ? <Header actions={actions} title={title} /> : null;

--- a/src/components/Card/components/Section/Section.tsx
+++ b/src/components/Card/components/Section/Section.tsx
@@ -14,6 +14,8 @@ export interface SectionProps {
   subdued?: boolean;
   flush?: boolean;
   fullWidth?: boolean;
+  /** Allow the card to be hidden when printing */
+  hideOnPrint?: boolean;
   actions?: ComplexAction[];
 }
 
@@ -24,12 +26,14 @@ export function Section({
   flush,
   fullWidth,
   actions,
+  hideOnPrint,
 }: SectionProps) {
   const className = classNames(
     styles.Section,
     flush && styles['Section-flush'],
     subdued && styles['Section-subdued'],
     fullWidth && styles['Section-fullWidth'],
+    hideOnPrint && styles['Section-hideOnPrint'],
   );
 
   const actionMarkup = actions ? (

--- a/src/components/Card/components/Section/tests/Section.test.tsx
+++ b/src/components/Card/components/Section/tests/Section.test.tsx
@@ -34,11 +34,21 @@ describe('<Card.Section />', () => {
     expect(headerMarkup.text()).toStrictEqual(titleString);
   });
 
-  it('renders classname "Section Section-hideOnPrint" when hideOnPrint prop is passed', () => {
-    const card = mountWithApp(<Section hideOnPrint />);
+  describe('hideWhenPrinting prop', () => {
+    it('renders classname "Section Section-hideOnPrint" when prop is passed', () => {
+      const card = mountWithApp(<Section hideOnPrint />);
 
-    expect(card).toContainReactComponent('div', {
-      className: 'Section Section-hideOnPrint',
+      expect(card).toContainReactComponent('div', {
+        className: 'Section Section-hideOnPrint',
+      });
+    });
+
+    it('does not render classname "Section Section-hideOnPrint" when prop is not passed', () => {
+      const card = mountWithApp(<Section />);
+
+      expect(card).not.toContainReactComponent('div', {
+        className: 'Section Section-hideOnPrint',
+      });
     });
   });
 

--- a/src/components/Card/components/Section/tests/Section.test.tsx
+++ b/src/components/Card/components/Section/tests/Section.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {Badge, Subheading, ButtonGroup, Button} from 'components';
 
 import {Section} from '../Section';
@@ -31,6 +32,14 @@ describe('<Card.Section />', () => {
 
     expect(headerMarkup.exists()).toBeTruthy();
     expect(headerMarkup.text()).toStrictEqual(titleString);
+  });
+
+  it('renders classname "Section Section-hideOnPrint" when hideOnPrint prop is passed', () => {
+    const card = mountWithApp(<Section hideOnPrint />);
+
+    expect(card).toContainReactComponent('div', {
+      className: 'Section Section-hideOnPrint',
+    });
   });
 
   describe('actions', () => {

--- a/src/components/Card/tests/Card.test.tsx
+++ b/src/components/Card/tests/Card.test.tsx
@@ -134,6 +134,18 @@ describe('<Card />', () => {
         className: 'Card hideOnPrint',
       });
     });
+
+    it('does not render the classname "Card hideOnPrint" when prop is not passed', () => {
+      const card = mountWithApp(
+        <Card>
+          <p>Some card content.</p>
+        </Card>,
+      );
+
+      expect(card).not.toContainReactComponent('div', {
+        className: 'Card hideOnPrint',
+      });
+    });
   });
 
   it('renders a primary footer action', () => {

--- a/src/components/Card/tests/Card.test.tsx
+++ b/src/components/Card/tests/Card.test.tsx
@@ -122,6 +122,20 @@ describe('<Card />', () => {
     });
   });
 
+  describe('hideWhenPrinting prop', () => {
+    it('renders the classname "Card hideOnPrint" when passed', () => {
+      const card = mountWithApp(
+        <Card hideOnPrint>
+          <p>Some card content.</p>
+        </Card>,
+      );
+
+      expect(card).toContainReactComponent('div', {
+        className: 'Card hideOnPrint',
+      });
+    });
+  });
+
   it('renders a primary footer action', () => {
     const card = mountWithAppProvider(
       <Card primaryFooterAction={{content: 'test action'}}>


### PR DESCRIPTION
### WHY are these changes introduced?

During the [Port Draft Orders To React](https://vault.shopify.io/projects/10929) project requirements were created to prevent form elements from appearing on printed draft orders. Some of these elements were cards and card sections.

Polaris currently does not support a hideOnPrint prop for Cards and Card Sections, and so attempts were made to use div wrappers to allow use of the  Polaris`@hidden-when-printing` mixin. This results in the desired behaviour of the element (ie, the element not appearing in a printed document), but interrupts proper usage of the Card component itself. 

An example of this broken UI behaviour can be seen below where two Cards no longer have proper margins separating them:
<img width="297" alt="Polaris cards showing no margin between cards when wrapped in custom div blocks to allow hide On Print behaviour" src="https://user-images.githubusercontent.com/24965135/112044005-e99b3c80-8b0e-11eb-84ed-2dacb8f2ff08.png">

### WHAT is this pull request doing?

This pull request creates a hideOnPrint prop for the Card and Card Section Polaris components similar to those already implemented elsewhere in project.

Cards and Card Sections having the hideOnPrint prop passed to them will appear normally in a UI view, but will not appear in  either print previews or printed documents.

### How to 🎩

1. Create a Polaris Card
2. View the Card in the UI and ensure it appears as per the [Polaris documentation](https://polaris.shopify.com/components/structure/card)
3. Use Cmd+P to call up a print preview for the page. The card should appear properly
4. Print the page, and the card should appear as per the UI representation 
5. Tag that card with the hideOnPrint prop. 
6. Make sure the card does not appear in either the print preview or printed copy of the document, but that the on-screen UI behaviour of the card is unchanged.

HideOnPrint prop added to standard Polaris card example:
```
<Card hideOnPrint title="Online store dashboard" sectioned>
  <p>View a summary of your online store’s performance.</p>
</Card>
```

7. Repeat steps 1-6 above for a card section, rather than for a full card. The card section should appear normally in the UI, but should not appear in a print or print preview 

HideOnPrint prop added to upper section of the standard sectioned Polaris card example:
```
<Card title="Online store dashboard">
  <Card.Section hideOnPrint>
    <p>View a summary of your online store’s performance.</p>
  </Card.Section>
​
  <Card.Section>
    <p>
      View a summary of your online store’s performance, including sales,
      visitors, top products, and referrals.
    </p>
  </Card.Section>
</Card>
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
