### PR TITLE
[IndexTable] fix sticky cell borders in Chrome v91+

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fix console warnings when `DataTable` unmounts ([#4249](https://github.com/Shopify/polaris-react/pull/4249))
 - Fix console warnings displaying multiple times in `Sheet` ([#4269](https://github.com/Shopify/polaris-react/pull/4269))
 - Remove top shadow when `Popover` and `Scrollable` scroll hinting is complete ([#4265](https://github.com/Shopify/polaris-react/pull/4265))
+- Fix bug in Chrome where `IndexTable` borders are missing for the first two cells ([#4247](https://github.com/Shopify/polaris-react/pull/4283))
 
 ### Documentation
 

--- a/src/components/IndexTable/IndexTable.scss
+++ b/src/components/IndexTable/IndexTable.scss
@@ -197,7 +197,7 @@ $loading-panel-height: rem(53px);
   text-align: left;
   padding: spacing(tight) spacing();
   white-space: nowrap;
-  box-shadow: 0 rem(-1px) 0 0 var(--p-divider);
+  border-top: border(divider);
 }
 
 .TableCell-flush {


### PR DESCRIPTION
### WHY are these changes introduced?

#### Issue
* Fixes #4247 
  * Thanks @lauramann [for the original patch in web's `polaris-next`](https://github.com/Shopify/web/pull/44951)
  * We are receiving many bug reports about IndexTables in SFN, so I'd like to promote this fix into public Polaris.

#### Context
* Chrome v91 features a [rewrite of tables](https://twitter.com/atotic/status/1400513832993234945), which improves support for sticky headers and footers. 
* In the process, they introduced regressions with how box-shadows render on these sticky elements. 
See https://github.com/w3c/csswg-drafts/issues/3136
* This causes the borders to disappear for the first two "sticky" cells of the IndexTable.

### WHAT is this pull request doing?
**Restores missing borders for the non-scrolling view of the IndexTable cells, by using border instead of box-shadow.**

Before, missing borders:
<img width="904" alt="Screen Shot 2021-06-28 at 11 45 16 AM" src="https://user-images.githubusercontent.com/428636/123666147-f2369980-d806-11eb-87e6-10b0189f6d38.png">

After, borders restored:
<img width="893" alt="Screen Shot 2021-06-28 at 11 46 02 AM" src="https://user-images.githubusercontent.com/428636/123666161-f498f380-d806-11eb-8406-d6f9a559f2f2.png">

**This does not fix the more complex behaviour where box shadows were used for scrolling sticky cells.**
I did some quick testing and it doesn't look like we can swap in borders 1:1 for box-shadows here. I don't think I have the bandwidth to explore a full solution, but if anyone wants to pair on it, let me know.

Chrome:
<img width="893" alt="Screen Shot 2021-06-28 at 11 46 02 AM" src="https://user-images.githubusercontent.com/428636/123666332-1befc080-d807-11eb-8fc7-5a08b92e1935.png">

Safari:
<img width="791" alt="Screen Shot 2021-06-28 at 11 52 56 AM" src="https://user-images.githubusercontent.com/428636/123666700-738e2c00-d807-11eb-9b40-7796087caaa9.png">


### How to 🎩
* Open Google Chrome v91+
* `yarn storybook` and navigate to any IndexTable example

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
