### PR TITLE
[Documentation] Update incorrect url for Playground tophatting inside iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To test the changes on a mobile or virtual machine, you will need to open the so
 
 1.  Run `yarn dev`
 1.  Make sure your virtual machine and mobile device are on the same network
-1.  Open http://YOUR_IP_ADDRESS:ASSIGNED_PORT/iframe.html?selectedKind=Playground&selectedStory=Playground in your mobile device or virtual machine
+1.  Open http://YOUR_IP_ADDRESS:ASSIGNED_PORT/iframe.html?path=/story/playground-playground--playground in your mobile device or virtual machine
 
 ### Testing in a consuming project
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes: https://github.com/Shopify/polaris-react/issues/4391

In the current project README.md the instructions contain a link to tophat the Playground in an isolated environment at the url: `http://YOUR_IP_ADDRESS:ASSIGNED_PORT/iframe.html?selectedKind=Playground&selectedStory=Playground`. This link brings up an error dialogue.

### WHAT is this pull request doing?

This updates the documentation to use the `path` param [as suggested by Storybook](https://github.com/storybookjs/storybook/blob/b00cb054dfd4972296e85d1b798b7ad5a04fbea5/MIGRATION.md#deprecated-layout-url-params).

To 🎩 :

1. Open up `Playground.tsx` and paste the following in:

```jsx
import React from 'react';

import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <span role="img" aria-label="Hand wave emoji">
        👋
      </span>
    </Page>
  );
}

```

2. Run `yarn dev`
3. Visit `http://YOUR_IP_ADDRESS:ASSIGNED_PORT/iframe.html?selectedKind=Playground&selectedStory=Playground`
4. This should return an error dialogue
5. Visit `http://YOUR_IP_ADDRESS:ASSIGNED_PORT/iframe.html?path=/story/playground-playground--playground`
6. You should see the contents of the Playground on the page 