### PR TITLE
[DualThumb] Add an offset to push the minimum range value to the left

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed heading overflow issue on dismissible CalloutCard ([#4135](https://github.com/Shopify/polaris-react/pull/4135))
 - Fixed `Loading` setting state after it has unmounted ([#4158](https://github.com/Shopify/polaris-react/pull/4158))
 - Prevent extra right margin being added to the `Filter` component when used without filters. ([#4134](https://github.com/Shopify/polaris-react/pull/4134))
+- Fixed offset in `DualThumb` when used with a min value different from 0 [#4172](https://github.com/Shopify/polaris-react/pull/4172)
 
 ### Documentation
 

--- a/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
+++ b/src/components/RangeSlider/components/DualThumb/DualThumb.tsx
@@ -86,9 +86,12 @@ export class DualThumb extends Component<DualThumbProps, State> {
         const adjustedTrackWidth = width - thumbSize;
         const adjustedTrackLeft = left + thumbSize / 2;
 
+        const range = this.props.max - this.props.min;
+        const minValuePosition = (this.props.min / range) * adjustedTrackWidth;
+
         this.setState({
           trackWidth: adjustedTrackWidth,
-          trackLeft: adjustedTrackLeft,
+          trackLeft: adjustedTrackLeft - minValuePosition,
         });
       }
     },
@@ -168,9 +171,12 @@ export class DualThumb extends Component<DualThumbProps, State> {
 
     const trackWidth = this.state.trackWidth;
     const range = max - min;
+    const minValuePosition = (min / range) * trackWidth;
 
-    const leftPositionThumbLower = (value[0] / range) * trackWidth;
-    const leftPositionThumbUpper = (value[1] / range) * trackWidth;
+    const leftPositionThumbLower =
+      (value[0] / range) * trackWidth - minValuePosition;
+    const leftPositionThumbUpper =
+      (value[1] / range) * trackWidth - minValuePosition;
 
     const outputLowerClassName = classNames(styles.Output, styles.OutputLower);
     const outputMarkupLower =

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -296,6 +296,46 @@ describe('<DualThumb />', () => {
 
       expect(actual).toStrictEqual(expected);
     });
+
+    describe('when min is above 0', () => {
+      it('sets min lower position to 0px', () => {
+        const min = 10;
+        const max = 50;
+
+        const dualThumb = mountWithAppProvider(
+          <DualThumb {...mockProps} min={min} max={max} value={[10, 11]} />,
+        );
+
+        const expected = {
+          '--Polaris-RangeSlider-progress-lower': '0px',
+          '--Polaris-RangeSlider-progress-upper': '-0.40000000000000036px',
+        };
+        const track = findByTestID(dualThumb, 'track');
+        const actual = track.find('[style]').prop('style');
+
+        expect(actual).toStrictEqual(expected);
+      });
+    });
+
+    describe('when min is below 0', () => {
+      it('sets min lower position to 0px', () => {
+        const min = -10;
+        const max = 30;
+
+        const dualThumb = mountWithAppProvider(
+          <DualThumb {...mockProps} min={min} max={max} value={[-10, -9]} />,
+        );
+
+        const expected = {
+          '--Polaris-RangeSlider-progress-lower': '0px',
+          '--Polaris-RangeSlider-progress-upper': '-0.3999999999999999px',
+        };
+        const track = findByTestID(dualThumb, 'track');
+        const actual = track.find('[style]').prop('style');
+
+        expect(actual).toStrictEqual(expected);
+      });
+    });
   });
 
   describe('keyboard control', () => {


### PR DESCRIPTION

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4155

When using the [Dual thumb range slider](https://polaris.shopify.com/components/forms/range-slider) with a min value different from 0, there is an extra padding on the left. This prevents selecting a value when having a range [10, 50] for example:

<img width="332" alt="Screenshot 2021-05-06 at 11 10 43" src="https://user-images.githubusercontent.com/22640631/117273107-18ba0300-ae5c-11eb-981d-f3de49d7b9de.png">

<img width="310" alt="Screenshot 2021-05-06 at 11 09 26" src="https://user-images.githubusercontent.com/22640631/117273096-16f03f80-ae5c-11eb-8fac-acc17fb7727c.png">



| What's happening | What's expected |
|--|--|
| <img width="724" alt="current" src="https://user-images.githubusercontent.com/22640631/116860205-81f20a00-ac01-11eb-883c-6bb29f3cebca.png"> | <img width="724" alt="expected" src="https://user-images.githubusercontent.com/22640631/116860211-83233700-ac01-11eb-8119-ccfed8b1698f.png">

### WHAT is this pull request doing?

Substract the minimum range value position to the position.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page} from '../src';
import {DualThumb} from '../src/components/RangeSlider/components/DualThumb';

export function Playground() {
  const handleChange = (value) => value;
  return (
    <Page title="Playground">
      <DualThumb
        id="test"
        label="Range=[0,50] - Value=[10,50]"
        min={0}
        max={50}
        value={[10, 50]}
        step={1}
        onChange={handleChange}
      />
      <DualThumb
        id="test"
        label="Range=[10,50] - Value=[10,50]"
        min={10}
        max={50}
        value={[10, 50]}
        step={1}
        onChange={handleChange}
      />
      <DualThumb
        id="test"
        label="Range=[10,50] - Value=[20,40]"
        min={10}
        max={50}
        value={[20, 40]}
        step={1}
        onChange={handleChange}
      />
     <DualThumb
        id="test"
        label="Range=[-10,30] - Value=[-10,-9]"
        min={-10}
        max={30}
        value={[-10, -9]}
        step={1}
        onChange={handleChange}
      />
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
