### PR TITLE
Update "VSCode" to "VS Code"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Polaris is our design system that helps us work together to build a great experi
 ```sh
 polaris/
 ├── documentation               # Documentation for working in the monorepo
-├── polaris-for-vscode          # VSCode plugin for Polaris
+├── polaris-for-vscode          # VS Code plugin for Polaris
 ├── polaris-react               # Components for @shopify/polaris package
 ├── polaris-shopify-com         # Documentation website
 └── stylelint-polaris           # Rules for custom property usage and mainline coverage

--- a/polaris-for-vscode/CONTRIBUTING.md
+++ b/polaris-for-vscode/CONTRIBUTING.md
@@ -4,10 +4,10 @@ We love receiving pull requests! Please read the `polaris` contributing docs for
 
 ## Extension Development Workflow
 
-The development workflow for a VSCode Extension is built right into the VSCode Editor. Check out the [VSCode API Docs](https://code.visualstudio.com/api/get-started/your-first-extension#developing-the-extension) for more guidnace on the VSCode extension development workflow. To get started with this project:
+The development workflow for a VS Code Extension is built right into the VS Code Editor. Check out the [VS Code API Docs](https://code.visualstudio.com/api/get-started/your-first-extension#developing-the-extension) for more guidnace on the VS Code extension development workflow. To get started with this project:
 
 1. Download the [`polaris` project](https://github.com/Shopify/polaris)
-2. Open the `polaris-react/polaris-for-vscode` directory in a dedicated VSCode window
+2. Open the `polaris-react/polaris-for-vscode` directory in a dedicated VS Code window
 3. Install all dependencies
 
 ```bash
@@ -21,7 +21,7 @@ yarn run generateCustomPropertyNames
 ```
 
 5. Run the `build` command with `cmd + shift + B`. This will start the server in watch mode.
-6. Press `F5` to run the client using the [VSCode debugger](https://code.visualstudio.com/api/get-started/your-first-extension#debugging-the-extension). This will open up a new `Extension Development Host` window
+6. Press `F5` to run the client using the [VS Code debugger](https://code.visualstudio.com/api/get-started/your-first-extension#debugging-the-extension). This will open up a new `Extension Development Host` window
 7. Open a `.css` or `.scss` file of your choosing in the `Extensions Development Host` window
 8. Start typing the extension trigger characters `--` to bring up the Polaris custom properties autocomplete
 9. You're ready to make changes to `polaris-for-vscode` 🎉

--- a/polaris-for-vscode/README.md
+++ b/polaris-for-vscode/README.md
@@ -1,6 +1,6 @@
-# Polaris for VSCode
+# Polaris for VS Code
 
-Official VSCode extension for building with the Shopify [Polaris Design System](https://polaris.shopify.com/).
+Official VS Code extension for building with the Shopify [Polaris Design System](https://polaris.shopify.com/).
 
 ![Demo of Polaris for figma autocompleting token code](https://github.com/Shopify/polaris/blob/main/polaris-for-vscode/docs/polaris-for-vscode-preview.gif?raw=true)
 
@@ -17,7 +17,7 @@ Get code autocomplete suggestions for the [Polaris Design Tokens](https://polari
 
 ## How to use
 
-Once installed and enabled, the Polaris for VSCode extension will automatically run in any CSS and Sass files.
+Once installed and enabled, the Polaris for VS Code extension will automatically run in any CSS and Sass files.
 
 To trigger tokens automcomplete feature:
 

--- a/polaris-for-vscode/client/package.json
+++ b/polaris-for-vscode/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polaris-for-vscode",
-  "description": "Polaris Design System VSCode extension",
+  "description": "Polaris Design System VS Code extension",
   "author": "Polaris",
   "license": "SEE LICENSE IN LICENSE.md",
   "version": "0.1.0",

--- a/polaris-for-vscode/client/src/extension.ts
+++ b/polaris-for-vscode/client/src/extension.ts
@@ -41,7 +41,7 @@ export function activate(context: ExtensionContext) {
   // Create the language client and start the client.
   client = new LanguageClient(
     'polarisForVSCode',
-    'Polaris For VSCode',
+    'Polaris For VS Code',
     serverOptions,
     clientOptions
   );

--- a/polaris-for-vscode/package.json
+++ b/polaris-for-vscode/package.json
@@ -1,9 +1,9 @@
 {
   "name": "polaris-for-vscode",
-  "displayName": "Polaris for VSCode",
+  "displayName": "Polaris for VS Code",
   "publisher": "Shopify",
   "license": "SEE LICENSE IN LICENSE.md",
-  "description": "Polaris Design System VSCode extension",
+  "description": "Polaris Design System VS Code extension",
   "icon": "docs/polaris-icon.png",
   "repository": {
     "type": "git",

--- a/polaris-for-vscode/server/package.json
+++ b/polaris-for-vscode/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polaris-for-vscode",
-  "description": "Polaris Design System VSCode extension",
+  "description": "Polaris Design System VS Code extension",
   "version": "0.1.0",
   "author": "Polaris",
   "license": "SEE LICENSE IN LICENSE.md",

--- a/polaris-react/scripts/utilities/getCustomPropertyNames.js
+++ b/polaris-react/scripts/utilities/getCustomPropertyNames.js
@@ -27,7 +27,7 @@ const getCustomPropertyNames = () => {
 
 /**
  * Used by the prepublish script in polaris-for-vscode to create an object of
- * grouped custom properties as VSCode CompletionItems
+ * grouped custom properties as VS Code CompletionItems
  */
 const getGroupedCustomPropertyCompletionItems = () => {
   return Object.fromEntries(


### PR DESCRIPTION
Replacing "VSCode" with "VS Code" to match what is used in the official documentation and marketing materials.

https://code.visualstudio.com/
