### PR TITLE
[Modal] Add prop small to decrease Modal's width

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Add `noScroll` prop to `Modal` which prevents modal contents from scrolling ([#4153](https://github.com/Shopify/polaris-react/pull/4153))
 - Added new `color` prop to ProgressBar ([#3415](https://github.com/Shopify/polaris-react/pull/3415))
 - Added `requiredIndicator` prop to `Label`, `Labelled`, `Select` and `TextField` ([#4119](https://github.com/Shopify/polaris-react/pull/4119))
+- Add `small` prop to `Modal` so that width can be decreased to 380px ([#4177](https://github.com/Shopify/polaris-react/pull/4177))
 
 ### Bug fixes
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -41,6 +41,8 @@ export interface ModalProps extends FooterProps {
   sectioned?: boolean;
   /** Increases the modal width */
   large?: boolean;
+  /** Decreases the modal width */
+  small?: boolean;
   /** Limits modal height on large sceens with scrolling */
   limitHeight?: boolean;
   /** Replaces modal content with a spinner while a background action is being performed */
@@ -72,6 +74,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
   sectioned,
   loading,
   large,
+  small,
   limitHeight,
   footer,
   primaryAction,
@@ -186,6 +189,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
         onEntered={handleEntered}
         onExited={handleExited}
         large={large}
+        small={small}
         limitHeight={limitHeight}
       >
         <Header titleHidden={titleHidden} id={headerId} onClose={onClose}>

--- a/src/components/Modal/README.md
+++ b/src/components/Modal/README.md
@@ -20,6 +20,7 @@ keywords:
   - instant
   - sectioned
   - large
+  - small
   - limit height
   - loading
   - outer wrapper
@@ -519,6 +520,65 @@ function LargeModalExample() {
     <div style={{height: '500px'}}>
       <Modal
         large
+        activator={activator}
+        open={active}
+        onClose={toggleActive}
+        title="Import customers by CSV"
+        primaryAction={{
+          content: 'Import customers',
+          onAction: toggleActive,
+        }}
+        secondaryActions={[
+          {
+            content: 'Cancel',
+            onAction: toggleActive,
+          },
+        ]}
+      >
+        <Modal.Section>
+          <Stack vertical>
+            <DropZone
+              accept=".csv"
+              errorOverlayText="File type must be .csv"
+              type="file"
+              onDrop={() => {}}
+            >
+              <DropZone.FileUpload />
+            </DropZone>
+            <Checkbox
+              checked={checked}
+              label="Overwrite existing customers that have the same email or phone"
+              onChange={handleCheckbox}
+            />
+          </Stack>
+        </Modal.Section>
+      </Modal>
+    </div>
+  );
+}
+```
+
+### Small modal
+
+<!-- example-for: web -->
+
+Use when you need to decrease the width of your modal.
+
+```jsx
+function SmallModalExample() {
+  const [active, setActive] = useState(true);
+  const [checked, setChecked] = useState(false);
+
+  const toggleActive = useCallback(() => setActive((active) => !active), []);
+
+  const handleCheckbox = useCallback((value) => setChecked(value), []);
+
+  const activator = <Button onClick={toggleActive}>Open</Button>;
+
+  return (
+    <div style={{height: '500px'}}>
+      <Modal
+        small
         activator={activator}
         open={active}
         onClose={toggleActive}

--- a/src/components/Modal/components/Dialog/Dialog.scss
+++ b/src/components/Modal/components/Dialog/Dialog.scss
@@ -4,6 +4,7 @@ $top-offset-slide-in-start: rem(200px);
 $vertical-spacing: 60px;
 $horizontal-spacing: spacing(extra-loose) * 2;
 $height-limit: 600px;
+$xsmall-width: rem(380px);
 $small-width: rem(620px);
 $large-width: rem(980px);
 
@@ -59,6 +60,16 @@ $large-width: rem(980px);
       @media (min-height: $height-limit + $vertical-spacing) {
         max-height: $height-limit;
       }
+    }
+  }
+
+  &.sizeSmall {
+    @include breakpoint-after(layout-width(page-with-nav)) {
+      max-width: calc(100% - #{$horizontal-spacing});
+    }
+
+    @include breakpoint-after($xsmall-width + $horizontal-spacing) {
+      max-width: $xsmall-width;
     }
   }
 

--- a/src/components/Modal/components/Dialog/Dialog.tsx
+++ b/src/components/Modal/components/Dialog/Dialog.tsx
@@ -16,6 +16,7 @@ export interface DialogProps {
   children?: React.ReactNode;
   limitHeight?: boolean;
   large?: boolean;
+  small?: boolean;
   onClose(): void;
   onEntered?(): void;
   onExited?(): void;
@@ -30,12 +31,14 @@ export function Dialog({
   onExited,
   onEntered,
   large,
+  small,
   limitHeight,
   ...props
 }: DialogProps) {
   const containerNode = useRef<HTMLDivElement>(null);
   const classes = classNames(
     styles.Modal,
+    small && styles.sizeSmall,
     large && styles.sizeLarge,
     limitHeight && styles.limitHeight,
   );

--- a/src/components/Modal/tests/Modal.test.tsx
+++ b/src/components/Modal/tests/Modal.test.tsx
@@ -181,6 +181,28 @@ describe('<Modal>', () => {
     });
   });
 
+  describe('small', () => {
+    it('passes small to Dialog if true', () => {
+      const modal = mountWithAppProvider(
+        <Modal title="foo" small onClose={jest.fn()} open>
+          <Badge />
+        </Modal>,
+      );
+
+      expect(modal.find(Dialog).prop('small')).toBe(true);
+    });
+
+    it('does not pass small to Dialog be default', () => {
+      const modal = mountWithAppProvider(
+        <Modal title="foo" onClose={jest.fn()} open>
+          <Badge />
+        </Modal>,
+      );
+
+      expect(modal.find(Dialog).prop('small')).toBeUndefined();
+    });
+  });
+
   describe('limitHeight', () => {
     it('passes limitHeight to Dialog if true', () => {
       const modal = mountWithAppProvider(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Closes #4174 

<!--
  Context about the problem that’s being addressed.
-->

We'd like to be able to `decrease` Modals' width similarly to how we're currently able to increase it through the prop `large`.

### WHAT is this pull request doing?

This PR adds a prop `small` to the `Modal` component so that users are able to decrease Modals' width in a similar manner that they can increase it through the prop `large`. 

We've considered adding a prop `width` that could receive either `small | medium(default) | large`, which would avoid having two props that control width being passed into the component simultaneously, but that would break the current API. Therefore, if both `small` and `large` are passed in at the same time, we'll default to `large`.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:


-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


<img src="https://user-images.githubusercontent.com/10034981/117345905-17e19b00-ae75-11eb-8afa-7c6ed4769608.png" alt="Example of a Modal with prop small enabled and width limited to 380px"/>
<details>
<summary>Another example with the code from README.md</summary>
<img src="https://user-images.githubusercontent.com/10034981/117362814-bb3cab00-ae89-11eb-8ebb-a8255c31187b.png" atl="Another example of a Modal with prop small enabled and width limited to 380px" />
</details>

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

To see this addition live, just add a `small` prop to the Modal component. Please make sure the prop `large` is not being passed simultaneously, as it would take priority over the `small` prop.

```jsx
import React, {useState} from 'react';
import {Page, Modal, Button, TextContainer} from '../src';

export function Playground() {
  const [active, setActive] = useState(true);

  const handleChange = () => setActive(!active);

  const activator = <Button onClick={handleChange}>Open</Button>;

  return (
    <Page title="Playground">
      <Modal
        activator={activator}
        open={active}
        onClose={handleChange}
        title="Reach more shoppers with Instagram"
        small
        primaryAction={{
          content: 'Add Instagram',
          onAction: handleChange,
        }}
        secondaryActions={[
          {
            content: 'Learn more',
            onAction: handleChange,
          },
        ]}
      >
        <Modal.Section>
          <TextContainer>
            <p>
              Use Instagram posts to share your products with millions of
              people. Let shoppers buy from your store without leaving
              Instagram.
            </p>
          </TextContainer>
        </Modal.Section>
      </Modal>
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
