### PR TITLE
[Page] Add `divider` prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Prevented `KeypressListener` attaching/detaching on every render ([#4173](https://github.com/Shopify/polaris-react/pull/4173))
 - Added `animated` prop in `ProgressBar` ([#4251](https://github.com/Shopify/polaris-react/pull/4251))
+- Added `divider` prop to `Page` component ([#4260](https://github.com/Shopify/polaris-react/pull/4260))
 
 ### Bug fixes
 

--- a/src/components/Page/Page.scss
+++ b/src/components/Page/Page.scss
@@ -35,3 +35,7 @@ body {
 .Content {
   @include page-content-layout;
 }
+
+.divider {
+  border-top: border();
+}

--- a/src/components/Page/Page.scss
+++ b/src/components/Page/Page.scss
@@ -38,4 +38,5 @@ body {
 
 .divider {
   border-top: border();
+  padding-top: spacing();
 }

--- a/src/components/Page/Page.tsx
+++ b/src/components/Page/Page.tsx
@@ -12,10 +12,18 @@ export interface PageProps extends HeaderProps {
   fullWidth?: boolean;
   /** Decreases the maximum layout width. Intended for single-column layouts */
   narrowWidth?: boolean;
+  /** Displays a divider between the page header and the page content */
+  divider?: boolean;
 }
 
-export function Page({children, fullWidth, narrowWidth, ...rest}: PageProps) {
-  const className = classNames(
+export function Page({
+  children,
+  fullWidth,
+  narrowWidth,
+  divider,
+  ...rest
+}: PageProps) {
+  const pageClassName = classNames(
     styles.Page,
     fullWidth && styles.fullWidth,
     narrowWidth && styles.narrowWidth,
@@ -28,12 +36,17 @@ export function Page({children, fullWidth, narrowWidth, ...rest}: PageProps) {
     (rest.actionGroups != null && rest.actionGroups.length > 0) ||
     (rest.breadcrumbs != null && rest.breadcrumbs.length > 0);
 
+  const contentClassName = classNames(
+    styles.Content,
+    divider && hasHeaderContent && styles.divider,
+  );
+
   const headerMarkup = hasHeaderContent ? <Header {...rest} /> : null;
 
   return (
-    <div className={className}>
+    <div className={pageClassName}>
       {headerMarkup}
-      <div className={styles.Content}>{children}</div>
+      <div className={contentClassName}>{children}</div>
     </div>
   );
 }

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -450,6 +450,22 @@ Title metadata appears immediately after the page’s title. Use it to communica
 </Page>
 ```
 
+### Page with divider
+
+<!-- example-for: web -->
+
+Use when the page needs visual separation between the page header and the content.
+
+```jsx
+<Page
+  breadcrumbs={[{content: 'Settings', url: '/settings'}]}
+  title="General"
+  divider
+>
+  <p>Page content</p>
+</Page>
+```
+
 ---
 
 ## Related components

--- a/src/components/Page/tests/Page.test.tsx
+++ b/src/components/Page/tests/Page.test.tsx
@@ -253,6 +253,35 @@ describe('<Page />', () => {
     });
   });
 
+  describe('divider', () => {
+    it('renders border when divider is true and header props exist', () => {
+      const wrapper = mountWithApp(<Page {...mockProps} divider />);
+      expect(wrapper).toContainReactComponent('div', {
+        className: 'Content divider',
+      });
+    });
+
+    it('does not render border when divider is true and no header props exist', () => {
+      const wrapper = mountWithApp(<Page divider />);
+      expect(wrapper).not.toContainReactComponent('div', {
+        className: 'Content divider',
+      });
+      expect(wrapper).toContainReactComponent('div', {
+        className: 'Content',
+      });
+    });
+
+    it('does not render border when divider is false', () => {
+      const wrapper = mountWithApp(<Page {...mockProps} divider={false} />);
+      expect(wrapper).not.toContainReactComponent('div', {
+        className: 'Content divider',
+      });
+      expect(wrapper).toContainReactComponent('div', {
+        className: 'Content',
+      });
+    });
+  });
+
   describe('<Header />', () => {
     it('is not rendered when there is no header content', () => {
       const page = mountWithAppProvider(<Page title="" />);


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4238

Some pages within the admin have design requirements to include borders below the page header. 

![Page header with title "Shop Pay Installments" title and border separating the page header and the page content](https://user-images.githubusercontent.com/16295605/121605288-2560e680-ca1a-11eb-8082-ec2d30083788.png)

The `divider` prop is added to the `Page` component to avoid the need to use unstable, hacky CSS like the snippet below.

```scss
.PageWrapper {
  [class^='Polaris-Page__Content'] {
    border-top: border();
  }
}
```

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR introduces the `divider` prop to the `Page` component. By default, the divider not rendered for the `Page` component. The PR adds the new prop, styles, tests, and adds an example to the documentation. 

```jsx
<Page {...PageProps} divider />
```

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥  &nbsp; [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒  &nbsp; [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄  &nbsp; [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page} from '../src';

export function Playground() {
  return (
    <Page
      title="Playground"
      breadcrumbs={[{content: 'Settings', url: ''}]}
      divider
    >
      <p>This is the page content.</p>
    </Page>
  );
}
```

</details>

Test with the following scenarios:

- With `divider={true}` and any Header props present, e.g. `title="My Page"` (divider should appear)
- With `divider={true}` and no Header props present, e.g. `title=""` (divider should _not_ appear)
- With `divider={false}` (divider should _not_ appear)

### 🎩  &nbsp; checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
