### PR TITLE
[Thumbnail] Add prop to make background transparent

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,6 +8,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Added `ReactNode` as an accepted prop type to `secondaryActions` on the `Page` component ([#5258](https://github.com/Shopify/polaris-react/pull/5258))
 - Added `useCapture` and `options` props in `KeypressListener` to allow passing through those options to the underlying `addEventListener` call ([#5221](https://github.com/Shopify/polaris-react/pull/5221))
+- Add option to make `Thumbnail` component transparent ([#5109](https://github.com/Shopify/polaris-react/pull/5109))
 
 ### Bug fixes
 

--- a/src/components/Thumbnail/Thumbnail.scss
+++ b/src/components/Thumbnail/Thumbnail.scss
@@ -29,6 +29,10 @@
   width: thumbnail-size(large);
 }
 
+.transparent {
+  background: transparent;
+}
+
 .Thumbnail > * {
   position: absolute;
   top: 0;

--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -18,12 +18,20 @@ export interface ThumbnailProps {
   source: string | React.SFC<React.SVGProps<SVGSVGElement>>;
   /** Alt text for the thumbnail image */
   alt: string;
+  /** Transparent background */
+  transparent?: boolean;
 }
 
-export function Thumbnail({source, alt, size = 'medium'}: ThumbnailProps) {
+export function Thumbnail({
+  source,
+  alt,
+  size = 'medium',
+  transparent,
+}: ThumbnailProps) {
   const className = classNames(
     styles.Thumbnail,
     size && styles[variationName('size', size)],
+    transparent && styles.transparent,
   );
 
   const content =

--- a/src/components/Thumbnail/tests/Thumbnail.test.tsx
+++ b/src/components/Thumbnail/tests/Thumbnail.test.tsx
@@ -16,4 +16,20 @@ describe('<Thumbnail />', () => {
       expect(thumbnail).toContainReactComponent('img');
     });
   });
+
+  describe('transparent', () => {
+    it('adds transparent class when transparent is true', () => {
+      const thumbnail = mountWithApp(<Thumbnail alt="" source="abc.jpg" />);
+
+      expect(thumbnail).toContainReactComponent('span', {
+        className: 'Thumbnail sizeMedium',
+      });
+
+      thumbnail.setProps({transparent: true});
+
+      expect(thumbnail).toContainReactComponent('span', {
+        className: 'Thumbnail sizeMedium transparent',
+      });
+    });
+  });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

The specific use case that prompted this was using black background for video thumbnails:

<img src ="https://user-images.githubusercontent.com/12047066/153221585-be29ed58-a28c-4a6a-8f09-6d5bfcf34859.png" alt="Image showing video thumbnail mockup with black background">

### WHAT is this pull request doing?

Adds option to pass a prop to make the thumbnail background transparent, so that the consumer can can use a different background. 

Transparent false (prop not passed):
<img src ="https://user-images.githubusercontent.com/12047066/153227810-4c8712fa-e02d-42f4-b79f-1a4e9029b5b1.png" alt="Image showing thumbnail without the transparent prop displaying with white background" />


Transparent true:
<img src="https://user-images.githubusercontent.com/12047066/153227750-ab727eaa-b23b-4ddd-9257-c7aa76cc6dd3.png" alt="Image showing thumbnail with the transparent prop displaying with transparent background" />

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
