### PR TITLE
[Test Modernization] Switch to using mountWithApp on ColorPicker tests.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -63,5 +63,6 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Modernized tests for Scrollable, ScrollTo, ScrollLock, Select, SettingToggle, Sheet, Spinner, and Sticky components([#4386](https://github.com/Shopify/polaris-react/pull/4386))
 - Modernized tests for Message, Menu, Search, SearchDismissOverlay, SearchField, UserMenu and TopBar components. ([#4311](https://github.com/Shopify/polaris-react/pull/4311))
 - Modernized tests for MediaCard, and Layout components ([#4393](https://github.com/Shopify/polaris-react/pull/4393))
+- Modernized tests for ColorPicker component ([#4413](https://github.com/Shopify/polaris-react/pull/4413))
 
 ### Deprecations

--- a/src/components/ColorPicker/tests/ColorPicker-ssr.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker-ssr.test.tsx
@@ -22,7 +22,7 @@ describe('<ColorPicker /> Server-side only', () => {
       <ColorPicker color={red} onChange={noop} />,
     );
 
-    colorPicker!.find(Slidable)!.find('div')!.trigger('onMouseDown', {
+    colorPicker.find(Slidable)!.find('div')!.trigger('onMouseDown', {
       type: 'mousedown',
       clientX: 1,
       clientY: 1,

--- a/src/components/ColorPicker/tests/ColorPicker-ssr.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker-ssr.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {Slidable} from '../components';
 import {ColorPicker} from '../ColorPicker';
@@ -19,11 +18,15 @@ jest.mock('../../../utilities/target', () => ({
 
 describe('<ColorPicker /> Server-side only', () => {
   it('does not attach the touchmove handler to the window', () => {
-    const colorPicker = mountWithAppProvider(
+    const colorPicker = mountWithApp(
       <ColorPicker color={red} onChange={noop} />,
     );
 
-    colorPicker.find(Slidable).first().simulate('mousedown');
+    colorPicker!.find(Slidable)!.find('div')!.trigger('onMouseDown', {
+      type: 'mousedown',
+      clientX: 1,
+      clientY: 1,
+    });
 
     const touch = {clientX: 0, clientY: 0};
     const event = new TouchEvent('touchmove', {

--- a/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -26,9 +26,10 @@ describe('<ColorPicker />', () => {
           <ColorPicker color={red} onChange={spy} />,
         );
 
-        colorPicker
-          .findAll(Slidable)
-          [SlidableType.Color].trigger('onChange', {x: 1, y: 1});
+        colorPicker.findAll(Slidable)[SlidableType.Color].trigger('onChange', {
+          x: 1,
+          y: 1,
+        });
 
         expect(spy).toHaveBeenCalled();
       });
@@ -51,9 +52,10 @@ describe('<ColorPicker />', () => {
           <ColorPicker color={red} onChange={spy} />,
         );
 
-        colorPicker
-          .findAll(Slidable)
-          [SlidableType.Hue].trigger('onChange', {x: 1, y: 1});
+        colorPicker.findAll(Slidable)[SlidableType.Hue].trigger('onChange', {
+          x: 1,
+          y: 1,
+        });
 
         expect(spy).toHaveBeenCalled();
       });
@@ -76,9 +78,10 @@ describe('<ColorPicker />', () => {
           <ColorPicker color={red} onChange={spy} allowAlpha />,
         );
 
-        colorPicker
-          .findAll(Slidable)
-          [SlidableType.Alpha].trigger('onChange', {x: 1, y: 1});
+        colorPicker.findAll(Slidable)[SlidableType.Alpha].trigger('onChange', {
+          x: 1,
+          y: 1,
+        });
 
         expect(spy).toHaveBeenCalled();
       });

--- a/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {EventListener} from '../../EventListener';
 import {Slidable, AlphaPicker} from '../components';
@@ -13,26 +12,30 @@ const red = {
 };
 
 enum SlidableType {
-  BrightnessSaturation,
+  Color,
   Hue,
+  Alpha,
 }
 
 describe('<ColorPicker />', () => {
-  describe('Saturation/ Brightness pane', () => {
+  describe('Color slider (big square/rectangle)', () => {
     describe('onChange', () => {
-      it('is called when the user mouse downs', () => {
+      it("is called when Slidable's onChange is triggered", () => {
         const spy = jest.fn();
-        mountWithAppProvider(<ColorPicker color={red} onChange={spy} />)
-          .find(Slidable)
-          .at(SlidableType.BrightnessSaturation)
-          .simulate('mousedown');
+        const colorPicker = mountWithApp(
+          <ColorPicker color={red} onChange={spy} />,
+        );
+
+        colorPicker
+          .findAll(Slidable)
+          [SlidableType.Color].trigger('onChange', {x: 1, y: 1});
 
         expect(spy).toHaveBeenCalled();
       });
 
       it('is not called on mousemove when not dragging', () => {
         const spy = jest.fn();
-        mountWithAppProvider(<ColorPicker color={red} onChange={spy} />);
+        mountWithApp(<ColorPicker color={red} onChange={spy} />);
 
         window.dispatchEvent(new Event('mousemove'));
         expect(spy).not.toHaveBeenCalled();
@@ -42,19 +45,47 @@ describe('<ColorPicker />', () => {
 
   describe('Hue slider', () => {
     describe('onChange', () => {
-      it('is called when the user mouse downs', () => {
+      it("is called when Slidable's onChange is triggered", () => {
         const spy = jest.fn();
-        mountWithAppProvider(<ColorPicker color={red} onChange={spy} />)
-          .find(Slidable)
-          .at(SlidableType.Hue)
-          .simulate('mousedown');
+        const colorPicker = mountWithApp(
+          <ColorPicker color={red} onChange={spy} />,
+        );
+
+        colorPicker
+          .findAll(Slidable)
+          [SlidableType.Hue].trigger('onChange', {x: 1, y: 1});
 
         expect(spy).toHaveBeenCalled();
       });
 
       it('is not called on mousemove when not dragging', () => {
         const spy = jest.fn();
-        mountWithAppProvider(<ColorPicker color={red} onChange={spy} />);
+        mountWithApp(<ColorPicker color={red} onChange={spy} />);
+
+        window.dispatchEvent(new Event('mousemove'));
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Alpha slider', () => {
+    describe('onChange', () => {
+      it("is called when Slidable's onChange is triggered", () => {
+        const spy = jest.fn();
+        const colorPicker = mountWithApp(
+          <ColorPicker color={red} onChange={spy} allowAlpha />,
+        );
+
+        colorPicker
+          .findAll(Slidable)
+          [SlidableType.Alpha].trigger('onChange', {x: 1, y: 1});
+
+        expect(spy).toHaveBeenCalled();
+      });
+
+      it('is not called on mousemove when not dragging', () => {
+        const spy = jest.fn();
+        mountWithApp(<ColorPicker color={red} onChange={spy} allowAlpha />);
 
         window.dispatchEvent(new Event('mousemove'));
         expect(spy).not.toHaveBeenCalled();
@@ -65,22 +96,21 @@ describe('<ColorPicker />', () => {
   describe('id', () => {
     it('is passed down to the first child', () => {
       const id = 'MyID';
-      const colorPicker = mountWithAppProvider(
+      const colorPicker = mountWithApp(
         <ColorPicker id={id} color={red} onChange={jest.fn()} />,
       );
-
-      expect(colorPicker.childAt(0).prop('id')).toBe(id);
+      expect(colorPicker.children[0]).toHaveReactProps({id});
     });
   });
 
   describe('color', () => {
     it('is passed down to AlphaPicker if allowAlpha is true', () => {
       const id = 'MyID';
-      const colorPicker = mountWithAppProvider(
+      const colorPicker = mountWithApp(
         <ColorPicker id={id} color={red} onChange={jest.fn()} allowAlpha />,
       );
 
-      expect(colorPicker.find(AlphaPicker).prop('color')).toStrictEqual(red);
+      expect(colorPicker).toContainReactComponent(AlphaPicker, {color: red});
     });
   });
 
@@ -91,46 +121,50 @@ describe('<ColorPicker />', () => {
 
     it('passes false to passive prop for "mousemove" EventListener when dragging', () => {
       const onChangeSpy = jest.fn();
-      const colorPicker = mountWithAppProvider(
+      const colorPicker = mountWithApp(
         <ColorPicker color={red} onChange={onChangeSpy} />,
       );
 
-      colorPicker
-        .find(Slidable)
-        .at(SlidableType.BrightnessSaturation)
-        .simulate('mousedown');
+      colorPicker!.find(Slidable)!.find('div')!.trigger('onMouseDown', {
+        type: 'mousedown',
+        clientX: 1,
+        clientY: 1,
+      });
 
-      const mouseMoveListener = colorPicker
-        .find(EventListener)
-        .filterWhere((listener) => listener.prop('event') === 'mousemove');
-
-      expect(mouseMoveListener.prop('passive')).toBe(false);
+      expect(colorPicker).toContainReactComponent(EventListener, {
+        event: 'mousemove',
+        passive: false,
+      });
     });
 
     it('passes false to passive prop for "touchmove" EventListener when dragging', () => {
       const onChangeSpy = jest.fn();
-      const colorPicker = mountWithAppProvider(
+      const colorPicker = mountWithApp(
         <ColorPicker color={red} onChange={onChangeSpy} />,
       );
 
-      colorPicker
-        .find(Slidable)
-        .at(SlidableType.BrightnessSaturation)
-        .simulate('mousedown');
+      colorPicker!.find(Slidable)!.find('div')!.trigger('onMouseDown', {
+        type: 'mousedown',
+        clientX: 1,
+        clientY: 1,
+      });
 
-      const touchMoveListener = colorPicker
-        .find(EventListener)
-        .filterWhere((listener) => listener.prop('event') === 'touchmove');
-
-      expect(touchMoveListener.prop('passive')).toBe(false);
+      expect(colorPicker).toContainReactComponent(EventListener, {
+        event: 'touchmove',
+        passive: false,
+      });
     });
 
     it('prevents default for touchmove events if dragging the slider', () => {
-      const colorPicker = mountWithAppProvider(
+      const colorPicker = mountWithApp(
         <ColorPicker color={red} onChange={noop} />,
       );
 
-      colorPicker.find(Slidable).first().simulate('mousedown');
+      colorPicker!.find(Slidable)!.find('div')!.trigger('onMouseDown', {
+        type: 'mousedown',
+        clientX: 1,
+        clientY: 1,
+      });
 
       const touch = {clientX: 0, clientY: 0};
       const event = new TouchEvent('touchmove', {

--- a/src/components/ColorPicker/tests/ColorPicker.test.tsx
+++ b/src/components/ColorPicker/tests/ColorPicker.test.tsx
@@ -11,12 +11,6 @@ const red = {
   brightness: 1,
 };
 
-enum SlidableType {
-  Color,
-  Hue,
-  Alpha,
-}
-
 describe('<ColorPicker />', () => {
   describe('Color slider (big square/rectangle)', () => {
     describe('onChange', () => {
@@ -26,10 +20,7 @@ describe('<ColorPicker />', () => {
           <ColorPicker color={red} onChange={spy} />,
         );
 
-        colorPicker.findAll(Slidable)[SlidableType.Color].trigger('onChange', {
-          x: 1,
-          y: 1,
-        });
+        colorPicker.findAll(Slidable)[0].trigger('onChange', {x: 1, y: 1});
 
         expect(spy).toHaveBeenCalled();
       });
@@ -52,10 +43,7 @@ describe('<ColorPicker />', () => {
           <ColorPicker color={red} onChange={spy} />,
         );
 
-        colorPicker.findAll(Slidable)[SlidableType.Hue].trigger('onChange', {
-          x: 1,
-          y: 1,
-        });
+        colorPicker.findAll(Slidable)[1].trigger('onChange', {x: 1, y: 1});
 
         expect(spy).toHaveBeenCalled();
       });
@@ -78,10 +66,7 @@ describe('<ColorPicker />', () => {
           <ColorPicker color={red} onChange={spy} allowAlpha />,
         );
 
-        colorPicker.findAll(Slidable)[SlidableType.Alpha].trigger('onChange', {
-          x: 1,
-          y: 1,
-        });
+        colorPicker.findAll(Slidable)[2].trigger('onChange', {x: 1, y: 1});
 
         expect(spy).toHaveBeenCalled();
       });
@@ -128,7 +113,7 @@ describe('<ColorPicker />', () => {
         <ColorPicker color={red} onChange={onChangeSpy} />,
       );
 
-      colorPicker!.find(Slidable)!.find('div')!.trigger('onMouseDown', {
+      colorPicker.find(Slidable)!.find('div')!.trigger('onMouseDown', {
         type: 'mousedown',
         clientX: 1,
         clientY: 1,
@@ -146,7 +131,7 @@ describe('<ColorPicker />', () => {
         <ColorPicker color={red} onChange={onChangeSpy} />,
       );
 
-      colorPicker!.find(Slidable)!.find('div')!.trigger('onMouseDown', {
+      colorPicker.find(Slidable)!.find('div')!.trigger('onMouseDown', {
         type: 'mousedown',
         clientX: 1,
         clientY: 1,
@@ -163,7 +148,7 @@ describe('<ColorPicker />', () => {
         <ColorPicker color={red} onChange={noop} />,
       );
 
-      colorPicker!.find(Slidable)!.find('div')!.trigger('onMouseDown', {
+      colorPicker.find(Slidable)!.find('div')!.trigger('onMouseDown', {
         type: 'mousedown',
         clientX: 1,
         clientY: 1,


### PR DESCRIPTION
### WHY are these changes introduced?

Modernizes tests to use the new modern framework (`{mountWithApp}` from `test-utilities`).

### WHAT is this pull request doing?

Updates tests using `{mountWithAppProvider}` from `test-utilities/legacy` to use `{mountWithApp}` from `test-utilities`