### PR TITLE
Replace "master" with "main" in Contributing.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Every significant change is documented in the [CHANGELOG](https://github.com/Sho
 
 ## Branch organization
 
-We do our best to keep `master` releasable at all times, with work for major releases happening in separate branches. [Breaking changes](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md#major) should never be merged directly to `master`. Otherwise, if you send a pull request please do it against the `master` branch. Continue reading for more about pull requests and breaking changes.
+We do our best to keep `main` releasable at all times, with work for major releases happening in separate branches. [Breaking changes](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md#major) should never be merged directly to `main`. Otherwise, if you send a pull request please do it against the `main` branch. Continue reading for more about pull requests and breaking changes.
 
 ## Bugs
 
@@ -64,7 +64,7 @@ We’ll review your pull request and either merge it, request changes to it, or 
 
 **Before submitting a pull request**, please:
 
-1. Fork the repository and create your branch from `master`
+1. Fork the repository and create your branch from `main`
 1. Run `yarn` in the repository root
 1. If you’ve fixed a bug or added code that [should be tested](https://github.com/Shopify/web-foundation/blob/master/Best%20practices/Testing.md), add tests
 1. Ensure the test suite passes with `yarn test` (protip: `yarn test:watch TestName` is helpful in development)
@@ -120,4 +120,4 @@ However, there are still some styles that the linter cannot pick up. If you are 
 
 ## Breaking changes
 
-If your pull request contains breaking changes, please target the branch for the next major release and open a pull request against `master` that introduces the deprecation warnings and upgrade path. If you are unsure if the changes are considered breaking or not, open your pull request against the `master` branch and let us know. We understand it can be uncomfortable asking for help and this is why we have a [code of conduct](https://github.com/Shopify/polaris-react/blob/master/.github/CODE_OF_CONDUCT.md) to ensure the community is positive, encouraging, and helpful.
+If your pull request contains breaking changes, please target the branch for the next major release and open a pull request against `main` that introduces the deprecation warnings and upgrade path. If you are unsure if the changes are considered breaking or not, open your pull request against the `main` branch and let us know. We understand it can be uncomfortable asking for help and this is why we have a [code of conduct](https://github.com/Shopify/polaris-react/blob/master/.github/CODE_OF_CONDUCT.md) to ensure the community is positive, encouraging, and helpful.


### PR DESCRIPTION
### WHY are these changes introduced?

The main branch was renamed recently from "master" to "main". The docs don't reflect that.

### WHAT is this pull request doing?

Replace "master" with "main" in Contributing.md

### How to 🎩

No tophat required