### PR TITLE
[Nav/Item] Delegate onClick prop to UnstyledLink for secondaryAction

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
+- Added optional `onClick` key to `secondaryAction` on `Nav/Item` component ([#4374](https://github.com/Shopify/polaris-react/pull/4374))
 - Added `id` prop to `Layout` and `Heading` for hash linking ([#4307](https://github.com/Shopify/polaris-react/pull/4307))
 - Added `external` prop to `Navigation.Item` component ([#4310](https://github.com/Shopify/polaris-react/pull/4310))
 - Added consistent spacing to `ActionList` ([#4355](https://github.com/Shopify/polaris-react/pull/4355))

--- a/src/components/Navigation/components/Item/Item.tsx
+++ b/src/components/Navigation/components/Item/Item.tsx
@@ -43,6 +43,7 @@ interface SecondaryAction {
   url: string;
   accessibilityLabel: string;
   icon: IconProps['source'];
+  onClick?(): void;
 }
 
 export interface ItemProps extends ItemURLDetails {
@@ -209,6 +210,7 @@ export function Item({
       tabIndex={tabIndex}
       aria-disabled={disabled}
       aria-label={secondaryAction.accessibilityLabel}
+      onClick={secondaryAction.onClick}
     >
       <Icon source={secondaryAction.icon} />
     </UnstyledLink>

--- a/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -147,6 +147,76 @@ describe('<Nav.Item />', () => {
     });
   });
 
+  describe('with secondaryAction', () => {
+    it('renders an external icon', () => {
+      const item = mountWithNavigationProvider(
+        <Item
+          label="some label"
+          url="foo"
+          secondaryAction={{
+            url: 'bar',
+            icon: PlusMinor,
+            accessibilityLabel: 'label',
+          }}
+        />,
+        {
+          location: 'bar',
+        },
+      );
+
+      expect(item).toContainReactComponent(Icon, {
+        source: PlusMinor,
+      });
+    });
+
+    it('renders an UnstyledLink with props delegated', () => {
+      const item = mountWithNavigationProvider(
+        <Item
+          label="some label"
+          url="foo"
+          secondaryAction={{
+            url: 'bar',
+            icon: PlusMinor,
+            accessibilityLabel: 'label',
+          }}
+        />,
+        {
+          location: 'bar',
+        },
+      );
+
+      expect(item).toContainReactComponent(UnstyledLink, {
+        url: 'bar',
+        'aria-label': 'label',
+      });
+    });
+
+    it('renders an UnstyledLink with onClick handler if provided', () => {
+      const handler = () => {};
+      const item = mountWithNavigationProvider(
+        <Item
+          label="some label"
+          url="foo"
+          secondaryAction={{
+            url: 'bar',
+            icon: PlusMinor,
+            onClick: handler,
+            accessibilityLabel: 'label',
+          }}
+        />,
+        {
+          location: 'bar',
+        },
+      );
+
+      expect(item).toContainReactComponent(UnstyledLink, {
+        url: 'bar',
+        'aria-label': 'label',
+        onClick: handler,
+      });
+    });
+  });
+
   describe('with SubNavigationItems', () => {
     it('renders expanded when given url is a perfect match for location', () => {
       const item = itemForLocation('/admin/orders');


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/core-workflows/issues/26, we would like to instrument events in the admin nav to start tracking all clicks. Currently, we can do that fairly easily except for the case of using a `secondaryAction` on a `Nav/Item` component. To my knowledge, this is only used for the "View Storefront" icon but we may add more secondary actions in the future.

This allows a click handler to be passed in and used from the parent `Item` component when specifying a secondary action icon.

### WHAT is this pull request doing?

Prop chains to `UnstyledLink` when create the secondary action components.

### How to 🎩

- Run this Polaris version in local web
- Modify [this object] to contain an `onClick` prop with a function that does something
- Load web and click on the View Storefront icon. Notice the click handler executed

Please let me know if there's a better way to tophat this as I don't normally work in react :).
Also, the current documentation for `Item` does not specify prop requirements for `secondaryAction` so I didn't modify the docs to include this -- should this be updated?

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- ~~[ ] Updated the component's `README.md` with documentation changes~~
- ~~[ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide~~
- ~~[ ] For visual design changes, ping @ sarahill to update the Polaris UI kit~~

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
