### PR TITLE
[IndexTable] Add support for non-selectable table when selectable prop is false

### DIFF
--- a/src/components/IndexProvider/IndexProvider.tsx
+++ b/src/components/IndexProvider/IndexProvider.tsx
@@ -18,6 +18,7 @@ export function IndexProvider({
   itemCount,
   hasMoreItems,
   condensed,
+  selectable,
 }: IndexProviderProps) {
   const {
     paginatedSelectAllText,
@@ -26,7 +27,6 @@ export function IndexProvider({
     resourceName,
     selectMode,
     bulkSelectState,
-    selectable,
   } = useBulkSelectionData({
     selectedItemsCount,
     itemCount,

--- a/src/components/IndexTable/IndexTable.tsx
+++ b/src/components/IndexTable/IndexTable.tsx
@@ -70,6 +70,7 @@ function IndexTableBase({
     bulkSelectState,
     resourceName,
     bulkActionsAccessibilityLabel,
+    selectable,
     selectMode,
     paginatedSelectAllText,
     itemCount,
@@ -290,7 +291,7 @@ function IndexTableBase({
     }
   }, [condensed, isSmallScreenSelectable]);
 
-  const selectable = Boolean(
+  const actionable = Boolean(
     (promotedBulkActions && promotedBulkActions.length > 0) ||
       (bulkActions && bulkActions.length > 0),
   );
@@ -674,7 +675,7 @@ function IndexTableBase({
   }
 
   function getPaginatedSelectAllAction() {
-    if (!selectable || !hasMoreItems) {
+    if (!actionable || !hasMoreItems) {
       return;
     }
 

--- a/src/components/IndexTable/IndexTable.tsx
+++ b/src/components/IndexTable/IndexTable.tsx
@@ -568,7 +568,7 @@ function IndexTableBase({
     const isSecond = index === 0;
     const headingContentClassName = classNames(
       styles.TableHeading,
-      isSecond && styles['TableHeading-second'],
+      selectable && isSecond && styles['TableHeading-second'],
     );
 
     const stickyPositioningStyle =
@@ -589,7 +589,7 @@ function IndexTableBase({
       </th>
     );
 
-    if (index !== 0) return headingContent;
+    if (index !== 0 || !selectable) return headingContent;
 
     const checkboxClassName = classNames(
       styles.TableHeading,

--- a/src/components/IndexTable/IndexTable.tsx
+++ b/src/components/IndexTable/IndexTable.tsx
@@ -296,9 +296,8 @@ function IndexTableBase({
       (bulkActions && bulkActions.length > 0),
   );
 
-  const headingsMarkup = headings
-    .map(renderHeading)
-    .reduce<JSX.Element[]>((acc, heading) => acc.concat(heading), []);
+  const headingsMarkup = headings.map(renderHeading);
+  if (selectable) headingsMarkup.unshift(renderCheckboxCell());
 
   const bulkActionsSelectable = Boolean(
     promotedBulkActions.length > 0 || bulkActions.length > 0,
@@ -569,7 +568,7 @@ function IndexTableBase({
     const isSecond = index === 0;
     const headingContentClassName = classNames(
       styles.TableHeading,
-      selectable && isSecond && styles['TableHeading-second'],
+      isSecond && styles['TableHeading-second'],
     );
 
     const stickyPositioningStyle =
@@ -579,7 +578,7 @@ function IndexTableBase({
         ? {left: tableHeadingRects.current[0].offsetWidth}
         : undefined;
 
-    const headingContent = (
+    return (
       <th
         className={headingContentClassName}
         key={heading.title}
@@ -589,25 +588,23 @@ function IndexTableBase({
         {renderHeadingContent(heading)}
       </th>
     );
+  }
 
-    if (index !== 0 || !selectable) return headingContent;
-
+  function renderCheckboxCell() {
     const checkboxClassName = classNames(
       styles.TableHeading,
-      index === 0 && styles['TableHeading-first'],
+      styles['TableHeading-first'],
     );
 
-    const checkboxContent = (
+    return (
       <th
         className={checkboxClassName}
-        key={`${heading}-${index}`}
+        key="heading-checkbox"
         data-index-table-heading
       >
         {renderCheckboxContent()}
       </th>
     );
-
-    return [checkboxContent, headingContent];
   }
 
   function renderCheckboxContent() {

--- a/src/components/IndexTable/IndexTable.tsx
+++ b/src/components/IndexTable/IndexTable.tsx
@@ -711,7 +711,7 @@ export interface IndexTableProps
 
 export function IndexTable({
   children,
-  selectable,
+  selectable = true,
   itemCount,
   selectedItemsCount,
   resourceName: passedResourceName,

--- a/src/components/IndexTable/components/Row/Row.tsx
+++ b/src/components/IndexTable/components/Row/Row.tsx
@@ -2,6 +2,7 @@ import React, {useMemo, memo, useRef, useCallback} from 'react';
 
 import {useToggle} from '../../../../utilities/use-toggle';
 import {
+  useIndexValue,
   useIndexRow,
   SelectionType,
   useIndexSelectionChange,
@@ -32,6 +33,7 @@ export const Row = memo(function Row({
   status,
   onNavigation,
 }: RowProps) {
+  const {selectable} = useIndexValue();
   const {selectMode, condensed} = useIndexRow();
   const onSelectionChange = useIndexSelectionChange();
   const {
@@ -57,9 +59,9 @@ export const Row = memo(function Row({
         ? SelectionType.Multi
         : SelectionType.Single;
 
-      onSelectionChange(selectionType, !selected, id, position);
+      if (selectable) onSelectionChange(selectionType, !selected, id, position);
     },
-    [id, onSelectionChange, position, selected],
+    [id, selectable, onSelectionChange, position, selected],
   );
 
   const contextValue = useMemo(

--- a/src/components/IndexTable/components/Row/Row.tsx
+++ b/src/components/IndexTable/components/Row/Row.tsx
@@ -115,6 +115,7 @@ export const Row = memo(function Row({
   };
 
   const RowWrapper = condensed ? 'li' : 'tr';
+  const checkbox = selectable ? <Checkbox /> : null;
 
   return (
     <RowContext.Provider value={contextValue}>
@@ -127,7 +128,7 @@ export const Row = memo(function Row({
           onClick={handleRowClick}
           ref={tableRowRef}
         >
-          <Checkbox />
+          {checkbox}
           {children}
         </RowWrapper>
       </RowHoveredContext.Provider>

--- a/src/components/IndexTable/components/Row/tests/Row.test.tsx
+++ b/src/components/IndexTable/components/Row/tests/Row.test.tsx
@@ -2,6 +2,7 @@ import React, {ReactElement} from 'react';
 import {mountWithApp} from 'test-utilities';
 import type {DeepPartial, ThenType} from '@shopify/useful-types';
 
+import {Checkbox} from '../../Checkbox';
 import {IndexTable, IndexTableProps} from '../../../IndexTable';
 import {RowHoveredContext} from '../../../../../utilities/index-table';
 import {Row} from '../Row';
@@ -241,6 +242,17 @@ describe('<Row />', () => {
     expect(row).toContainReactComponent('tr', {
       className: 'TableRow statusSubdued',
     });
+  });
+
+  it('does not render a checkbox when not selectable', () => {
+    const row = mountWithTable(
+      <Row {...defaultProps}>
+        <td />
+      </Row>,
+      {indexTableProps: {selectable: false}},
+    );
+
+    expect(row).not.toContainReactComponent(Checkbox);
   });
 });
 

--- a/src/components/IndexTable/tests/IndexTable.test.tsx
+++ b/src/components/IndexTable/tests/IndexTable.test.tsx
@@ -466,4 +466,21 @@ describe('<IndexTable>', () => {
       });
     });
   });
+
+  describe('not selectable', () => {
+    it('does not render a checkbox in the headings', () => {
+      const index = mountWithApp(
+        <IndexTable
+          {...defaultProps}
+          itemCount={mockTableItems.length}
+          selectable={false}
+        >
+          {mockTableItems.map(mockRenderRow)}
+        </IndexTable>,
+      );
+      const headings = index.find('thead');
+
+      expect(headings).not.toContainReactComponent(Checkbox);
+    });
+  });
 });

--- a/src/utilities/index-provider/hooks.ts
+++ b/src/utilities/index-provider/hooks.ts
@@ -48,7 +48,7 @@ export function useBulkSelectionData({
 }: BulkSelectionDataOptions) {
   const i18n = useI18n();
 
-  const selectable = Boolean(selectedItemsCount);
+  const hasSelections = Boolean(selectedItemsCount);
   const selectMode = selectedItemsCount === 'All' || selectedItemsCount > 0;
 
   const defaultResourceName = {
@@ -82,11 +82,11 @@ export function useBulkSelectionData({
     resourceName,
     selectMode,
     bulkSelectState,
-    selectable,
+    hasSelections,
   };
 
   function getPaginatedSelectAllText() {
-    if (!selectable || !hasMoreItems) {
+    if (!hasSelections || !hasMoreItems) {
       return;
     }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #4076

Introduces a variant of the `IndexTable` that has no checkboxes in the leftmost column when the `selectable` prop is false. This is inline with the naming of the prop and makes the table usable for resources where the user may not need to support selection, and is instead just using the table as a resource-specific version of a DataTable.

### WHAT is this pull request doing?

- Updates the IndexProvider to pass through the `selectable` prop into the context. This was one of the allowed props on the context but wasn't actually being passed into the context object itself. Instead the context was deriving its own value of "selectable" to mean "there are more than 0 items present" which is renamed to "hasSelections"
- Updates previous uses of the term "selectable" where it meant "has bulk actions" to be "actionable" instead to indicate intent, and to differentiate it from "selectable" which indicates "rows in this table should be able to be selected"
- Refactored the `renderHeading` inline-component to have a simpler signature by separating out a new `renderCheckboxCell` inline-component. Previously, `renderHeading` would return a 2-tuple of JSX on the first heading, and a single JSX otherwise, which was a bit confusing and harder to manage when checkbox is optional. Instead we'll do a simple map with `renderHeading` and then insert the checkbox content at the front of the array if desired.

A screenshot of the approach rendered with many columns so that it scrolls horizontally. Note the lack of checkbox:

![image](https://user-images.githubusercontent.com/3004111/126665458-df52f51c-5fb2-47da-8fe3-fd811d9e8f55.png)

#### TODO
- Still needs some additional work in order to get the styling of the sticky columns correct when a checkbox is not rendered. Currently our code makes a lot of assumptions that the first column will be there, and uses it to calculate the offset width for the second column. When the checkbox isn't present, the sticky column calculation doesn't work.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

Copy-paste the code from the parent ticket into the Playground in order to test this out.


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
