### PR TITLE
[DataTable] Fix console warnings caused by setting state after unmount

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fix console warnings when `DataTable` unmounts ([#4249](https://github.com/Shopify/polaris-react/pull/4249))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -123,6 +123,10 @@ class DataTableInner extends PureComponent<CombinedProps, DataTableState> {
     this.handleResize();
   }
 
+  componentWillUnmount() {
+    this.handleResize.cancel();
+  }
+
   render() {
     const {
       headings,

--- a/src/components/DataTable/tests/DataTable.test.tsx
+++ b/src/components/DataTable/tests/DataTable.test.tsx
@@ -60,6 +60,18 @@ describe('<DataTable />', () => {
     expect(test).not.toThrow();
   });
 
+  it('does not set state after the component has been unmounted', () => {
+    // When a React component calls setState after being unmounted it logs the error:
+    // "Warning: Can't perform a React state update on an unmounted component ..."
+    const consoleSpy = jest.spyOn(console, 'error');
+    const dataTable = mountWithApp(
+      <DataTable columnContentTypes={[]} headings={[]} rows={[]} />,
+    );
+    dataTable.unmount();
+    timer.runAllTimers();
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
   describe('columnContentTypes', () => {
     it('sets the provided contentType of Cells in each column', () => {
       const headings = ['Column 1', 'Column 2'];


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4245 
The DataTable component "debounces" an internal method which can cause state to be set after the component has mounted. This results in console warnings, which can break some test environments.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Cancels the debounced method when the component is unmounting so that it won't try to call setState. Introduces test coverage to capture the issue.

**Before**
![image](https://user-images.githubusercontent.com/3004111/120815285-a7827400-c51d-11eb-80fd-739c311be1cd.png)

**After**
![image](https://user-images.githubusercontent.com/3004111/120815202-99345800-c51d-11eb-8c88-f6e5866f0916.png)