### PR TITLE
[CalloutCard] Fix heading overflow when dismissible

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed heading overflow issue on dismissible CalloutCard ([#4135](https://github.com/Shopify/polaris-react/pull/4135))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/CalloutCard/CalloutCard.scss
+++ b/src/components/CalloutCard/CalloutCard.scss
@@ -41,3 +41,7 @@
   top: spacing();
   position: absolute;
 }
+
+.hasDismiss {
+  padding-right: calc(#{2 * spacing()} + var(--p-icon-size));
+}

--- a/src/components/CalloutCard/CalloutCard.tsx
+++ b/src/components/CalloutCard/CalloutCard.tsx
@@ -65,9 +65,14 @@ export function CalloutCard({
     onDismiss && styles.DismissImage,
   );
 
+  const containerClassName = classNames(
+    styles.Container,
+    onDismiss && styles.hasDismiss,
+  );
+
   return (
     <Card>
-      <div className={styles.Container}>
+      <div className={containerClassName}>
         {dismissButton}
         <Card.Section>
           <div className={styles.CalloutCard}>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes heading overflow issue when the CalloutCard is dismissible. 

![Screen Shot 2021-04-20 at 10 41 29 PM](https://user-images.githubusercontent.com/2091116/115489437-2f404780-a22a-11eb-9e3d-7fcb94e12b3c.png)


### WHAT is this pull request doing?

Fixes the issue by adding padding to the right on the CalloutCard container when it is dismissible. The spacing was inspired by the [dismissible Banner](https://github.com/Shopify/polaris-react/blob/main/src/components/Banner/Banner.scss#L212-L214).

#### Mobile

![Screen Shot 2021-04-20 at 10 41 57 PM](https://user-images.githubusercontent.com/2091116/115490946-0e2d2600-a22d-11eb-8d2a-027ed57d70db.png)

#### Tablet/Desktop

![Screen Shot 2021-04-20 at 10 39 25 PM](https://user-images.githubusercontent.com/2091116/115490960-11c0ad00-a22d-11eb-9e93-967337f14450.png)


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, CalloutCard} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <CalloutCard
        title="Customize the style of your checkout"
        illustration="https://cdn.shopify.com/s/assets/admin/checkout/settings-customizecart-705f57c725ac05be5a34ec20c05b94298cb8afd10aac7bd9c7ad02030f48cfa0.svg"
        primaryAction={{content: 'Customize checkout'}}
        onDismiss={() => {}}
      >
        <p>Upload your store’s logo, change colors and fonts, and more.</p>
      </CalloutCard>
      );
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
