### PR TITLE
Replace remaining hardcoded duration values with tokens

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -15,7 +15,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Replaced hard coded `font-size` and `line-height` values with tokens ([5355](https://github.com/Shopify/polaris/pull/5355/))
 - Replaced hard coded spacing values with tokens ([5364](https://github.com/Shopify/polaris/pull/5364/))
 - Simplified usage of color tokens ([5360](https://github.com/Shopify/polaris/pull/5360/))
-- Replaced hard coded motion values with tokens or removed them ([5405](https://github.com/Shopify/polaris/pull/5405/))
+- Replaced hard coded motion duration values with tokens or removed them ([5405](https://github.com/Shopify/polaris/pull/5405/))
 
 ### Bug fixes
 

--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -15,6 +15,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Replaced hard coded `font-size` and `line-height` values with tokens ([5355](https://github.com/Shopify/polaris/pull/5355/))
 - Replaced hard coded spacing values with tokens ([5364](https://github.com/Shopify/polaris/pull/5364/))
 - Simplified usage of color tokens ([5360](https://github.com/Shopify/polaris/pull/5360/))
+- Replaced hard coded motion values with tokens or removed them ([5405](https://github.com/Shopify/polaris/pull/5405/))
 
 ### Bug fixes
 

--- a/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
@@ -81,7 +81,7 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-4));
 
   &::placeholder {
     color: var(--p-text);
-    transition: var(--p-duration-150) color var(--p-ease) 33ms;
+    transition: var(--p-duration-150) color var(--p-ease) var(--p-duration-50));
   }
 
   &::-webkit-search-decoration,
@@ -102,7 +102,7 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-4));
   transform: translateY(-50%);
 
   svg {
-    transition: var(--p-duration-150) fill var(--p-ease) 33ms;
+    transition: var(--p-duration-150) fill var(--p-ease) var(--p-duration-50));
   }
 }
 

--- a/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
@@ -76,7 +76,6 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-4));
 
   &::placeholder {
     color: var(--p-text);
-    transition: var(--p-duration-150) color var(--p-ease) var(--p-duration-50);
   }
 
   &::-webkit-search-decoration,

--- a/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
@@ -150,14 +150,4 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-4));
   will-change: background-color;
   transition: background-color var(--p-duration-200) var(--p-ease);
   border-radius: var(--p-border-radius-1);
-  animation: toLightBackground 0.01ms;
-}
-
-@keyframes toLightBackground {
-  to {
-    background-color: var(
-      --p-surface-neutral,
-      var(--pc-top-bar-background-lighter)
-    );
-  }
 }

--- a/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
@@ -100,10 +100,6 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-4));
   height: $icon-size;
   pointer-events: none;
   transform: translateY(-50%);
-
-  svg {
-    transition: var(--p-duration-150) fill var(--p-ease) var(--p-duration-50);
-  }
 }
 
 .Clear {

--- a/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
@@ -81,7 +81,7 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-4));
 
   &::placeholder {
     color: var(--p-text);
-    transition: var(--p-duration-150) color var(--p-ease) var(--p-duration-50));
+    transition: var(--p-duration-150) color var(--p-ease) var(--p-duration-50);
   }
 
   &::-webkit-search-decoration,
@@ -102,7 +102,7 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-4));
   transform: translateY(-50%);
 
   svg {
-    transition: var(--p-duration-150) fill var(--p-ease) var(--p-duration-50));
+    transition: var(--p-duration-150) fill var(--p-ease) var(--p-duration-50);
   }
 }
 

--- a/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
+++ b/polaris-react/src/components/TopBar/components/SearchField/SearchField.scss
@@ -38,7 +38,6 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-4));
 .Input:focus {
   ~ .Backdrop {
     @include focus-ring($style: 'focused');
-    background-color: var(--p-surface-search-field);
   }
 
   ~ .BackdropShowFocusBorder {
@@ -51,10 +50,6 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-4));
 }
 
 .focused {
-  .Backdrop {
-    background-color: var(--p-surface-search-field);
-  }
-
   .BackdropShowFocusBorder {
     border: 1px solid var(--pc-top-bar-border);
   }
@@ -139,11 +134,6 @@ $search-icon-width: calc(#{$icon-size} + var(--p-space-4));
   right: 0;
   bottom: 0;
   left: 0;
-  background-color: var(
-    --p-surface-search-field,
-    var(--pc-top-bar-background-lighter)
-  );
-  will-change: background-color;
-  transition: background-color var(--p-duration-200) var(--p-ease);
+  background-color: var(--p-surface-search-field);
   border-radius: var(--p-border-radius-1);
 }

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.scss
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.scss
@@ -25,8 +25,3 @@
   color: var(--p-text);
   text-align: left;
 }
-
-.Name,
-.Detail {
-  transition: var(--p-duration-150) color var(--p-ease) var(--p-duration-50);
-}

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.scss
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.scss
@@ -28,5 +28,5 @@
 
 .Name,
 .Detail {
-  transition: var(--p-duration-150) color var(--p-ease) 33ms;
+  transition: var(--p-duration-150) color var(--p-ease) var(--p-duration-50));
 }

--- a/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.scss
+++ b/polaris-react/src/components/TopBar/components/UserMenu/UserMenu.scss
@@ -28,5 +28,5 @@
 
 .Name,
 .Detail {
-  transition: var(--p-duration-150) color var(--p-ease) var(--p-duration-50));
+  transition: var(--p-duration-150) color var(--p-ease) var(--p-duration-50);
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Increase coverage of motion tokens. Relates to #5339

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
~~Replacing remaining hardcoded duration (ms) values with tokens.~~  Removing unnecessary `transitions` and `animations` with hard coded duration values.
- [SearchField] Remove unnecessary `transition` for backdrop `background-color`, placeholder text `color`, and search icon svg `fill`
- [SearchField] Remove unnecessary `animation` for `background-color`
- [UserMenu] Remove unnecessary `transition` for name and detail text `color`
  