### PR TITLE
[BulkActions] - Allowing promoted actions to be rendered as menus

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added consistent spacing to `ActionList` ([#4355](https://github.com/Shopify/polaris-react/pull/4355))
 - Added `ariaLabelledBy` props to `Navigation` component to allow a hidden label for accessibility ([#4343](https://github.com/Shopify/polaris-react/pull/4343))
 - Add `lastColumnSticky` prop to `IndexTable` to create a sticky last cell and optional sticky last heading on viewports larger than small ([#4150](https://github.com/Shopify/polaris-react/pull/4150))
+- Allow promoted actions to be rendered as a menu on the `BulkAction` component ([#4266](https://github.com/Shopify/polaris-react/pull/4266))
 
 ### Bug fixes
 

--- a/src/components/BulkActions/BulkActions.tsx
+++ b/src/components/BulkActions/BulkActions.tsx
@@ -11,6 +11,7 @@ import type {
   DisableableAction,
   Action,
   ActionListSection,
+  MenuGroupDescriptor,
 } from '../../types';
 import {ActionList} from '../ActionList';
 import {Popover} from '../Popover';
@@ -19,10 +20,10 @@ import {ButtonGroup} from '../ButtonGroup';
 import {EventListener} from '../EventListener';
 import {CheckableButton} from '../CheckableButton';
 
-import {BulkActionButton} from './components';
+import {BulkActionButton, BulkActionMenu} from './components';
 import styles from './BulkActions.scss';
 
-type BulkAction = DisableableAction & BadgeAction;
+export type BulkAction = DisableableAction & BadgeAction;
 
 type BulkActionListSection = ActionListSection;
 
@@ -42,7 +43,7 @@ export interface BulkActionsProps {
   /** List is in a selectable state */
   selectMode?: boolean;
   /** Actions that will be given more prominence */
-  promotedActions?: BulkAction[];
+  promotedActions?: (BulkAction | MenuGroupDescriptor)[];
   /** List of actions */
   actions?: (BulkAction | BulkActionListSection)[];
   /** Text to select all across pages */
@@ -178,6 +179,28 @@ class BulkActionsInner extends PureComponent<CombinedProps, State> {
     }
   }
 
+  private rolledInPromotedActions() {
+    const {promotedActions} = this.props;
+    const numberOfPromotedActionsToRender = this.numberOfPromotedActionsToRender();
+
+    if (
+      !promotedActions ||
+      promotedActions.length === 0 ||
+      numberOfPromotedActionsToRender >= promotedActions.length
+    ) {
+      return [];
+    }
+
+    const rolledInPromotedActions = promotedActions.map((action) => {
+      if (instanceOfMenuGroupDescriptor(action)) {
+        return {items: [...action.actions]};
+      }
+      return {items: [action]};
+    });
+
+    return rolledInPromotedActions.slice(numberOfPromotedActionsToRender);
+  }
+
   // eslint-disable-next-line @typescript-eslint/member-ordering
   componentDidMount() {
     const {actions, promotedActions} = this.props;
@@ -297,21 +320,28 @@ class BulkActionsInner extends PureComponent<CombinedProps, State> {
       promotedActions && numberOfPromotedActionsToRender > 0
         ? [...promotedActions]
             .slice(0, numberOfPromotedActionsToRender)
-            .map((action, index) => (
-              <BulkActionButton
-                disabled={disabled}
-                {...action}
-                key={index}
-                handleMeasurement={this.handleMeasurement}
-              />
-            ))
+            .map((action, index) => {
+              if (instanceOfMenuGroupDescriptor(action)) {
+                return (
+                  <BulkActionMenu
+                    key={index}
+                    {...action}
+                    isNewBadgeInBadgeActions={this.isNewBadgeInBadgeActions()}
+                  />
+                );
+              }
+              return (
+                <BulkActionButton
+                  disabled={disabled}
+                  {...action}
+                  key={index}
+                  handleMeasurement={this.handleMeasurement}
+                />
+              );
+            })
         : null;
 
-    const rolledInPromotedActions =
-      promotedActions &&
-      numberOfPromotedActionsToRender < promotedActions.length
-        ? [...promotedActions].slice(numberOfPromotedActionsToRender)
-        : [];
+    const rolledInPromotedActions = this.rolledInPromotedActions();
 
     const activatorLabel =
       !promotedActions ||
@@ -326,11 +356,11 @@ class BulkActionsInner extends PureComponent<CombinedProps, State> {
     let combinedActions: ActionListSection[] = [];
 
     if (actionSections && rolledInPromotedActions.length > 0) {
-      combinedActions = [{items: rolledInPromotedActions}, ...actionSections];
+      combinedActions = [...rolledInPromotedActions, ...actionSections];
     } else if (actionSections) {
       combinedActions = actionSections;
     } else if (rolledInPromotedActions.length > 0) {
-      combinedActions = [{items: rolledInPromotedActions}];
+      combinedActions = [...rolledInPromotedActions];
     }
 
     const actionsPopover =
@@ -546,6 +576,12 @@ function instanceOfBulkActionArray(
   });
 
   return actions.length === validList.length;
+}
+
+function instanceOfMenuGroupDescriptor(
+  action: MenuGroupDescriptor | BulkAction,
+): action is MenuGroupDescriptor {
+  return 'title' in action;
 }
 
 export function BulkActions(props: BulkActionsProps) {

--- a/src/components/BulkActions/components/BulkActionMenu/BulkActionMenu.tsx
+++ b/src/components/BulkActions/components/BulkActionMenu/BulkActionMenu.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import {Popover} from '../../../Popover';
+import {ActionList} from '../../../ActionList';
+import {BulkActionButton} from '../BulkActionButton';
+import {useToggle} from '../../../../utilities/use-toggle';
+import type {MenuGroupDescriptor} from '../../../../types';
+
+export interface BulkActionsMenuProps extends MenuGroupDescriptor {
+  isNewBadgeInBadgeActions: boolean;
+}
+
+export function BulkActionMenu({
+  title,
+  actions,
+  isNewBadgeInBadgeActions,
+}: BulkActionsMenuProps) {
+  const {value: isVisible, toggle: toggleMenuVisibility} = useToggle(false);
+
+  return (
+    <>
+      <Popover
+        active={isVisible}
+        activator={
+          <BulkActionButton
+            disclosure
+            onAction={toggleMenuVisibility}
+            content={title}
+            indicator={isNewBadgeInBadgeActions}
+          />
+        }
+        onClose={toggleMenuVisibility}
+        preferInputActivator
+      >
+        <ActionList items={actions} onActionAnyItem={toggleMenuVisibility} />
+      </Popover>
+    </>
+  );
+}

--- a/src/components/BulkActions/components/BulkActionMenu/index.tsx
+++ b/src/components/BulkActions/components/BulkActionMenu/index.tsx
@@ -1,0 +1,1 @@
+export * from './BulkActionMenu';

--- a/src/components/BulkActions/components/BulkActionMenu/tests/BulkActionMenu.test.tsx
+++ b/src/components/BulkActions/components/BulkActionMenu/tests/BulkActionMenu.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {Popover, ActionList} from 'components';
+import {mountWithApp} from 'test-utilities';
+
+import {BulkActionMenu, BulkActionsMenuProps, BulkActionButton} from '../..';
+
+const defaultProps: BulkActionsMenuProps = {
+  title: 'New promoted action',
+  actions: [{content: 'Action1', onAction: jest.fn}],
+  isNewBadgeInBadgeActions: false,
+};
+
+describe('BulkActionMenu', () => {
+  describe('initial render', () => {
+    it('renders an inactive Popover', () => {
+      const bulkActionMenu = mountWithApp(<BulkActionMenu {...defaultProps} />);
+
+      expect(bulkActionMenu).toContainReactComponent(Popover, {
+        active: false,
+      });
+    });
+
+    it('does not render an ActionList', () => {
+      const bulkActionMenu = mountWithApp(<BulkActionMenu {...defaultProps} />);
+
+      expect(bulkActionMenu).not.toContainReactComponent(ActionList);
+    });
+
+    it('renders a BulkActionButton as the Popover activator with the right props', () => {
+      const bulkActionMenu = mountWithApp(<BulkActionMenu {...defaultProps} />);
+
+      expect(bulkActionMenu).toContainReactComponent(BulkActionButton, {
+        indicator: defaultProps.isNewBadgeInBadgeActions,
+        disclosure: true,
+        content: defaultProps.title,
+      });
+    });
+  });
+
+  describe('upon click', () => {
+    it('renders an active Popover', () => {
+      const bulkActionMenu = mountWithApp(<BulkActionMenu {...defaultProps} />);
+      const bulkActionButton = bulkActionMenu.find(BulkActionButton);
+      bulkActionButton!.trigger('onAction');
+
+      expect(bulkActionMenu).toContainReactComponent(Popover, {
+        active: true,
+      });
+    });
+
+    it('renders an ActionList with the supplied actions', () => {
+      const bulkActionMenu = mountWithApp(<BulkActionMenu {...defaultProps} />);
+      const bulkActionButton = bulkActionMenu.find(BulkActionButton);
+      bulkActionButton!.trigger('onAction');
+
+      expect(bulkActionMenu).toContainReactComponent(ActionList, {
+        items: defaultProps.actions,
+      });
+    });
+
+    it('closes the Popover when an action is clicked', () => {
+      const bulkActionMenu = mountWithApp(<BulkActionMenu {...defaultProps} />);
+      const bulkActionButton = bulkActionMenu.find(BulkActionButton);
+      bulkActionButton!.trigger('onAction');
+      const actionList = bulkActionMenu.find(ActionList);
+      actionList!.trigger('onActionAnyItem');
+
+      expect(bulkActionMenu).toContainReactComponent(Popover, {
+        active: false,
+      });
+    });
+  });
+});

--- a/src/components/BulkActions/components/index.ts
+++ b/src/components/BulkActions/components/index.ts
@@ -1,1 +1,2 @@
 export * from './BulkActionButton';
+export * from './BulkActionMenu';


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Closes #4246 

Currently, promoted actions are single buttons and are limited to only 2 actions in the `BulkAction` component. With this change, we're proposing that each one of these buttons can become a menu where we would group relevant actions by subject. This can be seen [on this card](https://github.com/Shopify/core-issues/issues/24023) with the real use case where it would be first used.

### WHAT is this pull request doing?

<details>
  <summary>What it looks like now 🎩</summary>
 <b>On large screens</b>
  <br />
  <img src="https://user-images.githubusercontent.com/10034981/122355118-a2f78b80-cf1f-11eb-8552-3f28228ff59d.png" alt="promoted action as a menu, with an open popover"/>
 <b>On small screens</b>
  <br />
   <img src="https://user-images.githubusercontent.com/10034981/122355423-e0f4af80-cf1f-11eb-90d4-64961cb632e4.png" alt="promoted action menu rolled into the general actions menu when in small screens"/>
 <b>when the two buttons are menus</b>
  <br />

![image](https://user-images.githubusercontent.com/10034981/122358495-b0624500-cf22-11eb-87bc-464d6450940c.png)
![image](https://user-images.githubusercontent.com/10034981/122358588-c7089c00-cf22-11eb-9211-6f1ed51a51c5.png)
    </details>



https://user-images.githubusercontent.com/10034981/122357313-a12ec780-cf21-11eb-9590-867902cb8870.mp4

To make this possible, we're basically changing the `promotedActions` prop to also accept values of type `MenuGroupDescriptor`, which are essentially the type of the menus that we'll be rendering. Then where we define what the `promotedActions` markup will look like, we're mapping through the actions, checking for their type through a type guard function and deciding based on it whether we should render a `BulkActionButton` or a `BulkActionMenu` (which is also being introduced in this PR).

The other change introduced on this PR was for smaller screens, where promoted actions will get rolled into a general `Actions` menu. Here we still want the actions on the menus to be grouped together, so we're making sure they work as `ActionListSection`, similarly to how the prop `actions` is being treated.

##### Notes
1. This should be backwards compatible as we're just extending the capabilities of promoted actions. 
2. Regular button actions and newly added menu actions can coexist.
3. We can have as many menus as we'd like (the warning for keeping promoted actions up to 2 actions will still be thrown though)

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {Page, UnstableBulkActions, Button, Badge, Frame} from '../src';

export function Playground() {
  const [active, setActive] = useState(true);

  const toggleActive = useCallback(() => setActive((active) => !active), []);

  const bulkActionProps = {
    bulkActions: ['button 3', 'button 4', 'button 5'],
    promotedActions: [
      {
        title: 'button1',
        actions: [
          {
            content: 'action1',
          },
          {
            content: 'action2',
          },
          {
            content: 'action3',
            badge: {content: 'new', status: 'new'},
            helpText: 'Short help text',
          },
        ],
      },
      {
        content: 'button 2',
      },
    ],
    actions: [
      {
        content: 'button 7',
      },
      {
        content: 'button 6',
      },
    ],
    paginatedSelectAllText: 'paginated select all text string',
    selected: true,
    accessibilityLabel: 'test-aria-label',
    label: 'Test-Label',
    disabled: false,
    smallScreen: false,
    selectMode: true,
  };

  return (
    <Page title="Playground">
      <UnstableBulkActions {...bulkActionProps} />
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit
- Updated the component's `README.md` with documentation changes (there's no readme for this component)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
