### PR TITLE
[ActionList] Wrap MenuItem Focus Arrow Navigation

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@ Use [the changelog guidelines](https://git.io/polaris-changelog-guidelines) to f
 
 - Keyboard arrow navigation support added in `ActionList` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
 - Menu role attribute value support added in `ActionList/Section` ([#4505](https://github.com/Shopify/polaris-react/pull/4505))
+- Keyboard wrapping arrow navigation added in `ActionList` ([#4654](https://github.com/Shopify/polaris-react/pull/4654))
 
 ### Bug fixes
 

--- a/src/components/ActionList/ActionList.tsx
+++ b/src/components/ActionList/ActionList.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, {useRef} from 'react';
 
-import {KeypressListener} from '../KeypressListener';
 import {
-  focusNextFocusableNode,
-  focusPreviousFocusableNode,
+  wrapFocusNextFocusableMenuItem,
+  wrapFocusPreviousFocusableMenuItem,
 } from '../../utilities/focus';
+import {KeypressListener} from '../KeypressListener';
 import {ActionListItemDescriptor, ActionListSection, Key} from '../../types';
 import {classNames} from '../../utilities/css';
 
@@ -29,6 +29,7 @@ export function ActionList({
   onActionAnyItem,
 }: ActionListProps) {
   let finalSections: ActionListSection[] = [];
+  const actionListRef = useRef<HTMLDivElement & HTMLUListElement>(null);
 
   if (items) {
     finalSections = [{items}, ...sections];
@@ -55,16 +56,26 @@ export function ActionList({
 
   const handleFocusPreviousItem = (evt: KeyboardEvent) => {
     evt.preventDefault();
-    focusPreviousFocusableNode(document.activeElement as HTMLElement);
+    if (actionListRef.current && evt.target) {
+      wrapFocusPreviousFocusableMenuItem(
+        actionListRef.current,
+        evt.target as HTMLElement,
+      );
+    }
   };
 
   const handleFocusNextItem = (evt: KeyboardEvent) => {
     evt.preventDefault();
-    focusNextFocusableNode(document.activeElement as HTMLElement);
+    if (actionListRef.current && evt.target) {
+      wrapFocusNextFocusableMenuItem(
+        actionListRef.current,
+        evt.target as HTMLElement,
+      );
+    }
   };
 
   const listeners =
-    actionRole === 'menu' ? (
+    actionRole === 'menuitem' ? (
       <>
         <KeypressListener
           keyEvent="keydown"
@@ -80,7 +91,7 @@ export function ActionList({
     ) : null;
 
   return (
-    <Element className={className}>
+    <Element ref={actionListRef} className={className}>
       {listeners}
       {sectionMarkup}
     </Element>

--- a/src/components/ActionList/README.md
+++ b/src/components/ActionList/README.md
@@ -115,7 +115,7 @@ function ActionListInPopoverExample() {
         onClose={toggleActive}
       >
         <ActionList
-          actionRole="menu"
+          actionRole="menuitem"
           items={[
             {
               content: 'Import file',
@@ -160,7 +160,7 @@ function ActionListWithMediaExample() {
         onClose={toggleActive}
       >
         <ActionList
-          actionRole="menu"
+          actionRole="menuitem"
           items={[
             {content: 'Import file', icon: ImportMinor, role: 'menuitem'},
             {content: 'Export file', icon: ExportMinor, role: 'menuitem'},
@@ -197,7 +197,7 @@ function ActionListWithSuffixExample() {
         onClose={toggleActive}
       >
         <ActionList
-          actionRole="menu"
+          actionRole="menuitem"
           items={[
             {
               active: true,
@@ -240,7 +240,7 @@ function SectionedActionListExample() {
         onClose={toggleActive}
       >
         <ActionList
-          actionRole="menu"
+          actionRole="menuitem"
           sections={[
             {
               title: 'File options',
@@ -282,7 +282,7 @@ function ActionListWithDestructiveItemExample() {
         onClose={toggleActive}
       >
         <ActionList
-          actionRole="menu"
+          actionRole="menuitem"
           sections={[
             {
               title: 'File options',
@@ -335,7 +335,7 @@ function ActionListWithHelpTextExample() {
         onClose={toggleActive}
       >
         <ActionList
-          actionRole="menu"
+          actionRole="menuitem"
           sections={[
             {
               items: [
@@ -368,6 +368,7 @@ function ActionListWithPrefixSuffixExample() {
   return (
     <div style={{height: '250px', maxWidth: '350px'}}>
       <ActionList
+        actionRole="menuitem"
         items={[
           {
             content: 'Go here',

--- a/src/components/ActionList/components/Item/Item.tsx
+++ b/src/components/ActionList/components/Item/Item.tsx
@@ -120,7 +120,7 @@ export function Item({
   );
 
   return (
-    <li>
+    <li role={role === 'menuitem' ? 'presentation' : undefined}>
       {scrollMarkup}
       {control}
     </li>

--- a/src/components/ActionList/components/Section/Section.tsx
+++ b/src/components/ActionList/components/Section/Section.tsx
@@ -68,7 +68,7 @@ export function Section({
     case 'option':
       sectionRole = 'presentation';
       break;
-    case 'menu':
+    case 'menuitem':
       sectionRole = 'menu';
       break;
     default:

--- a/src/components/ActionList/tests/ActionList.test.tsx
+++ b/src/components/ActionList/tests/ActionList.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import {ImportMinor, ExportMinor} from '@shopify/polaris-icons';
+import {KeypressListener} from 'components';
 import {mountWithApp} from 'test-utilities';
 
 import {ActionList} from '../ActionList';
 import {Badge} from '../../Badge';
 import {Item, Section} from '../components';
+import {Key} from '../../../types';
 
 describe('<ActionList />', () => {
   let mockOnActionAnyItem: jest.Mock;
@@ -176,5 +178,96 @@ describe('<ActionList />', () => {
       children: 'badge',
       status: 'new',
     });
+  });
+  it('wraps focus to first item in action list after keydown event on last element', () => {
+    const actionList = mountWithApp(
+      <ActionList
+        sections={[
+          {
+            title: 'One',
+            items: [
+              {content: 'First section'},
+              {content: 'First section second item'},
+            ],
+          },
+          {
+            title: 'Two',
+            items: [
+              {content: 'Second section'},
+              {content: 'Second section second item'},
+            ],
+          },
+        ]}
+        onActionAnyItem={mockOnActionAnyItem}
+        actionRole="menuitem"
+      />,
+    );
+
+    const actionListButtons = actionList.findAll('button');
+    const keypressListener = actionList.find(KeypressListener, {
+      keyCode: Key.DownArrow,
+    });
+
+    const event = new KeyboardEvent('keydown', {
+      keyCode: Key.DownArrow,
+    });
+
+    Object.defineProperty(event, 'target', {
+      writable: false,
+      // set target to last focusable item in list
+      value: actionListButtons[actionListButtons.length - 1].domNode,
+    });
+
+    keypressListener?.trigger('handler', event);
+
+    // expect focus to wrap back to first item in action list
+    expect(document.activeElement).toStrictEqual(actionListButtons[0].domNode);
+  });
+
+  it('wraps focus to last item in action list after keyup event on first element', () => {
+    const actionList = mountWithApp(
+      <ActionList
+        sections={[
+          {
+            title: 'One',
+            items: [
+              {content: 'First section'},
+              {content: 'First section second item'},
+            ],
+          },
+          {
+            title: 'Two',
+            items: [
+              {content: 'Second section'},
+              {content: 'Second section second item'},
+            ],
+          },
+        ]}
+        onActionAnyItem={mockOnActionAnyItem}
+        actionRole="menuitem"
+      />,
+    );
+
+    const actionListButtons = actionList.findAll('button');
+    const keypressListener = actionList.find(KeypressListener, {
+      keyCode: Key.UpArrow,
+    });
+
+    const event = new KeyboardEvent('keydown', {
+      keyCode: Key.UpArrow,
+    });
+
+    Object.defineProperty(event, 'target', {
+      writable: false,
+      // set target to first focusable item in list
+      value: actionListButtons[0].domNode,
+    });
+
+    keypressListener?.trigger('handler', event);
+
+    // expect focus to wrap to last item in action list
+    expect(document.activeElement).toStrictEqual(
+      actionListButtons[actionListButtons.length - 1].domNode,
+    );
   });
 });

--- a/src/components/Popover/README.md
+++ b/src/components/Popover/README.md
@@ -149,11 +149,8 @@ function PopoverWithActionListExample() {
         onClose={togglePopoverActive}
       >
         <ActionList
-          actionRole="menu"
-          items={[
-            {content: 'Import', role: 'menuitem'},
-            {content: 'Export', role: 'menuitem'},
-          ]}
+          actionRole="menuitem"
+          items={[{content: 'Import'}, {content: 'Export'}]}
         />
       </Popover>
     </div>
@@ -207,7 +204,7 @@ function PopoverContentExample() {
         </Popover.Pane>
         <Popover.Pane>
           <ActionList
-            actionRole="menu"
+            actionRole="menuitem"
             items={[
               {content: 'Online store', role: 'menuitem'},
               {content: 'Facebook', role: 'menuitem'},

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -177,7 +177,7 @@ function getCurrentFocusedElementIndex(
     }
     currentItemIdx++;
   }
-  return currentItemIdx;
+  return currentItemIdx === allFocusableChildren.length ? -1 : currentItemIdx;
 }
 
 export function wrapFocusPreviousFocusableMenuItem(
@@ -189,11 +189,13 @@ export function wrapFocusPreviousFocusableMenuItem(
     allFocusableChildren,
     currentFocusedElement,
   );
-
-  if (currentItemIdx === 0) {
-    allFocusableChildren[allFocusableChildren.length - 1].focus();
+  if (currentItemIdx === -1) {
+    allFocusableChildren[0].focus();
   } else {
-    allFocusableChildren[currentItemIdx - 1].focus();
+    allFocusableChildren[
+      (currentItemIdx - 1 + allFocusableChildren.length) %
+        allFocusableChildren.length
+    ].focus();
   }
 }
 
@@ -206,11 +208,12 @@ export function wrapFocusNextFocusableMenuItem(
     allFocusableChildren,
     currentFocusedElement,
   );
-
-  if (currentItemIdx === allFocusableChildren.length - 1) {
+  if (currentItemIdx === -1) {
     allFocusableChildren[0].focus();
   } else {
-    allFocusableChildren[currentItemIdx + 1].focus();
+    allFocusableChildren[
+      (currentItemIdx + 1) % allFocusableChildren.length
+    ].focus();
   }
 }
 

--- a/src/utilities/focus.ts
+++ b/src/utilities/focus.ts
@@ -9,7 +9,8 @@ const FOCUSABLE_SELECTOR =
   'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]';
 const KEYBOARD_FOCUSABLE_SELECTORS =
   'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]:not([tabindex="-1"])';
-
+const MENUITEM_FOCUSABLE_SELECTORS =
+  'a[role="menuitem"],frame[role="menuitem"],iframe[role="menuitem"],input[role="menuitem"]:not([type=hidden]):not(:disabled),select[role="menuitem"]:not(:disabled),textarea[role="menuitem"]:not(:disabled),button[role="menuitem"]:not(:disabled),*[tabindex]:not([tabindex="-1"])';
 export const handleMouseUpByBlurring: MouseUpBlurHandler = ({currentTarget}) =>
   currentTarget.blur();
 
@@ -156,6 +157,61 @@ export function focusLastKeyboardFocusableNode(
   }
 
   return false;
+}
+
+function getMenuFocusableDescendants(element: HTMLElement) {
+  return element.querySelectorAll(
+    MENUITEM_FOCUSABLE_SELECTORS,
+  ) as NodeListOf<HTMLElement>;
+}
+
+function getCurrentFocusedElementIndex(
+  allFocusableChildren: NodeListOf<HTMLElement>,
+  currentFocusedElement: HTMLElement,
+) {
+  let currentItemIdx = 0;
+
+  for (const focusableChild of allFocusableChildren) {
+    if (focusableChild === currentFocusedElement) {
+      break;
+    }
+    currentItemIdx++;
+  }
+  return currentItemIdx;
+}
+
+export function wrapFocusPreviousFocusableMenuItem(
+  parentElement: HTMLElement,
+  currentFocusedElement: HTMLElement,
+) {
+  const allFocusableChildren = getMenuFocusableDescendants(parentElement);
+  const currentItemIdx = getCurrentFocusedElementIndex(
+    allFocusableChildren,
+    currentFocusedElement,
+  );
+
+  if (currentItemIdx === 0) {
+    allFocusableChildren[allFocusableChildren.length - 1].focus();
+  } else {
+    allFocusableChildren[currentItemIdx - 1].focus();
+  }
+}
+
+export function wrapFocusNextFocusableMenuItem(
+  parentElement: HTMLElement,
+  currentFocusedElement: HTMLElement,
+) {
+  const allFocusableChildren = getMenuFocusableDescendants(parentElement);
+  const currentItemIdx = getCurrentFocusedElementIndex(
+    allFocusableChildren,
+    currentFocusedElement,
+  );
+
+  if (currentItemIdx === allFocusableChildren.length - 1) {
+    allFocusableChildren[0].focus();
+  } else {
+    allFocusableChildren[currentItemIdx + 1].focus();
+  }
 }
 
 function matches(node: HTMLElement, selector: string) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Works towards  #4419

This PR will be merged into Patrick's PR: https://github.com/Shopify/polaris-react/pull/4505 and will add arrow warapping focus navigation.
The goal of this PR is to wrap Focus For menuitems in an actionlist. 

### WHAT is this pull request doing?
Focus wrap is done by adding a few new functions to `focus.ts`:
1. `getMenuFocusableDescendants` --> finds all focusable children of an element with the role `menuitem`
2. `getCurrentFocusedElementIndex` --> of a list of focusable elements, find the index of the currently focused item (important for knowing when at top or bottom of list in order to wrap)
3. `wrapFocusPreviousFocusableMenuItem` --> move focus to previous node or if at the top, wrap to the bottom element in the list
4. `wrapFocusNextFocusableMenuItem` --> move focus to next node or if at the bottom, wrap to the top element.

I also changed that actionList should expect "menuitem" as actionRole. This is because the actionRole is applied to the individual items if the item objects themselves don't specify a role themselves. If the role is "menuitem" the section role will default to "menu" and surrounding `<li>` objects to "presentation". This will also mean for these changes to applied to actionLists in admin, a user just needs to add `actionRole={"menuitem"} instead of individually adding `menuitem` to each item.

There is an issue that Patrick and I determined would be out of scope for this particular PR. If there is an active item, `ScrollTo` is called so that the active element is scrolled to. It does this by adding an anchor element. There are two issues here:
1. If the first element is active, when the popover autofocus is set to `first-node`, the first focusable node it finds is the anchor element that was scrolled to, breaking focus wrapping
2. Although the scroll to scrolls to the active element, focus is still controlled by the popover and focus will be set to the first node in the list if the popover has autofocus set to `first-node`, not to the active element like it should


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
I have been using `yarn storrybook` and testing arrow navigation from there. The README.md in `src/components/ActionList` defines the actionList storybook's components if you wanted to test with more items. Again if there is an active item, focus is broken. Because to fix focus with active items would require changes to popover or scroll to and focus behaviour isn't worsened, to keep this PR scoped to `ActionList`, it is not addressed here.

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
