### PR TITLE
[Button] Fix slim buttons height inconsistencies for mixed icons and text

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -339,7 +339,7 @@ $stacking-order: (
     padding-left: spacing(base-tight);
     padding-right: spacing(base-tight);
   }
-  
+
   &.sizeSlim {
     margin-top: rem(2px);
   }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -339,6 +339,10 @@ $stacking-order: (
     padding-left: spacing(base-tight);
     padding-right: spacing(base-tight);
   }
+  
+  &.sizeSlim {
+    margin-top: rem(2px);
+  }
 
   .Icon:first-child {
     margin-left: 0;


### PR DESCRIPTION
### WHY are these changes introduced?

When slim buttons are used in a button group with mixed icons and text the size of the buttons are different by 1px. This solution fixes this but I'm not sure it's the right solution. I'm open to any suggestions. Maybe it should be a change on ButtonGroup.

Examples:
<img width="247" alt="Screen Shot 2021-05-26 at 1 20 34 PM" src="https://user-images.githubusercontent.com/7470936/119719317-43312780-be2e-11eb-9f94-c6ca2aba9d29.png">

https://codesandbox.io/s/gifted-gates-c9zlp?file=/App.js

It seems the icon is just slightly larger at `2rem` than the text. Adjusting the padding on the top from 0.3rem to 0.2rem here seems to help.


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
