### PR TITLE
[TextField] - Add monospaced prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added `divider` prop to `Page` component ([#4260](https://github.com/Shopify/polaris-react/pull/4260))
 - Add `activator` prop to `Sheet` so the triggering element will regain focus ([#4201](https://github.com/Shopify/polaris-react/pull/4201))
 - Rename and expose Card compound components types ([#4261](https://github.com/Shopify/polaris-react/pull/4261))
+- Add `monospaced` prop to `TextField` component ([#4264](https://github.com/Shopify/polaris-react/pull/4264))
 
 ### Bug fixes
 

--- a/src/components/TextField/README.md
+++ b/src/components/TextField/README.md
@@ -799,6 +799,32 @@ function TextFieldWithClearButtonExample() {
 }
 ```
 
+### Text field with monospaced font
+
+<!-- example-for: web -->
+
+Use to apply a monospaced font to the TextField
+
+```jsx
+function TextFieldWithMonospacedFontExample() {
+  const [textFieldValue, setTextFieldValue] = useState('Jaded Pixel');
+
+  const handleTextFieldChange = useCallback(
+    (value) => setTextFieldValue(value),
+    [],
+  );
+
+  return (
+    <TextField
+      label="Store name"
+      value={textFieldValue}
+      onChange={handleTextFieldChange}
+      monospaced
+    />
+  );
+}
+```
+
 ---
 
 ## Related components

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -310,3 +310,7 @@ $stacking-order: (
     margin-top: 0;
   }
 }
+
+.monospaced {
+  font-family: font-family($family: 'monospace');
+}

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -132,6 +132,8 @@ interface NonMutuallyExclusiveProps {
   onBlur?(): void;
   /** Visual required indicator, adds an asterisk to label */
   requiredIndicator?: boolean;
+  /** Indicates whether or not a monospaced font should be used */
+  monospaced?: boolean;
 }
 
 export type TextFieldProps = NonMutuallyExclusiveProps &
@@ -184,6 +186,7 @@ export function TextField({
   onFocus,
   onBlur,
   requiredIndicator,
+  monospaced,
 }: TextFieldProps) {
   const i18n = useI18n();
   const [height, setHeight] = useState<number | null>(null);
@@ -398,6 +401,7 @@ export function TextField({
     align && styles[variationName('Input-align', align)],
     suffix && styles['Input-suffixed'],
     clearButton && styles['Input-hasClearButton'],
+    monospaced && styles.monospaced,
   );
 
   const input = createElement(multiline ? 'textarea' : 'input', {

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1139,6 +1139,23 @@ describe('<TextField />', () => {
       expect(labelled.prop('requiredIndicator')).toBe(true);
     });
   });
+
+  describe('monospaced', () => {
+    it('passes monospaced prop to TextField', () => {
+      const element = mountWithAppProvider(
+        <TextField label="TextField" onChange={noop} monospaced />,
+      );
+      expect(element.prop('monospaced')).toBe(true);
+    });
+
+    it('applies the monospaced style', () => {
+      const input = mountWithAppProvider(
+        <TextField label="TextField" onChange={noop} monospaced />,
+      ).find('input');
+
+      expect(input.prop('className')).toContain('monospaced');
+    });
+  });
 });
 
 function noop() {}

--- a/src/styles/foundation/_typography.scss
+++ b/src/styles/foundation/_typography.scss
@@ -8,10 +8,13 @@ $font-family-data: (
   'Roboto',
   'Helvetica Neue',
   sans-serif},
-  monospace: #{Monaco,
+  monospace: #{ui-monospace,
+  SFMono-Regular,
+  SF Mono,
   Consolas,
-  'Lucida Console',
-  monospace},
+  Liberation Mono,
+  Menlo,
+  monospace !default},
 );
 
 $line-height-data: (


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

- For our particular use case, we use a `<TextField />` to display an access token that needs to be clearly interpreted by the user
- The use of our current default font on `<TextField />` leads to some mix ups including not being able to differentiate certain characters like I (uppercase i) and l (lowercase L).
- This introduces a `monospaced` prop that applies a monospaced font to the `<TextField />` allowing for easy character distinction

Example - Top is default, bottom is with `monospaced` prop:
![image](https://user-images.githubusercontent.com/29992628/122292693-4024d680-cec4-11eb-82c3-df3251cd6352.png)


<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- adds a `monospaced` prop to `<TextField />`
- This applies the `.Monospaced` css class to the input
  -  The font-families applied try to use the `SF Mono` font first, while falling back to system defaults as per our design suggestions
- I followed a suggestion to take a look at how `<TextStyle />` conditionally applies fonts/colours but did not think a whole `variation` prop was needed right now. If we think this would be useful instead I can change it, but would I also support the other variations currently on `<TextStyle />`?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, TextField} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <TextField value="test 1IlLI1" />
      <TextField monospaced value="test 1IlLI1" />
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
