### PR TITLE
TextField added event return to onChange and updated the test

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Rename and expose Card compound components types ([#4261](https://github.com/Shopify/polaris-react/pull/4261))
 - Add `monospaced` prop to `TextField` component ([#4264](https://github.com/Shopify/polaris-react/pull/4264))
 - Add base tight spacing option to `Stack` component([#4273](https://github.com/Shopify/polaris-react/pull/4273))
+- Add the ability to retian the event.target from the `TextField` (https://github.com/Shopify/polaris-react/pull/4280 and https://github.com/Shopify/shipping/issues/3083)
 
 ### Bug fixes
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -128,7 +128,7 @@ interface NonMutuallyExclusiveProps {
   onChange?(
     value: string,
     id: string,
-    inputEvent?: React.ChangeEvent<HTMLInputElement>,
+    target?: EventTarget & HTMLInputElement
   ): void;
   /** Callback when input is focused */
   onFocus?(): void;
@@ -148,7 +148,7 @@ export type TextFieldProps = NonMutuallyExclusiveProps &
         onChange(
           value: string,
           id: string,
-          inputEvent?: React.ChangeEvent<HTMLInputElement>,
+          target?: EventTarget & HTMLInputElement, 
         ): void;
       }
   );
@@ -510,7 +510,7 @@ export function TextField({
   }
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
-    onChange && onChange(event.currentTarget.value, id, event);
+    onChange && onChange(event.currentTarget.value, id, event.target);
   }
 
   function handleFocus({target}: React.FocusEvent) {

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -84,7 +84,7 @@ describe('<TextField />', () => {
       expect(spy).toHaveBeenCalledWith(
         'two',
         'MyTextField',
-        expect.objectContaining({type: 'change'}),
+        expect.any(HTMLInputElement)
       );
     });
   });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
As part of fixing this https://github.com/Shopify/shipping/issues/3083 we need to pass the event to `addressLine` in web, and to that end the polaris TextField is being updated to allow passing the event. 
Next part of the above issue fix is to use the event to prevent the curser from jumping to the end.

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
Allow TextField to pass the input event so that components that need it can access it.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
https://user-images.githubusercontent.com/23269759/123495307-394b4180-d5f1-11eb-9e61-eee7f5bdfecd.mp4

🖥 [Local development instructions]()
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, pinged one of @ HYPD, @ mirualves, @ sarahill, or @ ry5n to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
