### PR TITLE
[IndexTable] Add link component

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Add `variableHeight` prop to `DropZone` so children control its height ([#4136](https://github.com/Shopify/polaris-react/pull/4136))
+- Added `IndexTable.Link` component for allowing rows to link to a resource. ([#4139](https://github.com/Shopify/polaris-react/pull/4139))
 
 ### Bug fixes
 

--- a/src/components/IndexTable/IndexTable.tsx
+++ b/src/components/IndexTable/IndexTable.tsx
@@ -29,7 +29,7 @@ import {IndexProvider} from '../IndexProvider';
 import type {NonEmptyArray} from '../../types';
 
 import {getTableHeadingsBySelector} from './utilities';
-import {ScrollContainer, Cell, Row} from './components';
+import {ScrollContainer, Cell, Row, Link} from './components';
 import styles from './IndexTable.scss';
 
 export interface IndexTableHeading {
@@ -738,3 +738,4 @@ export function IndexTable({
 
 IndexTable.Cell = Cell;
 IndexTable.Row = Row;
+IndexTable.Link = Link;

--- a/src/components/IndexTable/README.md
+++ b/src/components/IndexTable/README.md
@@ -200,6 +200,84 @@ function SimpleSmallScreenIndexTableExample() {
 }
 ```
 
+### Index table with row links
+
+A index table with rows that will link to a resource.
+
+```jsx
+function LinkingIndexTableExample() {
+  const customers = [
+    {
+      id: '3411',
+      url: 'customers/341',
+      name: 'Mae Jemison',
+      location: 'Decatur, USA',
+      orders: 20,
+      amountSpent: '$2,400',
+    },
+    {
+      id: '2561',
+      url: 'customers/256',
+      name: 'Ellen Ochoa',
+      location: 'Los Angeles, USA',
+      orders: 30,
+      amountSpent: '$140',
+    },
+  ];
+  const resourceName = {
+    singular: 'customer',
+    plural: 'customers',
+  };
+
+  const {
+    selectedResources,
+    allResourcesSelected,
+    handleSelectionChange,
+  } = useIndexResourceState(customers);
+
+  const rowMarkup = customers.map(
+    ({id, name, location, orders, amountSpent}, index) => (
+      <IndexTable.Row
+        id={id}
+        key={id}
+        selected={selectedResources.includes(id)}
+        position={index}
+      >
+        <IndexTable.Cell>
+          <IndexTable.Link primary url={`/customers/${id}`}>
+            {name}
+          </IndexTable.Link>
+        </IndexTable.Cell>
+        <IndexTable.Cell>{location}</IndexTable.Cell>
+        <IndexTable.Cell>{orders}</IndexTable.Cell>
+        <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
+      </IndexTable.Row>
+    ),
+  );
+
+  return (
+    <Card>
+      <IndexTable
+        resourceName={resourceName}
+        itemCount={customers.length}
+        selectedItemsCount={
+          allResourcesSelected ? 'All' : selectedResources.length
+        }
+        onSelectionChange={handleSelectionChange}
+        headings={[
+          {title: 'Name'},
+          {title: 'Location'},
+          {title: 'Order count'},
+          {title: 'Amount spent'},
+        ]}
+      >
+        {rowMarkup}
+      </IndexTable>
+    </Card>
+  );
+}
+```
+
 ### IndexTable with empty state
 
 Use to explain the purpose of a index table when no resources exist yet. This allows a smooth transition from a list in a loading state to a list where zero, one, or many resources exist.

--- a/src/components/IndexTable/components/Link/Link.scss
+++ b/src/components/IndexTable/components/Link/Link.scss
@@ -1,0 +1,31 @@
+@import '../../../../styles/common';
+
+.Link {
+  @include text-emphasis-strong;
+  @include focus-ring;
+  height: 100%;
+  padding: spacing('tight') spacing();
+  color: var(--p-text, color('blue'));
+  display: block;
+  text-decoration: none;
+
+  &:hover,
+  &:active {
+    text-decoration: none;
+  }
+
+  &:focus:not(:active) {
+    @include focus-ring($style: 'focused');
+    outline: none;
+    text-decoration: none;
+  }
+}
+
+.subdued {
+  @include text-emphasis-normal;
+  @include text-emphasis-subdued;
+}
+
+.condensed {
+  padding: 0;
+}

--- a/src/components/IndexTable/components/Link/Link.tsx
+++ b/src/components/IndexTable/components/Link/Link.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import {classNames} from '../../../../utilities/css';
+import {UnstyledLink} from '../../../UnstyledLink';
+
+import styles from './Link.scss';
+
+interface LinkProps {
+  url: string;
+  children: React.ReactNode;
+  subdued?: boolean;
+  primary?: boolean;
+  condensed?: boolean;
+  onClick?(): void;
+}
+
+export function Link({
+  url,
+  subdued,
+  primary,
+  condensed,
+  onClick,
+  children,
+}: LinkProps) {
+  const linkClasses = classNames(
+    styles.Link,
+    subdued && styles.subdued,
+    condensed && styles.condensed,
+  );
+
+  const linkAttributes = {
+    ...(primary && {'data-primary-link': true}),
+    className: linkClasses,
+    url,
+  };
+
+  const handleClick = (event: React.MouseEvent) => {
+    if (onClick) {
+      onClick();
+    }
+
+    stopPropagation(event);
+  };
+
+  return (
+    <UnstyledLink {...linkAttributes} onClick={handleClick}>
+      {children}
+    </UnstyledLink>
+  );
+}
+
+function stopPropagation(event: React.MouseEvent) {
+  event.stopPropagation();
+}

--- a/src/components/IndexTable/components/Link/index.ts
+++ b/src/components/IndexTable/components/Link/index.ts
@@ -1,0 +1,1 @@
+export {Link} from './Link';

--- a/src/components/IndexTable/components/Link/tests/Link.test.tsx
+++ b/src/components/IndexTable/components/Link/tests/Link.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {mountWithApp} from 'test-utilities';
+
+import {UnstyledLink} from '../../../../UnstyledLink';
+import {Link} from '../Link';
+
+describe('<Link />', () => {
+  it('renders an UnstyledLink with passed url', () => {
+    const link = mountWithApp(<Link url="https://shopify.com">Test link</Link>);
+
+    expect(link).toContainReactComponent(UnstyledLink, {
+      url: 'https://shopify.com',
+    });
+  });
+
+  it('renders passed children as content', () => {
+    const link = mountWithApp(
+      <Link url="https://shopify.com">Test link content</Link>,
+    );
+    const unstyledLink = link.find(UnstyledLink);
+
+    expect(unstyledLink!.text()).toContain('Test link content');
+  });
+
+  it('stops click propagation', () => {
+    const spy = jest.fn();
+    const link = mountWithApp(
+      <Link url="https://shopify.com">Test link content</Link>,
+    );
+    link.find(UnstyledLink)!.trigger('onClick', {stopPropagation: spy});
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('invokes provided onClick when clicked', () => {
+    const onClickSpy = jest.fn();
+    const link = mountWithApp(
+      <Link url="https://shopify.com" onClick={onClickSpy}>
+        Test link content
+      </Link>,
+    );
+    link.find(UnstyledLink)!.trigger('onClick', {stopPropagation: () => {}});
+
+    expect(onClickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds the primary link data attribute when primary is true', () => {
+    const link = mountWithApp(
+      <Link url="https://shopify.com" primary>
+        Test link content
+      </Link>,
+    );
+    expect(link).toContainReactComponent(UnstyledLink, {
+      'data-primary-link': true,
+    });
+  });
+});

--- a/src/components/IndexTable/components/index.ts
+++ b/src/components/IndexTable/components/index.ts
@@ -2,3 +2,4 @@ export * from './Cell';
 export * from './Row';
 export * from './Checkbox';
 export * from './ScrollContainer';
+export * from './Link';


### PR DESCRIPTION
### WHY are these changes introduced?

Currently the `IndexTable` doesn't have a way to link to a resource from a row.

### WHAT is this pull request doing?

This brings over the `IndexTable.Link` component, similar to what we are doing on our indexes that use an `IndexTable` in the admin. I also added a new story to demonstrate how it works.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Try using the new `Index table with row links` example in storybook.

https://5d559397bae39100201eedc1-cxcwmiazhf.chromatic.com/?path=/story/all-components-index-table--index-table-with-row-links

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
