### PR TITLE
[Navigation] Add ariaLabelledBy prop in order to add menu label for screen readers

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Added `id` prop to `Layout` and `Heading` for hash linking ([#4307](https://github.com/Shopify/polaris-react/pull/4307))
 - Added `external` prop to `Navigation.Item` component ([#4310](https://github.com/Shopify/polaris-react/pull/4310))
+- Added `ariaLabelledBy` props to `Navigation` component to allow a hidden label for accessibility ([#4343](https://github.com/Shopify/polaris-react/pull/4343))
 
 ### Bug fixes
 

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -16,6 +16,8 @@ export interface NavigationProps {
   children?: React.ReactNode;
   contextControl?: React.ReactNode;
   onDismiss?(): void;
+  /** id of the element used as aria-labelledby */
+  ariaLabelledBy?: string;
 }
 
 export const Navigation: React.FunctionComponent<NavigationProps> & {
@@ -26,6 +28,7 @@ export const Navigation: React.FunctionComponent<NavigationProps> & {
   contextControl,
   location,
   onDismiss,
+  ariaLabelledBy,
 }: NavigationProps) {
   const {logo} = useTheme();
   const width = getWidth(logo, 104);
@@ -61,7 +64,7 @@ export const Navigation: React.FunctionComponent<NavigationProps> & {
   return (
     <NavigationContext.Provider value={context}>
       <WithinContentContext.Provider value>
-        <nav className={styles.Navigation}>
+        <nav className={styles.Navigation} aria-labelledby={ariaLabelledBy}>
           {mediaMarkup}
           <Scrollable className={styles.PrimaryNavigation}>
             {children}

--- a/src/components/Navigation/README.md
+++ b/src/components/Navigation/README.md
@@ -518,6 +518,38 @@ This example showcases the many elements that can compose a navigation, especial
 </Navigation>
 ```
 
+### Navigation with aria-labelledby
+
+This example shows how to add an aria-labelledby to add a hidden label to the `nav` element.
+
+```jsx
+<Navigation location="/" ariaLabelledBy="label-id">
+  <VisuallyHidden>
+    <p id="label-id">Hidden label</p>
+  </VisuallyHidden>
+  <Navigation.Section
+    items={[
+      {
+        url: '/path/to/place',
+        label: 'Home',
+        icon: HomeMajor,
+      },
+      {
+        url: '/path/to/place',
+        label: 'Orders',
+        icon: OrdersMajor,
+        badge: '15',
+      },
+      {
+        url: '/path/to/place',
+        label: 'Products',
+        icon: ProductsMajor,
+      },
+    ]}
+  />
+</Navigation>
+```
+
 ---
 
 ## Related components

--- a/src/components/Navigation/tests/Navigation.test.tsx
+++ b/src/components/Navigation/tests/Navigation.test.tsx
@@ -21,6 +21,16 @@ describe('<Navigation />', () => {
     expect(navigation).toContainReactComponent(Image);
   });
 
+  it('renders nav with aria-labelledby when passed as prop', () => {
+    const label = 'label-id';
+    const navigation = mountWithApp(
+      <Navigation location="/" ariaLabelledBy={label} />,
+    );
+    expect(navigation).toContainReactComponent('nav', {
+      'aria-labelledby': label,
+    });
+  });
+
   describe('context', () => {
     it('passes location context', () => {
       const Child: React.SFC = (_props) => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4289 
Fixes Shopify/handshake-discovery-team#247

Currently it's not possible to pass a label to the Navigation component that can be used to differentiate this `nav` from other nav when navigating with landmarks.

This PR is adding a way to generate the following output (described here: https://www.w3.org/WAI/tutorials/menus/structure/#label-menus):

```html
<nav aria-labelledby="mainmenulabel">
    <h2 id="mainmenulabel" class="visuallyhidden">Main Menu</h2>
</nav>
```

From this implementation:

```html
<Navigation ariaLabelledBy="mainmenulabel">
    <VisuallyHidden>
        <h2 id="mainmenulabel">Main</h2>
    </VisuallyHidden>
</Navigation>
```


### WHAT is this pull request doing?

Adds `ariaLabelledBy` props to `Navigation` component. It is then passed as `aria-labelledby` property to the `<nav>` element.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Navigation, Page, VisuallyHidden} from '../src';

export function Playground() {
  const ariaLabelledById = 'label-1';

  const children = (
    <ul>
      <li>Item</li>
    </ul>
  );
  return (
    <Page title="Playground">
      <Navigation location="/" ariaLabelledBy={ariaLabelledById}>
        <VisuallyHidden>
          <h2 id={ariaLabelledById}>Hidden label</h2>
        </VisuallyHidden>
        {children}
      </Navigation>
    </Page>
  );
}
```
</details>

**Tophat instructions:**
* There is not visible change in the UI
* Use the above Playground code

**1. Inspect the the HTML output:**
* The label should be not be visible and the id of the label should equal the aria-labelledby value of the `<nav>`

**2. Use landmark navigation**
* Use Voice over and open landmarks navigation:
  * Activate Voice over (hold down the Command key and triple-tap the Touch ID button)
   * Open the rotor by pressing control + option + U
   * Use left/right arrows to find "Landmark navigation" panel
   * In this panel there should be an entry "Hidden label navigation"



### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
