### PR TITLE
[Tooltip] Open/close on active prop changes

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -7,6 +7,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 ### Enhancements
 
 - Added helper hooks `useIndexTableRowHovered`, `useIndexTableRowSelected`, and `useIndexTableContainerScroll` to `IndexTable` ([#4286](https://github.com/Shopify/polaris-react/pull/4286))
+- Updated the primary and secondary action type on `MediaCard` to `ComplexAction` ([#4546](https://github.com/shopify/polaris-react/pull/4546))
+- Updated `Tooltip` to open and close on `active` prop changes ([#4558](https://github.com/Shopify/polaris-react/pull/4558))
 
 ### Bug fixes
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -35,20 +35,33 @@ export function Tooltip({
   children,
   content,
   dismissOnMouseOut,
-  active: originalActive,
+  active: givenActive,
   preferredPosition = 'below',
   activatorWrapper = 'span',
   accessibilityLabel,
 }: TooltipProps) {
   const WrapperComponent: any = activatorWrapper;
+  const previousGivenActive = useRef(Boolean(givenActive));
   const {value: active, setTrue: handleFocus, setFalse: handleBlur} = useToggle(
-    Boolean(originalActive),
+    Boolean(givenActive),
   );
   const [activatorNode, setActivatorNode] = useState<HTMLElement | null>(null);
 
   const id = useUniqueId('TooltipContent');
   const activatorContainer = useRef<HTMLElement>(null);
   const mouseEntered = useRef(false);
+
+  useEffect(() => {
+    if (previousGivenActive.current === givenActive) return;
+
+    if (previousGivenActive.current === false && givenActive === true) {
+      handleFocus();
+    } else if (previousGivenActive.current === true && givenActive === false) {
+      handleBlur();
+    }
+
+    previousGivenActive.current = Boolean(givenActive);
+  }, [givenActive, handleFocus, handleBlur]);
 
   useEffect(() => {
     const firstFocusable = activatorContainer.current

--- a/src/components/Tooltip/tests/Tooltip.test.tsx
+++ b/src/components/Tooltip/tests/Tooltip.test.tsx
@@ -90,6 +90,34 @@ describe('<Tooltip />', () => {
     expect(tooltip.find(TooltipOverlay)).not.toContainReactComponent('div');
   });
 
+  it('opens when active changes later on', () => {
+    const tooltip = mountWithApp(
+      <Tooltip active={false} content="This order has shipping labels.">
+        <div>Order #1001</div>
+      </Tooltip>,
+    );
+
+    tooltip.setProps({active: true});
+
+    expect(tooltip).toContainReactComponent(TooltipOverlay, {
+      active: true,
+    });
+  });
+
+  it('closes when active changes later on', () => {
+    const tooltip = mountWithApp(
+      <Tooltip active content="This order has shipping labels.">
+        <div>Order #1001</div>
+      </Tooltip>,
+    );
+
+    tooltip.setProps({active: false});
+
+    expect(tooltip).toContainReactComponent(TooltipOverlay, {
+      active: false,
+    });
+  });
+
   it('closes itself when escape is pressed on keyup', () => {
     const tooltip = mountWithApp(
       <Tooltip active content="This order has shipping labels.">


### PR DESCRIPTION
### WHY are these changes introduced?

Opening and closing `Tooltip` manually, which I need for some very specific use-cases, is currently not possible. To make this possible I'm introducing a change that makes a lot of sense on it's own IMO: making sure that when you change `active` after the component has mounted that change actually results in the tooltip opening or closing.

### WHAT is this pull request doing?
Adding logic to open/close the tooltip based on post-mount changes to the `active` prop

### How to 🎩
1. Write an example that mounts a tooltip
2. Toggle the `active` prop when you click a button
3. Make sure the tooltip opens and closes when you click the button

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
