### PR TITLE
[ProgressBar] Add critical color prop option

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Add `lastColumnSticky` prop to `IndexTable` to create a sticky last cell and optional sticky last heading on viewports larger than small ([#4150](https://github.com/Shopify/polaris-react/pull/4150))
 - Allow promoted actions to be rendered as a menu on the `BulkAction` component ([#4266](https://github.com/Shopify/polaris-react/pull/4266))
 - Add `extraSmall` prop to `Avatar` ([#4371](https://github.com/Shopify/polaris-react/pull/4371))
+- Add `critical` color option to `ProgressBar` component ([#4408](https://github.com/Shopify/polaris-react/pull/4408))
 
 ### Bug fixes
 

--- a/src/components/ProgressBar/ProgressBar.scss
+++ b/src/components/ProgressBar/ProgressBar.scss
@@ -55,6 +55,11 @@
   --p-progressbar-indicator: var(--p-border-success);
 }
 
+.colorCritical {
+  --p-progressbar-background: var(--p-surface-neutral);
+  --p-progressbar-indicator: var(--p-interactive-critical);
+}
+
 .Indicator {
   height: inherit;
   width: 0;

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -6,7 +6,7 @@ import {useI18n} from '../../utilities/i18n';
 import styles from './ProgressBar.scss';
 
 type Size = 'small' | 'medium' | 'large';
-type Color = 'highlight' | 'primary' | 'success';
+type Color = 'highlight' | 'primary' | 'success' | 'critical';
 
 export interface ProgressBarProps {
   /**


### PR DESCRIPTION
### WHY are these changes introduced?

Within web we have a use case where a full progress bar is indicative of a critical event that requires immediate action:

<img width="438" alt="Screen Shot 2021-08-18 at 9 35 34 AM" src="https://user-images.githubusercontent.com/9326713/129937151-9581c6f2-92b5-49da-9f54-ac4b54db0a7e.png">

### WHAT is this pull request doing?

This PR adds the `Interactive/Critical` color to the `ProgressBar` component

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <ProgressBar progress={70} color="critical" />
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
