### PR TITLE
[TextField] Fully removed clear button when there is no text

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,7 +18,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed a bug in `Banner` where loading state wasn't getting passed to `primaryAction` ([#4338](https://github.com/Shopify/polaris-react/pull/4338))
 - Fixed `Popover` not correctly positioning itself ([#4357](https://github.com/Shopify/polaris-react/pull/4357))
 - Fixed a bug `TextField` where Safari would render the incorrect text color ([#4344](https://github.com/Shopify/polaris-react/pull/4344))
-- Fixed screen readers reading out the clear button in `TextField` when when there is no input ([#4369](https://github.com/Shopify/polaris-react/pull/4369))
+- Fixed screen readers reading out the clear button in `TextField` when there is no input ([#4369](https://github.com/Shopify/polaris-react/pull/4369))
 - Fix bug in Safari where `Button` text is gray instead of white after changing state from disabled to enabled ([#4270](https://github.com/Shopify/polaris-react/pull/4270))
 - Bring back borders on the `IndexTable` sticky cells ([#4150](https://github.com/Shopify/polaris-react/pull/4150))
 - Adjust `IndexTable` sticky z-index to avoid collisions with focused `TextField` ([#4150](https://github.com/Shopify/polaris-react/pull/4150))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -18,6 +18,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Fixed a bug in `Banner` where loading state wasn't getting passed to `primaryAction` ([#4338](https://github.com/Shopify/polaris-react/pull/4338))
 - Fixed `Popover` not correctly positioning itself ([#4357](https://github.com/Shopify/polaris-react/pull/4357))
 - Fixed a bug `TextField` where Safari would render the incorrect text color ([#4344](https://github.com/Shopify/polaris-react/pull/4344))
+- Fixed screen readers reading out the clear button in `TextField` when when there is no input ([#4369](https://github.com/Shopify/polaris-react/pull/4369))
 - Fix bug in Safari where `Button` text is gray instead of white after changing state from disabled to enabled ([#4270](https://github.com/Shopify/polaris-react/pull/4270))
 - Bring back borders on the `IndexTable` sticky cells ([#4150](https://github.com/Shopify/polaris-react/pull/4150))
 - Adjust `IndexTable` sticky z-index to avoid collisions with focused `TextField` ([#4150](https://github.com/Shopify/polaris-react/pull/4150))

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -231,10 +231,6 @@ $stacking-order: (
   &:disabled {
     cursor: default;
   }
-
-  &.ClearButton-hidden {
-    @include visually-hidden;
-  }
 }
 
 .Spinner {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -274,14 +274,13 @@ export function TextField({
   }
 
   const clearButtonVisible = normalizedValue !== '';
-  const clearButtonClassName = classNames(styles.ClearButton);
 
   const clearButtonMarkup =
     clearButtonVisible && clearButton ? (
       <button
         type="button"
         testID="clearButton"
-        className={clearButtonClassName}
+        className={styles.ClearButton}
         onClick={handleClearButtonPress}
         disabled={disabled}
       >

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -274,24 +274,23 @@ export function TextField({
   }
 
   const clearButtonVisible = normalizedValue !== '';
-  const clearButtonClassName = classNames(
-    styles.ClearButton,
-    !clearButtonVisible && styles['ClearButton-hidden'],
-  );
+  const clearButtonClassName = classNames(styles.ClearButton);
 
-  const clearButtonMarkup = clearButton ? (
-    <button
-      type="button"
-      testID="clearButton"
-      className={clearButtonClassName}
-      onClick={handleClearButtonPress}
-      disabled={disabled}
-      tabIndex={clearButtonVisible ? 0 : -1}
-    >
-      <VisuallyHidden>{i18n.translate('Polaris.Common.clear')}</VisuallyHidden>
-      <Icon source={CircleCancelMinor} color="base" />
-    </button>
-  ) : null;
+  const clearButtonMarkup =
+    clearButtonVisible && clearButton ? (
+      <button
+        type="button"
+        testID="clearButton"
+        className={clearButtonClassName}
+        onClick={handleClearButtonPress}
+        disabled={disabled}
+      >
+        <VisuallyHidden>
+          {i18n.translate('Polaris.Common.clear')}
+        </VisuallyHidden>
+        <Icon source={CircleCancelMinor} color="base" />
+      </button>
+    ) : null;
 
   const handleNumberChange = useCallback(
     (steps: number) => {

--- a/src/components/TextField/tests/TextField.test.tsx
+++ b/src/components/TextField/tests/TextField.test.tsx
@@ -1068,8 +1068,8 @@ describe('<TextField />', () => {
       expect(findByTestID(textField, 'clearButton').exists()).toBeTruthy();
     });
 
-    it('renders a visually hidden clear button in inputs without a value', () => {
-      const textField = mountWithAppProvider(
+    it('does not render a clear button in inputs without a value', () => {
+      const textField = mountWithApp(
         <TextField
           id="MyTextField"
           label="TextField"
@@ -1079,9 +1079,9 @@ describe('<TextField />', () => {
         />,
       );
 
-      const clearButton = findByTestID(textField, 'clearButton');
-      expect(clearButton.hasClass('ClearButton-hidden')).toBeTruthy();
-      expect(clearButton.prop('tabIndex')).toBe(-1);
+      expect(textField).not.toContainReactComponent('button', {
+        testID: 'clearButton',
+      });
     });
 
     it('calls onClearButtonClicked() with an id when the clear button is clicked', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

This was noticed durning a bug hunt

### WHAT is this pull request doing?

Removing the complexity around changing the clear buttons state so the clear button won't be visible to screen readers when the field is empty

### Screenies
|Before|After|
|-|-|
|![Screen Shot 2021-08-09 at 12 06 07 PM](https://user-images.githubusercontent.com/24610840/128737989-04b40589-5991-459a-bafa-ee94c91dbeaf.png)|![Screen Shot 2021-08-09 at 11 38 29 AM](https://user-images.githubusercontent.com/24610840/128738003-c9843eb1-6bd8-4fe3-a0c6-835ff31d45f4.png)|


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
