### PR TITLE
✨ [Popover] New mutationObserveConfig prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added `ariaLabelledBy` props to `Navigation` component to allow a hidden label for accessibility ([#4343](https://github.com/Shopify/polaris-react/pull/4343))
 - Add `lastColumnSticky` prop to `IndexTable` to create a sticky last cell and optional sticky last heading on viewports larger than small ([#4150](https://github.com/Shopify/polaris-react/pull/4150))
 - Allow promoted actions to be rendered as a menu on the `BulkAction` component ([#4266](https://github.com/Shopify/polaris-react/pull/4266))
+- Added `mutationObserveConfig` prop to `Popover` and `PositionedOverlay` ([#4303](https://github.com/Shopify/polaris-react/pull/4303))
 
 ### Bug fixes
 

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -44,6 +44,8 @@ export interface PopoverProps {
    * @default true
    */
   preferInputActivator?: PopoverOverlayProps['preferInputActivator'];
+  /** Customize the MutationObserveInit object for more precise Popover re-rendering on `children` changes */
+  mutationObserveConfig?: PopoverOverlayProps['mutationObserveConfig'];
   /**
    * The element type to wrap the activator with
    * @default 'div'
@@ -96,6 +98,7 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
   fixed,
   ariaHaspopup,
   preferInputActivator = true,
+  mutationObserveConfig,
   colorScheme,
   zIndexOverride,
   ...rest
@@ -181,6 +184,7 @@ export const Popover: React.FunctionComponent<PopoverProps> & {
         id={id}
         activator={activatorNode}
         preferInputActivator={preferInputActivator}
+        mutationObserveConfig={mutationObserveConfig}
         onClose={handleClose}
         active={active}
         fixed={fixed}

--- a/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -47,6 +47,7 @@ export interface PopoverOverlayProps {
   zIndexOverride?: number;
   activator: HTMLElement;
   preferInputActivator?: PositionedOverlayProps['preferInputActivator'];
+  mutationObserveConfig?: PositionedOverlayProps['mutationObserveConfig'];
   sectioned?: boolean;
   fixed?: boolean;
   hideOnPrint?: boolean;
@@ -120,6 +121,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
       preferInputActivator = true,
       fixed,
       zIndexOverride,
+      mutationObserveConfig,
     } = this.props;
     const {transitionStatus} = this.state;
     if (transitionStatus === TransitionStatus.Exited && !active) return null;
@@ -148,6 +150,7 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
         onScrollOut={this.handleScrollOut}
         classNames={className}
         zIndexOverride={zIndexOverride}
+        mutationObserveConfig={mutationObserveConfig}
       />
     );
   }

--- a/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
+++ b/src/components/Popover/components/PopoverOverlay/tests/PopoverOverlay.test.tsx
@@ -188,6 +188,27 @@ describe('<PopoverOverlay />', () => {
     });
   });
 
+  it('passes mutationObserveConfig to PositionedOverlay', () => {
+    const mockMutationObserveConfig = {
+      attributes: true,
+    };
+    const popoverOverlay = mountWithApp(
+      <PopoverOverlay
+        active
+        mutationObserveConfig={mockMutationObserveConfig}
+        id="PopoverOverlay-1"
+        activator={activator}
+        onClose={noop}
+      >
+        {children}
+      </PopoverOverlay>,
+    );
+
+    expect(popoverOverlay).toContainReactComponent(PositionedOverlay, {
+      mutationObserveConfig: mockMutationObserveConfig,
+    });
+  });
+
   it("doesn't include a tabindex prop when autofocusTarget is 'none'", () => {
     const popoverOverlay = mountWithAppProvider(
       <PopoverOverlay

--- a/src/components/Popover/tests/Popover.test.tsx
+++ b/src/components/Popover/tests/Popover.test.tsx
@@ -136,6 +136,25 @@ describe('<Popover />', () => {
     });
   });
 
+  it('passes mutationObserveConfig to PopoverOverlay', () => {
+    const mockMutationObserveConfig = {
+      attributes: true,
+    };
+    const popover = mountWithApp(
+      <Popover
+        active={false}
+        preferredPosition="above"
+        activator={<div>Activator</div>}
+        onClose={spy}
+        mutationObserveConfig={mockMutationObserveConfig}
+      />,
+    );
+
+    expect(popover).toContainReactComponent(PopoverOverlay, {
+      mutationObserveConfig: mockMutationObserveConfig,
+    });
+  });
+
   it('has a div as activatorWrapper by default', () => {
     const popover = mountWithApp(
       <Popover

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -58,7 +58,7 @@ interface State {
   lockPosition: boolean;
 }
 
-const DEFAULT_OBSERVER_CONFIG: PositionedOverlayProps['mutationObserveConfig'] = {
+export const DEFAULT_OBSERVER_CONFIG: PositionedOverlayProps['mutationObserveConfig'] = {
   childList: true,
   subtree: true,
   characterData: true,

--- a/src/components/PositionedOverlay/PositionedOverlay.tsx
+++ b/src/components/PositionedOverlay/PositionedOverlay.tsx
@@ -39,6 +39,7 @@ export interface PositionedOverlayProps {
   preventInteraction?: boolean;
   classNames?: string;
   zIndexOverride?: number;
+  mutationObserveConfig?: MutationObserverInit;
   render(overlayDetails: OverlayDetails): React.ReactNode;
   onScrollOut?(): void;
 }
@@ -57,7 +58,7 @@ interface State {
   lockPosition: boolean;
 }
 
-const OBSERVER_CONFIG = {
+const DEFAULT_OBSERVER_CONFIG: PositionedOverlayProps['mutationObserveConfig'] = {
   childList: true,
   subtree: true,
   characterData: true,
@@ -208,6 +209,7 @@ export class PositionedOverlay extends PureComponent<
           fullWidth,
           fixed,
           preferInputActivator = true,
+          mutationObserveConfig,
         } = this.props;
 
         const preferredActivator = preferInputActivator
@@ -281,8 +283,13 @@ export class PositionedOverlay extends PureComponent<
           },
           () => {
             if (!this.overlay) return;
-            this.observer.observe(this.overlay, OBSERVER_CONFIG);
-            this.observer.observe(activator, OBSERVER_CONFIG);
+
+            this.observer.observe(this.overlay, {
+              ...DEFAULT_OBSERVER_CONFIG,
+              ...mutationObserveConfig,
+            });
+
+            this.observer.observe(activator, DEFAULT_OBSERVER_CONFIG);
           },
         );
       },

--- a/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -291,10 +291,13 @@ describe('<PositionedOverlay />', () => {
     });
 
     it('passes default config', () => {
-      mountWithAppProvider(<PositionedOverlay {...mockProps} />);
+      const positionedOverlay = mountWithAppProvider(
+        <PositionedOverlay {...mockProps} />,
+      );
+      const element = positionedOverlay.find('div').getDOMNode();
 
       expect(mutationObserverObserveSpy).toHaveBeenCalledWith(
-        expect.any(Function),
+        element,
         DEFAULT_OBSERVER_CONFIG,
       );
     });
@@ -304,20 +307,18 @@ describe('<PositionedOverlay />', () => {
         subtree: false,
         attributes: true,
       };
-      mountWithAppProvider(
+      const positionedOverlay = mountWithAppProvider(
         <PositionedOverlay
           {...mockProps}
           mutationObserveConfig={mockMutationObserveConfig}
         />,
       );
+      const element = positionedOverlay.find('div').getDOMNode();
 
-      expect(mutationObserverObserveSpy).toHaveBeenCalledWith(
-        expect.any(Function),
-        {
-          ...DEFAULT_OBSERVER_CONFIG,
-          ...mockMutationObserveConfig,
-        },
-      );
+      expect(mutationObserverObserveSpy).toHaveBeenCalledWith(element, {
+        ...DEFAULT_OBSERVER_CONFIG,
+        ...mockMutationObserveConfig,
+      });
     });
   });
 });

--- a/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -38,20 +38,54 @@ describe('<PositionedOverlay />', () => {
       mutationObserverObserveSpy.mockRestore();
     });
 
-    it('observers the activator', () => {
-      const activator = document.createElement('button');
-      mountWithAppProvider(
-        <PositionedOverlay
-          {...mockProps}
-          activator={activator}
-          preferredPosition="above"
-        />,
-      );
+    describe('overlay', () => {
+      it('passes default config to', () => {
+        const positionedOverlay = mountWithAppProvider(
+          <PositionedOverlay {...mockProps} />,
+        );
+        const element = positionedOverlay.find('div').getDOMNode();
 
-      expect(mutationObserverObserveSpy).toHaveBeenCalledWith(activator, {
-        characterData: true,
-        childList: true,
-        subtree: true,
+        expect(mutationObserverObserveSpy).toHaveBeenCalledWith(
+          element,
+          DEFAULT_OBSERVER_CONFIG,
+        );
+      });
+
+      it('merges prop with default config', () => {
+        const mockMutationObserveConfig = {
+          subtree: false,
+          attributes: true,
+        };
+        const positionedOverlay = mountWithAppProvider(
+          <PositionedOverlay
+            {...mockProps}
+            mutationObserveConfig={mockMutationObserveConfig}
+          />,
+        );
+        const element = positionedOverlay.find('div').getDOMNode();
+
+        expect(mutationObserverObserveSpy).toHaveBeenCalledWith(element, {
+          ...DEFAULT_OBSERVER_CONFIG,
+          ...mockMutationObserveConfig,
+        });
+      });
+    });
+
+    describe('activator', () => {
+      it('observers the activator', () => {
+        const activator = document.createElement('button');
+
+        mountWithAppProvider(
+          <PositionedOverlay
+            {...mockProps}
+            activator={activator}
+            preferredPosition="above"
+          />,
+        );
+
+        expect(mutationObserverObserveSpy).toHaveBeenCalledWith(activator, {
+          ...DEFAULT_OBSERVER_CONFIG,
+        });
       });
     });
   });
@@ -273,52 +307,6 @@ describe('<PositionedOverlay />', () => {
       expect(
         getRectForNodeSpy.mock.calls.some(([node]) => node === input),
       ).toBe(false);
-    });
-  });
-
-  describe('mutationObserveConfig', () => {
-    let mutationObserverObserveSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      mutationObserverObserveSpy = jest.spyOn(
-        MutationObserver.prototype,
-        'observe',
-      );
-    });
-
-    afterEach(() => {
-      mutationObserverObserveSpy.mockRestore();
-    });
-
-    it('passes default config', () => {
-      const positionedOverlay = mountWithAppProvider(
-        <PositionedOverlay {...mockProps} />,
-      );
-      const element = positionedOverlay.find('div').getDOMNode();
-
-      expect(mutationObserverObserveSpy).toHaveBeenCalledWith(
-        element,
-        DEFAULT_OBSERVER_CONFIG,
-      );
-    });
-
-    it('merges prop with default config', () => {
-      const mockMutationObserveConfig = {
-        subtree: false,
-        attributes: true,
-      };
-      const positionedOverlay = mountWithAppProvider(
-        <PositionedOverlay
-          {...mockProps}
-          mutationObserveConfig={mockMutationObserveConfig}
-        />,
-      );
-      const element = positionedOverlay.find('div').getDOMNode();
-
-      expect(mutationObserverObserveSpy).toHaveBeenCalledWith(element, {
-        ...DEFAULT_OBSERVER_CONFIG,
-        ...mockMutationObserveConfig,
-      });
     });
   });
 });

--- a/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -275,6 +275,13 @@ describe('<PositionedOverlay />', () => {
       ).toBe(false);
     });
   });
+
+  describe('mutationObserveConfig', () => {
+    // Find the `overlay` and compare against DEFAULT_OBSERVER_CONFIG
+    it.todo('passes default config');
+    // Find the `overlay` and compare against mockMutationObserveConfig
+    it.todo('merges prop with default config');
+  });
 });
 
 function mockRender() {

--- a/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
+++ b/src/components/PositionedOverlay/tests/PositionedOverlay.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {mountWithAppProvider} from 'test-utilities/legacy';
 
 import {EventListener} from '../../EventListener';
-import {PositionedOverlay} from '../PositionedOverlay';
+import {PositionedOverlay, DEFAULT_OBSERVER_CONFIG} from '../PositionedOverlay';
 import * as mathModule from '../utilities/math';
 import * as geometry from '../../../utilities/geometry';
 import styles from '../PositionedOverlay.scss';
@@ -277,10 +277,48 @@ describe('<PositionedOverlay />', () => {
   });
 
   describe('mutationObserveConfig', () => {
-    // Find the `overlay` and compare against DEFAULT_OBSERVER_CONFIG
-    it.todo('passes default config');
-    // Find the `overlay` and compare against mockMutationObserveConfig
-    it.todo('merges prop with default config');
+    let mutationObserverObserveSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      mutationObserverObserveSpy = jest.spyOn(
+        MutationObserver.prototype,
+        'observe',
+      );
+    });
+
+    afterEach(() => {
+      mutationObserverObserveSpy.mockRestore();
+    });
+
+    it('passes default config', () => {
+      mountWithAppProvider(<PositionedOverlay {...mockProps} />);
+
+      expect(mutationObserverObserveSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        DEFAULT_OBSERVER_CONFIG,
+      );
+    });
+
+    it('merges prop with default config', () => {
+      const mockMutationObserveConfig = {
+        subtree: false,
+        attributes: true,
+      };
+      mountWithAppProvider(
+        <PositionedOverlay
+          {...mockProps}
+          mutationObserveConfig={mockMutationObserveConfig}
+        />,
+      );
+
+      expect(mutationObserverObserveSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        {
+          ...DEFAULT_OBSERVER_CONFIG,
+          ...mockMutationObserveConfig,
+        },
+      );
+    });
   });
 });
 


### PR DESCRIPTION
This PR adds a new `mutationObserveConfig?: MutationObserverInit;` prop to the `PositionedOverlay` component.

Within `Polaris`, the `PositionedOverlay` component is used by both `PopoverOverlay` and `TooltipOverlay`. At the moment, I only have an interest in leveraging `mutationObserveConfig` for `Popover`. So, both `Popover` and `PopoverOverlay` have been updated to include the new `mutationObserveConfig` prop. I have left `TooltipOverlay` alone for now.

The motivation for this PR stems from a need to have dynamically updating content within a `Popover` for use within Online Store. We are implementing some new UI that will utilize a `Collapsible` within a `Popover`. As it stands currently, toggling a nested `Collapsible` will not always update the dimensions of the `Popover`. This is because the `MutationObserver` used within `PositionedOverlay` ignores everything except `childList` and `subtree`. By opening up the `options` argument of `.observe()` for customization, I am now able to pass in `attributes: true` as part of the `options` object, enabling a re-render of the `Popover` when `Collapsible` changes.

Props go to @AndrewMusgrave for helping me get to this solution.

<details>
<summary><strong>Playground code</strong></summary>

```tsx
import React, {useCallback, useState} from 'react';

import {ActionList, Button, Collapsible, Page, Popover} from '../src';
import type {ActionListProps, ButtonProps, CollapsibleProps} from '../src';

interface CollapsibleSectionProps {
  id: string;
  title: string;
  items: ActionListProps['items'];
  open: CollapsibleProps['open'];
  onAction: ButtonProps['onClick'];
}

const POLARIS_COLLAPSIBLE_DISABLE_TRANSITION = {
  timingFunction: 'unset',
  duration: '1ms',
};

const popoverWrapperStyles = {
  width: 300,
  maxHeight: '50vh',
};

const pageItems: CollapsibleSectionProps['items'] = [
  {content: 'Import'},
  {content: 'Export'},
  {content: 'Something else'},
  {content: 'Shorter content'},
  {content: 'Spring loaded'},
  {content: 'Explore'},
  {content: 'Save'},
  {content: 'Delete'},
  {content: 'Very long thing'},
  {content: 'Final'},
];

const productItems: CollapsibleSectionProps['items'] = [
  {content: 'Another type of something else'},
  {content: 'Lots of stuff that gets written within this element'},
  {
    content:
      'It looks like when I use the fluidContent prop, I need to specify both a max-width and a max-height',
  },
  {
    content:
      'Otherwise, I will end up with a page full of Popover once it opens.',
  },
  {content: 'We need to provide sensible limits to our max Popover size'},
  {content: 'Final'},
];

const requiredMutationConfig = {
  attributes: true,
};

export function Playground() {
  const [popoverActive, setPopoverActive] = useState(false);
  const popoverActiveToggle = useCallback(
    () => setPopoverActive((popoverActive) => !popoverActive),
    [],
  );
  const popoverActiveClose = () => setPopoverActive(false);

  const popoverActivator = (
    <Button onClick={popoverActiveToggle} disclosure>
      More actions
    </Button>
  );

  const [openPages, setOpenPages] = useState(true);
  const toggleOpenPages = useCallback(
    () => setOpenPages((openPages) => !openPages),
    [],
  );

  const [openProducts, setOpenProducts] = useState(false);
  const toggleOpenProducts = useCallback(
    () => setOpenProducts((openProducts) => !openProducts),
    [],
  );

  return (
    <Page
      title="Prototype for Popover + Collapsible"
      subtitle="This code explores how we can use the Popover component to render dynamic content"
      primaryAction={{content: 'Primary action', disabled: true}}
    >
      <Popover
        // Try commenting out this prop to see how this breaks our Collapsible + Popover UI
        mutationObserveConfig={requiredMutationConfig}
        active={popoverActive}
        activator={popoverActivator}
        onClose={popoverActiveClose}
      >
        <div style={popoverWrapperStyles}>
          <CollapsibleSection
            id="PagesCollapsible"
            title="Pages"
            items={pageItems}
            open={openPages}
            onAction={toggleOpenPages}
          />

          <CollapsibleSection
            id="ProductsCollapsible"
            title="Products"
            items={productItems}
            open={openProducts}
            onAction={toggleOpenProducts}
          />
        </div>
      </Popover>
    </Page>
  );
}

function CollapsibleSection({
  id,
  title,
  items,
  open,
  onAction,
}: CollapsibleSectionProps) {
  return (
    <>
      <Button
        primary
        fullWidth
        textAlign="left"
        disclosure={open ? 'up' : 'down'}
        ariaControls={id}
        ariaExpanded={open}
        onClick={onAction}
      >
        {title}
      </Button>
      <Collapsible
        id={id}
        open={open}
        transition={POLARIS_COLLAPSIBLE_DISABLE_TRANSITION}
      >
        <ActionList items={items} />
      </Collapsible>
    </>
  );
}
```

</details>

https://user-images.githubusercontent.com/643944/125333037-c1cb2100-e317-11eb-8327-82edd21bb26f.mp4
