### PR TITLE
[Test modernization] Modernizes ActionMenu and its components

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -20,6 +20,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Modernized tests for Avatar, Backdrop, Badge, Banner components([#4306](https://github.com/Shopify/polaris-react/pull/4306))
 - Modernized tests for AccountConnection, ActionList components([#4316](https://github.com/Shopify/polaris-react/pull/4316))
+- Modernized tests for ActionMenu and its subcomponents ([#4318](https://github.com/Shopify/polaris-react/pull/4318))
 
 ### Deprecations
 

--- a/src/components/ActionMenu/components/Actions/tests/Actions.test.tsx
+++ b/src/components/ActionMenu/components/Actions/tests/Actions.test.tsx
@@ -1,7 +1,5 @@
 import React, {useCallback, useState} from 'react';
 import {ActionMenuProps, ActionMenu} from 'index';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 
 import {Actions, MenuGroup, RollupActions, SecondaryAction} from '../..';
@@ -18,13 +16,13 @@ describe('<Actions />', () => {
   ];
 
   it('renders as <RollupActions /> `items` when `rollup` is `true`', () => {
-    const wrapper = mountWithAppProvider(
+    const wrapper = mountWithApp(
       <ActionMenu {...mockProps} actions={mockActions} rollup />,
     );
 
-    expect(wrapper.find(RollupActions).prop('items')).toStrictEqual(
-      mockActions,
-    );
+    expect(wrapper).toContainReactComponent(RollupActions, {
+      items: mockActions,
+    });
   });
 
   describe('Actions', () => {

--- a/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
+++ b/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {
-  mountWithAppProvider,
-  trigger,
-  ReactWrapper,
-} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {Popover, ActionList, Button} from 'components';
 
 import {MenuGroup} from '../MenuGroup';
@@ -21,18 +16,23 @@ describe('<MenuGroup />', () => {
   describe('<Popover />', () => {
     it('passes `details`', () => {
       const mockDetails = 'mock details';
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <MenuGroup {...mockProps} details={mockDetails} />,
       );
-      const popoverContents = getPopoverContents(wrapper);
 
-      expect(popoverContents.text()).toContain(mockDetails);
+      const popoverContents = mountWithApp(
+        <div>{wrapper.find(Popover)!.prop('children')}</div>,
+      );
+
+      expect(popoverContents).toContainReactText(mockDetails);
     });
 
     it('passes `active`', () => {
-      const wrapper = mountWithAppProvider(<MenuGroup {...mockProps} active />);
+      const wrapper = mountWithApp(<MenuGroup {...mockProps} active />);
 
-      expect(wrapper.find(Popover).prop('active')).toBeTruthy();
+      expect(wrapper).toContainReactComponent(Popover, {
+        active: true,
+      });
     });
 
     it('passes `actions` into the <ActionList />', () => {
@@ -40,23 +40,25 @@ describe('<MenuGroup />', () => {
         {content: 'mock content 1'},
         {content: 'mock content 2'},
       ];
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <MenuGroup {...mockProps} actions={mockActions} />,
       );
-      const popoverContents = getPopoverContents(wrapper);
-
-      expect(popoverContents.find(ActionList).prop('items')).toStrictEqual(
-        mockActions,
+      const popoverContents = mountWithApp(
+        <div>{wrapper.find(Popover)!.prop('children')}</div>,
       );
+
+      expect(popoverContents).toContainReactComponent(ActionList, {
+        items: mockActions,
+      });
     });
 
     it('triggers `onClose` after the <Popover /> closes', () => {
       const onCloseSpy = jest.fn();
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <MenuGroup {...mockProps} onClose={onCloseSpy} />,
       );
 
-      trigger(wrapper.find(Popover), 'onClose');
+      wrapper.find(Popover)!.trigger('onClose');
 
       expect(onCloseSpy).toHaveBeenCalledTimes(1);
     });
@@ -64,7 +66,7 @@ describe('<MenuGroup />', () => {
     it('triggers `onClose` after an action', () => {
       const mockTitle = 'mock title';
       const onCloseSpy = jest.fn();
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <MenuGroup
           {...mockProps}
           title={mockTitle}
@@ -73,23 +75,17 @@ describe('<MenuGroup />', () => {
         />,
       );
 
-      trigger(wrapper.find(ActionList), 'onActionAnyItem');
+      wrapper.find(ActionList)!.trigger('onActionAnyItem');
 
       expect(onCloseSpy).toHaveBeenCalledTimes(1);
     });
   });
 
   it('uses Button instead as subcomponents', () => {
-    const wrapper = mountWithAppProvider(<MenuGroup {...mockProps} />);
+    const wrapper = mountWithApp(<MenuGroup {...mockProps} />);
 
-    expect(wrapper.find(Button)).toHaveLength(1);
+    expect(wrapper.findAll(Button)).toHaveLength(1);
   });
 });
 
 function noop() {}
-
-function getPopoverContents(menuGroup: ReactWrapper) {
-  return mountWithAppProvider(
-    <div>{menuGroup.find(Popover).prop('children')}</div>,
-  );
-}

--- a/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
+++ b/src/components/ActionMenu/components/RollupActions/tests/RollupActions.test.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import {HorizontalDotsMinor} from '@shopify/polaris-icons';
-// eslint-disable-next-line no-restricted-imports
-import {
-  mountWithAppProvider,
-  trigger,
-  ReactWrapper,
-} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {Button, Popover} from 'components';
 
 // eslint-disable-next-line @shopify/strict-component-boundaries
@@ -13,7 +8,7 @@ import {
   Item as ActionListItem,
   Section as ActionListSection,
 } from '../../../../ActionList/components';
-import {RollupActions, RollupActionsProps} from '../RollupActions';
+import {RollupActions} from '../RollupActions';
 
 describe('<RollupActions />', () => {
   const mockProps = {
@@ -22,9 +17,9 @@ describe('<RollupActions />', () => {
   };
 
   it('does not render without either `items` or `sections`', () => {
-    const wrapper = mountWithAppProvider(<RollupActions {...mockProps} />);
+    const wrapper = mountWithApp(<RollupActions {...mockProps} />);
 
-    expect(wrapper.find(Popover).exists()).toBe(false);
+    expect(wrapper).not.toContainReactComponent(Popover);
   });
 
   describe('items', () => {
@@ -40,30 +35,34 @@ describe('<RollupActions />', () => {
     ];
 
     it('gets rendered as ActionList > Item', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <RollupActions {...mockProps} items={mockItems} />,
       );
 
-      activatePopover(wrapper);
+      wrapper.find(Button, {icon: HorizontalDotsMinor})!.trigger('onClick');
 
-      expect(wrapper.find(ActionListItem)).toHaveLength(mockItems.length);
+      expect(wrapper.findAll(ActionListItem)).toHaveLength(mockItems.length);
     });
 
     it('<ActionList /> closes the <Popover /> when `onActionAnyItem` is called', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <RollupActions {...mockProps} items={mockItems} />,
       );
 
-      activatePopover(wrapper);
+      wrapper.find(Button, {icon: HorizontalDotsMinor})!.trigger('onClick');
 
       let popoverComponent = wrapper.find(Popover);
-      expect(popoverComponent.prop('active')).toBe(true);
+      expect(popoverComponent!).toHaveReactProps({
+        active: true,
+      });
 
-      const firstActionListItem = wrapper.find(ActionListItem).first();
-      trigger(firstActionListItem, 'onAction');
+      const firstActionListItem = wrapper.findAll(ActionListItem)[0];
+      firstActionListItem.trigger('onAction');
 
       popoverComponent = wrapper.find(Popover);
-      expect(popoverComponent.prop('active')).toBe(false);
+      expect(popoverComponent!).toHaveReactProps({
+        active: false,
+      });
     });
   });
 
@@ -88,24 +87,15 @@ describe('<RollupActions />', () => {
     ];
 
     it('gets rendered as ActionList > Section', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <RollupActions {...mockProps} sections={mockSections} />,
       );
 
-      activatePopover(wrapper);
+      wrapper.find(Button, {icon: HorizontalDotsMinor})!.trigger('onClick');
 
-      expect(wrapper.find(ActionListSection)).toHaveLength(mockSections.length);
+      expect(wrapper.findAll(ActionListSection)).toHaveLength(
+        mockSections.length,
+      );
     });
   });
 });
-
-function findPopoverActivator(wrapper: ReactWrapper<RollupActionsProps>) {
-  return wrapper
-    .find(Button)
-    .filterWhere((button) => button.prop('icon') === HorizontalDotsMinor);
-}
-
-function activatePopover(wrapper: ReactWrapper<RollupActionsProps>) {
-  const activator = findPopoverActivator(wrapper);
-  trigger(activator, 'onClick');
-}

--- a/src/components/ActionMenu/tests/ActionMenu.test.tsx
+++ b/src/components/ActionMenu/tests/ActionMenu.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import type {
   MenuGroupDescriptor,
@@ -24,8 +23,8 @@ describe('<ActionMenu />', () => {
   ];
 
   it('does not render when there are no `actions` or `groups`', () => {
-    const wrapper = mountWithAppProvider(<ActionMenu {...mockProps} />);
-    expect(wrapper.find(MenuGroup)).toHaveLength(0);
+    const wrapper = mountWithApp(<ActionMenu {...mockProps} />);
+    expect(wrapper.findAll(MenuGroup)).toHaveLength(0);
   });
 
   describe('groups', () => {
@@ -46,31 +45,31 @@ describe('<ActionMenu />', () => {
     ];
 
     it('renders as <MenuGroup /> when `rollup` is `false`', () => {
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ActionMenu {...mockProps} groups={mockGroups} />,
       );
 
-      expect(wrapper.find(MenuGroup)).toHaveLength(mockGroups.length);
+      expect(wrapper.findAll(MenuGroup)).toHaveLength(mockGroups.length);
     });
 
     it('renders as <RollupActions /> `sections` when `rollup` is `true`', () => {
       const convertedSections = mockGroups.map((group) => {
         return {title: group.title, items: group.actions};
       });
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ActionMenu {...mockProps} groups={mockGroups} rollup />,
       );
 
-      expect(wrapper.find(RollupActions).prop('sections')).toStrictEqual(
-        convertedSections,
-      );
+      expect(wrapper).toContainReactComponent(RollupActions, {
+        sections: convertedSections,
+      });
     });
 
     it('renders groups in their initial order when no indexes are set', () => {
-      const wrapper = mountWithAppProvider(<ActionMenu groups={mockGroups} />);
+      const wrapper = mountWithApp(<ActionMenu groups={mockGroups} />);
 
-      wrapper.find(MenuGroup).forEach((group, index) => {
-        expect(group.props()).toMatchObject(mockGroups[index]);
+      wrapper.findAll(MenuGroup).forEach((group, index) => {
+        expect(group.props).toMatchObject(mockGroups[index]);
       });
     });
 
@@ -82,73 +81,79 @@ describe('<ActionMenu />', () => {
         },
       ];
 
-      const wrapper = mountWithAppProvider(<ActionMenu groups={groups} />);
+      const wrapper = mountWithApp(<ActionMenu groups={groups} />);
 
-      expect(wrapper.find(MenuGroup)).toHaveLength(1);
+      expect(wrapper.findAll(MenuGroup)).toHaveLength(1);
     });
   });
 
   describe('<MenuGroup />', () => {
     it('does not render when there are no `groups`', () => {
-      const wrapper = mountWithAppProvider(<ActionMenu {...mockProps} />);
+      const wrapper = mountWithApp(<ActionMenu {...mockProps} />);
 
-      expect(wrapper.find(MenuGroup)).toHaveLength(0);
+      expect(wrapper).not.toContainReactComponent(MenuGroup);
     });
 
     it('is inactive by default', () => {
       const mockGroups = [fillMenuGroup()];
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ActionMenu {...mockProps} groups={mockGroups} />,
       );
 
-      expect(wrapper.find(MenuGroup).prop('active')).toBeFalsy();
+      expect(wrapper).toContainReactComponent(MenuGroup, {
+        active: false,
+      });
     });
 
     it('becomes active when opened', () => {
       const mockTitle = 'mock title';
       const mockGroups = [fillMenuGroup({title: mockTitle})];
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ActionMenu {...mockProps} groups={mockGroups} />,
       );
 
-      trigger(wrapper.find(MenuGroup), 'onOpen', mockTitle);
+      wrapper.find(MenuGroup)!.trigger('onOpen', mockTitle);
 
-      expect(wrapper.find(MenuGroup).prop('active')).toBeTruthy();
+      expect(wrapper).toContainReactComponent(MenuGroup, {
+        active: true,
+      });
     });
 
     it('becomes inactive when closed', () => {
       const mockTitle = 'mock title';
       const mockGroups = [fillMenuGroup({title: mockTitle})];
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <ActionMenu {...mockProps} groups={mockGroups} />,
       );
 
-      trigger(wrapper.find(MenuGroup), 'onOpen', mockTitle);
-      trigger(wrapper.find(MenuGroup), 'onClose', mockTitle);
+      wrapper.find(MenuGroup)!.trigger('onOpen', mockTitle);
+      wrapper.find(MenuGroup)!.trigger('onClose', mockTitle);
 
-      expect(wrapper.find(MenuGroup).prop('active')).toBeFalsy();
+      expect(wrapper).toContainReactComponent(MenuGroup, {
+        active: false,
+      });
     });
   });
 
   it('uses Button and ButtonGroup as subcomponents', () => {
-    const wrapper = mountWithAppProvider(
+    const wrapper = mountWithApp(
       <ActionMenu {...mockProps} actions={mockActions} />,
     );
 
-    expect(wrapper.find(Button)).toHaveLength(2);
-    expect(wrapper.find(ButtonGroup)).toHaveLength(1);
+    expect(wrapper.findAll(Button)).toHaveLength(2);
+    expect(wrapper.findAll(ButtonGroup)).toHaveLength(1);
   });
 
   it('action callbacks are passed through to Button', () => {
     const spy = jest.fn();
-    const wrapper = mountWithAppProvider(
+    const wrapper = mountWithApp(
       <ActionMenu
         {...mockProps}
         actions={[{content: 'mock', onAction: spy}]}
       />,
     );
 
-    trigger(wrapper.find(Button), 'onClick');
+    wrapper.find(Button)!.trigger('onClick');
 
     expect(spy).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
### WHY are these changes introduced?

Modernizes tests to use the new modern framework (`{mountWithApp}` from `test-utilities`).

### WHAT is this pull request doing?

Updates tests using `{mountWithAppProvider}` from `test-utilities/legacy` to use `{mountWithApp}` from `test-utilities`