### PR TITLE
[Test Modernization]: Add test modernization to Item, Panel, List, Tab, TabMeasurer

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Code quality
 
-Modernized tests for Avatar, Backdrop, Badge, Banner components([#4306](https://github.com/Shopify/polaris-react/pull/4306))
+- Modernized tests for Avatar, Backdrop, Badge, Banner components([#4306](https://github.com/Shopify/polaris-react/pull/4306))
+- Modernized tests for Item, Panel, List, Tab, TabMeasurer (from Tabs components). ([#4313](https://github.com/Shopify/polaris-react/pull/4313))
 
 ### Deprecations

--- a/src/components/Tabs/components/Item/tests/Item.test.tsx
+++ b/src/components/Tabs/components/Item/tests/Item.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {UnstyledLink} from 'components';
 
 import {Item} from '../Item';
@@ -14,16 +13,16 @@ describe('<Item />', () => {
   it('renders UnstyledLink when item has url', () => {
     const url = 'http://shopify.com';
 
-    const item = mountWithAppProvider(<Item {...mockProps} url={url} />);
+    const item = mountWithApp(<Item {...mockProps} url={url} />);
 
-    expect(item.find(UnstyledLink).exists()).toBe(true);
-    expect(item.find('button').exists()).toBe(false);
+    expect(item).toContainReactComponent(UnstyledLink);
+    expect(item).not.toContainReactComponent('button');
   });
 
   it('renders button when item does not have url', () => {
-    const item = mountWithAppProvider(<Item {...mockProps} url={undefined} />);
+    const item = mountWithApp(<Item {...mockProps} url={undefined} />);
 
-    expect(item.find('button').exists()).toBe(true);
-    expect(item.find(UnstyledLink).exists()).toBe(false);
+    expect(item).not.toContainReactComponent(UnstyledLink);
+    expect(item).toContainReactComponent('button');
   });
 });

--- a/src/components/Tabs/components/List/tests/List.test.tsx
+++ b/src/components/Tabs/components/List/tests/List.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {List} from '../List';
 import {Item} from '../../Item';
@@ -21,27 +20,29 @@ describe('<List />', () => {
   };
 
   it('renders an unordered list', () => {
-    const list = mountWithAppProvider(<List {...mockProps} />);
-    expect(list.find('ul')).toHaveLength(1);
+    const list = mountWithApp(<List {...mockProps} />);
+    expect(list).toContainReactComponent('ul');
   });
 
   describe('focusIndex', () => {
     it('does not pass focusIndex to last Item', () => {
       const focusIndex = 1;
-      const list = mountWithAppProvider(
+      const list = mountWithApp(
         <List {...mockProps} focusIndex={focusIndex} />,
       );
-      const items = list.find(Item);
-      expect(items.first().prop('focused')).toBe(false);
+      expect(list).toContainReactComponent(Item, {
+        focused: false,
+      });
     });
 
     it('passes focusIndex to first Item', () => {
       const focusIndex = 1;
-      const list = mountWithAppProvider(
+      const list = mountWithApp(
         <List {...mockProps} focusIndex={focusIndex} />,
       );
-      const items = list.find(Item);
-      expect(items.last().prop('focused')).toBe(true);
+      expect(list).toContainReactComponent(Item, {
+        focused: true,
+      });
     });
   });
 
@@ -58,17 +59,19 @@ describe('<List />', () => {
     ];
 
     it('renders a button for each item in disclosureTabs', () => {
-      const list = mountWithAppProvider(
+      const list = mountWithApp(
         <List {...mockProps} disclosureTabs={disclosureTabs} />,
       );
-      expect(list.find('button')).toHaveLength(2);
+      expect(list).toContainReactComponentTimes('button', 2);
     });
 
     it('passes the id to the button', () => {
-      const list = mountWithAppProvider(
+      const list = mountWithApp(
         <List {...mockProps} disclosureTabs={disclosureTabs} />,
       );
-      expect(list.find('button').first().prop('id')).toBe('repeat-customers');
+      expect(list).toContainReactComponent('button', {
+        id: 'repeat-customers',
+      });
     });
   });
 
@@ -85,18 +88,17 @@ describe('<List />', () => {
     ];
 
     it('renders an Item for each item in disclosureTabs', () => {
-      const list = mountWithAppProvider(
+      const list = mountWithApp(
         <List {...mockProps} disclosureTabs={disclosureTabs} />,
       );
-      expect(list.find(Item)).toHaveLength(2);
+      expect(list).toContainReactComponentTimes(Item, 2);
     });
 
     it('renders the provided content', () => {
-      const list = mountWithAppProvider(
+      const list = mountWithApp(
         <List {...mockProps} disclosureTabs={disclosureTabs} />,
       );
-      const firstItem = list.find(Item).first();
-      expect(firstItem.contains('Repeat customers')).toBe(true);
+      expect(list).toContainReactText('Repeat customers');
     });
   });
 });

--- a/src/components/Tabs/components/Panel/tests/Panel.test.tsx
+++ b/src/components/Tabs/components/Panel/tests/Panel.test.tsx
@@ -1,30 +1,31 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {Panel} from '../Panel';
 
 describe('<Panel />', () => {
   it('adds the tabpanel role', () => {
-    const panel = mountWithAppProvider(<Panel id="panel" tabID="tab" />);
-    expect(panel.find('div').prop('role')).toBe('tabpanel');
+    const panel = mountWithApp(<Panel id="panel" tabID="tab" />);
+    expect(panel).toContainReactComponent('div', {
+      role: 'tabpanel',
+    });
   });
 
   describe('id', () => {
     it('uses the ID for panel', () => {
-      const panel = mountWithAppProvider(
-        <Panel id="my-panel" tabID="my-tab" />,
-      );
-      expect(panel.find('div').prop('id')).toBe('my-panel');
+      const panel = mountWithApp(<Panel id="my-panel" tabID="my-tab" />);
+      expect(panel).toContainReactComponent('div', {
+        id: 'my-panel',
+      });
     });
   });
 
   describe('tabID', () => {
     it('uses the ID as the labeling element', () => {
-      const panel = mountWithAppProvider(
-        <Panel id="my-panel" tabID="my-tab" />,
-      );
-      expect(panel.find('div').prop('aria-labelledby')).toBe('my-tab');
+      const panel = mountWithApp(<Panel id="my-panel" tabID="my-tab" />);
+      expect(panel).toContainReactComponent('div', {
+        'aria-labelledby': 'my-tab',
+      });
     });
   });
 });

--- a/src/components/Tabs/components/Tab/tests/Tab.test.tsx
+++ b/src/components/Tabs/components/Tab/tests/Tab.test.tsx
@@ -1,78 +1,92 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {Tab} from '../Tab';
 
 describe('<Tab />', () => {
   it('has the tab role', () => {
-    const tab = mountWithAppProvider(<Tab id="my-tab">Tab</Tab>);
-    expect(tab.find('button').prop('role')).toBe('tab');
+    const tab = mountWithApp(<Tab id="my-tab">Tab</Tab>);
+
+    expect(tab).toContainReactComponent('button', {
+      role: 'tab',
+    });
   });
 
   describe('id', () => {
     it('uses the ID for the underlying actionable item', () => {
-      const tab = mountWithAppProvider(<Tab id="my-tab">Tab</Tab>);
-      expect(tab.find('button').prop('id')).toBe('my-tab');
+      const tab = mountWithApp(<Tab id="my-tab">Tab</Tab>);
+      expect(tab).toContainReactComponent('button', {
+        id: 'my-tab',
+      });
     });
   });
 
   describe('selected', () => {
     it('is aria-selected when the tab is selected', () => {
-      const tab = mountWithAppProvider(
+      const tab = mountWithApp(
         <Tab id="my-tab" selected>
           Tab
         </Tab>,
       );
-      expect(tab.find('button').prop('aria-selected')).toBe(true);
+
+      expect(tab).toContainReactComponent('button', {
+        'aria-selected': true,
+      });
     });
 
     it('is not aria-selected when the tab is not selected', () => {
-      let tab = mountWithAppProvider(<Tab id="my-tab">Tab</Tab>);
-      expect(tab.find('button').prop('aria-selected')).toBeFalsy();
+      let tab = mountWithApp(<Tab id="my-tab">Tab</Tab>);
+      expect(tab.find('button')!.prop('aria-selected')).toBeFalsy();
 
-      tab = mountWithAppProvider(
+      tab = mountWithApp(
         <Tab id="my-tab" selected={false}>
           Tab
         </Tab>,
       );
-      expect(tab.find('button').prop('aria-selected')).toBeFalsy();
+
+      expect(tab).toContainReactComponent('button', {
+        'aria-selected': false,
+      });
     });
   });
 
   describe('panelID', () => {
     it('uses the panelID as the controlled element’s ID', () => {
-      const tab = mountWithAppProvider(
+      const tab = mountWithApp(
         <Tab id="my-tab" panelID="my-panel">
           Tab
         </Tab>,
       );
-      expect(tab.find('button').prop('aria-controls')).toBe('my-panel');
+
+      expect(tab).toContainReactComponent('button', {
+        'aria-controls': 'my-panel',
+      });
     });
   });
 
   describe('url', () => {
     it('uses an anchor tag when a URL is passed', () => {
-      const tab = mountWithAppProvider(
+      const tab = mountWithApp(
         <Tab url="https://shopify.com" id="my-tab">
           Tab
         </Tab>,
       );
-      const anchor = tab.find('a');
-      expect(anchor.exists()).toBe(true);
-      expect(anchor.prop('href')).toStrictEqual('https://shopify.com');
+
+      expect(tab).toContainReactComponent('a', {
+        href: 'https://shopify.com',
+      });
     });
   });
 
   describe('onClick()', () => {
     it('is called when the underlying button is clicked', () => {
       const spy = jest.fn();
-      const tab = mountWithAppProvider(
+      const tab = mountWithApp(
         <Tab id="my-tab" onClick={spy}>
           Tab
         </Tab>,
       );
-      tab.find('button').simulate('click');
+      tab.find('button')!.trigger('onClick');
       expect(spy).toHaveBeenCalled();
     });
   });
@@ -81,19 +95,25 @@ describe('<Tab />', () => {
     it('uses the label for aria-label', () => {
       const label = 'Tab contents';
 
-      const button = mountWithAppProvider(
+      const button = mountWithApp(
         <Tab id="my-tab" accessibilityLabel={label}>
           Tab
         </Tab>,
-      ).find('button');
-      expect(button.prop<string>('aria-label')).toBe(label);
+      );
 
-      const anchor = mountWithAppProvider(
+      expect(button).toContainReactComponent('button', {
+        'aria-label': label,
+      });
+
+      const anchor = mountWithApp(
         <Tab id="my-tab" url="https://shopify.com" accessibilityLabel={label}>
           Tab
         </Tab>,
-      ).find('a');
-      expect(anchor.prop<string>('aria-label')).toBe(label);
+      );
+
+      expect(anchor).toContainReactComponent('a', {
+        'aria-label': label,
+      });
     });
   });
 });

--- a/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
+++ b/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 
 import {TabMeasurer} from '../TabMeasurer';
@@ -58,60 +56,75 @@ describe('<TabMeasurer />', () => {
     const tabToFocus = 0;
 
     it('passes focused value of 0 to Tab', () => {
-      const tabMeasurer = mountWithAppProvider(
+      const tabMeasurer = mountWithApp(
         <TabMeasurer {...mockProps} tabToFocus={tabToFocus} />,
       );
-      const tabs = tabMeasurer.find(Tab);
-      expect(tabs.first().prop('focused')).toBe(true);
+      expect(tabMeasurer).toContainReactComponent(Tab, {
+        id: 'repeat-customersMeasurer',
+        focused: true,
+      });
     });
 
     it('does not pass wrong focused value to Tab', () => {
-      const tabMeasurer = mountWithAppProvider(
+      const tabMeasurer = mountWithApp(
         <TabMeasurer {...mockProps} tabToFocus={tabToFocus} />,
       );
-      const tabs = tabMeasurer.find(Tab);
-      expect(tabs.last().prop('focused')).toBe(false);
+
+      expect(tabMeasurer).toContainReactComponent(Tab, {
+        id: 'prospectsMeasurer',
+        focused: false,
+      });
     });
   });
 
   describe('siblingTabHasFocus', () => {
     it('gets passed to Tab', () => {
       const siblingTabHasFocus = true;
-      const tabMeasurer = mountWithAppProvider(
+      const tabMeasurer = mountWithApp(
         <TabMeasurer {...mockProps} siblingTabHasFocus={siblingTabHasFocus} />,
       );
-      const tabs = tabMeasurer.find(Tab);
-      expect(tabs.first().prop('siblingTabHasFocus')).toBe(true);
+
+      expect(tabMeasurer).toContainReactComponent(Tab, {
+        id: 'prospectsMeasurer',
+        siblingTabHasFocus: true,
+      });
     });
   });
 
   describe('activator', () => {
     it('renders activator', () => {
       const activator = <Item id="id" focused />;
-      const tabMeasurer = mountWithAppProvider(
+      const tabMeasurer = mountWithApp(
         <TabMeasurer {...mockProps} activator={activator} />,
       );
-      expect(tabMeasurer.contains(activator)).toBe(true);
+      expect(tabMeasurer).toContainReactComponent(Item, {
+        id: 'id',
+      });
     });
   });
 
   describe('selected', () => {
     it('passes selected to Tab', () => {
       const selected = 1;
-      const tabMeasurer = mountWithAppProvider(
+      const tabMeasurer = mountWithApp(
         <TabMeasurer {...mockProps} selected={selected} />,
       );
-      const tabs = tabMeasurer.find(Tab);
-      expect(tabs.first().prop('selected')).toBe(false);
+      expect(tabMeasurer).toContainReactComponent(Tab, {
+        id: 'prospectsMeasurer',
+        selected: true,
+      });
     });
 
     it('does not pass the wrong selected to Tab', () => {
       const selected = 1;
-      const tabMeasurer = mountWithAppProvider(
+      const tabMeasurer = mountWithApp(
         <TabMeasurer {...mockProps} selected={selected} />,
       );
-      const tabs = tabMeasurer.find(Tab);
-      expect(tabs.last().prop('selected')).toBe(true);
+
+      expect(tabMeasurer).toContainReactComponent(Tab, {
+        id: 'repeat-customersMeasurer',
+        selected: false,
+      });
     });
   });
 
@@ -127,10 +140,11 @@ describe('<TabMeasurer />', () => {
           content: 'prospects',
         },
       ];
-      const tabMeasurer = mountWithAppProvider(
+      const tabMeasurer = mountWithApp(
         <TabMeasurer {...mockProps} tabs={tabs} />,
       );
-      expect(tabMeasurer.find(Tab)).toHaveLength(2);
+
+      expect(tabMeasurer).toContainReactComponentTimes(Tab, 2);
     });
   });
 });


### PR DESCRIPTION
**WHY are these changes introduced?**

I am updating existing tests for Item, Panel, List, Tab, TabMeasurer components to use the new testing framework.

**WHAT is this pull request doing?**

Part of test modernization (https://docs.google.com/spreadsheets/d/1GBuEZbOpVYJLNISK7gL69DU8rCxocn5L5GYaKtPXPbU/edit#gid=1498187033), updating tests using {mountWithAppProvider} from 'test-utilities/legacy' to {mountWithApp} from 'test-utilities'.

First time doing this, so if you have any suggestion, it would be really appreciate it. 
