### PR TITLE
[TextField] Add maxHeight prop

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -99,6 +99,8 @@ interface NonMutuallyExclusiveProps {
   /** Maximum character length for an input */
   maxLength?: number;
   /** Mimics the behavior of the native HTML attribute, limiting the minimum value */
+  maxHeight?: number | string;
+  /** Maximum height of the element */
   min?: number | string;
   /** Minimum character length for an input */
   minLength?: number;
@@ -169,6 +171,7 @@ export function TextField({
   autoComplete,
   max,
   maxLength,
+  maxHeight,
   min,
   minLength,
   pattern,
@@ -354,7 +357,7 @@ export function TextField({
       />
     ) : null;
 
-  const style = multiline && height ? {height} : null;
+  const style = multiline && height ? {height, maxHeight} : null;
 
   const handleExpandingResize = useCallback((height: number) => {
     setHeight(height);


### PR DESCRIPTION
### WHY are these changes introduced?

The TextField allows multiline values, but if a long input is created, the component can become extremely tall. `maxHeight` gives developers an option to cap the height of the element.

I'm creating a page that needs to have a transcript pasted into a textfield, it's possibly very long and required a lot of scrolling to get to the bottom of the form. If I could limit the size of the TextForm component that wouldn't be a problem.

### WHAT is this pull request doing?

Adds a `maxHeight` prop to the TextField component, which adds a `max-height` property to the component's inline style. It only appears if `multiline` is present, as it's not required otherwise.

![image](https://user-images.githubusercontent.com/43040593/133834531-24da3bb5-bdd3-48c0-ad80-ce2e2ddc8d04.png)
