### PR TITLE
Remove stale reference to yarn:watch script

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -67,7 +67,7 @@ We’ll review your pull request and either merge it, request changes to it, or 
 1. Fork the repository and create your branch from `main`
 1. Run `yarn` in the repository root
 1. If you’ve fixed a bug or added code, make sure to add tests
-1. Ensure the test suite passes with `yarn test` (protip: `yarn test:watch TestName` is helpful in development)
+1. Ensure the test suite passes with `yarn test` (protip: `yarn test TestName` is helpful in development)
 1. If your pull request modifies any SVG files run `yarn run sewing-kit optimize`
 1. Format your code with `yarn format`
 1. Make sure your code lints with `yarn lint`


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes contributing documentation to have correct test command.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Changing the instructions from `yarn test:watch` (outdated) to `yarn test` (current)

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->
