### PR TITLE
Migration guidance `em()`

### DIFF
--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -151,9 +151,10 @@ A list of functions/mixins and their value equivalents or new token values.
 
 #### `em()`
 
-| Function | Source to copy       |
+This function has been deprecated, but the definition can be copied and used locally.
+| Function | Source |
 | -------- | -------------------- |
-| `px()`   | [link to function]() |
+| `em()` | [definition](https://github.com/Shopify/polaris-react/blob/b443d114d447df15d9e72914c8ca5058439a175e/documentation/guides/legacy-polaris-v8-public-api.scss#L333) |
 
 #### `easing()`
 

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -100,6 +100,10 @@ A list of functions/mixins and their value equivalents or new token values.
 | `duration(slower)`               | `--p-duration-400`      |
 | `duration(slowest)`              | `--p-duration-500`      |
 
+#### `em()`
+
+Any usage of this function can be hardcoded to `em` units. Alternatively, values can also be hardcoded to `px` units, which will automatically be converted to `rem` in postcss.
+
 #### `easing()`
 
 | Function                     | Replacement Value/Token                |

--- a/documentation/guides/migrating-from-v8-to-v9.md
+++ b/documentation/guides/migrating-from-v8-to-v9.md
@@ -102,7 +102,9 @@ A list of functions/mixins and their value equivalents or new token values.
 
 #### `em()`
 
-Any usage of this function can be hardcoded to `em` units. Alternatively, values can also be hardcoded to `px` units, which will automatically be converted to `rem` in postcss.
+| Function | Source to copy       |
+| -------- | -------------------- |
+| `px()`   | [link to function]() |
 
 #### `easing()`
 


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes #5022

### WHAT is this pull request doing?

Adds migration guidance for deprecated `em()` scss function