### PR TITLE
[ThemeProvider] Add example for custom config

### DIFF
--- a/src/components/ThemeProvider/README.md
+++ b/src/components/ThemeProvider/README.md
@@ -141,6 +141,74 @@ A theme provider can be nested within the theme provider rendered by the app pro
 </AppProvider>
 ```
 
+### Theme provider with a color scheme and custom config nested within an app provider
+
+You can pass in a custom config to the theme provider to override default HSL values. Find the lightness value you need using www.hsluv.org
+
+```jsx
+<AppProvider i18n={{}}>
+  <TextContainer>
+    <Card
+      title="Shipment 1234"
+      secondaryFooterActions={[{content: 'Edit shipment'}]}
+      primaryFooterAction={{content: 'Add tracking number'}}
+    >
+      <Card.Section title="Items">
+        <List>
+          <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+          <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+        </List>
+      </Card.Section>
+    </Card>
+    <ThemeProvider
+      theme={{
+        colors: {
+          surface: '#054948',
+        },
+        config: {
+          surface: [
+            {
+              name: 'surface',
+              description:
+                'For use as a background color, in components such as Card, Modal, and Popover.',
+              light: {lightness: 27.5},
+              dark: {lightness: 27.5},
+              meta: {
+                figmaName: 'Surface/Default',
+              },
+            },
+          ],
+          onSurface: [
+            {
+              name: 'text',
+              description: 'For use as a text color.',
+              light: {lightness: 100},
+              dark: {lightness: 100},
+              meta: {
+                figmaName: 'Text/Default',
+              },
+            },
+          ],
+        },
+      }}
+    >
+      <Card
+        title="Shipment 1234"
+        secondaryFooterActions={[{content: 'Edit shipment'}]}
+        primaryFooterAction={{content: 'Add tracking number'}}
+      >
+        <Card.Section title="Items">
+          <List>
+            <List.Item>1 × Oasis Glass, 4-Pack</List.Item>
+            <List.Item>1 × Anubis Cup, 2-Pack</List.Item>
+          </List>
+        </Card.Section>
+      </Card>
+    </ThemeProvider>
+  </TextContainer>
+</AppProvider>
+```
+
 ### Theme provider with colors nested within an app provider
 
 A theme provider can be nested within the theme provider rendered by the app provider in order to override colors at a local level.


### PR DESCRIPTION
![image](https://screenshot.click/All_Components__Theme_provider_-_Theme_provider_with_a_nested_color_scheme_and_custom_config_within_an_app_provider__Storybook_2021-07-07_11-53-12.png)

### WHY are these changes introduced?

Addresses https://shopify.slack.com/archives/C4Y8N30KD/p1625670603198300?thread_ts=1625609553.186000&cid=C4Y8N30KD

### WHAT is this pull request doing?

Adds another example to our theme provider readme where we pass it a custom config to achieve custom colors

## <!-- ℹ️ Delete the following for small / trivial changes -->

http://localhost:6006/?path=/story/all-components-theme-provider--theme-provider-with-a-color-scheme-and-custom-config-nested-within-an-app-provider