### PR TITLE
[IndexTable] Removed flicker from transition to bulk actions view

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Update `IndexTable` to select row when clicked ([#4062](https://github.com/Shopify/polaris-react/issues/4062))
 - Fixed `Filters` focus state when tabbing into the component from a popover ([#4073](https://github.com/Shopify/polaris-react/issues/4073))
 - Removed the `isMounted` check from `Portal` to only rely on the useEffect for calling `onPortalCreated` ([#4066](https://github.com/Shopify/polaris-react/pull/4066))
+- Removed transition from `BulkActions` to eliminate flicker ([#4080](https://github.com/Shopify/polaris-react/pulls/4080))
 
 ### Documentation
 

--- a/src/components/BulkActions/BulkActions.scss
+++ b/src/components/BulkActions/BulkActions.scss
@@ -8,8 +8,6 @@ $bulk-actions-offset-slide-in-start: rem(-40px);
 .Group {
   @include text-style-input;
   width: 100%;
-  will-change: opacity, display;
-  transition: opacity easing() duration();
   display: none;
   align-items: center;
   flex-wrap: wrap;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
There's a flicker when the `IndexTable` transitions between unselected and bulk actions state

https://user-images.githubusercontent.com/3619012/112192948-cee3c900-8bdd-11eb-9d74-e4c1461e319b.mp4

In this dev tools perf video, you can see when the header transitions from unselected state -> bulk actions state, there's a period where no elements are present:

https://user-images.githubusercontent.com/3619012/112193178-081c3900-8bde-11eb-867e-7d7b1a56d384.mp4

I caught up with the #motion-guild channel about alternate approaches to this, but the recommendation from them was that "These types of transitions should soften and reduce perceived change, not add. The current execution gives it a broken and untrustworthy feel. Agree that the best short term fix is to remove." More details in the [slack thread here](https://shopify.slack.com/archives/CEVLYHRGE/p1616443694020300).

### WHAT is this pull request doing?
This PR sets the transition duration to `0` on the `BulkActions` component. (Since the motion design team wants to take a look at this behavior eventually, IMO it makes sense for us to preserve the existing `Group-entering/exiting/entered/exited` logic in the BulkActions component)

👀  **after**  👀 

https://user-images.githubusercontent.com/3619012/112194214-056e1380-8bdf-11eb-8398-bb2d441f9dc8.mp4


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


- On the `IndexTable with bulk actions` example in the storybook, click the bulk select

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
