### PR TITLE
add React.ReactNode to content type of Action interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,7 @@ export interface Action {
   /** A unique identifier for the action */
   id?: string;
   /** Content the action displays */
-  content?: string;
+  content?: string | React.ReactNode;
   /** Visually hidden text for screen readers */
   accessibilityLabel?: string;
   /** A destination to link to, rendered in the action */


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

I would like to alter the type of content that can be sent in as an `Action` from `BulkActions` from `string` to `string | React.ReactNode`. I'm currently working on the `Orders` page in `Web` with a task to add a `Tooltip` to one of the BulkActions ("Create shipping label"), but it seems I cannot do so unless I can wrap the content which is a string with the `Tooltip` component.

### WHAT is this pull request doing?

Changes `content?: string;` to `content?: string | React.ReactNode;`

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
