### PR TITLE
[Test modernization] on TopBar components tests

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,4 +20,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 Modernized tests for Avatar, Backdrop, Badge, Banner components([#4306](https://github.com/Shopify/polaris-react/pull/4306))
 
+- Modernized tests for Message, Menu, Search, SearchDismissOverlay, SearchField, UserMenu and TopBar components. ([#4311](https://github.com/Shopify/polaris-react/pull/4311))
+
 ### Deprecations

--- a/src/components/TopBar/components/Menu/components/Message/tests/Message.test.tsx
+++ b/src/components/TopBar/components/Menu/components/Message/tests/Message.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {Message} from '../Message';
 import {Badge} from '../../../../../../Badge';
@@ -17,26 +16,26 @@ const messageProps = {
 
 describe('<Message />', () => {
   it('mounts', () => {
-    const message = mountWithAppProvider(<Message {...messageProps} />);
+    const message = mountWithApp(<Message {...messageProps} />);
 
-    expect(message.exists()).toBe(true);
+    expect(message).not.toBeNull();
   });
 
   it('will not render badge content by default', () => {
-    const message = mountWithAppProvider(<Message {...messageProps} />);
+    const message = mountWithApp(<Message {...messageProps} />);
 
-    expect(message.find(Badge)).toHaveLength(0);
+    expect(message).not.toContainReactComponent(Badge);
   });
 
   it('renders a badge when the badge prop is provided', () => {
-    const message = mountWithAppProvider(
+    const message = mountWithApp(
       <Message
         {...messageProps}
         badge={{content: 'new', status: 'new' as 'new'}}
       />,
     );
 
-    expect(message.find(Badge)).toHaveLength(1);
+    expect(message).toContainReactComponent(Badge);
   });
 });
 

--- a/src/components/TopBar/components/Menu/tests/Menu.test.tsx
+++ b/src/components/TopBar/components/Menu/tests/Menu.test.tsx
@@ -78,7 +78,7 @@ describe('<Menu />', () => {
       <Menu {...defaultProps} message={message} open />,
     );
 
-    expect(menu.find(Message)!.prop('badge')).toStrictEqual(message.badge);
+    expect(menu).toContainReactComponent(Message, {badge: message.badge});
   });
 
   it('calls the onClose prop in the Popover onClose', () => {

--- a/src/components/TopBar/components/Menu/tests/Menu.test.tsx
+++ b/src/components/TopBar/components/Menu/tests/Menu.test.tsx
@@ -125,7 +125,7 @@ describe('<Menu />', () => {
       const {message, ...rest} = defaultProps;
       const menu = mountWithApp(<Menu {...rest} open />);
 
-      expect(menu.find(Popover)!.prop('fullHeight')).toBe(false);
+      expect(menu).toContainReactComponent(Popover, {fullHeight: false});
     });
 
     it('passes isFullHeight to popover as true if menu is provided a message', () => {

--- a/src/components/TopBar/components/Menu/tests/Menu.test.tsx
+++ b/src/components/TopBar/components/Menu/tests/Menu.test.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {ActionList, Popover} from 'components';
 
@@ -27,11 +25,11 @@ describe('<Menu />', () => {
 
   it('renders the activator content', () => {
     const content = <div>Hello</div>;
-    const menu = mountWithAppProvider(
+    const menu = mountWithApp(
       <Menu {...defaultProps} activatorContent={content} />,
     );
 
-    expect(menu.contains(content)).toBe(true);
+    expect(menu).toContainReactComponent('div', {children: 'Hello'});
   });
 
   it('passes the actions prop down to the ActionList component', () => {
@@ -45,19 +43,21 @@ describe('<Menu />', () => {
       },
     ];
 
-    const menu = mountWithAppProvider(
+    const menu = mountWithApp(
       <Menu {...defaultProps} actions={actions} open />,
     );
 
-    expect(menu.find(ActionList).prop('sections')).toBe(actions);
+    expect(menu).toContainReactComponent(ActionList, {
+      sections: actions,
+    });
   });
 
   it('passes the open prop down to the Popover component', () => {
-    const menu = mountWithAppProvider(<Menu {...defaultProps} open />);
+    const menu = mountWithApp(<Menu {...defaultProps} open />);
 
-    const popover = menu.find(Popover);
-
-    expect(popover.prop('active')).toBe(true);
+    expect(menu).toContainReactComponent(Popover, {
+      active: true,
+    });
   });
 
   it('passes badge to the Message component when it exists on the message prop', () => {
@@ -74,61 +74,66 @@ describe('<Menu />', () => {
         status: 'new' as 'new',
       },
     };
-    const menu = mountWithAppProvider(
+    const menu = mountWithApp(
       <Menu {...defaultProps} message={message} open />,
     );
 
-    expect(menu.find(Message).prop('badge')).toStrictEqual(message.badge);
+    expect(menu.find(Message)!.prop('badge')).toStrictEqual(message.badge);
   });
 
   it('calls the onClose prop in the Popover onClose', () => {
     const onClose = jest.fn();
-    const menu = mountWithAppProvider(
+    const menu = mountWithApp(
       <Menu {...defaultProps} onClose={onClose} open />,
     );
 
-    trigger(menu.find(Popover), 'onClose');
+    menu.find(Popover)!.trigger('onClose');
+
     expect(onClose).toHaveBeenCalled();
   });
 
   it('calls the onClose callback when clicking on any ActionList item', () => {
     const onClose = jest.fn();
-    const menu = mountWithAppProvider(
+    const menu = mountWithApp(
       <Menu {...defaultProps} onClose={onClose} open />,
     );
 
-    trigger(menu.find(ActionList), 'onActionAnyItem');
+    menu.find(ActionList)!.triggerKeypath('onActionAnyItem');
+
     expect(onClose).toHaveBeenCalled();
   });
 
   it('calls the onOpen callback when clicking on the activator button', () => {
     const onOpenCallback = jest.fn();
-    const menu = mountWithAppProvider(
+    const menu = mountWithApp(
       <Menu {...defaultProps} onOpen={onOpenCallback} />,
     );
 
-    trigger(menu.find('button'), 'onClick');
+    menu.find('button')!.trigger('onClick');
+
     expect(onOpenCallback).toHaveBeenCalled();
   });
 
   it('renders the message content when a message is provided', () => {
-    const menu = mountWithAppProvider(<Menu {...defaultProps} open />);
+    const menu = mountWithApp(<Menu {...defaultProps} open />);
 
-    expect(menu.find(Message).exists()).toBe(true);
+    expect(menu).toContainReactComponent(Message);
   });
 
   describe('isFullHeight', () => {
     it('passes isFullHeight to popover as false if menu is not provided a message', () => {
       const {message, ...rest} = defaultProps;
-      const menu = mountWithAppProvider(<Menu {...rest} open />);
+      const menu = mountWithApp(<Menu {...rest} open />);
 
-      expect(menu.find(Popover).prop('fullHeight')).toBe(false);
+      expect(menu.find(Popover)!.prop('fullHeight')).toBe(false);
     });
 
     it('passes isFullHeight to popover as true if menu is provided a message', () => {
-      const menu = mountWithAppProvider(<Menu {...defaultProps} open />);
+      const menu = mountWithApp(<Menu {...defaultProps} open />);
 
-      expect(menu.find(Popover).prop('fullHeight')).toBe(true);
+      expect(menu).toContainReactComponent(Popover, {
+        fullHeight: true,
+      });
     });
   });
 

--- a/src/components/TopBar/components/Search/tests/Search.test.tsx
+++ b/src/components/TopBar/components/Search/tests/Search.test.tsx
@@ -1,33 +1,34 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {Search} from '../Search';
 import {SearchDismissOverlay} from '../../SearchDismissOverlay';
 
 describe('<Search />', () => {
   it('mounts', () => {
-    const search = mountWithAppProvider(<Search />);
-    expect(search.exists()).toBe(true);
+    const search = mountWithApp(<Search />);
+    expect(search).not.toBeNull();
   });
 
   it('renders its children', () => {
-    const search = mountWithAppProvider(<Search>Hello Polaris</Search>);
-    expect(search.text()).toContain('Hello Polaris');
+    const search = mountWithApp(<Search>Hello Polaris</Search>);
+    expect(search).toContainReactText('Hello Polaris');
   });
 
   it('renders a SearchDismissOverlay', () => {
-    const search = mountWithAppProvider(<Search visible>Hello Polaris</Search>);
-    expect(search.find(SearchDismissOverlay)).toHaveLength(1);
+    const search = mountWithApp(<Search visible>Hello Polaris</Search>);
+    expect(search).toContainReactComponent(SearchDismissOverlay);
   });
 
   it('passes the overlayVisible prop to SearchDismissOverlay', () => {
-    const search = mountWithAppProvider(
+    const search = mountWithApp(
       <Search visible overlayVisible>
         Hello Polaris
       </Search>,
     );
 
-    expect(search.find(SearchDismissOverlay).prop('visible')).toBe(true);
+    expect(search).toContainReactComponent(SearchDismissOverlay, {
+      visible: true,
+    });
   });
 });

--- a/src/components/TopBar/components/SearchDismissOverlay/tests/SearchDismissOverlay.test.tsx
+++ b/src/components/TopBar/components/SearchDismissOverlay/tests/SearchDismissOverlay.test.tsx
@@ -1,23 +1,24 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {SearchDismissOverlay} from '../SearchDismissOverlay';
 
 describe('<SearchDismissOverlay />', () => {
   it('mounts', () => {
-    const search = mountWithAppProvider(
-      <SearchDismissOverlay visible={false} />,
-    );
-    expect(search.exists()).toBe(true);
+    const search = mountWithApp(<SearchDismissOverlay visible={false} />);
+    expect(search).not.toBeNull();
   });
 
   it('calls onDismiss when clicked', () => {
     const spy = jest.fn();
-    const search = mountWithAppProvider(
+    const search = mountWithApp(
       <SearchDismissOverlay visible={false} onDismiss={spy} />,
     );
-    search.simulate('click');
+
+    search.find('div')!.trigger('onClick', {
+      target: search!.domNode as HTMLInputElement,
+    });
+
     expect(spy).toHaveBeenCalled();
   });
 });

--- a/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
+++ b/src/components/TopBar/components/SearchField/tests/SearchField.test.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import {CircleCancelMinor} from '@shopify/polaris-icons';
 import {mountWithApp} from 'test-utilities';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, ReactWrapper} from 'test-utilities/legacy';
 
+import {Icon} from '../../../../Icon';
 import {SearchField} from '../SearchField';
 
 describe('<SearchField />', () => {
   it('passes the placeholder prop to input', () => {
-    const textField = mountWithAppProvider(
+    const textField = mountWithApp(
       <SearchField value="" onChange={noop} placeholder="hello polaris" />,
     );
 
-    expect(findInput(textField).prop('placeholder')).toBe('hello polaris');
+    expect(textField).toContainReactComponent('input', {
+      placeholder: 'hello polaris',
+    });
   });
 
   describe('focused', () => {
@@ -47,24 +48,23 @@ describe('<SearchField />', () => {
 
   describe('clear content', () => {
     it('will render a cancel icon when a value is provided', () => {
-      const textField = mountWithAppProvider(
+      const textField = mountWithApp(
         <SearchField value="hello polaris" onChange={noop} />,
       );
 
-      expect(
-        textField
-          .find('Icon')
-          .filterWhere((el) => el.prop('source') === CircleCancelMinor),
-      ).toHaveLength(1);
+      expect(textField).toContainReactComponent(Icon, {
+        source: CircleCancelMinor,
+      });
     });
 
     it('will call the onChange with an empty string when the cancel button is pressed', () => {
       const spy = jest.fn();
-      const textField = mountWithAppProvider(
+      const textField = mountWithApp(
         <SearchField value="hello polaris" onChange={spy} />,
       );
 
-      textField.find('button').simulate('click');
+      textField.find('button')!.trigger('onClick');
+
       expect(spy).toHaveBeenCalledWith('');
     });
   });
@@ -72,11 +72,12 @@ describe('<SearchField />', () => {
   describe('onBlur()', () => {
     it('is called when the text field is blurred', () => {
       const spy = jest.fn();
-      const textField = mountWithAppProvider(
+      const textField = mountWithApp(
         <SearchField value="hello polaris" onChange={noop} onBlur={spy} />,
       );
 
-      textField.simulate('blur');
+      textField.find('div')!.trigger('onBlur');
+
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });
@@ -84,11 +85,12 @@ describe('<SearchField />', () => {
   describe('onFocus', () => {
     it('is called when the text field is focused', () => {
       const spy = jest.fn();
-      const textField = mountWithAppProvider(
+      const textField = mountWithApp(
         <SearchField value="hello polaris" onChange={noop} onFocus={spy} />,
       );
 
-      textField.simulate('focus');
+      textField.find('div')!.trigger('onFocus');
+
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });
@@ -96,24 +98,29 @@ describe('<SearchField />', () => {
   describe('onChange()', () => {
     it('is called with the new value', () => {
       const spy = jest.fn();
-      const textField = mountWithAppProvider(
-        <SearchField value="hello polaris" onChange={spy} />,
+      const newValue = 'hello polaris';
+      const textField = mountWithApp(
+        <SearchField value={newValue} onChange={spy} />,
       );
 
-      (findInput(textField) as any).instance().value = 'hello world';
-      findInput(textField).simulate('change');
-      expect(spy).toHaveBeenCalledWith('hello world');
+      textField.find('input')!.trigger('onChange', {
+        currentTarget: {
+          value: newValue,
+        },
+      });
+
+      expect(spy).toHaveBeenCalledWith(newValue);
     });
   });
 
   describe('onKeyDown', () => {
     it("will prevent default on the 'enter' keydown", () => {
       const spy = jest.fn();
-      const textField = mountWithAppProvider(
+      const textField = mountWithApp(
         <SearchField value="hello polaris" onChange={noop} />,
       );
 
-      findInput(textField).simulate('keydown', {
+      textField.find('input')!.trigger('onKeyDown', {
         key: 'Enter',
         preventDefault: spy,
       });
@@ -122,18 +129,14 @@ describe('<SearchField />', () => {
   });
 
   it('adds a "BackdropShowFocusBorder" class when "showFocusBorder" is passed', () => {
-    const textField = mountWithAppProvider(
+    const textField = mountWithApp(
       <SearchField value="" onChange={noop} showFocusBorder />,
     );
 
-    expect(textField.find('div').last().prop('className')).toBe(
-      'Backdrop BackdropShowFocusBorder',
-    );
+    expect(textField).toContainReactComponent('div', {
+      className: 'Backdrop BackdropShowFocusBorder',
+    });
   });
 });
 
 function noop() {}
-
-function findInput(wrapper: ReactWrapper) {
-  return wrapper.find('input');
-}

--- a/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
+++ b/src/components/TopBar/components/UserMenu/tests/UserMenu.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import {ViewMinor} from '@shopify/polaris-icons';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
+import {Avatar} from 'components/Avatar';
 
 import {UserMenu} from '../UserMenu';
 import {Menu} from '../../Menu';
@@ -17,13 +16,37 @@ describe('<UserMenu />', () => {
   };
 
   it('renders with the given props', () => {
-    const userMenu = mountWithAppProvider(<UserMenu {...userMenuProps} />);
-    expect(userMenu.find(UserMenu).props()).toStrictEqual(userMenuProps);
+    const userMenu = mountWithApp(<UserMenu {...userMenuProps} />);
+
+    expect(userMenu).toContainReactComponent(Menu, {
+      actions: userMenuProps.actions,
+      open: userMenuProps.open,
+      onOpen: userMenuProps.onToggle,
+      onClose: userMenuProps.onToggle,
+    });
+    expect(userMenu).toContainReactComponent('p', {
+      children: userMenuProps.name,
+    });
+    expect(userMenu).toContainReactComponent(Avatar, {
+      initials: userMenuProps.initials,
+    });
   });
 
   it('renders with the given props when in mobile view but no mobile props are available', () => {
-    const userMenu = mountWithAppProvider(<UserMenu {...userMenuProps} />);
-    expect(userMenu.find(UserMenu).props()).toStrictEqual(userMenuProps);
+    const userMenu = mountWithApp(<UserMenu {...userMenuProps} />);
+
+    expect(userMenu).toContainReactComponent(Menu, {
+      actions: userMenuProps.actions,
+      open: userMenuProps.open,
+      onOpen: userMenuProps.onToggle,
+      onClose: userMenuProps.onToggle,
+    });
+    expect(userMenu).toContainReactComponent('p', {
+      children: userMenuProps.name,
+    });
+    expect(userMenu).toContainReactComponent(Avatar, {
+      initials: userMenuProps.initials,
+    });
   });
 
   it('passes accessibilityLabel to the menu component', () => {

--- a/src/components/TopBar/tests/TopBar.test.tsx
+++ b/src/components/TopBar/tests/TopBar.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, findByTestID} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {Image, UnstyledLink} from 'components';
 
 import {TopBar} from '../TopBar';
@@ -14,9 +13,9 @@ const actions = [
 
 describe('<TopBar />', () => {
   it('mounts', () => {
-    const topBar = mountWithAppProvider(<TopBar />);
+    const topBar = mountWithApp(<TopBar />);
 
-    expect(topBar.exists()).toBe(true);
+    expect(topBar).not.toBeNull();
   });
 
   describe('compound components', () => {
@@ -37,16 +36,16 @@ describe('<TopBar />', () => {
           onToggle={noop}
         />
       );
-      const topBar = mountWithAppProvider(<TopBar userMenu={user} />);
-      expect(topBar.find(UserMenu)).toHaveLength(1);
+      const topBar = mountWithApp(<TopBar userMenu={user} />);
+      expect(topBar).toContainReactComponent(UserMenu);
     });
 
     it('renders the searchField prop', () => {
       const searchField = (
         <TopBar.SearchField onChange={noop} value="" placeholder="Search" />
       );
-      const topBar = mountWithAppProvider(<TopBar searchField={searchField} />);
-      expect(topBar.find(SearchField)).toHaveLength(1);
+      const topBar = mountWithApp(<TopBar searchField={searchField} />);
+      expect(topBar).toContainReactComponent(SearchField);
     });
 
     it('renders the secondaryMenu prop', () => {
@@ -59,27 +58,31 @@ describe('<TopBar />', () => {
           onOpen={noop}
         />
       );
-      const topBar = mountWithAppProvider(
-        <TopBar secondaryMenu={secondaryMenu} />,
-      );
-      expect(topBar.find(Menu)).toHaveLength(1);
+      const topBar = mountWithApp(<TopBar secondaryMenu={secondaryMenu} />);
+      expect(topBar).toContainReactComponent(Menu);
     });
   });
 
   describe('navigation content', () => {
     it('renders a navigation button when hasNavigation is true', () => {
-      const topBar = mountWithAppProvider(<TopBar showNavigationToggle />);
+      const topBar = mountWithApp(<TopBar showNavigationToggle />);
 
-      expect(topBar.find('[aria-label="Toggle menu"]')).toHaveLength(1);
+      expect(topBar).toContainReactComponent('button', {
+        'aria-label': 'Toggle menu',
+      });
     });
 
     it('sets onToggleNavigation on the navigation button', () => {
       const spy = jest.fn();
-      const topBar = mountWithAppProvider(
+      const topBar = mountWithApp(
         <TopBar showNavigationToggle onNavigationToggle={spy} />,
       );
 
-      topBar.find('[aria-label="Toggle menu"]').simulate('click');
+      topBar
+        .find('button', {
+          'aria-label': 'Toggle menu',
+        })
+        ?.trigger('onClick');
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });
@@ -92,7 +95,7 @@ describe('<TopBar />', () => {
     const searchResults = <div id="search-content">Hello</div>;
 
     it('renders the search results', () => {
-      const topBar = mountWithAppProvider(
+      const topBar = mountWithApp(
         <TopBar
           searchResults={searchResults}
           searchResultsVisible
@@ -100,11 +103,11 @@ describe('<TopBar />', () => {
         />,
       );
 
-      expect(topBar.find(Search)).toHaveLength(1);
+      expect(topBar).toContainReactComponent(Search);
     });
 
     it('renders the search results when `searchResultsVisible` is false', () => {
-      const topBar = mountWithAppProvider(
+      const topBar = mountWithApp(
         <TopBar
           searchResults={searchResults}
           searchResultsVisible={false}
@@ -112,11 +115,11 @@ describe('<TopBar />', () => {
         />,
       );
 
-      expect(topBar.find(Search)).toHaveLength(1);
+      expect(topBar).toContainReactComponent(Search);
     });
 
     it('renders the search prop', () => {
-      const topBar = mountWithAppProvider(
+      const topBar = mountWithApp(
         <TopBar
           searchResults={searchResults}
           searchResultsVisible
@@ -124,11 +127,13 @@ describe('<TopBar />', () => {
         />,
       );
 
-      expect(topBar.find('#search-content')).toHaveLength(1);
+      expect(topBar).toContainReactComponent('div', {
+        id: 'search-content',
+      });
     });
 
     it('passes the visible prop to search', () => {
-      const topBar = mountWithAppProvider(
+      const topBar = mountWithApp(
         <TopBar
           searchResults={searchResults}
           searchField={searchField}
@@ -136,11 +141,11 @@ describe('<TopBar />', () => {
         />,
       );
 
-      expect(topBar.find(Search).prop('visible')).toBe(true);
+      expect(topBar).toContainReactComponent(Search, {visible: true});
     });
 
     it('passes the searchResultsOverlayVisible prop to search', () => {
-      const topBar = mountWithAppProvider(
+      const topBar = mountWithApp(
         <TopBar
           searchResults={searchResults}
           searchField={searchField}
@@ -148,11 +153,11 @@ describe('<TopBar />', () => {
         />,
       );
 
-      expect(topBar.find(Search).prop('overlayVisible')).toBe(true);
+      expect(topBar).toContainReactComponent(Search, {overlayVisible: true});
     });
 
     it('passes the onSearchDismiss prop to search', () => {
-      const topBar = mountWithAppProvider(
+      const topBar = mountWithApp(
         <TopBar
           searchResults={searchResults}
           onSearchResultsDismiss={noop}
@@ -161,55 +166,63 @@ describe('<TopBar />', () => {
         />,
       );
 
-      expect(topBar.find(Search).prop('onDismiss')).toBe(noop);
+      expect(topBar).toContainReactComponent(Search, {onDismiss: noop});
     });
   });
 
   describe('logo', () => {
     it('will render an image with the logo top bar source', () => {
-      const topBar = mountWithAppProvider(<TopBar />, {
+      const topBar = mountWithApp(<TopBar />, {
         theme: {
           logo: {
             topBarSource: './assets/shopify.svg',
           },
         },
       });
-      expect(topBar.find(Image).prop('source')).toBe('./assets/shopify.svg');
+      expect(topBar).toContainReactComponent(Image, {
+        source: './assets/shopify.svg',
+      });
     });
 
     it('will render an image with the logo accessibility label', () => {
-      const topBar = mountWithAppProvider(<TopBar />, {
+      const topBar = mountWithApp(<TopBar />, {
         theme: {
           logo: {
             accessibilityLabel: 'Shopify',
           },
         },
       });
-      expect(topBar.find(Image).prop('alt')).toBe('Shopify');
+      expect(topBar).toContainReactComponent(Image, {
+        alt: 'Shopify',
+      });
     });
 
     it('will render an unstyled link with the logo URL', () => {
-      const topBar = mountWithAppProvider(<TopBar />, {
+      const topBar = mountWithApp(<TopBar />, {
         theme: {logo: {url: 'https://shopify.com'}},
       });
-      expect(topBar.find(UnstyledLink).prop('url')).toBe('https://shopify.com');
+
+      expect(topBar).toContainReactComponent(UnstyledLink, {
+        url: 'https://shopify.com',
+      });
     });
 
     it('will render an unstyled link with the logo width', () => {
-      const topBar = mountWithAppProvider(<TopBar />, {
+      const topBar = mountWithApp(<TopBar />, {
         theme: {logo: {width: 124}},
       });
-      expect(topBar.find(UnstyledLink).prop('style')).toStrictEqual({
-        width: '124px',
+
+      expect(topBar).toContainReactComponent(UnstyledLink, {
+        style: {width: '124px'},
       });
     });
 
     it('will render an unstyled link with a default width', () => {
-      const topBar = mountWithAppProvider(<TopBar />, {
+      const topBar = mountWithApp(<TopBar />, {
         theme: {logo: {}},
       });
-      expect(topBar.find(UnstyledLink).prop('style')).toStrictEqual({
-        width: '104px',
+      expect(topBar).toContainReactComponent(UnstyledLink, {
+        style: {width: '104px'},
       });
     });
   });
@@ -226,15 +239,17 @@ describe('<TopBar />', () => {
     );
 
     it('renders', () => {
-      const topBar = mountWithAppProvider(
+      const topBar = mountWithApp(
         <TopBar contextControl={mockContextControl} />,
       );
-      expect(findByTestID(topBar, 'ContextControl').exists()).toBe(true);
-      expect(topBar.contains(mockContextControl)).toBe(true);
+      expect(topBar).toContainReactComponent('div', {
+        className: 'ContextControl',
+      });
+      expect(topBar).toContainReactComponent(TopBar.Menu);
     });
 
     it('doesn’t render a logo when defined', () => {
-      const topBar = mountWithAppProvider(
+      const topBar = mountWithApp(
         <TopBar contextControl={mockContextControl} />,
         {
           theme: {
@@ -242,12 +257,14 @@ describe('<TopBar />', () => {
           },
         },
       );
-      expect(topBar.find(Image).exists()).toBe(false);
+      expect(topBar).not.toContainReactComponent(Image);
     });
 
     it('doesn’t render the wrapper when not defined and no logo is available', () => {
-      const topBar = mountWithAppProvider(<TopBar />);
-      expect(findByTestID(topBar, 'ContextControl').exists()).toBe(false);
+      const topBar = mountWithApp(<TopBar />);
+      expect(topBar).not.toContainReactComponent('div', {
+        className: 'ContextControl',
+      });
     });
   });
 });


### PR DESCRIPTION
**WHY are these changes introduced?**

I am updating existing tests for Message, Menu, Search, SearchDismissOverlay, SearchField, UserMenu and TopBar components to use the new modern framework.

**WHAT is this pull request doing?**

Part of test modernization (https://docs.google.com/spreadsheets/d/1GBuEZbOpVYJLNISK7gL69DU8rCxocn5L5GYaKtPXPbU/edit#gid=1498187033), updating tests using {mountWithAppProvider} from 'test-utilities/legacy' to {mountWithApp} from 'test-utilities'.
