### PR TITLE
[DropZone] Change DOM order of Visually hidden input in order to focus it before its children

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -25,6 +25,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Prevent extra right margin being added to the `Filter` component when used without filters. ([#4134](https://github.com/Shopify/polaris-react/pull/4134))
 - Fixed offset in `DualThumb` when used with a min value different from 0 [#4172](https://github.com/Shopify/polaris-react/pull/4172)
 - Fixed loading state stacking in `ResourceList` ([#4208](https://github.com/Shopify/polaris-react/issues/4208))
+- Fixed focus order of visually hidden input in `DropZone` ([#4219](https://github.com/Shopify/polaris-react/pull/4219))
 
 ### Documentation
 

--- a/src/components/DropZone/DropZone.tsx
+++ b/src/components/DropZone/DropZone.tsx
@@ -403,7 +403,6 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
         >
           {dragOverlay}
           {dragErrorOverlay}
-          <div className={styles.Container}>{children}</div>
           <VisuallyHidden>
             <DropZoneInput
               {...inputAttributes}
@@ -411,6 +410,7 @@ export const DropZone: React.FunctionComponent<DropZoneProps> & {
               onFileDialogClose={onFileDialogClose}
             />
           </VisuallyHidden>
+          <div className={styles.Container}>{children}</div>
         </div>
       </Labelled>
     </DropZoneContext.Provider>


### PR DESCRIPTION
### WHY are these changes introduced?

We have a use-case where there is a `Button` inside the `dropzone`

Currently, if we're navigating (tabbing) through the component with the keyboard:
1. `Button` inside `Dropzone` is focused first
2. `Dropzone` is focused

We expect a meaningful order when navigating through. Expected order:
1. Focus the `Dropzone` first
2. Then any focusable contents inside it


<details>

<summary> Current </summary>

https://user-images.githubusercontent.com/23648577/119017743-4e391300-b969-11eb-9c15-21f6fffaca9b.mp4

</details>

<details>

<summary> Correct order </summary>

https://user-images.githubusercontent.com/23648577/119017814-63ae3d00-b969-11eb-8bfe-f91a9b9d1c8f.mp4

</details>


### WHAT is this pull request doing?

Changes DOM order to accommodate a meaningful tabbing sequence. 

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)


Could this possibly break anything from the consumer side ? 

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
