### PR TITLE
[TextField] Fix disabled text color in Safari

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -11,6 +11,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Fixed a bug `TextField` where Safari would render the incorrect text color ([#4344](https://github.com/Shopify/polaris-react/pull/4344))
+
 ### Documentation
 
 ### Development workflow

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -112,10 +112,10 @@ $stacking-order: (
   }
 
   &:disabled {
-    background: none;
-    color: currentColor;
     opacity: 1;
-    -webkit-text-fill-color: currentColor;
+    background: none;
+    color: var(--p-text-disabled);
+    -webkit-text-fill-color: var(--p-text-disabled);
   }
 
   // remove the box shadow in Firefox when the input is invalid


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/182

### WHAT is this pull request doing?

I think webkit overrides the color value of disabled inputs. We were using current color here before because I think legacy Polaris had different colors for different disabled states i.e. error. Now they're all using `--p-text-disabled`

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, TextField} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <TextField
        disabled
        label="some value"
        value="some value"
        onChange={(value) => console.log(value)}
      />
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
