### PR TITLE
[TextField] Use “off” for autocomplete

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Reverts `<TextField>` to use `autocomplete=off` instead of `autocomplete=nope` ([#4108](https://github.com/Shopify/polaris-react/pull/4108))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -517,9 +517,7 @@ function normalizeAutoComplete(autoComplete?: boolean | string) {
   if (autoComplete === true) {
     return 'on';
   } else if (autoComplete === false) {
-    return 'nope';
-  } else if (autoComplete === 'off') {
-    return 'nope';
+    return 'off';
   } else {
     return autoComplete;
   }

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -186,18 +186,11 @@ describe('<TextField />', () => {
       expect(textField.find('input').prop('autoComplete')).toBeUndefined();
     });
 
-    it('sets autoComplete to "nope" when false', () => {
+    it('sets autoComplete to "off" when false', () => {
       const textField = mountWithAppProvider(
         <TextField label="TextField" autoComplete={false} onChange={noop} />,
       );
-      expect(textField.find('input').prop('autoComplete')).toBe('nope');
-    });
-
-    it('sets autoComplete to "nope" when "off"', () => {
-      const textField = mountWithAppProvider(
-        <TextField label="TextField" autoComplete="off" onChange={noop} />,
-      );
-      expect(textField.find('input').prop('autoComplete')).toBe('nope');
+      expect(textField.find('input').prop('autoComplete')).toBe('off');
     });
 
     it('sets autoComplete to "on" when true', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

This fixes #4107

### WHAT is this pull request doing?

It reverts the change introduced in #4053 and will go back to using the `off` value for autocomplete on the text field.

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)