### PR TITLE
[TextField][SearchField] Explicitly set opacity for placeholder elements

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -13,6 +13,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Fixed logo appearing in `Navigation` at 769px ([#5213](https://github.com/Shopify/polaris-react/pull/5213))
 - Reintroduced `top: 0` to `VisuallyHidden` CSS to prevent unexpected scrolling when using a `Sheet` ([#5208](https://github.com/Shopify/polaris-react/pull/5208))
 - Fixed `Form` > `VisuallyHidden` markup causing excessive vertical whitespace ([#5181](https://github.com/Shopify/polaris-react/pull/5181))
+- [ContextualSaveBar] Register `secondaryMenu` prop in frame context ([#5116](https://github.com/Shopify/polaris-react/pull/5116))
+- [TextField][searchfield] Explicitly set opacity to overwrite Firefox default 0.5 opacity for placeholders ([#5165](https://github.com/Shopify/polaris-react/pull/5165))
 
 ### Documentation
 

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -52,6 +52,9 @@ $prefix-horizontal-spacing: var(--p-space-2);
     // This is the only place this color is used.
     // stylelint-disable-next-line color-no-hex
     color: #9c9798;
+
+    // Firefox sets the default opacity to 50%. To keep browsers consistent we explicitly set opacity here.
+    opacity: 1;
   }
 
   // stylelint-disable-next-line selector-max-class, selector-max-combinators
@@ -120,6 +123,9 @@ $prefix-horizontal-spacing: var(--p-space-2);
 
   &::placeholder {
     color: var(--p-text-subdued);
+
+    // Firefox sets the default opacity to 50%. To keep browsers consistent we explicitly set opacity here.
+    opacity: 1;
   }
 
   // These properties are used to remove the default "spinner" controls

--- a/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/src/components/TopBar/components/SearchField/SearchField.scss
@@ -32,6 +32,9 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-4));
 
   &::placeholder {
     color: var(--p-text-subdued);
+
+    // Firefox sets the default opacity to 50%. To keep browsers consistent we explicitly set opacity here.
+    opacity: 1;
   }
 }
 
@@ -82,6 +85,9 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-4));
   &::placeholder {
     color: var(--p-text);
     transition: var(--p-duration-150) color var(--p-ease) 33ms;
+
+    // Firefox sets the default opacity to 50%. To keep browsers consistent we explicitly set opacity here.
+    opacity: 1;
   }
 
   &::-webkit-search-decoration,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
Firefox sets opacity of placeholder elements to 50%. This can be confirmed by going to https://polaris.shopify.com/components/forms/text-field and choosing a placeholder textfield. Compare in both Firefox and Google Chrome. This causes inconsistencies between browsers.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
To solve this, we explicitly set the opacity to 1 for components using `::placeholder`. 
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

### TextField
Before:
![textfield before](https://screenshot.click/22-02-q8dgt-avz18.png)
After:
![textfield after](https://screenshot.click/22-02-dum0b-o6hvf.png)

### TopBar using SearchField
Before:
![searchfield before](https://screenshot.click/22-02-nbzhq-832re.png)
After:
![searchfield after](https://screenshot.click/22-02-dk4is-l7xhw.png)
