### PR TITLE
[IndexTable] update sticky column hover styles

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Add `hoverable` prop to `DataTable` ([#4074](https://github.com/Shopify/polaris-react/pull/4074))
+- Update `IndexTable` hover styles for sticky column ([#4113](https://github.com/Shopify/polaris-react/pull/4113))
 
 ### Bug fixes
 

--- a/src/components/IndexTable/IndexTable.scss
+++ b/src/components/IndexTable/IndexTable.scss
@@ -114,8 +114,14 @@ $loading-panel-height: rem(53px);
 }
 
 .TableRow-hovered {
-  &, .TableCell-first, .TableCell-first + .TableCell {
-    background-color: var(--p-surface-selected-hovered, color('sky', 'lighter'));
+  // stylelint-disable-next-line selector-max-class, selector-max-combinators
+  &,
+  .TableCell-first,
+  .TableCell-first + .TableCell {
+    background-color: var(
+      --p-surface-selected-hovered,
+      color('sky', 'lighter')
+    );
   }
 }
 

--- a/src/components/IndexTable/IndexTable.scss
+++ b/src/components/IndexTable/IndexTable.scss
@@ -114,7 +114,9 @@ $loading-panel-height: rem(53px);
 }
 
 .TableRow-hovered {
-  background-color: var(--p-surface-selected-hovered, color('sky', 'lighter'));
+  &, .TableCell-first, .TableCell-first + .TableCell {
+    background-color: var(--p-surface-selected-hovered, color('sky', 'lighter'));
+  }
 }
 
 .SubTableRow {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
The sticky column background styles were more specific than the hover styles, added a line of CSS so it looks consistent:

👀  **Before** 👀 

https://user-images.githubusercontent.com/3619012/114405660-e70f8e00-9b74-11eb-8783-0be06266c370.mp4

👀  **After** 👀 

https://user-images.githubusercontent.com/3619012/114405671-e8d95180-9b74-11eb-9b16-61fd8b3eec52.mp4


### WHAT is this pull request doing?
Adds some specificity. (technically the same level as the css that sets the cell bg to white but it's later in the file)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
