### PR TITLE
Remove the esnext folder

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -10,6 +10,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Made `autoComplete` prop in `TextField` a required string ([#4267](https://github.com/Shopify/polaris-react/pull/4267)). If you do not want the browser to autofill a user's information (for example an email input which is a customer's email, but not the email of the user who is entering the information), we recommend setting `autoComplete` to `"off"`.
 - `Autocomplete` now requires `Autocomplete.TextField` to be used ([#3910](https://github.com/Shopify/polaris-react/pull/3910))
 - Removed ComboBox as a named export on `Autocomplete` ([#3910](https://github.com/Shopify/polaris-react/pull/3910))
+- Remove the `esnext` folder from the package. If you use Polaris in an app built with sewing-kit, it must use at least sewing-kit 0.152.0 to leverage esnext builds. ([#4425](https://github.com/Shopify/polaris-react/pull/4425))
 
 ### Enhancements
 

--- a/esnext/index.js
+++ b/esnext/index.js
@@ -1,7 +1,0 @@
-// Our esnext build lives in dist/esnext.
-// However currently sewing-kit expects the esnext's entrypoint to be this file
-// thanks to a hardcoded alias:
-// https://github.com/Shopify/sewing-kit/blob/9911ec817ebd21384f549187a481f6b624cf7182/packages/sewing-kit/src/tools/webpack/config/resolve.ts#L45-L50.
-// Once that alias is removed then sewing-kit will use the `esnext`
-// key in our package.json as the entrypoint and this file can be removed.
-export * from '../dist/esnext/index.ts.esnext';

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "files": [
     "dist",
-    "esnext",
     "locales",
     "!*.tsbuildinfo"
   ],


### PR DESCRIPTION
### WHY are these changes introduced?

Removing legacy configuration.

### WHAT is this pull request doing?

Removing the esnext folder.

The esnext folder was a relic from a time before sewing-kit supported reading
esnext entrypoints from the `esnext` key in package.json, which was
added in sewing-kit 0.135.0 (released Aug 2020).

The configuration that forced sewing-kit to always read from this folder (instead of looking at the esnext entrypoint) was removed in Shopify/sewing-kit#2566 and released as sewing-kit 0.152.0 (released Mar 2021).

If you are building an app using sewing-kit, you must use sewing-kit 0.152.0 or newer if you want esnext build support.

