### PR TITLE
[Modal] add noScroll prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Add `variableHeight` prop to `DropZone` so children control its height ([#4136](https://github.com/Shopify/polaris-react/pull/4136))
 - Add print styles to `Card`, `Heading`, `Layout`, `Layout.Section`, `Subheading`, `TextStyle` components ([#4142](https://github.com/Shopify/polaris-react/pull/4142))
 - Add `fullWidth` prop to `ColorPicker` so the color picker can take the full width ([#4152](https://github.com/Shopify/polaris-react/pull/4152))
+- Add `noScroll` prop to `Modal` which prevents modal contents from scrolling ([#4153](https://github.com/Shopify/polaris-react/pull/4153))
 
 ### Bug fixes
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -55,6 +55,8 @@ export interface ModalProps extends FooterProps {
   onScrolledToBottom?(): void;
   /** The element or the RefObject that activates the Modal */
   activator?: React.RefObject<HTMLElement> | React.ReactElement;
+  /** Removes Scrollable container from the modal content */
+  noScroll?: boolean;
 }
 
 export const Modal: React.FunctionComponent<ModalProps> & {
@@ -79,6 +81,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
   onClose,
   onIFrameLoad,
   onTransitionEnd,
+  noScroll,
 }: ModalProps) {
   const [iframeHeight, setIframeHeight] = useState(IFRAME_LOADING_HEIGHT);
 
@@ -150,6 +153,18 @@ export const Modal: React.FunctionComponent<ModalProps> & {
       content
     );
 
+    const scrollContainerMarkup = noScroll ? (
+      <div className={styles.Body}>{body}</div>
+    ) : (
+      <Scrollable
+        shadow
+        className={styles.Body}
+        onScrolledToBottom={onScrolledToBottom}
+      >
+        {body}
+      </Scrollable>
+    );
+
     const bodyMarkup = src ? (
       <iframe
         name={iFrameName}
@@ -160,13 +175,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
         style={{height: `${iframeHeight}px`}}
       />
     ) : (
-      <Scrollable
-        shadow
-        className={styles.Body}
-        onScrolledToBottom={onScrolledToBottom}
-      >
-        {body}
-      </Scrollable>
+      scrollContainerMarkup
     );
 
     dialog = (

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -325,6 +325,17 @@ describe('<Modal>', () => {
 
       expect(modal.find(Dialog).prop('limitHeight')).toBeTruthy();
     });
+
+    it('does not render a Scrollable with noScroll prop', () => {
+      const modal = mountWithAppProvider(
+        <Modal title="foo" onClose={jest.fn()} open noScroll>
+          <Badge />
+        </Modal>,
+      );
+
+      const scrollable = modal.find(Scrollable).first();
+      expect(scrollable.exists()).toBe(false);
+    });
   });
 
   describe('loading', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Needed to fix https://github.com/Shopify/core-issues/issues/23913

We're building a component that has its own sticky toolbar header, and then the main body content is wrapped in a `<ScrollableContainer>`, so that's how the user scrolls through the modal contents. The problem is, if the browser window is short enough, it'll squish the modal contents such that an outer scrollbar appears, which belongs to Polaris's `<Modal>`. So we have an outer container and an internal container, each of which will only partially scroll the modal contents 😬

You can see a video in the above issue.

### WHAT is this pull request doing?

`<Modal>` component now has the prop `noScroll` which when true wraps the body content in a `div` instead of the `Scrollable` component

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->

<!--
  If you don't have access to Percy, please request access in the #polaris Slack channel.
-->
