### PR TITLE
[DataTable] Add `hoverable` prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Add `hoverable` prop to `DataTable` ([#4074](https://github.com/Shopify/polaris-react/pull/4074))
+
 ### Bug fixes
 
 - Hide `IndexTable` header after scrolling past table body ([#4063](https://github.com/Shopify/polaris-react/issues/4063))

--- a/src/components/DataTable/DataTable.scss
+++ b/src/components/DataTable/DataTable.scss
@@ -51,7 +51,7 @@ $breakpoint: 768px;
   border-spacing: 0;
 }
 
-.TableRow {
+.hoverable {
   &:hover .Cell {
     @include breakpoint-after($breakpoint) {
       background: var(--p-surface-hovered);

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -53,6 +53,8 @@ export interface DataTableProps {
   verticalAlign?: VerticalAlign;
   /** Content centered in the full width cell of the table footer row. */
   footerContent?: TableData;
+  /** Table row has hover state. Defaults to true. */
+  hoverable?: boolean;
   /** List of booleans, which maps to whether sorting is enabled or not for each column. Defaults to false for all columns.  */
   sortable?: boolean[];
   /**
@@ -375,8 +377,16 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
   };
 
   private defaultRenderRow = (row: TableData[], index: number) => {
-    const className = classNames(styles.TableRow);
-    const {columnContentTypes, truncate = false, verticalAlign} = this.props;
+    const {
+      columnContentTypes,
+      truncate = false,
+      verticalAlign,
+      hoverable = true,
+    } = this.props;
+    const className = classNames(
+      styles.TableRow,
+      hoverable && styles.hoverable,
+    );
 
     return (
       <tr key={`row-${index}`} className={className}>

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -417,6 +417,28 @@ describe('<DataTable />', () => {
     });
   });
 
+  describe('hoverable', () => {
+    it('defaults to rows with hover state', () => {
+      const dataTable = mountWithAppProvider(<DataTable {...defaultProps} />);
+      const rows = dataTable.find('tbody tr');
+
+      rows.forEach((row) =>
+        expect(row.props().className).toContain('hoverable'),
+      );
+    });
+
+    it('renders rows without hover state class name when false', () => {
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} hoverable={false} />,
+      );
+      const rows = dataTable.find('tbody tr');
+
+      rows.forEach((row) =>
+        expect(row.props().className).not.toContain('hoverable'),
+      );
+    });
+  });
+
   describe('defaultSortDirection', () => {
     it('passes the value down to the Cell', () => {
       const sortable = [false, true, false, false, true];


### PR DESCRIPTION
### WHY are these changes introduced?

It is not always the case that rows within a `DataTable` are selectable and having a hover state implies that a table row can be clicked. In Taxes, we were encountering a few use cases where wanted to use this table, but did not think the hover effect made sense for a non-actionable UI.

### WHAT is this pull request doing?

This pull request creates a `hoverable` prop for the `DataTable` component that defaults to true. All existing implementations of `DataTable` will not be affected, but for any new use case, we can specify whether we want the hover style.
Gifs: 

 <details>
      <summary>`hoverable: true` (default)</summary>
      <img src="https://user-images.githubusercontent.com/9326713/112069023-4bb46b80-8b28-11eb-8a0c-39ec1d2fad80.gif" alt="Table when hoverable prop defaults to true">
    </details>

 <details>
      <summary>`hoverable: false`</summary>
      <img src="https://user-images.githubusercontent.com/9326713/112069134-84ecdb80-8b28-11eb-916b-2efac13899b5.gif" alt="Table when hoverable prop defaults to false">
    </details>


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Card, DataTable} from '../src';

export function Playground() {
  const rows = [
    ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
    ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
    [
      'Navy Merino Wool Blazer with khaki chinos and yellow belt',
      '$445.00',
      124518,
      32,
      '$14,240.00',
    ],
  ];

  return (
    <Page title="Sales by product">
      <Card>
        <DataTable
          columnContentTypes={[
            'text',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
          ]}
          headings={[
            'Product',
            'Price',
            'SKU Number',
            'Net quantity',
            'Net sales',
          ]}
          rows={rows}
          hoverable={false}
          totals={['', '', '', 255, '$155,830.00']}
        />
      </Card>
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
