### PR TITLE
changed trapped focus logic

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -17,6 +17,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Removed the `isMounted` check from `Portal` to only rely on the useEffect for calling `onPortalCreated` ([#4066](https://github.com/Shopify/polaris-react/pull/4066))
 - Removed transition from `BulkActions` to eliminate flicker ([#4080](https://github.com/Shopify/polaris-react/pulls/4080))
 - update error background color in `Select` ([#4089](https://github.com/Shopify/polaris-react/pull/4089))
+- Fixed `Trapfocus` issue that was preventing tabbing with react forms ([#4100](https://github.com/Shopify/polaris-react/pull/4100))
 
 ### Documentation
 

--- a/src/components/TrapFocus/TrapFocus.tsx
+++ b/src/components/TrapFocus/TrapFocus.tsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React, {useRef, useEffect, useState} from 'react';
 
 import {Key} from '../../types';
 import {EventListener} from '../EventListener';
@@ -13,7 +13,6 @@ import {
 } from '../../utilities/focus';
 import {useFocusManager} from '../../utilities/focus-manager';
 import {portal} from '../shared';
-import {useIsAfterInitialMount} from '../../utilities/use-is-after-initial-mount';
 
 export interface TrapFocusProps {
   trapping?: boolean;
@@ -23,17 +22,20 @@ export interface TrapFocusProps {
 export function TrapFocus({trapping = true, children}: TrapFocusProps) {
   const {canSafelyFocus} = useFocusManager({trapping});
   const focusTrapWrapper = useRef<HTMLDivElement>(null);
-  const isMounted = useIsAfterInitialMount();
+  const [disableFocus, setDisableFocus] = useState(true);
 
-  const disableFocus =
-    isMounted &&
-    canSafelyFocus &&
-    !(
-      focusTrapWrapper.current &&
-      focusTrapWrapper.current.contains(document.activeElement)
-    )
-      ? !trapping
-      : true;
+  useEffect(() => {
+    const disable =
+      canSafelyFocus &&
+      !(
+        focusTrapWrapper.current &&
+        focusTrapWrapper.current.contains(document.activeElement)
+      )
+        ? !trapping
+        : true;
+
+    setDisableFocus(disable);
+  }, [canSafelyFocus, trapping]);
 
   const handleFocusIn = (event: FocusEvent) => {
     const containerContentsHaveFocus =


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4086

The original update to react-form proves to cause more issues than fixing this in Polaris.

Essentially TrapFocus enables focusing the modal or whichever field as autofocus. This is a change that was made in the last couple of months. Unfortunately in conjunction with useReducer which is used with useField in react-form, this is breaking tabbing through forms in modal throughout the admin.

### WHAT is this pull request doing?

This pull request handles the focus logic within a useEffect which allows autofocus and doesn't break react forms

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

1. Load the playground and does the field autofocus ✅ 
2. Tab though it. Trap focus all good?  ✅ 

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {Button, Modal, TextField} from '../src';

export function Playground() {
  const [active, setActive] = useState(true);

  const handleModalChange = useCallback(() => setActive(!active), [active]);

  const handleClose = () => {
    handleModalChange();
  };

  const activator = <Button onClick={handleModalChange}>Open</Button>;

  const [name, setName] = useState('');
  const [price, setPrice] = useState('');
  const [quantity, setQuantity] = useState('');

  const handleNameChange = useCallback((newValue) => setName(newValue), []);
  const handlePriceChange = useCallback((newValue) => setPrice(newValue), []);
  const handleQuantityChange = useCallback(
    (newValue) => setQuantity(newValue),
    [],
  );

  return (
    <div style={{height: '500px'}}>
      <Modal
        activator={activator}
        open={active}
        onClose={handleClose}
        title="Export customers"
        primaryAction={{
          content: 'Export customers',
          onAction: handleClose,
        }}
        secondaryActions={[
          {
            content: 'Cancel',
            onAction: handleClose,
          },
        ]}
      >
        <Modal.Section>
          <div>
            <div>
              <TextField
                label="Item Name"
                value={name}
                onChange={handleNameChange}
              />
            </div>
          </div>
          <div>
            <div>
              <TextField
                label="Price"
                value={price}
                onChange={handlePriceChange}
                autoFocus
              />
            </div>
            <div>
              <TextField
                label="Quantity"
                value={quantity}
                onChange={handleQuantityChange}
                type="number"
                min={1}
              />
            </div>
          </div>
        </Modal.Section>
      </Modal>
    </div>
  );
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
