### PR TITLE
Remove skeleton animation

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -6,6 +6,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Enhancements
 
+- Removed animtion from `Skeleton` components ([#](https://github.com/Shopify/polaris-react/pull/))
 - Allow for `readonly` items in ActionList ([#4623](https://github.com/Shopify/polaris-react/pull/4623))
 - Updated `VisuallyHidden` styles to not use `top` or `clip` ([#4641](https://github.com/Shopify/polaris-react/pull/4641))
 - Added `PlainAction` type to `ComplexAction`. ([#4489](https://github.com/Shopify/polaris-react/pull/4489))

--- a/src/components/SkeletonBodyText/SkeletonBodyText.scss
+++ b/src/components/SkeletonBodyText/SkeletonBodyText.scss
@@ -4,10 +4,6 @@ $body-text-height: rem(8px);
 $body-text-line-height: rem(12px);
 $body-text-last-line-width: 80%;
 
-.SkeletonBodyTextContainer {
-  @include skeleton-shimmer;
-}
-
 .SkeletonBodyText {
   height: $body-text-height;
 

--- a/src/components/SkeletonBodyText/SkeletonBodyText.tsx
+++ b/src/components/SkeletonBodyText/SkeletonBodyText.tsx
@@ -17,7 +17,5 @@ export function SkeletonBodyText({lines = 3}: SkeletonBodyTextProps) {
     bodyTextLines.push(<div className={styles.SkeletonBodyText} key={i} />);
   }
 
-  return (
-    <div className={styles.SkeletonBodyTextContainer}>{bodyTextLines}</div>
-  );
+  return bodyTextLines;
 }

--- a/src/components/SkeletonBodyText/SkeletonBodyText.tsx
+++ b/src/components/SkeletonBodyText/SkeletonBodyText.tsx
@@ -17,5 +17,5 @@ export function SkeletonBodyText({lines = 3}: SkeletonBodyTextProps) {
     bodyTextLines.push(<div className={styles.SkeletonBodyText} key={i} />);
   }
 
-  return bodyTextLines;
+  return <>{bodyTextLines}</>;
 }

--- a/src/components/SkeletonBodyText/tests/SkeletonBodyText.test.tsx
+++ b/src/components/SkeletonBodyText/tests/SkeletonBodyText.test.tsx
@@ -6,15 +6,11 @@ import {SkeletonBodyText} from '../SkeletonBodyText';
 describe('<SkeletonBodyText />', () => {
   it('renders the amount of lines provided', () => {
     const skeletonBodyText = mountWithApp(<SkeletonBodyText lines={2} />);
-    expect(
-      skeletonBodyText.find('div', {className: 'SkeletonBodyTextContainer'}),
-    ).toContainReactComponentTimes('div', 2);
+    expect(skeletonBodyText.findAll('div')).toHaveLength(2);
   });
 
   it('renders 3 lines if none are provided', () => {
     const skeletonBodyText = mountWithApp(<SkeletonBodyText />);
-    expect(
-      skeletonBodyText.find('div', {className: 'SkeletonBodyTextContainer'}),
-    ).toContainReactComponentTimes('div', 3);
+    expect(skeletonBodyText.findAll('div')).toHaveLength(3);
   });
 });

--- a/src/components/SkeletonDisplayText/SkeletonDisplayText.scss
+++ b/src/components/SkeletonDisplayText/SkeletonDisplayText.scss
@@ -13,7 +13,6 @@ $skeleton-display-text-max-width: rem(120px);
 .DisplayText {
   max-width: $skeleton-display-text-max-width;
 
-  @include skeleton-shimmer;
   @include skeleton-content;
 }
 

--- a/src/components/SkeletonPage/SkeletonPage.scss
+++ b/src/components/SkeletonPage/SkeletonPage.scss
@@ -56,7 +56,6 @@ $skeleton-display-text-max-width: rem(120px);
 }
 
 .SkeletonTitle {
-  @include skeleton-shimmer;
   @include skeleton-content;
   max-width: $skeleton-display-text-max-width;
   height: rem(28px);

--- a/src/components/SkeletonThumbnail/SkeletonThumbnail.scss
+++ b/src/components/SkeletonThumbnail/SkeletonThumbnail.scss
@@ -6,7 +6,6 @@
 }
 
 .SkeletonThumbnail {
-  @include skeleton-shimmer;
   @include skeleton-content;
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Breaking [this pr down](https://github.com/Shopify/polaris-react/pull/4462). Removing the animation in this PR and moving the removal of the animation mixin to v8. Removing the skeleton-shimmer mixin is a breaking change. These animations can safely be removed.

### WHAT is this pull request doing?

Removing animation from all skeleton components