### PR TITLE
[Frame/Loading] Fix async setState calls

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Bug fixes
 
 - Fixed heading overflow issue on dismissible CalloutCard ([#4135](https://github.com/Shopify/polaris-react/pull/4135))
+- Fixed `Loading` setting state after it has unmounted ([#4158](https://github.com/Shopify/polaris-react/pull/4158))
 - Prevent extra right margin being added to the `Filter` component when used without filters. ([#4134](https://github.com/Shopify/polaris-react/pull/4134))
 
 ### Documentation

--- a/src/components/Frame/components/Loading/Loading.tsx
+++ b/src/components/Frame/components/Loading/Loading.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react';
 
 import {useI18n} from '../../../../utilities/i18n';
+import {useIsMountedRef} from '../../../../utilities/use-is-mounted-ref';
 
 import styles from './Loading.scss';
 
@@ -8,7 +9,7 @@ const STUCK_THRESHOLD = 99;
 
 export function Loading() {
   const i18n = useI18n();
-
+  const isMountedRef = useIsMountedRef();
   const [progress, setProgress] = useState(0);
   const [animating, setAnimating] = useState(false);
 
@@ -18,11 +19,13 @@ export function Loading() {
     }
 
     requestAnimationFrame(() => {
+      if (!isMountedRef.current) return;
+
       const step = Math.max((STUCK_THRESHOLD - progress) / 10, 1);
       setAnimating(true);
       setProgress(progress + step);
     });
-  }, [progress, animating]);
+  }, [progress, animating, isMountedRef]);
 
   const customStyles = {
     transform: `scaleX(${Math.floor(progress) / 100})`,


### PR DESCRIPTION
### WHY are these changes introduced?

Loading can call set state after the component has unmounted

![Screen Shot 2021-05-04 at 10 47 32 AM](https://user-images.githubusercontent.com/24610840/117022391-37869100-acc6-11eb-851c-7db0880e1472.png)


### WHAT is this pull request doing?

Adding an isMounted check

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

Unfortunately it's very hard to reproduce the error. @dleroux did you want to check it in off your branch?