### PR TITLE
[Avatar] Add new sizing 'extra-small'

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Added `ariaLabelledBy` props to `Navigation` component to allow a hidden label for accessibility ([#4343](https://github.com/Shopify/polaris-react/pull/4343))
 - Add `lastColumnSticky` prop to `IndexTable` to create a sticky last cell and optional sticky last heading on viewports larger than small ([#4150](https://github.com/Shopify/polaris-react/pull/4150))
 - Allow promoted actions to be rendered as a menu on the `BulkAction` component ([#4266](https://github.com/Shopify/polaris-react/pull/4266))
+- Add `extraSmall` prop to `Avatar` ([#4371](https://github.com/Shopify/polaris-react/pull/4371))
 
 ### Bug fixes
 

--- a/src/components/Avatar/Avatar.scss
+++ b/src/components/Avatar/Avatar.scss
@@ -1,5 +1,6 @@
 @import '../../styles/common';
 
+$extra-small-size: rem(24px);
 $small-size: rem(32px);
 $medium-size: rem(40px);
 $large-size: rem(60px);
@@ -8,7 +9,7 @@ $large-size: rem(60px);
   position: relative;
   display: block;
   overflow: hidden;
-  min-width: $small-size;
+  min-width: $extra-small-size;
   max-width: 100%;
   background: var(--p-surface-neutral);
   color: var(--p-icon-subdued);
@@ -28,6 +29,10 @@ $large-size: rem(60px);
 
 .hidden {
   visibility: hidden;
+}
+
+.sizeExtraSmall {
+  width: $extra-small-size;
 }
 
 .sizeSmall {

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -7,7 +7,7 @@ import {Image} from '../Image';
 
 import styles from './Avatar.scss';
 
-type Size = 'small' | 'medium' | 'large';
+type Size = 'extraSmall' | 'small' | 'medium' | 'large';
 
 enum Status {
   Pending = 'PENDING',

--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -36,6 +36,7 @@ business in the interface.
 
 Avatars should be one of 3 sizes:
 
+- Extra small (24 x 24 px): use when small size is too big
 - Small (32 × 32 px): use when the medium size is too big for the layout, or when the avatar has less importance
 - Medium (40 × 40 px): use as the default size
 - Large (60 × 60 px): use when an avatar is a focal point, such as on a single customer card
@@ -76,6 +77,12 @@ Use to present an avatar for a merchant, customer, or business.
 ![Default avatar](/public_images/components/Avatar/ios/default@2x.png)
 
 <!-- /content-for -->
+
+### Extra small avatar
+
+```jsx
+<Avatar name="Farrah Fawcett" size="extraSmall" />
+```
 
 ---
 

--- a/src/components/Avatar/README.md
+++ b/src/components/Avatar/README.md
@@ -34,9 +34,9 @@ business in the interface.
 
 ## Best practices
 
-Avatars should be one of 3 sizes:
+Avatars should be one of 4 sizes:
 
-- Extra small (24 x 24 px): use when small size is too big
+- Extra small (24 x 24 px): use in tightly condensed layouts
 - Small (32 × 32 px): use when the medium size is too big for the layout, or when the avatar has less importance
 - Medium (40 × 40 px): use as the default size
 - Large (60 × 60 px): use when an avatar is a focal point, such as on a single customer card
@@ -80,8 +80,39 @@ Use to present an avatar for a merchant, customer, or business.
 
 ### Extra small avatar
 
+Use to present an avatar in a condensed layout, such as a data table cell or an action list item.
+
 ```jsx
-<Avatar name="Farrah Fawcett" size="extraSmall" />
+function ExtraSmallAvatarExample() {
+  const [active, setActive] = useState(true);
+  const toggleActive = useCallback(() => setActive((active) => !active), []);
+  const activator = (
+    <Button onClick={toggleActive} disclosure>
+      Manage staff
+    </Button>
+  );
+
+  return (
+    <div style={{height: '250px'}}>
+      <Popover active={active} activator={activator} onClose={toggleActive}>
+        <ActionList
+          items={[
+            {
+              content: 'Chet Baker',
+              prefix: <Avatar customer size="extraSmall" name="Chet Baker" />,
+            },
+            {
+              content: 'Farrah Fawcett',
+              prefix: (
+                <Avatar customer size="extraSmall" name="Farrah Fawcett" />
+              ),
+            },
+          ]}
+        />
+      </Popover>
+    </div>
+  );
+}
 ```
 
 ---


### PR DESCRIPTION
### WHY are these changes introduced?

I work in Vault Tools and recently with the launch of Debrief the need for a new Avatar sizing came up.
In  section Prototypes being reviewed in  (exhibit A) we use an Avatar size of 24px to condense the list and reduce whitespace.
<img width="444" alt="Screen Shot 2021-08-05 at 10 12 11 AM" src="https://user-images.githubusercontent.com/1693147/128733787-7da5b017-dfb5-4183-a374-44fa19840526.png">



The Avatar small size has the following result (exhibit B).
<img width="435" alt="Screen Shot 2021-08-05 at 10 16 38 AM" src="https://user-images.githubusercontent.com/1693147/128733804-aafafc54-8617-43ca-94c6-879b042f49de.png">

Our designer, @chrishs, has also envisioned smaller avatar for single line text components (exhibit C)

![128158697-1f8e8004-3015-48c9-8d91-44c53c76abb6](https://user-images.githubusercontent.com/1693147/128733815-43613196-3af5-4a84-8f28-09e8fb5c6913.png)


Opening this contribution to extend applications of Avatar


### WHAT is this pull request doing?

1. Adds a new css variable for the extrasmall size at 24px
2. Created the `.sizeExtraSmall` css class and added an extra min-width so it doesn't affect the base value for that attr (currently `$sizeSmall`)
3. Added `extraSmall` to Size prop

Sizes for comparrison
<img width="412" alt="Screen Shot 2021-08-09 at 11 54 36 AM" src="https://user-images.githubusercontent.com/1693147/128736718-e1eafcf7-35e9-4d16-8d40-73a934e6a6e0.png">


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
     <Page title="Playground">
      <Avatar size="extraSmall" initials="XS" />
      <Avatar size="small" initials="SM" />
      <Avatar initials="MD" />
      <Avatar size="large" initials="LG" />
    </Page>
  );
}
```

</details>


Additional question:
- While testing with `initials` I saw that the Avatar component does not do any sort of control on that prop. It is clearly designed to handle 2 letters, but if for some reason someone enters 3+ this starts happening:
<img width="149" alt="Screen Shot 2021-08-09 at 12 06 20 PM" src="https://user-images.githubusercontent.com/1693147/128747395-267d1f77-6def-4705-97d4-751a3b158ed1.png">


I wonder if we shouldn't have some extra check or control for that. Added a 2nd commit with a suggestion to always crop initials to the first and last in case more than 2 characters are present. It was an arbitrary choice, btw.

<img width="162" alt="Screen Shot 2021-08-09 at 1 21 48 PM" src="https://user-images.githubusercontent.com/1693147/128747504-7cfa0e6a-d135-42f8-82bd-f1ef141f10d4.png">



### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
