### PR TITLE
[Stack] Add baseTight spacing option

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Add `activator` prop to `Sheet` so the triggering element will regain focus ([#4201](https://github.com/Shopify/polaris-react/pull/4201))
 - Rename and expose Card compound components types ([#4261](https://github.com/Shopify/polaris-react/pull/4261))
 - Add `monospaced` prop to `TextField` component ([#4264](https://github.com/Shopify/polaris-react/pull/4264))
+- Add base tight spacing option to `Stack` component([#4273](https://github.com/Shopify/polaris-react/pull/4273))
 
 ### Bug fixes
 

--- a/src/components/Stack/Stack.scss
+++ b/src/components/Stack/Stack.scss
@@ -37,6 +37,10 @@
   @include stack-spacing(tight);
 }
 
+.spacingBaseTight {
+  @include stack-spacing(base-tight);
+}
+
 .spacingLoose {
   @include stack-spacing(loose);
 }

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -6,7 +6,13 @@ import {elementChildren, wrapWithComponent} from '../../utilities/components';
 import {Item} from './components';
 import styles from './Stack.scss';
 
-type Spacing = 'extraTight' | 'tight' | 'loose' | 'extraLoose' | 'none';
+type Spacing =
+  | 'extraTight'
+  | 'tight'
+  | 'baseTight'
+  | 'loose'
+  | 'extraLoose'
+  | 'none';
 
 type Alignment = 'leading' | 'trailing' | 'center' | 'fill' | 'baseline';
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Adds `base-tight` spacing option to the `<Stack/>` component. 

### WHAT is this pull request doing?

Exposes [`base-tight` spacing](https://github.com/Shopify/polaris-tokens/blob/main/dist/spacing.spacing-map.scss#L5) (12px) as an option on the `Stack.Spacing` prop.

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Stack, Badge} from '../src';

export function Playground() {
  return (
  <Page title="Playground">
      HORIZONTAL:
      <Stack spacing="baseTight">
        <Badge>Paid</Badge>
        <Badge>Fulfilled</Badge>
      </Stack>
      VERTICAL:
      <Stack vertical spacing="baseTight">
        <Badge>Paid</Badge>
        <Badge>Fulfilled</Badge>
      </Stack>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
