### PR TITLE
[Filters] Remove extra margin when rightAction is `null`

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed heading overflow issue on dismissible CalloutCard ([#4135](https://github.com/Shopify/polaris-react/pull/4135))
+- Prevent extra right margin being added to the `Filter` component when used without filters. ([#4134](https://github.com/Shopify/polaris-react/pull/4134))
 
 ### Documentation
 

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -230,7 +230,7 @@ class FiltersInner extends Component<CombinedProps, State> {
           })
         : i18n.translate('Polaris.Filters.moreFilters');
 
-    const rightActionMarkup = (
+    const rightActionMarkup = filters.length ? (
       <div ref={this.moreFiltersButtonContainer}>
         <Button
           onClick={this.toggleFilters}
@@ -240,7 +240,7 @@ class FiltersInner extends Component<CombinedProps, State> {
           {moreFiltersLabel}
         </Button>
       </div>
-    );
+    ) : null;
 
     const filterResourceName = resourceName || {
       singular: i18n.translate('Polaris.ResourceList.defaultItemSingular'),

--- a/src/components/Filters/components/ConnectedFilterControl/tests/ConnectedFilterControl.test.tsx
+++ b/src/components/Filters/components/ConnectedFilterControl/tests/ConnectedFilterControl.test.tsx
@@ -108,6 +108,36 @@ describe('<ConnectedFilterControl />', () => {
     expect(connectedFilterControl.find(Button).exists()).toBe(false);
   });
 
+  it('renders rightActionMarkup if rightAction is not null', () => {
+    const connectedFilterControl = mountWithApp(
+      <ConnectedFilterControl
+        rightAction={mockRightAction}
+        forceShowMorefiltersButton={false}
+      >
+        <MockChild />
+      </ConnectedFilterControl>,
+    );
+
+    expect(connectedFilterControl).toContainReactComponent('div', {
+      className: 'MoreFiltersButtonContainer onlyButtonVisible',
+    });
+  });
+
+  it('does not render rightActionMarkup if rightAction is null', () => {
+    const connectedFilterControl = mountWithApp(
+      <ConnectedFilterControl
+        rightAction={null}
+        forceShowMorefiltersButton={false}
+      >
+        <MockChild />
+      </ConnectedFilterControl>,
+    );
+
+    expect(connectedFilterControl).not.toContainReactComponent('div', {
+      className: 'MoreFiltersButtonContainer onlyButtonVisible',
+    });
+  });
+
   it('does render a button with a popoverable action', () => {
     const connectedFilterControl = mountWithAppProvider(
       <ConnectedFilterControl

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import {matchMedia} from '@shopify/jest-dom-mocks';
-import {Button, Popover, Sheet, Tag, TextField, TextStyle} from 'components';
+import {
+  Button,
+  Popover,
+  Sheet,
+  Tag,
+  TextField,
+  TextStyle,
+  ButtonProps,
+} from 'components';
 // eslint-disable-next-line no-restricted-imports
 import {
   mountWithAppProvider,
@@ -335,6 +343,15 @@ describe('<Filters />', () => {
         resourceFilters.find(ConnectedFilterControl).props()
           .rightPopoverableActions,
       ).toHaveLength(0);
+    });
+
+    it('does not render the filter button when no filters are passed in', () => {
+      const resourceFilters = mountWithApp(
+        <Filters {...mockProps} filters={[]} />,
+      );
+      expect(resourceFilters).not.toContainReactComponent(Button, {
+        testID: 'SheetToggleButton',
+      } as ButtonProps);
     });
   });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

When the `ResourceList` & `Filter` components are used in either an empty state configuration, or one where no filters are passed in (i.e. just search via `TextField`), a class with extra right margin is added causing the input to appear misaligned. This can be seen on the "empty state resource list" story/example linked in the docs: https://codesandbox.io/s/uyg6i?module=App.js

<details>
<summary>Currently, with margin:</summary>
Empty state:
<img width="959" alt="Screen Shot 2021-04-20 at 10 46 23 AM" src="https://user-images.githubusercontent.com/9326713/115445861-41d76400-a1cb-11eb-91cd-d167cc6cd78b.png">
Existing web example:
<img src="https://user-images.githubusercontent.com/9326713/114600847-a9c90000-9c49-11eb-94fd-98467009acda.png">
</details>

<details>
<summary>This PR proposes:</summary>
Empty state:
<img width="968" alt="Screen Shot 2021-04-20 at 10 46 50 AM" src="https://user-images.githubusercontent.com/9326713/115446048-7e0ac480-a1cb-11eb-9543-b1d8e202f93b.png">

</details>

### WHAT is this pull request doing?

Sets `rightActionMarkup` in `Filters.tsx` to `null` when no filters are passed in, which prevents appending an empty div with the offending classes in `ConnectedFilterControl` [here](https://github.com/Shopify/polaris-react/blob/main/src/components/Filters/components/ConnectedFilterControl/ConnectedFilterControl.tsx#L114).


### How to 🎩

Either copy paste the following into the Playground example or run through all existing `ResourceList` and `Filter` examples.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';

import {
  Page,
  Card,
  ResourceList,
  ResourceItem,
  Filters,
  TextStyle,
} from '../src';

export function Playground() {
  const [queryValue, setQueryValue] = useState(null);
  const handleClearAll = () => {
    setQueryValue(null);
  };

  const resourceName = {
    singular: 'customer',
    plural: 'customers',
  };

  const items = [
    {
      id: 108,
      url: 'customers/341',
      name: 'Mae Jemison',
      location: 'Decatur, USA',
    },
    {
      id: 208,
      url: 'customers/256',
      name: 'Ellen Ochoa',
      location: 'Los Angeles, USA',
    },
  ];

  const filters = [];

  const appliedFilters = [];

  const filterControl = (
    <Filters
      queryValue={queryValue}
      filters={filters}
      appliedFilters={appliedFilters}
      onQueryChange={setQueryValue}
      onQueryClear={() => setQueryValue(null)}
      onClearAll={handleClearAll}
    />
  );

  return (
    <Page>
      <Card>
        <ResourceList
          resourceName={resourceName}
          items={items}
          renderItem={renderItem}
          filterControl={filterControl}
        />
      </Card>
    </Page>
  );

  function renderItem(item) {
    const {id, url, name, location} = item;
    return (
      <ResourceItem id={id} url={url}>
        <div>
          {name}: {location}
        </div>
      </ResourceItem>
    );
  }
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
