### PR TITLE
use setup-node's built-in caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '10.24.0'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
 
       - run: yarn --frozen-lockfile
       - run: yarn run type-check && yarn run build
@@ -40,18 +29,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '10.24.0'
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
 
       - run: yarn --frozen-lockfile
       - run: yarn run storybook:build --quiet


### PR DESCRIPTION
### WHY are these changes introduced?

A few weeks ago setup-node gained the ability to handle caching of node_modules content on its own instead of requiring users to do it by configuring the cache. See https://github.com/actions/setup-node#caching-packages-dependencies

Let's use that instead to make our CI configuration simpler.

### WHAT is this pull request doing?

Replace actions/cache with using actions/setup-node's `cache` option