### PR TITLE
Remove em() function

### DIFF
--- a/UNRELEASED-v8.md
+++ b/UNRELEASED-v8.md
@@ -22,6 +22,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Removed the `$duration-data` global variable ([#4699](https://github.com/Shopify/polaris-react/pull/4699))
 - Removed the `spacing()` scss function and replaced any instances with tokens ([#4691](https://github.com/Shopify/polaris-react/pull/4691/))
 - Removed the `px()` scss function ([#4751](https://github.com/Shopify/polaris-react/pull/4751))
+- Removed the `em()` scss function ([#4937](https://github.com/Shopify/polaris-react/pull/4937))
 - Removed the `z-index()` scss function ([#4753](https://github.com/Shopify/polaris-react/pull/4753))
 - Removed `nonDesignLangaugeCustomProperties` and `designLangaugeCustomProperties` ([#4770](https://github.com/Shopify/polaris-react/pull/4770))
 - Removed the `rem()` scss function and any references ([#4761](https://github.com/Shopify/polaris-react/pull/4761/))

--- a/src/components/Frame/components/Toast/Toast.scss
+++ b/src/components/Frame/components/Toast/Toast.scss
@@ -1,6 +1,6 @@
 @import '../../../../styles/common';
 
-$breakpoint: em(640px);
+$breakpoint: 640px;
 $Backdrop-opacity: 0.88;
 
 .Toast {

--- a/src/components/ResourceList/ResourceList.scss
+++ b/src/components/ResourceList/ResourceList.scss
@@ -187,7 +187,7 @@ $item-wrapper-loading-height: 64px;
   padding-top: var(--p-space-8);
   padding-bottom: var(--p-space-8);
 
-  @media (min-height: em(600px)) {
+  @media (min-height: breakpoint(600px)) {
     padding-top: calc(var(--p-space-8) * 2);
     padding-bottom: calc(var(--p-space-8) * 2);
   }

--- a/src/styles/foundation/_utilities.scss
+++ b/src/styles/foundation/_utilities.scss
@@ -1,27 +1,3 @@
-$default-browser-font-size: 16px;
-$base-font-size: 16px;
-
-/// Returns the value in ems for a given pixel value. Note that this
-/// only works for elements that have had no font-size changes.
-/// @param {Number} $value - The pixel value to be converted.
-/// @return {Number} The converted value in ems.
-
-@function em($value) {
-  $unit: unit($value);
-
-  @if $value == 0 {
-    @return 0;
-  } @else if $unit == 'em' {
-    @return $value;
-  } @else if $unit == 'rem' {
-    @return $value / 1rem * 1em * ($base-font-size / $default-browser-font-size);
-  } @else if $unit == 'px' {
-    @return $value / $default-browser-font-size * 1em;
-  } @else {
-    @error 'Value must be in px, rem, or em.';
-  }
-}
-
 /// Returns the list of available names in a given map.
 /// @param {Map} $map - The map of data to list the names from.
 /// @param {Number} $map - The level of depth to get names from.

--- a/src/styles/shared/_breakpoints.scss
+++ b/src/styles/shared/_breakpoints.scss
@@ -1,40 +1,39 @@
+@function breakpoint($value) {
+  $value-unit: unit($value);
+
+  @if $value-unit == 'em' {
+    @return $value;
+  } @else if $value-unit == 'px' {
+    @return $value / 16px * 1em;
+  } @else {
+    @error 'The $value passed into breakpoint() must be a pixel or em value. Got "#{$value}"';
+  }
+}
+
 $page-max-width: layout-width(primary, max) + layout-width(secondary, max) +
   layout-width(inner-spacing);
 $frame-with-nav-max-width: layout-width(nav) + $page-max-width;
 
-$stacked-content: em(
+$stacked-content: breakpoint(
   layout-width(primary, min) + layout-width(secondary, min) +
     layout-width(inner-spacing)
 );
-$not-condensed-content: em(layout-width(page-content, not-condensed));
-$partially-condensed-content: em(
+$not-condensed-content: breakpoint(layout-width(page-content, not-condensed));
+$partially-condensed-content: breakpoint(
   layout-width(page-content, partially-condensed)
 );
 
-$not-condensed-outer-spacing: em(2 * layout-width(outer-spacing, max));
-$partially-condensed-outer-spacing: em(2 * layout-width(outer-spacing, min));
+$not-condensed-outer-spacing: breakpoint(2 * layout-width(outer-spacing, max));
+$partially-condensed-outer-spacing: breakpoint(
+  2 * layout-width(outer-spacing, min)
+);
 
 $not-condensed-min-page: $not-condensed-content + $not-condensed-outer-spacing;
 $partially-condensed-min-page: $partially-condensed-content +
   $partially-condensed-outer-spacing;
 
-$nav-size: em(layout-width(nav));
-$nav-min-window: em(layout-width(page-with-nav));
-
-@function breakpoint($value, $adjustment: 0) {
-  $adjusted-value: em($adjustment);
-
-  // Reduces chances to have a style void
-  // between two media queries
-  // See https://github.com/sass-mq/sass-mq/issues/6
-  @if $adjustment == -1px {
-    $adjusted-value: -0.01em;
-  } @else if $adjustment == 1px {
-    $adjusted-value: 0.01em;
-  }
-
-  @return em($value) + $adjusted-value;
-}
+$nav-size: breakpoint(layout-width(nav));
+$nav-min-window: breakpoint(layout-width(page-with-nav));
 
 @mixin page-content-breakpoint-before($size) {
   $size: breakpoint($size);
@@ -121,13 +120,13 @@ $nav-min-window: em(layout-width(page-with-nav));
 }
 
 @mixin breakpoint-after($breakpoint, $inclusive: true) {
-  @media (min-width: #{breakpoint($breakpoint, if($inclusive, 0, 1px))}) {
+  @media (min-width: #{breakpoint($breakpoint) + if($inclusive, 0, 0.01em)}) {
     @content;
   }
 }
 
 @mixin breakpoint-before($breakpoint, $inclusive: true) {
-  @media (max-width: #{breakpoint($breakpoint, if($inclusive, 0, -1px))}) {
+  @media (max-width: #{breakpoint($breakpoint) + if($inclusive, 0, -0.01em)}) {
     @content;
   }
 }

--- a/src/styles/shared/_typography.scss
+++ b/src/styles/shared/_typography.scss
@@ -1,4 +1,4 @@
-$typography-condensed: em(640px);
+$typography-condensed: 640px;
 
 @mixin when-typography-not-condensed {
   @include breakpoint-after($typography-condensed) {


### PR DESCRIPTION
### WHY are these changes introduced?

Attempting to reduce API surface area. We've removed the `px()` and `rem()` functions, let's see if we can remove `em()` too.

I was hoping to get it so that usage of `breakpoint()` no longer triggered deprecation warnings in dart-sass but I don't think that is possible without reworking all the layout stuff which is a gordian knot that needs more drastic reworking, so that's a problem for later. At least now deprecation warnings are scoped solely to usage of `breakpoint()` rather being in a utility `em()` function that anybody could use for anything.

Breaking changes:

- `$typography-condensed` is now a value in px (previously it was in ems)
- Remove `em()` sass function
- The `breakpoint()` sass function's signature has changed slightly but I highly doubt people used the ways that we have dropped support for (nothing in web uses the $adjustment argument):
  -  The $value argument now only accepts px and em values. It no longer accepts rem values.
  - The $adjustment argument has been removed

### WHAT is this pull request doing?

Outside of `_breakpoint.scss` all usage of `em()` defines values that then get passed into `breakpoint()`. `breakpoint()` converts values to ems anyway so this wrapping does nothing, and has been removed. In our public-api `$typography-condensed` is now in pixels instead of ems, but nobody externally should be using that value directly anyway.

Inside of `_breakpoint.scss`:

- The `breakpoint()` function's usage of `em()` has been inlined instead of calling out to `em()`
- Usage of `em()` to define values used when generating breakpoint variables has been replaced with calls to `breakpoint()`

And so there is no more usage of the `em()` function, and so it has been removed

### How to 🎩

Compare the build style file to what is produced by a build on the v9.0.0-major branch and confirm that the generated CSS is identical.