### PR TITLE
Remove dangling default

### DIFF
--- a/src/styles/foundation/_typography.scss
+++ b/src/styles/foundation/_typography.scss
@@ -14,7 +14,7 @@ $font-family-data: (
   Consolas,
   Liberation Mono,
   Menlo,
-  monospace !default},
+  monospace},
 );
 
 $line-height-data: (


### PR DESCRIPTION
### WHY are these changes introduced?

Ran into a parsing issue while experimenting with dart-sass and running sass-migrator:

```
Error: expected "}".
   ╷
17 │   monospace !default},
   │             ^
   ╵
  src/styles/foundation/_typography.scss 17:13  root stylesheet
Migration failed!
```
### WHAT is this pull request doing?

Removing dangling `!default` that causes the parsing issue. I don't know what it's supposed to do. According to @bpscott:

> This looks like a straight up bug and we can remove this ...

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit
