### PR TITLE
[SettingToggle]: Implement accessibility role and attributes

### DIFF
--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -10,6 +10,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added `extraSmall` to the available sizes of the `Thumbnail` and `SkeletonThumbnail` ([#5770](https://github.com/Shopify/polaris/pull/5770))
 - Updated experimental breakpoint values ([#5804](https://github.com/Shopify/polaris/pull/5804))
 - Added support for tooltips on Navigation items ([#5750](https://github.com/Shopify/polaris/pull/5750))
+- Implemented accessibility role and attributes in `SettingToggle` [#5470](https://github.com/Shopify/polaris/pull/5470)
 
 ### Bug fixes
 

--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -10,6 +10,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Added `extraSmall` to the available sizes of the `Thumbnail` and `SkeletonThumbnail` ([#5770](https://github.com/Shopify/polaris/pull/5770))
 - Updated experimental breakpoint values ([#5804](https://github.com/Shopify/polaris/pull/5804))
 - Added support for tooltips on Navigation items ([#5750](https://github.com/Shopify/polaris/pull/5750))
+- Change types for DataTable `totalsName` prop to allow for ReactNode ([#5454](https://github.com/Shopify/polaris/pull/5365/))
 - Implemented accessibility role and attributes in `SettingToggle` [#5470](https://github.com/Shopify/polaris/pull/5470)
 
 ### Bug fixes

--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -11,7 +11,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Updated experimental breakpoint values ([#5804](https://github.com/Shopify/polaris/pull/5804))
 - Added support for tooltips on Navigation items ([#5750](https://github.com/Shopify/polaris/pull/5750))
 - Change types for DataTable `totalsName` prop to allow for ReactNode ([#5454](https://github.com/Shopify/polaris/pull/5365/))
-- Implemented accessibility role and attributes in `SettingToggle` [#5470](https://github.com/Shopify/polaris/pull/5470)
+- Implemented accessibility role and attributes in `SettingToggle` ([#5470](https://github.com/Shopify/polaris/pull/5470))
 
 ### Bug fixes
 

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -78,6 +78,7 @@ type ActionButtonProps = Pick<
   | 'loading'
   | 'ariaControls'
   | 'ariaExpanded'
+  | 'ariaChecked'
   | 'pressed'
   | 'onKeyDown'
   | 'onKeyUp'
@@ -101,6 +102,7 @@ export function Button({
   ariaControls,
   ariaExpanded,
   ariaDescribedBy,
+  ariaChecked,
   onClick,
   onFocus,
   onBlur,
@@ -226,6 +228,7 @@ export function Button({
         disabled={disabled}
         aria-label={disclosureLabel}
         aria-describedby={ariaDescribedBy}
+        aria-checked={ariaChecked}
         onClick={toggleDisclosureActive}
         onMouseUp={handleMouseUpByBlurring}
       >
@@ -274,6 +277,7 @@ export function Button({
     loading,
     ariaControls,
     ariaExpanded,
+    ariaChecked,
     pressed,
     onKeyDown,
     onKeyUp,

--- a/polaris-react/src/components/SettingToggle/README.md
+++ b/polaris-react/src/components/SettingToggle/README.md
@@ -115,7 +115,8 @@ function SettingToggleExample() {
 
 <!-- content-for: web -->
 
-The setting toggle component is implemented as an HTML `<button>`. The current label should convey what happens when the button is pressed.
+The setting toggle component is implemented as an HTML `<button>` with the `switch` [ARIA role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/switch_role).
+The components passed as children will automatically be wrapped in a label element describing the `<button>`. Enabling and disabling the SettingToggle with update the `aria-checked` attribute to `"true"` or `"false"`.
 
 To learn more about button accessibility, see the [button component](https://polaris.shopify.com/components/actions/button).
 

--- a/polaris-react/src/components/SettingToggle/SettingToggle.tsx
+++ b/polaris-react/src/components/SettingToggle/SettingToggle.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 
 import type {ComplexAction} from '../../types';
 import {SettingAction} from '../SettingAction';
 import {buttonFrom} from '../Button';
 import {Card} from '../Card';
+import {globalIdGeneratorFactory} from '../../utilities/unique-id';
 
 export interface SettingToggleProps {
   /** Inner content of the card */
@@ -14,12 +15,25 @@ export interface SettingToggleProps {
   enabled?: boolean;
 }
 
+const getUniqueSettingToggleId = globalIdGeneratorFactory('SettingToggle');
+
 export function SettingToggle({enabled, action, children}: SettingToggleProps) {
-  const actionMarkup = action ? buttonFrom(action, {primary: !enabled}) : null;
+  const id = useMemo(getUniqueSettingToggleId, []);
+
+  const actionMarkup = action
+    ? buttonFrom(action, {
+        primary: !enabled,
+        role: 'switch',
+        id,
+        ariaChecked: enabled ? 'true' : 'false',
+      })
+    : null;
 
   return (
     <Card sectioned>
-      <SettingAction action={actionMarkup}>{children}</SettingAction>
+      <SettingAction action={actionMarkup}>
+        <label htmlFor={id}>{children}</label>
+      </SettingAction>
     </Card>
   );
 }

--- a/polaris-react/src/components/SettingToggle/tests/SettingToggle.test.tsx
+++ b/polaris-react/src/components/SettingToggle/tests/SettingToggle.test.tsx
@@ -3,6 +3,7 @@ import {mountWithApp} from 'tests/utilities';
 
 import {SettingAction} from '../../SettingAction';
 import {SettingToggle} from '../SettingToggle';
+import {Button} from '../../Button';
 
 describe('<SettingToggle />', () => {
   function getComponentProps(node: React.ReactNode) {
@@ -60,15 +61,15 @@ describe('<SettingToggle />', () => {
   describe('accessibility', () => {
     it('renders as a switch widget', () => {
       const toggle = mountWithApp(<SettingToggle enabled />);
-      expect(toggle).toContainReactComponent('button', {role: 'switch'});
+      expect(toggle).toContainReactComponent(Button, {role: 'switch'});
     });
 
     describe('when enabled', () => {
       it('updates `aria-checked`', () => {
         const toggle = mountWithApp(<SettingToggle enabled />);
-        expect(toggle).toContainReactComponent('button', {
+        expect(toggle).toContainReactComponent(Button, {
           role: 'switch',
-          'aria-checked': 'true',
+          ariaChecked: 'true',
         });
       });
     });
@@ -76,9 +77,9 @@ describe('<SettingToggle />', () => {
     describe('when disabled', () => {
       it('updates `aria-checked`', () => {
         const toggle = mountWithApp(<SettingToggle enabled={false} />);
-        expect(toggle).toContainReactComponent('button', {
+        expect(toggle).toContainReactComponent(Button, {
           role: 'switch',
-          'aria-checked': 'false',
+          ariaChecked: 'false',
         });
       });
     });

--- a/polaris-react/src/components/SettingToggle/tests/SettingToggle.test.tsx
+++ b/polaris-react/src/components/SettingToggle/tests/SettingToggle.test.tsx
@@ -22,6 +22,48 @@ describe('<SettingToggle />', () => {
       );
       expect(children).toBe('Click me!');
     });
+
+    describe('accessibility', () => {
+      it('renders as a switch widget', () => {
+        const toggle = mountWithApp(
+          <SettingToggle
+            action={{content: 'Deactivate', onAction: () => {}}}
+            enabled
+          />,
+        );
+        expect(toggle).toContainReactComponent(Button, {role: 'switch'});
+      });
+
+      describe('when enabled', () => {
+        it('updates `aria-checked`', () => {
+          const toggle = mountWithApp(
+            <SettingToggle
+              action={{content: 'Deactivate', onAction: () => {}}}
+              enabled
+            />,
+          );
+          expect(toggle).toContainReactComponent('button', {
+            role: 'switch',
+            'aria-checked': 'true',
+          });
+        });
+      });
+
+      describe('when enabled=false', () => {
+        it('updates `aria-checked`', () => {
+          const toggle = mountWithApp(
+            <SettingToggle
+              action={{content: 'Activate', onAction: () => {}}}
+              enabled={false}
+            />,
+          );
+          expect(toggle).toContainReactComponent('button', {
+            role: 'switch',
+            'aria-checked': 'false',
+          });
+        });
+      });
+    });
   });
 
   describe('enabled', () => {
@@ -55,33 +97,6 @@ describe('<SettingToggle />', () => {
       const children = <div id="someId" />;
       const toggle = mountWithApp(<SettingToggle>{children}</SettingToggle>);
       expect(toggle).toContainReactComponent('div', {id: 'someId'});
-    });
-  });
-
-  describe('accessibility', () => {
-    it('renders as a switch widget', () => {
-      const toggle = mountWithApp(<SettingToggle enabled />);
-      expect(toggle).toContainReactComponent(Button, {role: 'switch'});
-    });
-
-    describe('when enabled', () => {
-      it('updates `aria-checked`', () => {
-        const toggle = mountWithApp(<SettingToggle enabled />);
-        expect(toggle).toContainReactComponent(Button, {
-          role: 'switch',
-          ariaChecked: 'true',
-        });
-      });
-    });
-
-    describe('when disabled', () => {
-      it('updates `aria-checked`', () => {
-        const toggle = mountWithApp(<SettingToggle enabled={false} />);
-        expect(toggle).toContainReactComponent(Button, {
-          role: 'switch',
-          ariaChecked: 'false',
-        });
-      });
     });
   });
 });

--- a/polaris-react/src/components/SettingToggle/tests/SettingToggle.test.tsx
+++ b/polaris-react/src/components/SettingToggle/tests/SettingToggle.test.tsx
@@ -56,6 +56,33 @@ describe('<SettingToggle />', () => {
       expect(toggle).toContainReactComponent('div', {id: 'someId'});
     });
   });
+
+  describe('accessibility', () => {
+    it('renders as a switch widget', () => {
+      const toggle = mountWithApp(<SettingToggle enabled />);
+      expect(toggle).toContainReactComponent('button', {role: 'switch'});
+    });
+
+    describe('when enabled', () => {
+      it('updates `aria-checked`', () => {
+        const toggle = mountWithApp(<SettingToggle enabled />);
+        expect(toggle).toContainReactComponent('button', {
+          role: 'switch',
+          'aria-checked': 'true',
+        });
+      });
+    });
+
+    describe('when disabled', () => {
+      it('updates `aria-checked`', () => {
+        const toggle = mountWithApp(<SettingToggle enabled={false} />);
+        expect(toggle).toContainReactComponent('button', {
+          role: 'switch',
+          'aria-checked': 'false',
+        });
+      });
+    });
+  });
 });
 
 function noop() {}

--- a/polaris-react/src/components/UnstyledButton/UnstyledButton.tsx
+++ b/polaris-react/src/components/UnstyledButton/UnstyledButton.tsx
@@ -28,6 +28,7 @@ export function UnstyledButton({
   ariaControls,
   ariaExpanded,
   ariaDescribedBy,
+  ariaChecked,
   onClick,
   onFocus,
   onBlur,
@@ -82,6 +83,7 @@ export function UnstyledButton({
         aria-controls={ariaControls}
         aria-expanded={ariaExpanded}
         aria-describedby={ariaDescribedBy}
+        aria-checked={ariaChecked}
         aria-pressed={pressed}
         onKeyDown={onKeyDown}
         onKeyUp={onKeyUp}

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -68,6 +68,8 @@ export interface BaseButton {
   ariaExpanded?: boolean;
   /** Indicates the ID of the element that describes the button */
   ariaDescribedBy?: string;
+  /** Indicates the current checked state of the button when acting as a toggle or switch */
+  ariaChecked?: 'false' | 'mixed' | 'true';
   /** Callback when clicked */
   onClick?(): void;
   /** Callback when button becomes focussed */

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -69,7 +69,7 @@ export interface BaseButton {
   /** Indicates the ID of the element that describes the button */
   ariaDescribedBy?: string;
   /** Indicates the current checked state of the button when acting as a toggle or switch */
-  ariaChecked?: 'false' | 'mixed' | 'true';
+  ariaChecked?: 'false' | 'true';
   /** Callback when clicked */
   onClick?(): void;
   /** Callback when button becomes focussed */


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/5462

### WHAT is this pull request doing?

- Allow `aria-checked` attribute to be passed to `<Button />`
- Set role on SettingAction button to `switch`
- Set `aria-checked` attributes on Setting Action based on `enabled` value
- Labelling the `switch` with the content passed in as children
- Reflected changes in the SettingToggle accessibility documentation

<details>
  <summary>Screenshot showing which sub-component becomes the label & switch</summary>
  <img src="https://user-images.githubusercontent.com/80279872/162249596-be9c78a8-0799-4e96-aaed-005939b16803.png" alt="Screenshot showing which sub-component becomes the label & switch">
</details>

There should be **no visual** change in this PR to the SettingToggle component.

https://user-images.githubusercontent.com/80279872/162252121-6f64a1cc-2aa3-44e8-be78-a7540a62c86e.mov

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris-react/blob/master/README.md#development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState, useCallback} from "react";
import {Page} from "../src";

export function Playground() {
  const [active, setActive] = useState(false);

  const handleToggle = useCallback(() => setActive((active) => !active), []);

  const contentStatus = active ? 'Deactivate' : 'Activate';
  const textStatus = active ? 'activated' : 'deactivated';

  return (
    <Page title="Playground">
      <SettingToggle
        action={{
          content: contentStatus,
          onAction: handleToggle,
        }}
        enabled={active}
      >
        This setting is <TextStyle variation="strong">{textStatus}</TextStyle>.
      </SettingToggle>
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [X] Tested on [mobile](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting.md#cross-browser-testing)
- [X] Tested on [multiple browsers](https://help.shopify.com/en/manual/intro-to-shopify/shopify-admin/supported-browsers)
- [X] Tested for [accessibility](https://github.com/Shopify/polaris-react/blob/master/documentation/Accessibility%20testing.md)
- [X] Updated the component's `README.md` with documentation changes
- [X] [Tophatted documentation](https://github.com/Shopify/polaris-react/blob/master/documentation/Tophatting%20documentation.md) changes in the style guide
- [X] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris-react/blob/master/documentation/Versioning%20and%20changelog.md).
-->
