### PR TITLE
[OptionList] Use relative path for type imports

### DIFF
--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useCallback} from 'react';
-import type {Descriptor, OptionDescriptor, SectionDescriptor} from 'types';
+import type {Descriptor, OptionDescriptor, SectionDescriptor} from '../../types';
 
 import {isSection} from '../../utilities/options';
 import {arraysAreEqual} from '../../utilities/arrays';


### PR DESCRIPTION
fixes https://github.com/Shopify/polaris-react/issues/4507
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4507

### WHAT is this pull request doing?

Uses relative, rather than absolute paths to import types, to prevent Typescript errors for consumers of polaris-react.

```
../../node_modules/@shopify/polaris/build/ts/latest/src/components/OptionList/OptionList.d.ts:2:58 - error TS2307: Cannot find module 'types' or its corresponding type declarations.

2 import type { OptionDescriptor, SectionDescriptor } from 'types';
```

More broadly, this repository needs a way to check for errors like this during build, or if possible to remove its dependency on this line in `tsconfig.json`

https://github.com/Shopify/polaris-react/blob/755b3ceaee9d9aedb508c2cc95db64fad28aba09/tsconfig.json#L4