### PR TITLE
[Tag] Add density changes —mobile

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -6,6 +6,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 ### Enhancements
 
+- Added visual density updates to `Tag` component for mobile view ([#5353](https://github.com/Shopify/polaris/pull/5353))
 - Added visual density updates to `Tag` component and bumped `@shopify/polaris-icons` package ([#5312](https://github.com/Shopify/polaris/pull/5312))
 - Added `ReactNode` as an accepted prop type to `secondaryActions` on the `Page` component ([#5258](https://github.com/Shopify/polaris-react/pull/5258))
 - Added `useCapture` and `options` props in `KeypressListener` to allow passing through those options to the underlying `addEventListener` call ([#5221](https://github.com/Shopify/polaris-react/pull/5221))

--- a/polaris-react/src/components/Tag/Tag.scss
+++ b/polaris-react/src/components/Tag/Tag.scss
@@ -2,12 +2,13 @@
 
 $height: 20px;
 $button-size: 20px;
+$breakpoint: 490px;
 
 .Tag {
   display: inline-flex;
   max-width: 100%;
   align-items: center;
-  min-height: 24px;
+  min-height: 28px;
   padding: 0 var(--p-space-2);
   background-color: var(--p-surface-neutral);
   border-radius: var(--p-border-radius-1);
@@ -23,10 +24,10 @@ $button-size: 20px;
   &.clickable {
     @include unstyled-button;
     cursor: pointer;
-    padding: var(--p-space-05) var(--p-space-2);
+    padding: var(--p-space-1) var(--p-space-2);
     background-color: var(--p-surface-neutral);
     outline: var(--p-border-width-1) solid transparent;
-    font-size: var(--p-font-size-1);
+    font-size: var(--p-font-size-2);
     line-height: var(--p-line-height-2);
 
     &:hover {
@@ -50,6 +51,11 @@ $button-size: 20px;
       pointer-events: none;
       color: var(--p-text-disabled);
     }
+
+    @include breakpoint-after($breakpoint) {
+      padding: var(--p-space-05) var(--p-space-2);
+      font-size: var(--p-font-size-1);
+    }
   }
 
   &.removable {
@@ -59,17 +65,26 @@ $button-size: 20px;
   &.linkable {
     padding: 0;
   }
+
+  @include breakpoint-after($breakpoint) {
+    min-height: 24px;
+  }
 }
 
 .TagText {
-  font-size: var(--p-font-size-1);
+  font-size: var(--p-font-size-2);
   line-height: var(--p-line-height-2);
   min-height: $height;
-  padding: var(--p-space-05) 0;
+  padding: var(--p-space-1) 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   vertical-align: middle;
+
+  @include breakpoint-after($breakpoint) {
+    font-size: var(--p-font-size-1);
+    padding: var(--p-space-05) 0;
+  }
 }
 
 .Button {
@@ -124,10 +139,16 @@ $button-size: 20px;
 
   .LinkText {
     @include truncate;
-    font-size: var(--p-font-size-1);
+    font-size: var(--p-font-size-2);
     line-height: var(--p-line-height-2);
-    padding-top: var(--p-space-05);
-    padding-bottom: var(--p-space-05);
+    padding-top: var(--p-space-1);
+    padding-bottom: var(--p-space-1);
+
+    @include breakpoint-after($breakpoint) {
+      font-size: var(--p-font-size-1);
+      padding-top: var(--p-space-05);
+      padding-bottom: var(--p-space-05);
+    }
   }
 
   @include focus-ring;


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #5310.

Adds density improvements to `Tag` component for mobile view.

### WHAT is this pull request doing?

Changes:

- Adds breakpoint of `490px`
- Tag text/label height is **always** `min-height` of `20px` regardless of desktop or mobile, or else icons get cut off
- Tag `line-height` is **always** `var(--p-line-height-2)` aka `20px` regardless of desktop or mobile to match above
- Tag container `min-height` goes from `24px` to `28px` for desktop -> mobile
- Tag top/bottom margins go from `var(--p-space-05)` aka `2px` to `var(--p-space-1)` aka `4px` for desktop -> mobile
- Tag`font-size` goes from `var(--p-font-size-1)` aka `12px` to `var(--p-font-size-2)` aka `13px` for desktop -> mobile

    <details>
      <summary>Detailed screenshot</summary>
      <img src="https://user-images.githubusercontent.com/26749317/160166785-8978baf7-69c1-4576-8d74-518536e95dd4.png" alt="Detailed screenshot">
    </details>
    <details>
      <summary>Default Tag - desktop to mobile</summary>
      <img src="https://user-images.githubusercontent.com/26749317/160166793-20bf4a02-6789-4533-9d3f-4b0aa0fdbf22.gif" alt="Default Tag - desktop to mobile">
    </details>
    <details>
      <summary>Removable Tag - desktop to mobile</summary>
      <img src="https://user-images.githubusercontent.com/26749317/160166796-92506fa8-bb02-4874-83ce-4e89f173f4a4.gif" alt="Removable Tag - desktop to mobile">
    </details>
    <details>
      <summary>Clickable Tag - desktop to mobile</summary>
      <img src="https://user-images.githubusercontent.com/26749317/160166789-039bd031-ecec-404c-897c-f6261be083d0.gif" alt="Clickable Tag - desktop to mobile">
    </details>
    <details>
      <summary>Link Tag - desktop to mobile</summary>
      <img src="https://user-images.githubusercontent.com/26749317/160166794-099ac575-a996-46a8-b582-24dff48cc1e0.gif" alt="Link Tag - desktop to mobile">
    </details>
    <details>
      <summary>Custom content Tag - desktop to mobile</summary>
      <img src="https://user-images.githubusercontent.com/26749317/160166792-3f8c6bc9-5073-48eb-91ee-a75747788f66.gif" alt="Custom content Tag - desktop to mobile">
    </details>

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from 'react';

import {Page, Tag, Stack} from '../src';

export function Playground() {
  const [selectedTags, setSelectedTags] = useState([
    'Rustic',
    'Antique',
    'Vinyl',
    'Refurbished',
    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer at ipsum quam. Aliquam fermentum bibendum vestibulum. Vestibulum condimentum luctus metus, sed sagittis magna pellentesque eget. Duis dapibus pretium nisi, et venenatis tortor dignissim ut. Quisque eget lacus ac ex eleifend ultrices. Phasellus facilisis ex sit amet leo elementum condimentum. Ut vel maximus felis. Etiam eget diam eu eros blandit interdum. Sed eu metus sed justo aliquam iaculis ac sit amet ex. Curabitur justo magna, porttitor non pulvinar eu, malesuada at leo. Cras mollis consectetur eros, quis maximus lorem dignissim at. Proin in rhoncus massa. Vivamus lectus nunc, fringilla euismod risus commodo, mattis blandit nulla.',
  ]);

  const removeTag = useCallback(
    (tag) => () => {
      setSelectedTags((previousTags) =>
        previousTags.filter((previousTag) => previousTag !== tag),
      );
    },
    [],
  );

  const tagMarkup = selectedTags.map((option) => (
    <Tag key={option} onRemove={removeTag(option)}>
      {option}
    </Tag>
  ));
  return (
    <Page title="Playground">
      <Stack spacing="tight">{tagMarkup}</Stack>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [x] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
