### PR TITLE
Update service classification to tier4

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,7 @@
-classification: library
+classification: tier4
 slack_channels:
   - polaris
+url: https://polaris-react.shopifycloud.com
 oncall_url: https://shopify.pagerduty.com/services/PQNFXB1
 security:
   data_management:


### PR DESCRIPTION
### WHY are these changes introduced?

We need to deploy the master branch storybook builds to Shopify infrastructure. We can't run `dev runtime create` without the classification being updated.

### WHAT is this pull request doing?

Changing the classification from `library` to `tier4`