### PR TITLE
fix: Pass TextField event object to the onFocus callback

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -8,7 +8,6 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Bug fixes
 
-- Moved all CSS custom properties to be defined under the Polaris color-scheme selector ([#5257](https://github.com/Shopify/polaris-react/pull/5257))
 - Passed TextField event object to onFocus handler to address failing admin unit tests ([#5265](https://github.com/Shopify/polaris-react/pull/5265))
 
 ### Documentation

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -9,6 +9,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 ### Bug fixes
 
 - Moved all CSS custom properties to be defined under the Polaris color-scheme selector ([#5257](https://github.com/Shopify/polaris-react/pull/5257))
+- Passed TextField event object to onFocus handler to address failing admin unit tests ([#5265](https://github.com/Shopify/polaris-react/pull/5265))
 
 ### Documentation
 

--- a/src/components/Combobox/components/TextField/TextField.tsx
+++ b/src/components/Combobox/components/TextField/TextField.tsx
@@ -39,14 +39,11 @@ export function TextField({
     if (setTextFieldLabelId) setTextFieldLabelId(labelId);
   }, [labelId, setTextFieldLabelId]);
 
-  const handleFocus = useCallback(
-    (event: React.FocusEvent<HTMLElement>) => {
-      if (onFocus) onFocus(event);
-      if (onTextFieldFocus) onTextFieldFocus();
-      if (setTextFieldFocused) setTextFieldFocused(true);
-    },
-    [onFocus, onTextFieldFocus, setTextFieldFocused],
-  );
+  const handleFocus = useCallback(() => {
+    if (onFocus) onFocus();
+    if (onTextFieldFocus) onTextFieldFocus();
+    if (setTextFieldFocused) setTextFieldFocused(true);
+  }, [onFocus, onTextFieldFocus, setTextFieldFocused]);
 
   const handleBlur = useCallback(() => {
     if (onBlur) onBlur();

--- a/src/components/Combobox/components/TextField/TextField.tsx
+++ b/src/components/Combobox/components/TextField/TextField.tsx
@@ -39,11 +39,14 @@ export function TextField({
     if (setTextFieldLabelId) setTextFieldLabelId(labelId);
   }, [labelId, setTextFieldLabelId]);
 
-  const handleFocus = useCallback(() => {
-    if (onFocus) onFocus();
-    if (onTextFieldFocus) onTextFieldFocus();
-    if (setTextFieldFocused) setTextFieldFocused(true);
-  }, [onFocus, onTextFieldFocus, setTextFieldFocused]);
+  const handleFocus = useCallback(
+    (event: React.FocusEvent<HTMLElement>) => {
+      if (onFocus) onFocus(event);
+      if (onTextFieldFocus) onTextFieldFocus();
+      if (setTextFieldFocused) setTextFieldFocused(true);
+    },
+    [onFocus, onTextFieldFocus, setTextFieldFocused],
+  );
 
   const handleBlur = useCallback(() => {
     if (onBlur) onBlur();

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -129,7 +129,7 @@ interface NonMutuallyExclusiveProps {
   /** Callback when value is changed */
   onChange?(value: string, id: string): void;
   /** Callback when input is focused */
-  onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
+  onFocus?: (event?: React.FocusEvent<HTMLElement>) => void;
   /** Callback when focus is removed */
   onBlur?(): void;
   /** Visual required indicator, adds an asterisk to label */

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -129,7 +129,7 @@ interface NonMutuallyExclusiveProps {
   /** Callback when value is changed */
   onChange?(value: string, id: string): void;
   /** Callback when input is focused */
-  onFocus?(): void;
+  onFocus?: (event: React.FocusEvent<HTMLElement>) => void;
   /** Callback when focus is removed */
   onBlur?(): void;
   /** Visual required indicator, adds an asterisk to label */
@@ -409,12 +409,12 @@ export function TextField({
     monospaced && styles.monospaced,
   );
 
-  const handleOnFocus = () => {
+  const handleOnFocus = (event: React.FocusEvent<HTMLElement>) => {
     if (selectTextOnFocus) {
       inputRef.current?.select();
     }
     if (onFocus) {
-      onFocus();
+      onFocus(event);
     }
   };
 


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses failing unit tests in the admin.

### WHAT is this pull request doing?

Passes the `TextField` focus event object through to the `onFocus` callback.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
