### PR TITLE
[Stack] do not wrap empty children with Item

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,7 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
-- Do not wrap empty children with `Item` in the `Stack` component ([#4487](https://github.com/Shopify/polaris-react/pull/4487))
+- Fixed empty children being wrapped with `Item` in `Stack` ([#4487](https://github.com/Shopify/polaris-react/pull/4487))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Bug fixes
 
+- Do not wrap empty children with `Item` in the `Stack` component ([#4487](https://github.com/Shopify/polaris-react/pull/4487))
+
 ### Documentation
 
 - Light edits to the best practices for `Modal` and `Banner` ([#4501]https://github.com/Shopify/polaris-react/pull/4501/)

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -39,6 +39,10 @@ export interface StackProps {
   distribution?: Distribution;
 }
 
+interface ChildProps {
+  readonly key: number;
+}
+
 export const Stack = memo(function Stack({
   children,
   vertical,
@@ -56,9 +60,20 @@ export const Stack = memo(function Stack({
     wrap === false && styles.noWrap,
   );
 
+  const unwrappedComponent = (child: JSX.Element, props: ChildProps) => ({
+    ...child,
+    props: {
+      ...child.props,
+      ...props,
+    },
+  });
+
   const itemMarkup = elementChildren(children).map((child, index) => {
-    const props = {key: index};
-    return wrapWithComponent(child, Item, props);
+    const props: ChildProps = {key: index};
+    const isValidChildren = child.props.children;
+    return isValidChildren
+      ? wrapWithComponent(child, Item, props)
+      : unwrappedComponent(child, props);
   });
 
   return <div className={className}>{itemMarkup}</div>;

--- a/src/components/Stack/tests/Stack.test.tsx
+++ b/src/components/Stack/tests/Stack.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {mountWithApp} from 'test-utilities';
+
+import {Stack} from '../Stack';
+
+describe('<Stack />', () => {
+  const renderChildren = () => [0, 1].map((i) => <div key={i}>Child {i}</div>);
+
+  it('renders its children', () => {
+    const stack = mountWithApp(<Stack>{renderChildren()}</Stack>);
+
+    expect(stack).toContainReactComponentTimes(Stack.Item, 2);
+  });
+
+  it('does not render a Stack.Item to falsy children', () => {
+    const stack = mountWithApp(
+      <Stack>
+        {renderChildren()}
+        <FalsyComponent />
+      </Stack>,
+    );
+
+    expect(stack).toContainReactComponentTimes(Stack.Item, 2);
+  });
+});
+
+const FalsyComponent = () => null;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

Fixes #1890 

### WHY are these changes introduced?

This PR fixes an issue with `Stack` when one of its children returns `null` instead of a `JSX.Element`. I attached an example of the issue below.

![image](https://user-images.githubusercontent.com/44816587/134378976-3e3b1052-91e9-403e-906e-4df4e32ba426.png)
In this example, there is a component above the Purchase summary card that can conditionally be rendered. In our case, it is not, hence the double padding.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

This PR validates that each children has content (or children) before wrapping them with a `Stack.Item`. Doing so to falsy children would cause unwanted extra spacing.

The PR also adds a basic suite of unit tests to `Stack`.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
