### PR TITLE
[Page] Add compactTitle prop

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -21,6 +21,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 - `PositionedOverlay` now exposes an imperative `forceUpdatePosition()` API for programmatically triggering a re-render of the component ([#4385](https://github.com/Shopify/polaris-react/pull/4385))
 - Updated `IndexTable` component to hide checkboxes when `selectable` prop is `false` ([#4376](https://github.com/Shopify/polaris-react/pull/4376))
 - [Accessibility] - Removes skeleton shimmer animation on devices that have Reduced motion setting enabled [#4460](https://github.com/Shopify/polaris-react/pull/4460)
+- Added optional `compactTitle` prop to `Page` which removes margin between `title` and `subtitle` ([#4463](https://github.com/Shopify/polaris-react/pull/4463))
 
 ### Bug fixes
 

--- a/src/components/Page/README.md
+++ b/src/components/Page/README.md
@@ -143,6 +143,7 @@ Use for detail pages, which should have pagination and breadcrumbs, and also oft
       alt="Black leather pet collar"
     />
   }
+  compactTitle
   primaryAction={{content: 'Save', disabled: true}}
   secondaryActions={[
     {

--- a/src/components/Page/components/Header/Header.tsx
+++ b/src/components/Page/components/Header/Header.tsx
@@ -76,6 +76,7 @@ export function Header({
   breadcrumbs = [],
   secondaryActions = [],
   actionGroups = [],
+  compactTitle = false,
 }: HeaderProps) {
   const {isNavigationCollapsed} = useMediaQuery();
   const isSingleRow =
@@ -120,6 +121,7 @@ export function Header({
         subtitle={subtitle}
         titleMetadata={titleMetadata}
         thumbnail={thumbnail}
+        compactTitle={compactTitle}
       />
     </div>
   );

--- a/src/components/Page/components/Header/components/Title/Title.scss
+++ b/src/components/Page/components/Header/components/Title/Title.scss
@@ -14,6 +14,9 @@
 .SubTitle {
   margin-top: spacing(tight);
   color: var(--p-text-subdued);
+  &.SubtitleCompact {
+    margin-top: 0;
+  }
 }
 
 .hasThumbnail {

--- a/src/components/Page/components/Header/components/Title/Title.tsx
+++ b/src/components/Page/components/Header/components/Title/Title.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import type {AvatarProps} from '../../../../../Avatar';
 import type {ThumbnailProps} from '../../../../../Thumbnail';
+import {classNames} from '../../../../../../utilities/css';
 
 import styles from './Title.scss';
 
@@ -16,9 +17,17 @@ export interface TitleProps {
   thumbnail?:
     | React.ReactElement<AvatarProps | ThumbnailProps>
     | React.SFC<React.SVGProps<SVGSVGElement>>;
+  /** Removes spacing between title and subtitle */
+  compactTitle?: boolean;
 }
 
-export function Title({title, subtitle, titleMetadata, thumbnail}: TitleProps) {
+export function Title({
+  title,
+  subtitle,
+  titleMetadata,
+  thumbnail,
+  compactTitle,
+}: TitleProps) {
   const titleMarkup = title ? <h1 className={styles.Title}>{title}</h1> : null;
 
   const titleMetadataMarkup = titleMetadata ? (
@@ -35,7 +44,12 @@ export function Title({title, subtitle, titleMetadata, thumbnail}: TitleProps) {
   );
 
   const subtitleMarkup = subtitle ? (
-    <div className={styles.SubTitle}>
+    <div
+      className={classNames(
+        styles.SubTitle,
+        compactTitle && styles.SubtitleCompact,
+      )}
+    >
       <p>{subtitle}</p>
     </div>
   ) : null;

--- a/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
+++ b/src/components/Page/components/Header/components/Title/tests/Title.test.tsx
@@ -40,6 +40,15 @@ describe('<Title />', () => {
       const pageTitle = mountWithApp(<Title {...mockProps} />);
       expect(pageTitle).not.toContainReactComponent('p');
     });
+
+    it('renders styles when compactTitle prop is defined', () => {
+      const pageTitle = mountWithApp(
+        <Title {...propsWithSubtitle} compactTitle />,
+      );
+      expect(pageTitle).toContainReactComponent('div', {
+        className: expect.stringContaining('SubtitleCompact'),
+      });
+    });
   });
 
   describe('titleMetadata', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

There are multiple locations within the new `markets` section of the admin application where we render a `Page` component without spacing between the `title` and `subtitle` props:

<img width="645" alt="Screen Shot 2021-09-01 at 3 29 17 PM" src="https://user-images.githubusercontent.com/9326713/131753692-ed9f6e8f-b309-4441-b117-b992da9e1273.png">

### WHAT is this pull request doing?

Adds a `compactTitle` prop that appends a new class, `SubtitleCompact`, which removes the top margin.

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Title" subtitle="Subtitle" compactTitle>
      <p>Test text</p>
    </Page>
  );
}
```

</details>

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->



### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
