### PR TITLE
[Stack] Fix valid children not getting wrapped in Item

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,9 +6,13 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Enhancements
 
-- Updated the MediaCard's primary and secondary action type to accept ComplexAction ([#4546](https://github.com/shopify/polaris-react/pull/4546))
+- Updated the primary and secondary action type on `MediaCard` to `ComplexAction` ([#4546](https://github.com/shopify/polaris-react/pull/4546))
 
 ### Bug fixes
+
+- Fixed `Stack.Item` having margin when empty ([#4556](https://github.com/Shopify/polaris-react/pull/4556))
+
+- Fixed `Stack` not wrapping valid children in `Stack.Item` ([#4556](https://github.com/Shopify/polaris-react/pull/4556)) (thanks [@benjamindoe](https://github.com/benjamindoe) for the [original issue](https://github.com/Shopify/polaris-react/issues/4555))
 
 ### Documentation
 

--- a/src/components/Stack/Stack.scss
+++ b/src/components/Stack/Stack.scss
@@ -7,7 +7,7 @@
   margin-top: -1 * spacing($spacing);
   margin-left: -1 * spacing($spacing);
 
-  > .Item {
+  > .Item:not(:empty) {
     margin-top: spacing($spacing);
     margin-left: spacing($spacing);
     max-width: 100%;

--- a/src/components/Stack/Stack.tsx
+++ b/src/components/Stack/Stack.tsx
@@ -39,10 +39,6 @@ export interface StackProps {
   distribution?: Distribution;
 }
 
-interface ChildProps {
-  readonly key: number;
-}
-
 export const Stack = memo(function Stack({
   children,
   vertical,
@@ -60,20 +56,9 @@ export const Stack = memo(function Stack({
     wrap === false && styles.noWrap,
   );
 
-  const unwrappedComponent = (child: JSX.Element, props: ChildProps) => ({
-    ...child,
-    props: {
-      ...child.props,
-      ...props,
-    },
-  });
-
   const itemMarkup = elementChildren(children).map((child, index) => {
-    const props: ChildProps = {key: index};
-    const isValidChildren = child.props.children;
-    return isValidChildren
-      ? wrapWithComponent(child, Item, props)
-      : unwrappedComponent(child, props);
+    const props = {key: index};
+    return wrapWithComponent(child, Item, props);
   });
 
   return <div className={className}>{itemMarkup}</div>;

--- a/src/components/Stack/tests/Stack.test.tsx
+++ b/src/components/Stack/tests/Stack.test.tsx
@@ -11,17 +11,4 @@ describe('<Stack />', () => {
 
     expect(stack).toContainReactComponentTimes(Stack.Item, 2);
   });
-
-  it('does not render a Stack.Item to falsy children', () => {
-    const stack = mountWithApp(
-      <Stack>
-        {renderChildren()}
-        <FalsyComponent />
-      </Stack>,
-    );
-
-    expect(stack).toContainReactComponentTimes(Stack.Item, 2);
-  });
 });
-
-const FalsyComponent = () => null;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #4555  

This PR undoes [the JS fix](https://github.com/Shopify/polaris-react/pull/4487) for #1890 and fixes empty `Stack.Item`s having margin using CSS instead.

<!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';
import {NoteMinor} from '@shopify/polaris-icons';

import {Page, Thumbnail, Caption, Button, Stack, DropZone} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Stack vertical>
        {null}
        <Button plain>
          My first sibling is null, but they're NOT rendering in an item so
          there's not unexpected margin above me!
        </Button>
        <DropZoneExample />
      </Stack>
    </Page>
  );
}

function DropZoneExample() {
  const [files, setFiles] = useState([]);

  const handleDropZoneDrop = useCallback(
    (_dropFiles, acceptedFiles, _rejectedFiles) =>
      setFiles((files) => [...files, ...acceptedFiles]),
    [],
  );

  const validImageTypes = ['image/gif', 'image/jpeg', 'image/png'];

  const fileUpload = !files.length && <DropZone.FileUpload />;
  const uploadedFiles = files.length > 0 && (
    <Stack vertical>
      {files.map((file, index) => (
        <Stack alignment="center" key={index}>
          <Thumbnail
            size="small"
            alt={file.name}
            source={
              validImageTypes.includes(file.type)
                ? window.URL.createObjectURL(file)
                : NoteMinor
            }
          />
          <div>
            {file.name} <Caption>{file.size} bytes</Caption>
          </div>
        </Stack>
      ))}
    </Stack>
  );

  return (
    <DropZone onDrop={handleDropZoneDrop}>
      {uploadedFiles}
      {fileUpload}
    </DropZone>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
