### PR TITLE
Reduce usage of absolute paths

### DIFF
--- a/loom.config.ts
+++ b/loom.config.ts
@@ -53,7 +53,7 @@ function jestAdjustmentsPlugin() {
         // These do not work in rollup builds, so perhaps we shouldn't configure
         // them to work in jest tests either
         configuration.jestModuleNameMapper?.hook((moduleMapper) => {
-          moduleMapper['^(components|test-utilities|types|utilities)(.*)'] =
+          moduleMapper['^(components|test-utilities)(.*)'] =
             '<rootDir>/src/$1$2';
 
           return moduleMapper;

--- a/src/components/Banner/tests/Banner.test.tsx
+++ b/src/components/Banner/tests/Banner.test.tsx
@@ -7,7 +7,6 @@ import {
   DiamondAlertMajor,
 } from '@shopify/polaris-icons';
 import {mountWithApp} from 'test-utilities';
-import {BannerContext} from 'utilities/banner-context';
 import {
   Button,
   Heading,
@@ -17,6 +16,7 @@ import {
   UnstyledLink,
 } from 'components';
 
+import {BannerContext} from '../../../utilities/banner-context';
 import {WithinContentContext} from '../../../utilities/within-content-context';
 import {Banner, BannerHandles} from '../Banner';
 

--- a/src/components/Collapsible/tests/Collapsible.test.tsx
+++ b/src/components/Collapsible/tests/Collapsible.test.tsx
@@ -1,7 +1,7 @@
 import React, {useState, useCallback} from 'react';
 import {mountWithApp} from 'test-utilities';
-import {Tokens} from 'utilities/theme';
 
+import {Tokens} from '../../../utilities/theme';
 import {Collapsible, CollapsibleProps} from '../Collapsible';
 
 describe('<Collapsible />', () => {

--- a/src/components/Listbox/tests/Listbox.test.tsx
+++ b/src/components/Listbox/tests/Listbox.test.tsx
@@ -1,12 +1,12 @@
 import React, {useState} from 'react';
 import {mountWithApp} from 'test-utilities';
 import {animationFrame, timer} from '@shopify/jest-dom-mocks';
-import {Key} from 'types';
 import {
   mountWithComboboxListContext,
   mountWithListboxProvider,
 } from 'test-utilities/listbox';
 
+import {Key} from '../../../types';
 import {Button} from '../../Button';
 import {KeypressListener} from '../../KeypressListener';
 import {Scrollable} from '../../Scrollable';

--- a/src/components/OptionList/OptionList.tsx
+++ b/src/components/OptionList/OptionList.tsx
@@ -1,6 +1,10 @@
 import React, {useState, useCallback} from 'react';
-import type {Descriptor, OptionDescriptor, SectionDescriptor} from 'types';
 
+import type {
+  Descriptor,
+  OptionDescriptor,
+  SectionDescriptor,
+} from '../../types';
 import {isSection} from '../../utilities/options';
 import {arraysAreEqual} from '../../utilities/arrays';
 import {useUniqueId} from '../../utilities/unique-id';

--- a/src/components/PolarisTestProvider/tests/PolarisTestProvider.test.tsx
+++ b/src/components/PolarisTestProvider/tests/PolarisTestProvider.test.tsx
@@ -1,7 +1,7 @@
 import React, {StrictMode} from 'react';
 import {mount, mountWithApp} from 'test-utilities';
-import {MediaQueryContext, useMediaQuery} from 'utilities/media-query';
 
+import {MediaQueryContext, useMediaQuery} from '../../../utilities/media-query';
 import {PolarisTestProvider} from '../PolarisTestProvider';
 
 describe('PolarisTestProvider', () => {

--- a/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
+++ b/src/components/RangeSlider/components/DualThumb/tests/DualThumb.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mountWithApp} from 'test-utilities';
-import {Key} from 'types';
 
+import {Key} from '../../../../../types';
 import {DualThumb, DualThumbProps} from '../DualThumb';
 
 describe('<DualThumb />', () => {

--- a/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -10,8 +10,8 @@ import {
   EmptyState,
 } from 'components';
 import {mountWithApp} from 'test-utilities';
-import {SELECT_ALL_ITEMS} from 'utilities/resource-list';
 
+import {SELECT_ALL_ITEMS} from '../../../utilities/resource-list';
 import {BulkActions} from '../../BulkActions';
 import {CheckableButton} from '../../CheckableButton';
 import styles from '../ResourceList.scss';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type {AvatarProps, IconProps, ThumbnailProps} from 'components';
+import type {AvatarProps, IconProps, ThumbnailProps} from './components';
 
 export interface OptionDescriptor {
   /** Value of the option */

--- a/src/utilities/options.ts
+++ b/src/utilities/options.ts
@@ -1,4 +1,4 @@
-import type {Descriptor, SectionDescriptor} from 'types';
+import type {Descriptor, SectionDescriptor} from '../types';
 
 export function isSection(arr: Descriptor[]): arr is SectionDescriptor[] {
   return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@shopify/typescript-configs/library",
   "compilerOptions": {
-    "baseUrl": "./src",
+    "baseUrl": "./",
     "rootDir": "./",
     "noEmit": false,
     "emitDeclarationOnly": true,
@@ -10,7 +10,13 @@
     "declarationMap": false,
     "isolatedModules": true,
     "importsNotUsedAsValues": "error",
-    "strictFunctionTypes": false
+    "strictFunctionTypes": false,
+    "paths": {
+      "components": ["src/components"],
+      "components/*": ["src/components/*"],
+      "test-utilities": ["src/test-utilities"],
+      "test-utilities/*": ["src/test-utilities/*"]
+    }
   },
   "include": ["./config/typescript", "./src", "./tests", "./playground"]
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #4507, Fixes #4542

Typescript sets the `baseUrl` to be `./src` which means that absolute path imports like "types" works. This is neat but means we need to be careful - we can't use these aliases in compiled code. Turns out somebody did that though and caused types to break per #4507.

This PR fixes that original issue, and starts the process of using './' as the default baseUrl to reduce the chance of this from happening in the future.

### WHAT is this pull request doing?

- Fix usage of absolute paths in published files (i.e. not tests) to be relative
- Replace absolute imports of 'utilities' and 'types' to be relative
- Change baseUrl in tsconfig to point to root, and add path mappings for
  `components` and `test-utilities`

At this point in time `components`, `components/*`, `test-utilities` and `test-utilities/*` are now the only recognised absolute paths. You can use these in test files, however the build will still fail if you try and use these paths in not-tests.


### Next steps

We should finish this job. removing any usage of importing  `components`, `components/*`, `test-utilities` and `test-utilities/*`.

We can now move the contents of `test-utilities` into the `tests` folder and access them with `tests/BLAH`. Move the contents of `src/test-utilities/` into `tests/utilities`, update the import path from 'test-utilities' to `tests/utilities' and remove the references to `test-utilities in tsconfig.json and loom.config.ts. We could not access the contents of the tests folder with absolute paths before because the baseUrl was not `./`.

We can should also replace all imports from 'components' to use relative imports.