### PR TITLE
[Test modernization] Modernizes FormLayout and some components of ColorPicker 

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -26,7 +26,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Modernized tests for ActionMenu and its subcomponents ([#4318](https://github.com/Shopify/polaris-react/pull/4318))
 - Modernized tests for Loading-List-Item-Label components([#4321](https://github.com/Shopify/polaris-react/pull/4321))
 - Modernized tests for PageActions, Page and its components ([#4326](https://github.com/Shopify/polaris-react/pull/4326))
-
+- Modernized tests for FormLayout and some components of ColorPicker ([#4330](https://github.com/Shopify/polaris-react/pull/4330))
 - Modernized tests for Breadcrumbs, BulkActions, Button, ButtonGroup/Item, and ButtonGroup components([#4315](https://github.com/Shopify/polaris-react/pull/4315))
 
 ### Deprecations

--- a/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
+++ b/src/components/ColorPicker/components/AlphaPicker/tests/AlphaPicker.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {calculateDraggerY, alphaForDraggerY} from '../utilities';
 import {Slidable} from '../../Slidable';
@@ -24,20 +23,22 @@ describe('<AlphaPicker />', () => {
     it('is used to calculate Slidable’s draggerY coordinate', () => {
       const alpha = 0.7;
       const expectedHue = calculateDraggerY(alpha, 0, 0);
-      const alphaPicker = mountWithAppProvider(
+      const alphaPicker = mountWithApp(
         <AlphaPicker {...mockProps} alpha={alpha} />,
       );
-      expect(alphaPicker.find(Slidable).prop('draggerY')).toBe(expectedHue);
+      expect(alphaPicker).toContainReactComponent(Slidable, {
+        draggerY: expectedHue,
+      });
     });
   });
 
   describe('onChange()', () => {
     it('is called when Slidable changes', () => {
       const onChangeSpy = jest.fn();
-      const alphaPicker = mountWithAppProvider(
+      const alphaPicker = mountWithApp(
         <AlphaPicker {...mockProps} onChange={onChangeSpy} />,
       );
-      trigger(alphaPicker.find(Slidable), 'onChange', {
+      alphaPicker.find(Slidable)!.trigger('onChange', {
         y: 0,
       });
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
@@ -45,12 +46,12 @@ describe('<AlphaPicker />', () => {
 
     it('is called with the new alpha value', () => {
       const onChangeSpy = jest.fn();
-      const alphaPicker = mountWithAppProvider(
+      const alphaPicker = mountWithApp(
         <AlphaPicker {...mockProps} onChange={onChangeSpy} />,
       );
       const yPosition = 7;
       const expectedHue = alphaForDraggerY(yPosition, 0);
-      trigger(alphaPicker.find(Slidable), 'onChange', {
+      alphaPicker.find(Slidable)!.trigger('onChange', {
         y: yPosition,
       });
       expect(onChangeSpy).toHaveBeenCalledWith(expectedHue);
@@ -60,18 +61,22 @@ describe('<AlphaPicker />', () => {
   describe('<Slidable />', () => {
     it('receives dragger height changes and uses them to calculate draggerY', () => {
       const alpha = 0.7;
-      const alphaPicker = mountWithAppProvider(
+      const alphaPicker = mountWithApp(
         <AlphaPicker {...mockProps} alpha={alpha} />,
       );
       const newDraggerHeight = 7;
       const expectedNewHue = calculateDraggerY(alpha, 0, newDraggerHeight);
-      trigger(alphaPicker.find(Slidable), 'onDraggerHeight', newDraggerHeight);
-      expect(alphaPicker.find(Slidable).prop('draggerY')).toBe(expectedNewHue);
+      alphaPicker.find(Slidable)!.trigger('onDraggerHeight', newDraggerHeight);
+      expect(alphaPicker).toContainReactComponent(Slidable, {
+        draggerY: expectedNewHue,
+      });
     });
 
     it('passes draggerX to Slidable with value 0', () => {
-      const alphaPicker = mountWithAppProvider(<AlphaPicker {...mockProps} />);
-      expect(alphaPicker.find(Slidable).prop('draggerX')).toBe(0);
+      const alphaPicker = mountWithApp(<AlphaPicker {...mockProps} />);
+      expect(alphaPicker).toContainReactComponent(Slidable, {
+        draggerX: 0,
+      });
     });
   });
 });

--- a/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
+++ b/src/components/ColorPicker/components/HuePicker/tests/HuePicker.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {calculateDraggerY, hueForDraggerY} from '../utilities';
 import {Slidable} from '../../Slidable';
@@ -16,20 +15,20 @@ describe('<HuePicker />', () => {
     it('is used to calculate Slidable’s draggerY coordinate', () => {
       const hue = 44;
       const expectedHue = calculateDraggerY(hue, 0, 0);
-      const huePicker = mountWithAppProvider(
-        <HuePicker {...mockProps} hue={hue} />,
-      );
-      expect(huePicker.find(Slidable).prop('draggerY')).toBe(expectedHue);
+      const huePicker = mountWithApp(<HuePicker {...mockProps} hue={hue} />);
+      expect(huePicker).toContainReactComponent(Slidable, {
+        draggerY: expectedHue,
+      });
     });
   });
 
   describe('onChange()', () => {
     it('gets called when slidable changes', () => {
       const onChangeSpy = jest.fn();
-      const huePicker = mountWithAppProvider(
+      const huePicker = mountWithApp(
         <HuePicker {...mockProps} onChange={onChangeSpy} />,
       );
-      trigger(huePicker.find(Slidable), 'onChange', {
+      huePicker.find(Slidable)!.trigger('onChange', {
         y: 0,
       });
       expect(onChangeSpy).toHaveBeenCalledTimes(1);
@@ -37,12 +36,12 @@ describe('<HuePicker />', () => {
 
     it('gets called with the new hue value', () => {
       const onChangeSpy = jest.fn();
-      const huePicker = mountWithAppProvider(
+      const huePicker = mountWithApp(
         <HuePicker {...mockProps} onChange={onChangeSpy} />,
       );
       const yPosition = 7;
       const expectedHue = hueForDraggerY(yPosition, 0);
-      trigger(huePicker.find(Slidable), 'onChange', {
+      huePicker.find(Slidable)!.trigger('onChange', {
         y: yPosition,
       });
       expect(onChangeSpy).toHaveBeenCalledWith(expectedHue);
@@ -52,18 +51,20 @@ describe('<HuePicker />', () => {
   describe('<Slidable />', () => {
     it('receives dragger height changes and uses them to calculate draggerY', () => {
       const hue = 80;
-      const huePicker = mountWithAppProvider(
-        <HuePicker {...mockProps} hue={hue} />,
-      );
+      const huePicker = mountWithApp(<HuePicker {...mockProps} hue={hue} />);
       const newDraggerHeight = 7;
       const expectedNewHue = calculateDraggerY(hue, 0, newDraggerHeight);
-      trigger(huePicker.find(Slidable), 'onDraggerHeight', newDraggerHeight);
-      expect(huePicker.find(Slidable).prop('draggerY')).toBe(expectedNewHue);
+      huePicker.find(Slidable)!.trigger('onDraggerHeight', newDraggerHeight);
+      expect(huePicker).toContainReactComponent(Slidable, {
+        draggerY: expectedNewHue,
+      });
     });
 
     it('passes draggerX to Slidable with value 0', () => {
-      const huePicker = mountWithAppProvider(<HuePicker {...mockProps} />);
-      expect(huePicker.find(Slidable).prop('draggerX')).toBe(0);
+      const huePicker = mountWithApp(<HuePicker {...mockProps} />);
+      expect(huePicker).toContainReactComponent(Slidable, {
+        draggerX: 0,
+      });
     });
   });
 });

--- a/src/components/FooterHelp/tests/FooterHelp.test.tsx
+++ b/src/components/FooterHelp/tests/FooterHelp.test.tsx
@@ -1,25 +1,24 @@
 import React from 'react';
 import {InfoMinor} from '@shopify/polaris-icons';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {Icon} from 'components';
 
 import {FooterHelp} from '../FooterHelp';
 
 describe('<FooterHelp />', () => {
-  let children: string;
-  let footerHelp: any;
-
-  beforeAll(() => {
-    children = 'Learn more about fulfilling orders';
-    footerHelp = mountWithAppProvider(<FooterHelp>{children}</FooterHelp>);
-  });
+  const children = 'Learn more about fulfilling orders';
 
   it('renders its children', () => {
-    expect(footerHelp.contains(children)).toBe(true);
+    const footerHelp = mountWithApp(<FooterHelp>{children}</FooterHelp>);
+    expect(footerHelp).toHaveReactProps({
+      children,
+    });
   });
 
   it('renders the help icon', () => {
-    expect(footerHelp.find(Icon).prop('source')).toBe(InfoMinor);
+    const footerHelp = mountWithApp(<FooterHelp>{children}</FooterHelp>);
+    expect(footerHelp).toContainReactComponent(Icon, {
+      source: InfoMinor,
+    });
   });
 });

--- a/src/components/FormLayout/components/Group/tests/Group.test.tsx
+++ b/src/components/FormLayout/components/Group/tests/Group.test.tsx
@@ -1,37 +1,42 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
 import {TextField} from 'components';
+import {mountWithApp} from 'test-utilities';
 
 import {Group} from '../Group';
 
 describe('<Group />', () => {
-  let children: React.ReactNode;
-  let title: string;
-  let helpText: string;
-  let item: any;
+  const children = <TextField onChange={noop} label="test" />;
+  const title = 'Title';
+  const helpText = 'Help text';
 
-  beforeAll(() => {
-    children = <TextField onChange={noop} label="test" />;
-    title = 'Title';
-    helpText = 'Help text';
-    item = mountWithAppProvider(
+  it('renders its children', () => {
+    const group = mountWithApp(
       <Group title={title} helpText={helpText}>
         {children}
       </Group>,
     );
-  });
-
-  it('renders its children', () => {
-    expect(item.contains(children)).toBe(true);
+    expect(group).toContainReactComponent(TextField, {
+      onChange: noop,
+      label: 'test',
+    });
   });
 
   it('renders its title', () => {
-    expect(item.contains(title)).toBe(true);
+    const group = mountWithApp(
+      <Group title={title} helpText={helpText}>
+        {children}
+      </Group>,
+    );
+    expect(group).toContainReactText(title);
   });
 
   it('renders its help text', () => {
-    expect(item.contains(helpText)).toBe(true);
+    const group = mountWithApp(
+      <Group title={title} helpText={helpText}>
+        {children}
+      </Group>,
+    );
+    expect(group).toContainReactText(helpText);
   });
 });
 

--- a/src/components/FormLayout/components/Item/tests/Item.test.tsx
+++ b/src/components/FormLayout/components/Item/tests/Item.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 import {TextField} from 'components';
 
 import {Item} from '../Item';
@@ -8,8 +7,11 @@ import {Item} from '../Item';
 describe('<Item />', () => {
   it('renders its children', () => {
     const children = <TextField onChange={noop} label="test" />;
-    const item = mountWithAppProvider(<Item>{children}</Item>);
-    expect(item.contains(children)).toBe(true);
+    const item = mountWithApp(<Item>{children}</Item>);
+    expect(item).toContainReactComponent(TextField, {
+      onChange: noop,
+      label: 'test',
+    });
   });
 });
 

--- a/src/components/FormLayout/tests/FormLayout.test.tsx
+++ b/src/components/FormLayout/tests/FormLayout.test.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
 import {TextField} from 'components';
+import {mountWithApp} from 'test-utilities';
 
 import {FormLayout} from '../FormLayout';
 
 describe('<FormLayout />', () => {
   it('renders its children', () => {
     const children = <TextField onChange={noop} label="test" />;
-    const formLayout = mountWithAppProvider(
-      <FormLayout>{children}</FormLayout>,
-    );
-    expect(formLayout.contains(children)).toBe(true);
+    const formLayout = mountWithApp(<FormLayout>{children}</FormLayout>);
+    expect(formLayout).toContainReactComponent(TextField, {
+      onChange: noop,
+      label: 'test',
+    });
   });
 });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Modernizes tests to use the new modern framework (`{mountWithApp}` from `test-utilities`).

### WHAT is this pull request doing?

Updates tests using `{mountWithAppProvider}` from `test-utilities/legacy` to use `{mountWithApp}` from `test-utilities`