### PR TITLE
[Dropzone] Fix typo in DropZone Readme

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -12,6 +12,8 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 ### Documentation
 
+- Fixed typo in `DropZone` documentation [4566](https://github.com/Shopify/polaris-react/pull/4566)
+
 ### Development workflow
 
 - Updated Loom to v1 ([#950](https://github.com/Shopify/global-nav/pull/950))

--- a/src/components/DropZone/README.md
+++ b/src/components/DropZone/README.md
@@ -440,7 +440,7 @@ Use for cases with tight space constraints, such as variant thumbnails on the Pr
 </div>
 ```
 
-### Drop zone with varaible size
+### Drop zone with variable size
 
 Use for cases where you want the child contents of the dropzone to determine its height.
 


### PR DESCRIPTION
This PR fixes a very small typo in DropZone Readme : ~varaible~ variable

### 🎩 checklist

-   [ ]  Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
-   [ ]  Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
-   [ ]  Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
-   [x]  Updated the component's `README.md` with documentation changes
-   [ ]  [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide