### PR TITLE
[TestModernization]: Add test modernization to Collapsible, Tabs and TextStyle

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -65,7 +65,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Modernized tests for Message, Menu, Search, SearchDismissOverlay, SearchField, UserMenu and TopBar components. ([#4311](https://github.com/Shopify/polaris-react/pull/4311))
 - Modernized test for UnstyledLink, Tag, DisplayText, FileUpload, MessageIndicator, Choice and Dialog ([#4407](https://github.com/Shopify/polaris-react/pull/4407)).
 - Modernized tests for Konami, Labelled, and Link components([#4389](https://github.com/Shopify/polaris-react/pull/4389))
-- Modernized tests for TextStyle, Collapsible, Tabs ([]())
+- Modernized tests for TextStyle, Collapsible, Tabs ([#4453](https://github.com/Shopify/polaris-react/pull/4453))
 - Modernized tests for Scrollable, ScrollTo, ScrollLock, Select, SettingToggle, Sheet, Spinner, and Sticky components([#4386](https://github.com/Shopify/polaris-react/pull/4386))
 - Modernized tests for Message, Menu, Search, SearchDismissOverlay, SearchField, UserMenu and TopBar components. ([#4311](https://github.com/Shopify/polaris-react/pull/4311))
 - Modernized tests for MediaCard, and Layout components ([#4393](https://github.com/Shopify/polaris-react/pull/4393))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -63,7 +63,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Modernized tests for SkeletonBodyTest, SkeletonDisplayTest, SkeletonPage, SkeletonThumbnail, and Spinner components ([#4353](https://github.com/Shopify/polaris-react/pull/4353))
 - Modernized tests for CalloutCard, Caption, CheckableButton, Resizer, VideoThumbnail ([#4387](https://github.com/Shopify/polaris-react/pull/4387))
 - Modernized tests for Message, Menu, Search, SearchDismissOverlay, SearchField, UserMenu and TopBar components. ([#4311](https://github.com/Shopify/polaris-react/pull/4311))
-- Modernized test for UnstyledLink, Tag, DisplayText, FileUpload, MessageIndicator, Choice and Dialog ([#4407](https://github.com/Shopify/polaris-react/pull/4407)).
+- Modernized tests for UnstyledLink, Tag, DisplayText, FileUpload, MessageIndicator, Choice and Dialog ([#4407](https://github.com/Shopify/polaris-react/pull/4407)).
 - Modernized tests for Konami, Labelled, and Link components([#4389](https://github.com/Shopify/polaris-react/pull/4389))
 - Modernized tests for TextStyle, Collapsible, Tabs ([#4453](https://github.com/Shopify/polaris-react/pull/4453))
 - Modernized tests for Scrollable, ScrollTo, ScrollLock, Select, SettingToggle, Sheet, Spinner, and Sticky components([#4386](https://github.com/Shopify/polaris-react/pull/4386))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -65,6 +65,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Modernized tests for Message, Menu, Search, SearchDismissOverlay, SearchField, UserMenu and TopBar components. ([#4311](https://github.com/Shopify/polaris-react/pull/4311))
 - Modernized test for UnstyledLink, Tag, DisplayText, FileUpload, MessageIndicator, Choice and Dialog ([#4407](https://github.com/Shopify/polaris-react/pull/4407)).
 - Modernized tests for Konami, Labelled, and Link components([#4389](https://github.com/Shopify/polaris-react/pull/4389))
+- Modernized tests for TextStyle, Collapsible, Tabs ([]())
 - Modernized tests for Scrollable, ScrollTo, ScrollLock, Select, SettingToggle, Sheet, Spinner, and Sticky components([#4386](https://github.com/Shopify/polaris-react/pull/4386))
 - Modernized tests for Message, Menu, Search, SearchDismissOverlay, SearchField, UserMenu and TopBar components. ([#4311](https://github.com/Shopify/polaris-react/pull/4311))
 - Modernized tests for MediaCard, and Layout components ([#4393](https://github.com/Shopify/polaris-react/pull/4393))

--- a/src/components/Collapsible/tests/Collapsible.test.tsx
+++ b/src/components/Collapsible/tests/Collapsible.test.tsx
@@ -28,9 +28,7 @@ describe('<Collapsible />', () => {
       'aria-expanded': false,
     });
 
-    expect(collapsible).toContainReactComponent('div', {
-      children: expect.stringContaining('content'),
-    });
+    expect(collapsible).toContainReactText('content');
   });
 
   it('does not render its children when closed', () => {

--- a/src/components/Collapsible/tests/Collapsible.test.tsx
+++ b/src/components/Collapsible/tests/Collapsible.test.tsx
@@ -1,80 +1,87 @@
 import React, {useState, useCallback} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 import {Tokens} from 'utilities/theme';
 
 import {Collapsible, CollapsibleProps} from '../Collapsible';
 
 describe('<Collapsible />', () => {
-  const ariaExpandedSelector = '[aria-expanded=false]';
-
   it('does not render its children and indicates hidden with aria-hidden', () => {
-    const collapsible = mountWithAppProvider(
+    const collapsible = mountWithApp(
       <Collapsible id="test-collapsible" open={false}>
         content
       </Collapsible>,
     );
 
-    const hidden = collapsible.find(ariaExpandedSelector);
-    expect(hidden.exists()).toBe(true);
+    expect(collapsible).toContainReactComponent('div', {
+      'aria-expanded': false,
+    });
   });
 
   it('renders its children and does not render aria-hidden when open', () => {
-    const collapsible = mountWithAppProvider(
+    const collapsible = mountWithApp(
       <Collapsible id="test-collapsible" open>
         content
       </Collapsible>,
     );
 
-    const hidden = collapsible.find(ariaExpandedSelector);
-    expect(hidden.exists()).toBe(false);
-    expect(collapsible.contains('content')).toBe(true);
+    expect(collapsible).not.toContainReactComponent('div', {
+      'aria-expanded': false,
+    });
+
+    expect(collapsible).toContainReactComponent('div', {
+      children: expect.stringContaining('content'),
+    });
   });
 
   it('does not render its children when closed', () => {
-    const collapsible = mountWithAppProvider(
+    const collapsible = mountWithApp(
       <Collapsible id="test-collapsible" open={false}>
         content
       </Collapsible>,
     );
 
-    expect(collapsible.contains('content')).toBe(false);
+    expect(collapsible).not.toContainReactComponent('div', {
+      children: expect.stringContaining('content'),
+    });
   });
 
   it('renders its children when expandOnPrint is true and open is false', () => {
-    const collapsible = mountWithAppProvider(
+    const collapsible = mountWithApp(
       <Collapsible id="test-collapsible" open={false} expandOnPrint>
         content
       </Collapsible>,
     );
 
-    expect(collapsible.contains('content')).toBe(true);
+    expect(collapsible).toContainReactComponent('div', {
+      children: expect.stringContaining('content'),
+    });
   });
 
   it('renders its children when expandOnPrint is true and open is true', () => {
-    const collapsible = mountWithAppProvider(
+    const collapsible = mountWithApp(
       <Collapsible id="test-collapsible" open expandOnPrint>
         content
       </Collapsible>,
     );
 
-    expect(collapsible.contains('content')).toBe(true);
+    expect(collapsible).toContainReactComponent('div', {
+      children: expect.stringContaining('content'),
+    });
   });
 
   describe('Transition', () => {
     it('passes a duration property', () => {
       const duration = Tokens.duration150;
-      const collapsible = mountWithAppProvider(
+      const collapsible = mountWithApp(
         <Collapsible id="test-collapsible" open transition={{duration}} />,
       );
 
-      expect(collapsible.props()).toMatchObject({transition: {duration}});
+      expect(collapsible).toHaveReactProps({transition: {duration}});
     });
 
     it('passes a timingFunction property', () => {
       const timingFunction = Tokens.ease;
-      const collapsible = mountWithAppProvider(
+      const collapsible = mountWithApp(
         <Collapsible
           id="test-collapsible"
           open
@@ -82,7 +89,7 @@ describe('<Collapsible />', () => {
         />,
       );
 
-      expect(collapsible.props()).toMatchObject({transition: {timingFunction}});
+      expect(collapsible).toHaveReactProps({transition: {timingFunction}});
     });
   });
 

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -261,7 +261,6 @@ describe('<Tabs />', () => {
       const selectedTab = wrapper.find('ul')!.findAll(Tab)[0];
       const panel = wrapper.findAll(Panel)[0];
 
-      expect(panel).not.toBeNull();
       expect(panel).toContainReactComponent('p', {children: 'Tab content'});
       expect(panel).toHaveReactProps({id: selectedTab.prop('panelID')});
     });
@@ -438,8 +437,6 @@ describe('<Tabs />', () => {
 
         const popover = tabs.find(Popover)!;
         const disclosureActivator = popover.find('button')!;
-
-        disclosureActivator.domNode!.click;
 
         disclosureActivator.trigger('onClick');
 

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -126,7 +126,7 @@ describe('<Tabs />', () => {
       const wrapper = mountWithApp(<Tabs {...mockProps}>{content}</Tabs>);
 
       tabs.forEach((_, index) => {
-        const panelID = wrapper.find('ul')?.findAll(Tab)[index].prop('panelID');
+        const panelID = wrapper.find('ul')!.findAll(Tab)[index].prop('panelID');
         expect(typeof panelID).toBe('string');
         expect(panelID).not.toBe('');
       });

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -419,9 +419,7 @@ describe('<Tabs />', () => {
           disclosureWidth: 0,
         });
 
-        tabs.find(Popover)!.find('button')!.trigger('onClick', {
-          key: Key.Enter,
-        });
+        tabs.find(Popover)!.find('button')!.trigger('onClick');
 
         tabs.find('ul')!.trigger('onKeyUp', {
           key: 'ArrowRight',

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {mountWithApp} from 'test-utilities';
 
-import {Key} from '../../../types';
 import {Tab, Panel, TabMeasurer} from '../components';
 import {Tabs, TabsProps} from '../Tabs';
 import {getVisibleAndHiddenTabIndices} from '../utilities';

--- a/src/components/Tabs/tests/Tabs.test.tsx
+++ b/src/components/Tabs/tests/Tabs.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider, trigger} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 
+import {Key} from '../../../types';
 import {Tab, Panel, TabMeasurer} from '../components';
 import {Tabs, TabsProps} from '../Tabs';
 import {getVisibleAndHiddenTabIndices} from '../utilities';
@@ -95,10 +94,12 @@ describe('<Tabs />', () => {
         {content: 'Tab 1', id: 'tab-1'},
         {content: 'Tab 2', id: 'tab-2'},
       ];
-      const wrapper = mountWithAppProvider(<Tabs {...mockProps} tabs={tabs} />);
+      const wrapper = mountWithApp(<Tabs {...mockProps} tabs={tabs} />);
 
-      tabs.forEach((tab, index) => {
-        expect(wrapper.find('ul').find(Tab).at(index).prop('id')).toBe(tab.id);
+      tabs.forEach((tab) => {
+        expect(wrapper.find('ul')!).toContainReactComponent(Tab, {
+          id: tab.id,
+        });
       });
     });
 
@@ -108,38 +109,37 @@ describe('<Tabs />', () => {
         {...tabs[1], panelID: 'panel-2'},
       ];
       const content = <p>Panel contents</p>;
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <Tabs {...mockProps} tabs={panelIDedTabs}>
           {content}
         </Tabs>,
       );
 
-      panelIDedTabs.forEach((tab, index) => {
-        expect(wrapper.find('ul').find(Tab).at(index).prop('panelID')).toBe(
-          tab.panelID,
-        );
+      panelIDedTabs.forEach((tab) => {
+        expect(wrapper.find('ul')!).toContainReactComponent(Tab, {
+          panelID: tab.panelID,
+        });
       });
     });
 
     it('uses an auto-generated panelID if none is provided', () => {
       const content = <p>Panel contents</p>;
-      const wrapper = mountWithAppProvider(
-        <Tabs {...mockProps}>{content}</Tabs>,
-      );
+      const wrapper = mountWithApp(<Tabs {...mockProps}>{content}</Tabs>);
 
       tabs.forEach((_, index) => {
-        const panelID = wrapper.find('ul').find(Tab).at(index).prop('panelID');
+        const panelID = wrapper.find('ul')?.findAll(Tab)[index].prop('panelID');
         expect(typeof panelID).toBe('string');
         expect(panelID).not.toBe('');
       });
     });
 
     it('sets the panelID to undefined when the tab does not have an associated panel (child)', () => {
-      const wrapper = mountWithAppProvider(<Tabs {...mockProps} />);
+      const wrapper = mountWithApp(<Tabs {...mockProps} />);
 
       tabs.forEach((_, index) => {
-        const panelID = wrapper.find('ul').find(Tab).at(index).prop('panelID');
-        expect(panelID).toBeUndefined();
+        expect(wrapper.find('ul')!.findAll(Tab)[index]).toHaveReactProps({
+          panelID: undefined,
+        });
       });
     });
 
@@ -148,14 +148,12 @@ describe('<Tabs />', () => {
         {...tabs[0], url: 'https://shopify.com'},
         {...tabs[1], url: 'https://google.com'},
       ];
-      const wrapper = mountWithAppProvider(
-        <Tabs {...mockProps} tabs={urlTabs} />,
-      );
+      const wrapper = mountWithApp(<Tabs {...mockProps} tabs={urlTabs} />);
 
       urlTabs.forEach((tab, index) => {
-        expect(
-          wrapper.find('ul').find(Tab).at(index).prop('url'),
-        ).toStrictEqual(tab.url);
+        expect(wrapper.find('ul')!.findAll(Tab)[index]).toHaveReactProps({
+          url: tab.url,
+        });
       });
     });
 
@@ -164,14 +162,12 @@ describe('<Tabs />', () => {
         {...tabs[0], accessibilityLabel: 'Tab 1'},
         {...tabs[1], accessibilityLabel: 'Tab 2'},
       ];
-      const wrapper = mountWithAppProvider(
-        <Tabs {...mockProps} tabs={labelledTabs} />,
-      );
+      const wrapper = mountWithApp(<Tabs {...mockProps} tabs={labelledTabs} />);
 
       labelledTabs.forEach((tab, index) => {
-        expect(
-          wrapper.find('ul').find(Tab).at(index).prop('accessibilityLabel'),
-        ).toStrictEqual(tab.accessibilityLabel);
+        expect(wrapper.find('ul')!.findAll(Tab)[index]).toHaveReactProps({
+          accessibilityLabel: tab.accessibilityLabel,
+        });
       });
     });
 
@@ -180,14 +176,14 @@ describe('<Tabs />', () => {
         {content: 'Tab 1', id: 'tab-1'},
         {content: 'Tab 2', id: 'tab-2'},
       ];
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <Tabs {...mockProps} tabs={tabsWithContent} />,
       );
 
       tabsWithContent.forEach((tab, index) => {
-        expect(
-          wrapper.find('ul').find(Tab).at(index).prop('children'),
-        ).toStrictEqual(tab.content);
+        expect(wrapper.find('ul')!.findAll(Tab)[index]).toHaveReactProps({
+          children: tab!.content,
+        });
       });
     });
 
@@ -203,14 +199,14 @@ describe('<Tabs />', () => {
           id: 'tab-2',
         },
       ];
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <Tabs {...mockProps} tabs={tabsWithContent} />,
       );
 
       tabsWithContent.forEach((tab, index) => {
-        expect(
-          wrapper.find('ul').find(Tab).at(index).prop('children'),
-        ).toStrictEqual(tab.content);
+        expect(wrapper.find('ul')!.findAll(Tab)[index]).toHaveReactProps({
+          children: tab.content,
+        });
       });
     });
   });
@@ -235,7 +231,7 @@ describe('<Tabs />', () => {
         {...tabs[1], panelID: 'panel-2'},
       ];
 
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <Tabs {...mockProps} tabs={panelIDedTabs}>
           Panel contents
         </Tabs>,
@@ -248,35 +244,27 @@ describe('<Tabs />', () => {
   describe('panel', () => {
     it('renders a Panel for each of the Tabs', () => {
       const content = <p>Tab content</p>;
-      const wrapper = mountWithAppProvider(
-        <Tabs {...mockProps}>{content}</Tabs>,
-      );
-      const panel = wrapper.find(Panel);
-      expect(panel).toHaveLength(2);
+      const wrapper = mountWithApp(<Tabs {...mockProps}>{content}</Tabs>);
+      expect(wrapper).toContainReactComponentTimes(Panel, 2);
     });
 
     it('renders a Panel with a hidden prop for the non selected tabs', () => {
       const content = <p>Tab content</p>;
-      const wrapper = mountWithAppProvider(
-        <Tabs {...mockProps}>{content}</Tabs>,
-      );
+      const wrapper = mountWithApp(<Tabs {...mockProps}>{content}</Tabs>);
 
-      const nonSelectedPanel = wrapper.find(Panel).at(1);
-      expect(nonSelectedPanel.prop('hidden')).toBe(true);
+      expect(wrapper.findAll(Panel)[1]).toHaveReactProps({hidden: true});
     });
 
     it('wraps the children in a Panel with matching aria attributes to the tab', () => {
       const content = <p>Tab content</p>;
-      const wrapper = mountWithAppProvider(
-        <Tabs {...mockProps}>{content}</Tabs>,
-      );
+      const wrapper = mountWithApp(<Tabs {...mockProps}>{content}</Tabs>);
 
-      const selectedTab = wrapper.find('ul').find(Tab).at(0);
-      const panel = wrapper.find(Panel).at(0);
-      expect(panel.exists()).toBe(true);
-      expect(panel.contains(content)).toBe(true);
-      expect(panel.prop('id')).toBeTruthy();
-      expect(panel.prop('id')).toBe(selectedTab.prop('panelID'));
+      const selectedTab = wrapper.find('ul')!.findAll(Tab)[0];
+      const panel = wrapper.findAll(Panel)[0];
+
+      expect(panel).not.toBeNull();
+      expect(panel).toContainReactComponent('p', {children: 'Tab content'});
+      expect(panel).toHaveReactProps({id: selectedTab.prop('panelID')});
     });
 
     it('uses a custom panelID', () => {
@@ -285,25 +273,23 @@ describe('<Tabs />', () => {
         tabs[1],
       ];
       const content = <p>Tab content</p>;
-      const wrapper = mountWithAppProvider(
+      const wrapper = mountWithApp(
         <Tabs {...mockProps} tabs={panelIDedTabs}>
           {content}
         </Tabs>,
       );
 
-      const panel = wrapper.find(Panel).at(0);
-      const selectedTab = wrapper.find('ul').find(Tab).at(0);
-      expect(panel.prop('id')).toBe(selectedTab.prop('panelID'));
+      const panel = wrapper.findAll(Panel)[0];
+      const selectedTab = wrapper.find('ul')!.findAll(Tab)[0];
+      expect(panel).toHaveReactProps({id: selectedTab.prop('panelID')});
     });
   });
 
   describe('onSelect()', () => {
     it('is called with the index of the clicked tab', () => {
       const spy = jest.fn();
-      const wrapper = mountWithAppProvider(
-        <Tabs {...mockProps} onSelect={spy} />,
-      );
-      wrapper.find('ul').find(Tab).at(1).find('button').simulate('click');
+      const wrapper = mountWithApp(<Tabs {...mockProps} onSelect={spy} />);
+      wrapper.find('ul')!.findAll(Tab)[1].find('button')!.trigger('onClick');
       expect(spy).toHaveBeenCalledWith(1);
     });
   });
@@ -316,57 +302,52 @@ describe('<Tabs />', () => {
     ];
 
     it('is not set to anything by default', () => {
-      const tabs = mountWithAppProvider(<Tabs {...mockProps} />);
-      expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(-1);
+      const tabs = mountWithApp(<Tabs {...mockProps} />);
+      expect(tabs.find(TabMeasurer)).toHaveReactProps({tabToFocus: -1});
     });
 
     it('passes the provided selected value if given', () => {
-      const tabs = mountWithAppProvider(
+      const tabs = mountWithApp(
         <Tabs {...mockProps} selected={1} tabs={mockTabs} />,
       );
-      expect(tabs.find(TabMeasurer).prop('selected')).toBe(1);
+      expect(tabs.find(TabMeasurer)).toHaveReactProps({selected: 1});
     });
 
     describe('ArrowRight', () => {
       it('shifts focus to the next tab when pressing ArrowRight', () => {
-        const tabs = mountWithAppProvider(
-          <Tabs {...mockProps} tabs={mockTabs} />,
-        );
-        trigger(tabs.find('ul'), 'onKeyUp', {
+        const tabs = mountWithApp(<Tabs {...mockProps} tabs={mockTabs} />);
+        tabs.find('ul')!.trigger('onKeyUp', {
           key: 'ArrowRight',
         });
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
+        expect(tabs.find(TabMeasurer)).toHaveReactProps({tabToFocus: 0});
       });
 
       it('shifts focus to the first tab when pressing ArrowRight on the last tab', () => {
-        const tabs = mountWithAppProvider(
-          <Tabs {...mockProps} tabs={mockTabs} />,
-        );
-        trigger(tabs.find('ul'), 'onKeyUp', {
+        const tabs = mountWithApp(<Tabs {...mockProps} tabs={mockTabs} />);
+        tabs.find('ul')!.trigger('onKeyUp', {
           key: 'ArrowRight',
         });
-        trigger(tabs.find('ul'), 'onKeyUp', {
+        tabs.find('ul')!.trigger('onKeyUp', {
           key: 'ArrowRight',
         });
-        trigger(tabs.find('ul'), 'onKeyUp', {
+        tabs.find('ul')!.trigger('onKeyUp', {
           key: 'ArrowRight',
         });
-        trigger(tabs.find('ul'), 'onKeyUp', {
+
+        tabs.find('ul')!.trigger('onKeyUp', {
           key: 'ArrowRight',
         });
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
+        expect(tabs.find(TabMeasurer)).toHaveReactProps({tabToFocus: 0});
       });
     });
 
     describe('ArrowLeft', () => {
       it('shifts focus to the last tab when pressing ArrowLeft', () => {
-        const tabs = mountWithAppProvider(
-          <Tabs {...mockProps} tabs={mockTabs} />,
-        );
-        trigger(tabs.find('ul'), 'onKeyUp', {
+        const tabs = mountWithApp(<Tabs {...mockProps} tabs={mockTabs} />);
+        tabs.find('ul')!.trigger('onKeyUp', {
           key: 'ArrowLeft',
         });
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(2);
+        expect(tabs.find(TabMeasurer)).toHaveReactProps({tabToFocus: 2});
       });
     });
   });
@@ -408,108 +389,104 @@ describe('<Tabs />', () => {
     });
 
     it('passes preferredPosition below to the Popover', () => {
-      const tabs = mountWithAppProvider(<Tabs {...mockProps} />);
-      const tabMeasurer = tabs.find(TabMeasurer);
-      trigger(tabMeasurer, 'handleMeasurement', {
+      const tabs = mountWithApp(<Tabs {...mockProps} />);
+      tabs.find(TabMeasurer)!.trigger('handleMeasurement', {
         hiddenTabWidths: [82, 160, 150, 100, 80, 120],
         containerWidth: 300,
         disclosureWidth: 0,
       });
 
-      const popover = tabs.find(Popover);
-      expect(popover.prop('preferredPosition')).toBe('below');
+      expect(tabs.find(Popover)).toHaveReactProps({preferredPosition: 'below'});
     });
 
     it('renders with a button as the activator when there are hiddenTabs', () => {
-      const tabs = mountWithAppProvider(<Tabs {...mockProps} />);
-      const tabMeasurer = tabs.find(TabMeasurer);
-      trigger(tabMeasurer, 'handleMeasurement', {
+      const tabs = mountWithApp(<Tabs {...mockProps} />);
+      tabs.find(TabMeasurer)!.trigger('handleMeasurement', {
         hiddenTabWidths: [82, 160, 150, 100, 80, 120],
         containerWidth: 300,
         disclosureWidth: 0,
       });
 
-      const popover = tabs.find(Popover);
-      expect(popover.prop('activator').type).toBe('button');
+      expect(tabs.find(Popover)!.prop('activator').type).toBe('button');
     });
 
     describe('ArrowRight', () => {
       it('shifts focus to the first tab when pressing ArrowRight', () => {
-        const tabs = mountWithAppProvider(<Tabs {...mockProps} />);
-        const tabMeasurer = tabs.find(TabMeasurer);
-        trigger(tabMeasurer, 'handleMeasurement', {
+        const tabs = mountWithApp(<Tabs {...mockProps} />);
+        tabs.find(TabMeasurer)!.trigger('handleMeasurement', {
           hiddenTabWidths: [82, 160, 150, 100, 80, 120],
           containerWidth: 300,
           disclosureWidth: 0,
         });
 
-        const popover = tabs.find(Popover);
-        const disclosureActivator = popover.find('.DisclosureActivator');
-
-        trigger(disclosureActivator, 'onClick', {
-          key: 'Enter',
+        tabs.find(Popover)!.find('button')!.trigger('onClick', {
+          key: Key.Enter,
         });
 
-        trigger(tabs.find('ul'), 'onKeyUp', {
+        tabs.find('ul')!.trigger('onKeyUp', {
           key: 'ArrowRight',
         });
 
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
+        expect(tabs).toContainReactComponent(TabMeasurer, {tabToFocus: 0});
       });
 
       it('shifts focus to the first hidden tab when the last visible tab is focused and the disclosure popover is active', () => {
-        const tabs = mountWithAppProvider(<Tabs {...mockProps} />);
-        const tabMeasurer = tabs.find(TabMeasurer);
-        trigger(tabMeasurer, 'handleMeasurement', {
+        const tabs = mountWithApp(<Tabs {...mockProps} />);
+
+        tabs.find(TabMeasurer)!.trigger('handleMeasurement', {
           hiddenTabWidths: [82, 160, 150, 100, 80, 120],
           containerWidth: 300,
           disclosureWidth: 0,
         });
-        const popover = tabs.find(Popover);
-        const disclosureActivator = popover.find('button');
 
-        disclosureActivator.simulate('click');
+        const popover = tabs.find(Popover)!;
+        const disclosureActivator = popover.find('button')!;
 
-        trigger(disclosureActivator, 'onClick', {
-          key: 'Enter',
-        });
+        disclosureActivator.domNode!.click;
 
-        trigger(tabs.find('ul'), 'onKeyUp', {
+        disclosureActivator.trigger('onClick');
+
+        tabs.find('ul')!.trigger('onKeyUp', {
           key: 'ArrowRight',
         });
 
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
+        expect(tabs.find(TabMeasurer)!.prop('tabToFocus')).toBe(0);
 
-        trigger(tabs.find('ul'), 'onKeyUp', {
+        tabs.find('ul')!.trigger('onKeyUp', {
           key: 'ArrowRight',
         });
 
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(1);
+        expect(tabs.find(TabMeasurer)!.prop('tabToFocus')).toBe(1);
       });
 
       it('does not shift focus to the first hidden tab when the last visible tab is focused and the disclosure popover is not active', () => {
-        const tabs = mountWithAppProvider(<Tabs {...mockProps} />);
-        const tabMeasurer = tabs.find(TabMeasurer);
-        trigger(tabMeasurer, 'handleMeasurement', {
+        const tabs = mountWithApp(<Tabs {...mockProps} />);
+
+        tabs.find(TabMeasurer)!.trigger('handleMeasurement', {
           hiddenTabWidths: [82, 160, 150, 100, 80, 120],
           containerWidth: 300,
           disclosureWidth: 0,
         });
 
-        const popover = tabs.find(Popover);
-        expect(popover.prop('active')).toBe(false);
+        expect(tabs).toContainReactComponent(Popover, {
+          active: false,
+        });
 
-        trigger(tabs.find('ul'), 'onKeyUp', {
+        tabs.find('ul')!.trigger('onKeyUp', {
           key: 'ArrowRight',
         });
 
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
+        expect(tabs).toContainReactComponent(TabMeasurer, {
+          tabToFocus: 0,
+        });
 
-        trigger(tabs.find('ul'), 'onKeyUp', {
+        tabs.find('ul')!.trigger('onKeyUp', {
           key: 'Enter',
         });
 
-        expect(tabs.find(TabMeasurer).prop('tabToFocus')).toBe(0);
+        expect(tabs).toContainReactComponent(TabMeasurer, {
+          tabToFocus: 0,
+        });
       });
     });
   });

--- a/src/components/TextStyle/tests/TextStyle.test.tsx
+++ b/src/components/TextStyle/tests/TextStyle.test.tsx
@@ -1,61 +1,56 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {mountWithAppProvider} from 'test-utilities/legacy';
+import {mountWithApp} from 'test-utilities';
 
 import {TextStyle} from '../TextStyle';
 
 describe('<TextStyle />', () => {
   it('mounts', () => {
-    const textStyle = mountWithAppProvider(<TextStyle />);
-    expect(textStyle.exists()).toBe(true);
+    const textStyle = mountWithApp(<TextStyle />);
+    expect(textStyle).not.toBeNull();
   });
 
   it('renders children', () => {
-    const textStyle = mountWithAppProvider(
-      <TextStyle>Hello Polaris</TextStyle>,
-    );
-    expect(textStyle.find('span').text()).toBe('Hello Polaris');
+    const textStyle = mountWithApp(<TextStyle>Hello Polaris</TextStyle>);
+    expect(textStyle.find('span')).toContainReactText('Hello Polaris');
   });
 
   it('renders a span by default', () => {
-    const textStyle = mountWithAppProvider(
-      <TextStyle>Hello Polaris</TextStyle>,
-    );
-    expect(textStyle.find('span')).toHaveLength(1);
+    const textStyle = mountWithApp(<TextStyle>Hello Polaris</TextStyle>);
+    expect(textStyle).toContainReactComponent('span');
   });
 
   it('renders a span when the variant positive is provided', () => {
-    const textStyle = mountWithAppProvider(
+    const textStyle = mountWithApp(
       <TextStyle variation="positive">Hello Polaris</TextStyle>,
     );
-    expect(textStyle.find('span')).toHaveLength(1);
+    expect(textStyle).toContainReactComponent('span');
   });
 
   it('renders a span when the variant negative is provided', () => {
-    const textStyle = mountWithAppProvider(
+    const textStyle = mountWithApp(
       <TextStyle variation="negative">Hello Polaris</TextStyle>,
     );
-    expect(textStyle.find('span')).toHaveLength(1);
+    expect(textStyle).toContainReactComponent('span');
   });
 
   it('renders a span when the variant subdued is provided', () => {
-    const textStyle = mountWithAppProvider(
+    const textStyle = mountWithApp(
       <TextStyle variation="subdued">Hello Polaris</TextStyle>,
     );
-    expect(textStyle.find('span')).toHaveLength(1);
+    expect(textStyle).toContainReactComponent('span');
   });
 
   it('renders a span tag when the strong variant is provided', () => {
-    const textStyle = mountWithAppProvider(
+    const textStyle = mountWithApp(
       <TextStyle variation="strong">Hello Polaris</TextStyle>,
     );
-    expect(textStyle.find('span')).toHaveLength(1);
+    expect(textStyle).toContainReactComponent('span');
   });
 
   it('renders a code tag when the code variant is provided', () => {
-    const textStyle = mountWithAppProvider(
+    const textStyle = mountWithApp(
       <TextStyle variation="code">Hello Polaris</TextStyle>,
     );
-    expect(textStyle.find('code')).toHaveLength(1);
+    expect(textStyle).toContainReactComponent('code');
   });
 });


### PR DESCRIPTION
**WHY are these changes introduced?**

I am updating existing tests for Collapsible, Tabs and TextStyle components to use the new modern framework. I worked with @rdott  in solving several of the details here on those tests.

**WHAT is this pull request doing?**

Part of test modernization (https://docs.google.com/spreadsheets/d/1GBuEZbOpVYJLNISK7gL69DU8rCxocn5L5GYaKtPXPbU/edit#gid=1498187033), updating tests using {mountWithAppProvider} from 'test-utilities/legacy' to {mountWithApp} from 'test-utilities'.
