### PR TITLE
Stack - Fix stack children to retain internal react key

### DIFF
--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -1,7 +1,12 @@
-import React, {memo, NamedExoticComponent} from 'react';
+import React, {
+  memo,
+  NamedExoticComponent,
+  isValidElement,
+  Children,
+} from 'react';
 
 import {classNames, variationName} from '../../utilities/css';
-import {elementChildren, wrapWithComponent} from '../../utilities/components';
+import {wrapWithComponent} from '../../utilities/components';
 
 import {Item} from './components';
 import styles from './Stack.scss';
@@ -40,7 +45,7 @@ export interface StackProps {
 }
 
 interface ChildProps {
-  readonly key: number;
+  readonly key: number | string;
 }
 
 export const Stack = memo(function Stack({
@@ -68,8 +73,9 @@ export const Stack = memo(function Stack({
     },
   });
 
-  const itemMarkup = elementChildren(children).map((child, index) => {
-    const props: ChildProps = {key: index};
+  const itemMarkup = Children.map(children, (child, index) => {
+    if (!isValidElement(child)) return null;
+    const props: ChildProps = {key: child.key || index};
     const isValidChildren = child.props.children;
     return isValidChildren
       ? wrapWithComponent(child, Item, props)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

These changes fix the following issue:

**Issue**

- WHEN an input element is internally wrapped with `Stack.Item` 
- AND an additional element is conditionally rendered _before_ the input
- THEN the input loses focus

The component is being unnecessarily remounted.

Note: there are some other comments to potentially address, however i've left those changes out for now.



<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

A demo of the issue and the fix  can be found here at this codesandbox: https://codesandbox.io/s/stack-item-issue-9dpqu?file=/App.js


https://user-images.githubusercontent.com/7349258/138101725-f88b1a14-d676-4554-9b69-082ba2f4d999.mp4

The gist of what's happening under the hood is that `Children.toArray` somewhat modifies children and keys are assigned, furthermore we were manually assigning a key based on `index` so when an item is inserted at the beginning it now becomes `index=0` and the item previously in index 0 shifts up to 1. 

In our case we're using our own util function `elementChildren` which also performs a `.filter`, which makes using an `index` as a key less than ideal. 

What we can do to fix the issue is the following;

1. Modify `elementChildren` to optionally filter and then forward the `child.key` that is produced by `Children.toArray` to the wrapped component
2. Opt to use `Children.map` directly. - i've chosen this method


![image](https://user-images.githubusercontent.com/7349258/138102712-6ea47235-2a2e-4816-9fd8-6bff0e24fbd1.png)



A couple of ways around this for now, without modifying polaris; 

- Wrapping your child nodes with `<Stack.Item/>` prevents this issue since we void the whole wrapping process. (doesn't play nice with this lint rule `@shopify/polaris-no-bare-stack-item`)
- Wrapping conditional nodes with `<React.Fragment/>` so as to maintain the correct `index` number passed to `key` . This will still produce undesirable results, especially when rendering lists, we should forward the `child.key`. It's also a weird developer experience.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
