### PR TITLE
Update yarn to latest stable v1.22.18

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 name: polaris
 up:
   - node:
-      yarn: v1.13.0
+      yarn: v1.22.18
       version: v16.13.0 # to be kept in sync with .nvmrc and .github/workflows/ci.yml
   - git_hooks:
       pre-commit: pre-commit


### PR DESCRIPTION
Fixes #5444

There was discussion around potentially using [Yarn v3](https://github.com/yarnpkg/berry) or [pnpm](https://pnpm.io/) due to improved workspace support and performance.

@alex-page @aaronccasanova  Thoughts on doing this exploration now or should we open a ticket to explore these options later? 💭 