### PR TITLE
update Select error background color

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,7 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added `hideOnPrint` prop to `Card` and `CardSection` ([#4071](https://github.com/Shopify/polaris-react/pull/4071))
-- update Select error background color ([#4089](https://github.com/Shopify/polaris-react/pull/4089))
+- update `Select` error background color ([#4089](https://github.com/Shopify/polaris-react/pull/4089))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added `hideOnPrint` prop to `Card` and `CardSection` ([#4071](https://github.com/Shopify/polaris-react/pull/4071))
+- update Select error background color ([#4089](https://github.com/Shopify/polaris-react/pull/4089))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,7 +7,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added `hideOnPrint` prop to `Card` and `CardSection` ([#4071](https://github.com/Shopify/polaris-react/pull/4071))
-- update `Select` error background color ([#4089](https://github.com/Shopify/polaris-react/pull/4089))
 
 ### Bug fixes
 
@@ -16,6 +15,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed `Filters` focus state when tabbing into the component from a popover ([#4073](https://github.com/Shopify/polaris-react/issues/4073))
 - Removed the `isMounted` check from `Portal` to only rely on the useEffect for calling `onPortalCreated` ([#4066](https://github.com/Shopify/polaris-react/pull/4066))
 - Removed transition from `BulkActions` to eliminate flicker ([#4080](https://github.com/Shopify/polaris-react/pulls/4080))
+- update error background color in `Select` ([#4089](https://github.com/Shopify/polaris-react/pull/4089))
 
 ### Documentation
 

--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -128,7 +128,7 @@ $stacking-order: (
 .error {
   .Backdrop {
     border-color: var(--p-border-critical);
-    background-color: var(--p-surface-critical);
+    background-color: var(--p-surface-critical-subdued);
     // stylelint-disable-next-line selector-max-class, selector-max-specificity
     &.hover,
     &:hover {


### PR DESCRIPTION
### WHY are these changes introduced?

I want to align the error background color with [TextField](https://github.com/Shopify/polaris-react/blob/main/src/components/TextField/TextField.scss#L62) one.

#### Before
<img width="331" alt="Screen Shot 2021-03-28 at 9 14 48 PM" src="https://user-images.githubusercontent.com/5626729/112775506-14076100-900b-11eb-841e-fcebd0579864.png">

#### After
<img width="328" alt="Screen Shot 2021-03-28 at 9 15 18 PM" src="https://user-images.githubusercontent.com/5626729/112775508-1964ab80-900b-11eb-8ee5-32bbbc634144.png">

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
