### PR TITLE
[Layout][Heading] add ID prop to Heading, Layout.AnnotatedSection

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,7 +6,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-- [Layout] Add `id` prop for deeplinking to `AnnotatedSection` components
+- Added `id` prop to `Layout` and `Heading` for hash linking ([#4307](https://github.com/Shopify/polaris-react/pull/4307))
 
 ### Bug fixes
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- [Layout] Add `id` prop for deeplinking to `AnnotatedSection` components
+
 ### Bug fixes
 
 ### Documentation

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -12,8 +12,14 @@ export interface HeadingProps {
   element?: HeadingTagName;
   /** The content to display inside the heading */
   children?: React.ReactNode;
+  /** A unique identifier for the heading, used for reference in anchor links  */
+  id?: string;
 }
 
-export function Heading({element: Element = 'h2', children}: HeadingProps) {
-  return <Element className={styles.Heading}>{children}</Element>;
+export function Heading({element: Element = 'h2', children, id}: HeadingProps) {
+  return (
+    <Element className={styles.Heading} id={id}>
+      {children}
+    </Element>
+  );
 }

--- a/src/components/Heading/tests/Heading.test.tsx
+++ b/src/components/Heading/tests/Heading.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {mountWithApp} from 'test-utilities';
+
+import {Heading} from '../Heading';
+
+describe('<Heading />', () => {
+  it('renders its children', () => {
+    const text = 'Online store dashboard';
+    const heading = mountWithApp(<Heading element="h1">{text}</Heading>);
+    expect(heading).toContainReactText(text);
+  });
+
+  it('renders the specified element', () => {
+    const heading = mountWithApp(
+      <Heading element="h1">Online store dashboard</Heading>,
+    );
+    expect(heading.find('h1')).not.toBeNull();
+  });
+
+  it('renders an h2 element if not specified', () => {
+    const heading = mountWithApp(<Heading>Online store dashboard</Heading>);
+    expect(heading.find('h2')).not.toBeNull();
+  });
+
+  it('renders an ID for hash links', () => {
+    const heading = mountWithApp(
+      <Heading element="h1" id="dashboard">
+        Online store dashboard
+      </Heading>,
+    );
+    expect(heading.find('h1')!.props.id).toBe('dashboard');
+  });
+});

--- a/src/components/Layout/README.md
+++ b/src/components/Layout/README.md
@@ -411,6 +411,7 @@ Use for settings pages. When settings are grouped thematically in annotated sect
 ```jsx
 <Layout>
   <Layout.AnnotatedSection
+    id="storeDetails"
     title="Store details"
     description="Shopify and your customers will use this information to contact you."
   >
@@ -436,6 +437,7 @@ Use for settings pages that need a banner or other content at the top.
     </Banner>
   </Layout.Section>
   <Layout.AnnotatedSection
+    id="storeDetails"
     title="Store details"
     description="Shopify and your customers will use this information to contact you."
   >

--- a/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
+++ b/src/components/Layout/components/AnnotatedSection/AnnotatedSection.tsx
@@ -8,10 +8,11 @@ export interface AnnotatedSectionProps {
   children?: React.ReactNode;
   title?: React.ReactNode;
   description?: React.ReactNode;
+  id?: string;
 }
 
 export function AnnotatedSection(props: AnnotatedSectionProps) {
-  const {children, title, description} = props;
+  const {children, title, description, id} = props;
 
   const descriptionMarkup =
     typeof description === 'string' ? <p>{description}</p> : description;
@@ -21,7 +22,9 @@ export function AnnotatedSection(props: AnnotatedSectionProps) {
       <div className={styles.AnnotationWrapper}>
         <div className={styles.Annotation}>
           <TextContainer>
-            <Heading testID="AnnotationTitle">{title}</Heading>
+            <Heading id={id} testID="AnnotationTitle">
+              {title}
+            </Heading>
             {descriptionMarkup && (
               <div
                 className={styles.AnnotationDescription}

--- a/src/components/Layout/tests/Layout.test.tsx
+++ b/src/components/Layout/tests/Layout.test.tsx
@@ -86,6 +86,19 @@ describe('<Layout />', () => {
 
       expect(description.exists()).toBe(false);
     });
+
+    it('passes through an ID for deeplinking', () => {
+      const layout = mountWithAppProvider(
+        <Layout>
+          <Layout.AnnotatedSection id="MySection">
+            <MyComponent />
+          </Layout.AnnotatedSection>
+        </Layout>,
+      );
+      const section = layout.find('#MySection');
+
+      expect(section.exists()).toBe(true);
+    });
   });
 });
 


### PR DESCRIPTION
### WHY are these changes introduced?
* In the SFN application, we want to link users from the home page to a section of the Settings page
* The `AnnotatedSection` subcomponents allow us to break up content of a Settings page, but do not support hash links
* The implicit layout used by `Layout` assumes that `Section` or `AnnotatedSection` will always be the direct child node of the parent, which does not allow consumers to wrap their content section in a labelled div

Example of broken layout with a wrapper div around the shipping section:
<img width="623" alt="Screen Shot 2021-07-12 at 4 16 35 PM" src="https://user-images.githubusercontent.com/428636/125355169-b0dbd900-e332-11eb-86dc-44dcf06539aa.png">

### WHAT is this pull request doing?
* Adds an optional ID prop to the `Heading` component
* Adds an optional ID prop to the `Layout.AnnotatedSection` component, passed through to the primary Heading

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
**I couldn't get this working locally 🤔, but the changes seem pretty straightforward**
- [ ] ~For visual design changes, ping @ sarahill to update the Polaris UI kit~
