### PR TITLE
Delete `color()` function from sass API

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -14,6 +14,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Updated styling of `DropZone` border and overlay text. ([#4662](https://github.com/Shopify/polaris-react/pull/4662))
 - Remove duplicate duration(fast) usage. ([#4682](https://github.com/Shopify/polaris-react/pull/4682))
 - Updated the accessability label for the rollup actions in the `Page` header ([#4080](https://github.com/Shopify/polaris-react/pull/4080))
+- Delete `color()` function from sass API ([#4696](https://github.com/Shopify/polaris-react/pull/4696))
 
 ### Bug fixes
 

--- a/src/styles/foundation/_colors.scss
+++ b/src/styles/foundation/_colors.scss
@@ -27,36 +27,6 @@ $color-palette-data: map-extend(
   )
 );
 
-/// Returns the color value for a given color name and group.
-///
-/// @param {String} $hue - The color’s hue.
-/// @param {String} $value - The darkness/lightness of the color. Defaults to
-/// base.
-/// @param {Color} $for-background - The background color on which this color
-/// will appear. Applies a multiply filter to ensure appropriate contrast.
-/// @return {Color} The color value.
-
-@function color($hue, $value: base, $for-background: null) {
-  $fetched-color: map-get(map-get($color-palette-data, $hue), $value);
-
-  @if map-has-key($color-palette-data, $fetched-color) {
-    $fetched-color: map-get(
-      map-get($color-palette-data, $fetched-color),
-      $value
-    );
-  }
-
-  @if $for-background {
-    $fetched-color: color-multiply($fetched-color, $for-background);
-  }
-
-  @if type-of($fetched-color) == color {
-    @return $fetched-color;
-  } @else {
-    @error "Color `#{$hue}, #{$value}` not found.\a Make sure arguments are strings.\a GOOD: `color('yellow')`.\a BAD: `color(yellow)`.\a\a Available options: #{available-names($color-palette-data)}";
-  }
-}
-
 /// Darkens the foreground color by the background color. This is the same as
 /// the "multiply" filter in graphics apps.
 ///


### PR DESCRIPTION
### WHY are these changes introduced?
Resolves issue #4656

### WHAT is this pull request doing?
Removes `color()` sass function. Function has been deprecated and should be removed.

⚠️ This is a breaking change since this function is part of our `_public-api.scss` ⚠️ 

### How to 🎩
Run storybook and check Chromatic for visual regressions