### PR TITLE
[Label] Add required indicator prop to Label component

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Add `fullWidth` prop to `ColorPicker` so the color picker can take the full width ([#4152](https://github.com/Shopify/polaris-react/pull/4152))
 - Add `noScroll` prop to `Modal` which prevents modal contents from scrolling ([#4153](https://github.com/Shopify/polaris-react/pull/4153))
 - Added new `color` prop to ProgressBar ([#3415](https://github.com/Shopify/polaris-react/pull/3415))
+- Added `requiredIndicator` prop to `Label`, `Labelled`, `Select` and `TextField` ([#4119](https://github.com/Shopify/polaris-react/pull/4119))
 
 ### Bug fixes
 

--- a/src/components/Label/Label.scss
+++ b/src/components/Label/Label.scss
@@ -15,3 +15,9 @@
   color: currentColor;
   -webkit-tap-highlight-color: transparent;
 }
+
+.RequiredIndicator::after {
+  content: '*';
+  color: var(--p-text-critical);
+  margin-left: spacing(extra-tight);
+}

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -11,18 +11,27 @@ export interface LabelProps {
   id: string;
   /** Visually hide the label */
   hidden?: boolean;
+  /** Visual required indicator for the label */
+  requiredIndicator?: boolean;
 }
 
 export function labelID(id: string) {
   return `${id}Label`;
 }
 
-export function Label({children, id, hidden}: LabelProps) {
+export function Label({children, id, hidden, requiredIndicator}: LabelProps) {
   const className = classNames(styles.Label, hidden && styles.hidden);
 
   return (
     <div className={className}>
-      <label id={labelID(id)} htmlFor={id} className={styles.Text}>
+      <label
+        id={labelID(id)}
+        htmlFor={id}
+        className={classNames(
+          styles.Text,
+          requiredIndicator && styles.RequiredIndicator,
+        )}
+      >
         {children}
       </label>
     </div>

--- a/src/components/Labelled/Labelled.tsx
+++ b/src/components/Labelled/Labelled.tsx
@@ -25,6 +25,8 @@ export interface LabelledProps {
   children?: React.ReactNode;
   /** Visually hide the label */
   labelHidden?: boolean;
+  /** Visual required indicator for the label */
+  requiredIndicator?: boolean;
 }
 
 export function Labelled({
@@ -35,6 +37,7 @@ export function Labelled({
   helpText,
   children,
   labelHidden,
+  requiredIndicator,
   ...rest
 }: LabelledProps) {
   const className = classNames(labelHidden && styles.hidden);
@@ -57,7 +60,12 @@ export function Labelled({
 
   const labelMarkup = label ? (
     <div className={styles.LabelWrapper}>
-      <Label id={id} {...rest} hidden={false}>
+      <Label
+        id={id}
+        requiredIndicator={requiredIndicator}
+        {...rest}
+        hidden={false}
+      >
         {label}
       </Label>
 

--- a/src/components/Labelled/tests/Labelled.test.tsx
+++ b/src/components/Labelled/tests/Labelled.test.tsx
@@ -15,6 +15,15 @@ describe('<Labelled />', () => {
     expect(label.prop('children')).toBe('Label');
   });
 
+  it('passes required indicator prop along to the label', () => {
+    const element = mountWithAppProvider(
+      <Labelled id="my-label" label="Label" requiredIndicator />,
+    );
+    const label = element.find(Label);
+
+    expect(label.prop('requiredIndicator')).toBe(true);
+  });
+
   describe('error', () => {
     it('renders error markup when provided with a value', () => {
       const label = mountWithAppProvider(

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -65,10 +65,12 @@ export interface SelectProps {
   error?: Error | boolean;
   /** Callback when selection is changed */
   onChange?(selected: string, id: string): void;
-  /** Callback when select is focussed */
+  /** Callback when select is focused */
   onFocus?(): void;
   /** Callback when focus is removed */
   onBlur?(): void;
+  /** Visual required indicator, add an asterisk to label */
+  requiredIndicator?: boolean;
 }
 
 const PLACEHOLDER_VALUE = '';
@@ -89,6 +91,7 @@ export function Select({
   onChange,
   onFocus,
   onBlur,
+  requiredIndicator,
 }: SelectProps) {
   const id = useUniqueId('Select', idProp);
   const labelHidden = labelInline ? true : labelHiddenProp;
@@ -157,6 +160,7 @@ export function Select({
       action={labelAction}
       labelHidden={labelHidden}
       helpText={helpText}
+      requiredIndicator={requiredIndicator}
     >
       <div className={className}>
         <select
@@ -172,6 +176,7 @@ export function Select({
           aria-describedby={
             describedBy.length ? describedBy.join(' ') : undefined
           }
+          aria-required={requiredIndicator}
         >
           {optionsMarkup}
         </select>

--- a/src/components/Select/tests/Select.test.tsx
+++ b/src/components/Select/tests/Select.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {InlineError, Icon} from 'components';
+import {InlineError, Icon, Labelled} from 'components';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
 import {CircleTickOutlineMinor} from '@shopify/polaris-icons';
@@ -357,6 +357,17 @@ describe('<Select />', () => {
       );
 
       expect(select.find(InlineError)).toHaveLength(0);
+    });
+  });
+
+  describe('requiredIndicator', () => {
+    it('passes requiredIndicator prop to Labelled', () => {
+      const element = mountWithAppProvider(
+        <Select label="Select" onChange={noop} requiredIndicator />,
+      );
+      const labelled = element.find(Labelled);
+
+      expect(labelled.prop('requiredIndicator')).toBe(true);
     });
   });
 });

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -114,8 +114,8 @@ input. Field placeholder text should:
 
 ### Designating optional fields
 
-Try to only ask for information that’s required. If you need to ask merchants
-to provide optional information, mark the field optional by placing the text “(optional)” at the end of the field’s label. Don’t mark required fields with asterisks.
+Try to only ask for information that’s required. If you need to ask merchants to provide optional information, mark the field optional by placing the text “(optional)” at the end of the field’s label.
+Don’t mark required fields with asterisks unless it is expected by the [local cultural norm](https://polaris.shopify.com/foundations/internationalization#plan-for-cultural-differences).
 
 <!-- usagelist -->
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -130,6 +130,8 @@ interface NonMutuallyExclusiveProps {
   onFocus?(): void;
   /** Callback when focus is removed */
   onBlur?(): void;
+  /** Visual required indicator, adds an asterisk to label */
+  requiredIndicator?: boolean;
 }
 
 export type TextFieldProps = NonMutuallyExclusiveProps &
@@ -181,6 +183,7 @@ export function TextField({
   onChange,
   onFocus,
   onBlur,
+  requiredIndicator,
 }: TextFieldProps) {
   const i18n = useI18n();
   const [height, setHeight] = useState<number | null>(null);
@@ -431,6 +434,7 @@ export function TextField({
     'aria-autocomplete': ariaAutocomplete,
     'aria-controls': ariaControls,
     'aria-expanded': ariaExpanded,
+    'aria-required': requiredIndicator,
     ...normalizeAriaMultiline(multiline),
   });
 
@@ -448,6 +452,7 @@ export function TextField({
       action={labelAction}
       labelHidden={labelHidden}
       helpText={helpText}
+      requiredIndicator={requiredIndicator}
     >
       <Connected left={connectedLeft} right={connectedRight}>
         <div

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1128,6 +1128,17 @@ describe('<TextField />', () => {
       });
     });
   });
+
+  describe('requiredIndicator', () => {
+    it('passes requiredIndicator prop to Labelled', () => {
+      const element = mountWithAppProvider(
+        <TextField label="TextField" onChange={noop} requiredIndicator />,
+      );
+      const labelled = element.find(Labelled);
+
+      expect(labelled.prop('requiredIndicator')).toBe(true);
+    });
+  });
 });
 
 function noop() {}


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #4098
Resolves #4118

Following the experiment outlined [here](https://github.com/Shopify/web/issues/40128), we are moving ahead with adding a required indicator to form labelled components so that they could indicate to be so.

### WHAT is this pull request doing?

![Screenshot 2021-04-19 at 11 50 36 AM](https://user-images.githubusercontent.com/5773874/115179516-10489500-a106-11eb-8da6-81339341fd4c.png)

The new prop `requiredIndicator` is added to the `Label` component (instead of the higher level `TextField` or `Select` components) with 2 considerations:
1. This indicator should work like an inline text to the label
2. All components using the `Labelled` component would be able to add the required indicator easily.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Tophat with the following playground

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {Page, Select, TextField} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
      <SelectExample />
      <TextFieldExample />
    </Page>
  );
}


function SelectExample() {
  const [selected, setSelected] = useState('today');
  const handleSelectChange = useCallback((value) => setSelected(value), []);
  const options = [
    {label: 'Today', value: 'today'},
    {label: 'Yesterday', value: 'yesterday'},
    {label: 'Last 7 days', value: 'lastWeek'},
  ];
  return (
    <Select
      label="Date range"
      options={options}
      onChange={handleSelectChange}
      value={selected}
      requiredIndicator
    />
  );
}

function TextFieldExample() {
  const [value, setValue] = useState('Jaded Pixel');

  const handleChange = useCallback((newValue) => setValue(newValue), []);

  return <TextField label="Store name" value={value} onChange={handleChange} requiredIndicator />;
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
