### PR TITLE
[Data Table] Cells in a data table row fill to fit table headings width

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Add `hoverable` prop to `DataTable` ([#4074](https://github.com/Shopify/polaris-react/pull/4074))
 - Update `IndexTable` hover styles for sticky column ([#4113](https://github.com/Shopify/polaris-react/pull/4113))
+- Add `colSpan` to the cells in `DataTable` so that cells fill the table width ([#4120](https://github.com/Shopify/polaris-react/pull/4120))
 
 ### Bug fixes
 

--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 classification: library
 slack_channels:
-- polaris
+  - polaris
 oncall_url: https://shopify.pagerduty.com/services/PQNFXB1
 security:
   data_management:

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -376,12 +376,26 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
     );
   };
 
+  private getColSpan = (
+    rowLength: number,
+    headingsLength: number,
+    contentTypesLength: number,
+    cellIndex: number,
+  ) => {
+    const rowLen = rowLength ? rowLength : 1;
+    const colLen = headingsLength ? headingsLength : contentTypesLength;
+    const colSpan = Math.floor(colLen / rowLen);
+    const remainder = colLen % rowLen;
+    return cellIndex === 0 ? colSpan + remainder : colSpan;
+  };
+
   private defaultRenderRow = (row: TableData[], index: number) => {
     const {
       columnContentTypes,
       truncate = false,
       verticalAlign,
       hoverable = true,
+      headings,
     } = this.props;
     const className = classNames(
       styles.TableRow,
@@ -392,6 +406,12 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
       <tr key={`row-${index}`} className={className}>
         {row.map((content: CellProps['content'], cellIndex: number) => {
           const id = `cell-${cellIndex}-row-${index}`;
+          const colSpan = this.getColSpan(
+            row.length,
+            headings.length,
+            columnContentTypes.length,
+            cellIndex,
+          );
 
           return (
             <Cell
@@ -401,6 +421,7 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
               firstColumn={cellIndex === 0}
               truncate={truncate}
               verticalAlign={verticalAlign}
+              colSpan={colSpan}
             />
           );
         })}

--- a/src/components/DataTable/components/Cell/Cell.tsx
+++ b/src/components/DataTable/components/Cell/Cell.tsx
@@ -22,6 +22,7 @@ export interface CellProps {
   defaultSortDirection?: SortDirection;
   verticalAlign?: VerticalAlign;
   onSort?(): void;
+  colSpan?: number;
 }
 
 export function Cell({
@@ -38,6 +39,7 @@ export function Cell({
   verticalAlign = 'top',
   defaultSortDirection = 'ascending',
   onSort,
+  colSpan,
 }: CellProps) {
   const i18n = useI18n();
   const numeric = contentType === 'numeric';
@@ -86,9 +88,12 @@ export function Cell({
 
   const columnHeadingContent = sortable ? sortableHeadingContent : content;
 
+  const colSpanProp = colSpan && colSpan > 1 ? {colSpan} : {};
+
   const headingMarkup = header ? (
     <th
       {...headerCell.props}
+      {...colSpanProp}
       className={className}
       scope="col"
       aria-sort={sortDirection}
@@ -96,7 +101,7 @@ export function Cell({
       {columnHeadingContent}
     </th>
   ) : (
-    <th className={className} scope="row">
+    <th className={className} scope="row" {...colSpanProp}>
       {content}
     </th>
   );
@@ -105,7 +110,9 @@ export function Cell({
     header || firstColumn ? (
       headingMarkup
     ) : (
-      <td className={className}>{content}</td>
+      <td className={className} {...colSpanProp}>
+        {content}
+      </td>
     );
 
   return cellMarkup;

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -512,4 +512,50 @@ describe('<DataTable />', () => {
       expect(spyOnSort).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('colSpan', () => {
+    it('has a colSpan of 1 when header length and row length are equal', () => {
+      const rows = [['Emerald Silk Gown', '$230.00', 124689, 32, '$19,090.00']];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} rows={rows} />,
+      );
+
+      const singleSpanCells = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.prop('colSpan') === 1);
+
+      expect(singleSpanCells).toHaveLength(5);
+    });
+
+    it('has a colSpan that spans all headings when there is only one cell in the row', () => {
+      const rows = [['Emerald Silk Gown']];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} rows={rows} />,
+      );
+
+      const fullSpanCells = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.prop('colSpan') === headings.length);
+
+      expect(fullSpanCells).toHaveLength(1);
+    });
+
+    it('cells still fill the full table width when there are no headings', () => {
+      const rows = [['Emerald Silk Gown', '$230.00']];
+      const dataTable = mountWithAppProvider(
+        <DataTable {...defaultProps} headings={[]} rows={rows} />,
+      );
+
+      const twoSpanCells = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.prop('colSpan') === 2);
+
+      const threeSpanCells = dataTable
+        .find(Cell)
+        .filterWhere((cell) => cell.prop('colSpan') === 2);
+
+      expect(twoSpanCells).toHaveLength(1);
+      expect(threeSpanCells).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

While doing reactification projects, we've run into several cases where we needed a row cell to span the whole width of the row. We also thought it could be a useful for other uses of the Data Table in the future. 

### WHAT is this pull request doing?
<img width="808" alt="Screen Shot 2021-04-15 at 1 51 29 PM" src="https://user-images.githubusercontent.com/20652326/114916262-99a05480-9df2-11eb-9d86-3419cb76da2f.png">
<img width="802" alt="Screen Shot 2021-04-15 at 1 52 01 PM" src="https://user-images.githubusercontent.com/20652326/114916281-9efd9f00-9df2-11eb-83b6-b9e2e84ba470.png">
<img width="574" alt="Screen Shot 2021-04-15 at 1 53 12 PM" src="https://user-images.githubusercontent.com/20652326/114916309-a6bd4380-9df2-11eb-97a3-87d0af54da68.png">

both screenshots use this heading/row data

I determined `colSpan` by taking the headings length and dividing it by the number of cells in that row. if there are no headings, it falls back to the column content length. 

To use this, one would make a row array that has items less than the headings. 

note when `colLen / rowLen` has a remainder, I add that to the colSpan of the first cell item. Let me know if this default behaviour is an issue but devs can get around this by adding an empty column header.  

There are no changes for row items that are:
- row.length === heading.length (all `DataTable`s in web seem to follow this)
- row.length > heading.length
- empty rows

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Play around with rows with different cell lengths! 

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Card, DataTable, Page} from '../src';

const headings = [
  'transactionDate',
  'reference',
  'type',
  'amount',
  'fee',
  'net',
];

const rows = [
  [
    'Sep 19, 2010, 1:02 pm NDT',
    '#1234',
    'Adjustment',
    '$1.00',
    '$1.00',
    '$1.00',
  ],
  [<Card>hello</Card>],
  [
    'Sep 19, 2010, 1:02 pm NDT',
    '#1234',
    'Adjustment',
    '$1.00',
    '$1.00',
    '$1.00',
  ],
];

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
      <Card>
        <DataTable
          columnContentTypes={[
            'text',
            'text',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
            'numeric',
          ]}
          headings={headings}
          rows={rows}
          verticalAlign="middle"
        />
      </Card>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
