### PR TITLE
[Sheet] Add activator prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Prevented `KeypressListener` attaching/detaching on every render ([#4173](https://github.com/Shopify/polaris-react/pull/4173))
 - Added `animated` prop in `ProgressBar` ([#4251](https://github.com/Shopify/polaris-react/pull/4251))
+- Add `activator` prop to `Sheet` so the triggering element will regain focus ([#4201](https://github.com/Shopify/polaris-react/pull/4201))
 
 ### Bug fixes
 

--- a/src/components/Sheet/Sheet.tsx
+++ b/src/components/Sheet/Sheet.tsx
@@ -1,7 +1,8 @@
-import React, {useRef} from 'react';
+import React, {useCallback, useRef} from 'react';
 import {durationSlow} from '@shopify/polaris-tokens';
 import {CSSTransition} from 'react-transition-group';
 
+import {focusFirstFocusableNode} from '../../utilities/focus';
 import {useMediaQuery} from '../../utilities/media-query';
 import {classNames} from '../../utilities/css';
 import {Key} from '../../types';
@@ -40,6 +41,8 @@ export interface SheetProps {
   onExit?(): void;
   /** ARIA label for sheet */
   accessibilityLabel: string;
+  /** The element or the RefObject that activates the Sheet */
+  activator?: React.RefObject<HTMLElement> | React.ReactElement;
 }
 
 /** @deprecated Use <Modal /> instead or avoid modal patterns all together. */
@@ -50,9 +53,28 @@ export function Sheet({
   onEntered,
   onExit,
   accessibilityLabel,
+  activator,
 }: SheetProps) {
   const {isNavigationCollapsed} = useMediaQuery();
   const container = useRef<HTMLDivElement>(null);
+  const activatorRef = useRef<HTMLDivElement>(null);
+
+  const handleClose = useCallback(() => {
+    onClose();
+
+    const activatorElement =
+      activator && isRef(activator)
+        ? activator && activator.current
+        : activatorRef.current;
+    if (activatorElement) {
+      requestAnimationFrame(() => focusFirstFocusableNode(activatorElement));
+    }
+  }, [activator, onClose]);
+
+  const activatorMarkup =
+    activator && !isRef(activator) ? (
+      <div ref={activatorRef}>{activator}</div>
+    ) : null;
 
   if (process.env.NODE_ENV === 'development') {
     // eslint-disable-next-line no-console
@@ -62,40 +84,49 @@ export function Sheet({
   }
 
   return (
-    <Portal idPrefix="sheet">
-      <CSSTransition
-        nodeRef={container}
-        classNames={
-          isNavigationCollapsed ? BOTTOM_CLASS_NAMES : RIGHT_CLASS_NAMES
-        }
-        timeout={durationSlow}
-        in={open}
-        mountOnEnter
-        unmountOnExit
-        onEntered={onEntered}
-        onExit={onExit}
-      >
-        <div
-          className={styles.Container}
-          {...layer.props}
-          {...overlay.props}
-          ref={container}
+    <>
+      {activatorMarkup}
+      <Portal idPrefix="sheet">
+        <CSSTransition
+          nodeRef={container}
+          classNames={
+            isNavigationCollapsed ? BOTTOM_CLASS_NAMES : RIGHT_CLASS_NAMES
+          }
+          timeout={durationSlow}
+          in={open}
+          mountOnEnter
+          unmountOnExit
+          onEntered={onEntered}
+          onExit={onExit}
         >
-          <TrapFocus trapping={open}>
-            <div
-              role="dialog"
-              aria-modal
-              tabIndex={-1}
-              className={styles.Sheet}
-              aria-label={accessibilityLabel}
-            >
-              {children}
-            </div>
-          </TrapFocus>
-        </div>
-      </CSSTransition>
-      <KeypressListener keyCode={Key.Escape} handler={onClose} />
-      {open && <Backdrop transparent onClick={onClose} />}
-    </Portal>
+          <div
+            className={styles.Container}
+            {...layer.props}
+            {...overlay.props}
+            ref={container}
+          >
+            <TrapFocus trapping={open}>
+              <div
+                role="dialog"
+                aria-modal
+                tabIndex={-1}
+                className={styles.Sheet}
+                aria-label={accessibilityLabel}
+              >
+                {children}
+              </div>
+            </TrapFocus>
+          </div>
+        </CSSTransition>
+        <KeypressListener keyCode={Key.Escape} handler={handleClose} />
+        {open && <Backdrop transparent onClick={handleClose} />}
+      </Portal>
+    </>
   );
+}
+
+function isRef(
+  ref: React.RefObject<HTMLElement> | React.ReactElement,
+): ref is React.RefObject<HTMLElement> {
+  return Object.prototype.hasOwnProperty.call(ref, 'current');
 }

--- a/src/components/Sheet/tests/Sheet.test.tsx
+++ b/src/components/Sheet/tests/Sheet.test.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+/* eslint-disable import/no-deprecated */
+import React, {useRef} from 'react';
 import {CSSTransition} from 'react-transition-group';
 // eslint-disable-next-line no-restricted-imports
 import {mountWithAppProvider} from 'test-utilities/legacy';
-import {Backdrop} from 'components/Backdrop';
+import {Backdrop, Button} from 'components';
+import {mountWithApp} from 'test-utilities';
 
-// eslint-disable-next-line import/no-deprecated
 import {Sheet} from '../Sheet';
 
 describe('<Sheet />', () => {
@@ -32,7 +33,6 @@ describe('<Sheet />', () => {
     );
     const backdrop = sheet.find(Backdrop);
     expect(backdrop).not.toBeNull();
-    expect(backdrop.props().onClick).toBe(mockProps.onClose);
   });
 
   it('renders a css transition component with bottom class names at mobile sizes', () => {
@@ -76,6 +76,111 @@ describe('<Sheet />', () => {
     expect(sheet.find('div[role="dialog"]').prop('aria-label')).toBe(
       mockProps.accessibilityLabel,
     );
+  });
+
+  describe('activator', () => {
+    let rafSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      rafSpy = jest.spyOn(window, 'requestAnimationFrame');
+      rafSpy.mockImplementation((callback) => callback());
+    });
+
+    afterEach(() => {
+      rafSpy.mockRestore();
+    });
+
+    it('renders the element if an element is passed in', () => {
+      const sheet = mountWithAppProvider(
+        <Sheet {...mockProps} activator={<Button />}>
+          <div>Content</div>
+        </Sheet>,
+      );
+
+      expect(sheet.find(Button).exists()).toBe(true);
+    });
+
+    it('does not render the element if a ref object is passed in', () => {
+      const TestHarness = () => {
+        const buttonRef = useRef<HTMLDivElement>(null);
+        const button = (
+          <div ref={buttonRef}>
+            <Button />
+          </div>
+        );
+
+        return (
+          <div>
+            {button}
+            <Sheet {...mockProps} activator={buttonRef}>
+              <div>Content</div>
+            </Sheet>
+          </div>
+        );
+      };
+
+      const testHarness = mountWithApp(<TestHarness />);
+
+      expect(testHarness.find(Sheet)).not.toContainReactComponent(Button);
+    });
+
+    it('does not throw an error when no activator is passed in', () => {
+      const sheet = mountWithAppProvider(
+        <Sheet {...mockProps}>
+          <div>Content</div>
+        </Sheet>,
+      );
+
+      expect(() => {
+        sheet.setProps({open: false});
+      }).not.toThrow();
+    });
+
+    it('focuses the activator when the activator is an element on close', () => {
+      const id = 'activator-id';
+      const sheet = mountWithApp(
+        <Sheet {...mockProps} activator={<Button id={id} />}>
+          <div>Content</div>
+        </Sheet>,
+      );
+
+      sheet.find(Backdrop)!.trigger('onClick');
+      const activator = sheet.find('button', {id})!.domNode;
+
+      expect(document.activeElement).toBe(activator);
+    });
+
+    it('focuses the activator when the activator a ref on close', () => {
+      const buttonId = 'buttonId';
+      const TestHarness = () => {
+        const buttonRef = useRef<HTMLDivElement>(null);
+
+        const button = (
+          <div ref={buttonRef}>
+            <Button id={buttonId} />
+          </div>
+        );
+
+        return (
+          <div>
+            {button}
+            <Sheet {...mockProps} activator={buttonRef}>
+              <div>Content</div>
+            </Sheet>
+          </div>
+        );
+      };
+
+      const testHarness = mountWithApp(<TestHarness />);
+
+      testHarness.find(Sheet)!.find(Backdrop)!.trigger('onClick');
+
+      expect(document.activeElement).toBe(
+        testHarness.findWhere(
+          (wrap) => wrap.is('button') && wrap.prop('id') === buttonId,
+        )!.domNode,
+      );
+    });
   });
 });
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Needed to fix https://github.com/Shopify/banking/issues/4735

Adds an `activator` prop to the `Sheet` component so it re-focuses on the triggering element when the Sheet is closed. This is using the same implementation as the `Modal` component's `activator` prop.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Adds an `activator` prop that accepts an element or a Ref object to the `Sheet` component. When the Sheet is closed it will re-focus on the triggering element. If an element is passed into the prop it will also render that element.

https://user-images.githubusercontent.com/14224109/117994979-f23e1100-b30e-11eb-9074-d4f01ad423a3.mov


## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

Example passing an element
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {useToggle} from '../src/utilities/use-toggle';

import {Button, Card, Heading, Page, Sheet} from '../src';

export function Playground() {
  const sheetOpen = useToggle(false);

  return (
    <Page title="Playground">
      <Card sectioned>
        <Sheet
          open={sheetOpen.value}
          onClose={sheetOpen.setFalse}
          accessibilityLabel="sheet"
          activator={<Button onClick={sheetOpen.setTrue}>Open</Button>}
        >
          <Heading>Sheet title</Heading>
        </Sheet>
      </Card>
    </Page>
  );
}
```
</details>

Example passing a RefObject
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useRef} from 'react';
import {useToggle} from '../src/utilities/use-toggle';

import {Button, Card, Heading, Page, Sheet} from '../src';

export function Playground() {
  const sheetOpen = useToggle(false);
  const buttonRef = useRef(null);

  return (
    <Page title="Playground">
      <Card sectioned>
        <div ref={buttonRef}>
          <Button onClick={sheetOpen.setTrue}>Open</Button>
        </div>
      </Card>
      <Sheet
        open={sheetOpen.value}
        onClose={sheetOpen.setFalse}
        accessibilityLabel="sheet"
        activator={buttonRef}
      >
        <Heading>Sheet title</Heading>
      </Sheet>
    </Page>
  );
}
```
</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
