### PR TITLE
[TextField] Fix refocus bug

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,6 +16,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 ### Bug fixes
 
 - Fixed try-catch syntax error in `Modal` ([#4553](https://github.com/Shopify/polaris-react/pull/4553))
+- Fixed an issue with `TextField` where date time were uneditable on click ([#4671](https://github.com/Shopify/polaris-react/pull/4671))
 
 ### Documentation
 

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -16,7 +16,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 ### Bug fixes
 
 - Fixed try-catch syntax error in `Modal` ([#4553](https://github.com/Shopify/polaris-react/pull/4553))
-- Fixed an issue with `TextField` where date time were uneditable on click ([#4671](https://github.com/Shopify/polaris-react/pull/4671))
+- Fixed an issue with `TextField` where date and time were uneditable on click ([#4671](https://github.com/Shopify/polaris-react/pull/4671))
 
 ### Documentation
 

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -516,7 +516,7 @@ export function TextField({
   }
 
   function handleClick({target}: React.MouseEvent) {
-    if (containsAffix(target) || isInputFocused) {
+    if (containsAffix(target) || focus) {
       return;
     }
     inputRef.current?.focus();

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -16,7 +16,6 @@ import {Labelled, LabelledProps, helpTextID, labelID} from '../Labelled';
 import {Connected} from '../Connected';
 import {Error, Key} from '../../types';
 import {Icon} from '../Icon';
-import {isInputFocused} from '../../utilities/is-input-focused';
 
 import {Resizer, Spinner, SpinnerProps} from './components';
 import styles from './TextField.scss';

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -16,6 +16,7 @@ import {Labelled, LabelledProps, helpTextID, labelID} from '../Labelled';
 import {Connected} from '../Connected';
 import {Error, Key} from '../../types';
 import {Icon} from '../Icon';
+import {isInputFocused} from '../../utilities/is-input-focused';
 
 import {Resizer, Spinner, SpinnerProps} from './components';
 import styles from './TextField.scss';
@@ -515,10 +516,10 @@ export function TextField({
   }
 
   function handleClick({target}: React.MouseEvent) {
-    if (containsAffix(target)) {
+    if (containsAffix(target) || isInputFocused) {
       return;
     }
-    inputRef.current && inputRef.current.focus();
+    inputRef.current?.focus();
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-react/issues/4670

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {Stack, TextField} from '../src';

export function Playground() {
  const [value, setValue] = useState('November');

  const handleChange = useCallback((newValue) => setValue(newValue), []);

  return (
    <Stack vertical>
      <TextField
        label="Store name"
        value={value}
        onChange={handleChange}
        autoComplete="off"
        type="date"
      />
      <TextField
        label="Store name"
        value={value}
        onChange={handleChange}
        autoComplete="off"
        type="time"
      />
      <TextField
        label="Store name"
        value={value}
        onChange={handleChange}
        autoComplete="off"
        type="datetime-local"
      />
    </Stack>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
