### PR TITLE
[Test Modernization] Modernizing leftover Filters test.

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -75,7 +75,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Modernized tests for Pane, Section, PositionedOverlay, SingleThumb, RangeSlider, and ConnectedFilter components ([#4429](https://github.com/Shopify/polaris-react/pull/4429))
 - Modernized tests for ContextualSaveBar and DataTable and its subcomponents ([#4397](https://github.com/Shopify/polaris-react/pull/4397))
 - Modernized tests for IndexTable, Indicator, InlineError, KeyboardKey, and KeypressListener components([#4431](https://github.com/Shopify/polaris-react/pull/4431))
-- Modernized tests for Form and Filters components ([#4434](https://github.com/Shopify/polaris-react/pull/4434)).
+- Modernized tests for Form and Filters components ([#4434](https://github.com/Shopify/polaris-react/pull/4434))
 - Modernized tests for OptionList and its subcomponents ([#4441](https://github.com/Shopify/polaris-react/pull/4441))
 - Modernized tests for Modal ([#4433](https://github.com/Shopify/polaris-react/pull/4433))
 - Modernized tests for Navigation and Navigation.Section ([#4440](https://github.com/Shopify/polaris-react/pull/4440))

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -75,7 +75,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - Modernized tests for Pane, Section, PositionedOverlay, SingleThumb, RangeSlider, and ConnectedFilter components ([#4429](https://github.com/Shopify/polaris-react/pull/4429))
 - Modernized tests for ContextualSaveBar and DataTable and its subcomponents ([#4397](https://github.com/Shopify/polaris-react/pull/4397))
 - Modernized tests for IndexTable, Indicator, InlineError, KeyboardKey, and KeypressListener components([#4431](https://github.com/Shopify/polaris-react/pull/4431))
-- Modernized tests for Form and Filters components ([#4434](https://github.com/Shopify/polaris-react/pull/4434))
+- Modernized tests for Form and Filters components ([#4434](https://github.com/Shopify/polaris-react/pull/4434) and [#4458](https://github.com/Shopify/polaris-react/pull/4458))
 - Modernized tests for OptionList and its subcomponents ([#4441](https://github.com/Shopify/polaris-react/pull/4441))
 - Modernized tests for Modal ([#4433](https://github.com/Shopify/polaris-react/pull/4433))
 - Modernized tests for Navigation and Navigation.Section ([#4440](https://github.com/Shopify/polaris-react/pull/4440))

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -9,12 +9,6 @@ import {
   TextStyle,
   ButtonProps,
 } from 'components';
-// eslint-disable-next-line no-restricted-imports
-import {
-  findByTestID,
-  mountWithAppProvider,
-  trigger,
-} from 'test-utilities/legacy';
 import {mountWithApp} from 'test-utilities';
 
 import {WithinFilterContext} from '../../../utilities/within-filter-context';
@@ -22,6 +16,7 @@ import {Filters, FiltersProps} from '../Filters';
 import {ConnectedFilterControl, TagsWrapper} from '../components';
 import {Collapsible} from '../../Collapsible';
 import * as focusUtils from '../../../utilities/focus';
+import styles from '../Filters.scss';
 
 const MockFilter = (props: {id: string}) => <div id={props.id} />;
 const MockChild = () => <div />;
@@ -346,20 +341,21 @@ describe('<Filters />', () => {
     });
 
     it('toggles a shortcut filter', () => {
-      const resourceFilters = mountWithAppProvider(
+      const resourceFilters = mountWithApp(
         <Filters {...mockPropsWithShortcuts} />,
       );
 
-      const connected = resourceFilters.find(ConnectedFilterControl).first();
-      connected.setState({availableWidth: 999});
-      const shortcut = findByTestID(resourceFilters, 'FilterShortcutContainer')
-        .find(Button)
-        .first();
+      let connected = resourceFilters.find(ConnectedFilterControl);
+      connected!.instance.setState({availableWidth: 999});
+      resourceFilters.forceUpdate();
+      const shortcut = resourceFilters
+        .find('div', {className: styles.RightContainer})!
+        .find(Button);
 
-      trigger(shortcut, 'onClick');
-      expect(resourceFilters.find(Popover).first().props().active).toBe(true);
-      trigger(shortcut, 'onClick');
-      expect(resourceFilters.find(Popover).first().props().active).toBe(false);
+      shortcut!.trigger('onClick');
+      expect(resourceFilters).toContainReactComponent(Popover, {active: true});
+      shortcut!.trigger('onClick');
+      expect(resourceFilters).toContainReactComponent(Popover, {active: false});
     });
 
     it('receives the expected props when there are no shortcut filters', () => {

--- a/src/components/Filters/tests/Filters.test.tsx
+++ b/src/components/Filters/tests/Filters.test.tsx
@@ -345,7 +345,7 @@ describe('<Filters />', () => {
         <Filters {...mockPropsWithShortcuts} />,
       );
 
-      let connected = resourceFilters.find(ConnectedFilterControl);
+      const connected = resourceFilters.find(ConnectedFilterControl);
       connected!.instance.setState({availableWidth: 999});
       resourceFilters.forceUpdate();
       const shortcut = resourceFilters


### PR DESCRIPTION
Wrapping up leftover `Filters` test from https://github.com/Shopify/polaris-react/pull/4434/

### WHY are these changes introduced?

Modernizes tests to use the new modern framework (`{mountWithApp}` from `test-utilities`).

### WHAT is this pull request doing?

Updates tests using `{mountWithAppProvider}` from `test-utilities/legacy` to use `{mountWithApp}` from `test-utilities`