### PR TITLE
[Storybook] Add grid overlay

### DIFF
--- a/polaris-react/.storybook/GridOverlay/GridOverlay.scss
+++ b/polaris-react/.storybook/GridOverlay/GridOverlay.scss
@@ -1,0 +1,23 @@
+.GridOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  display: grid;
+  gap: var(--p-space-3);
+  grid-template-columns: repeat(4, 1fr);
+  padding: 0 var(--p-space-6);
+  background-color: var(--p-action-critical);
+  opacity: 0.25;
+  pointer-events: none;
+
+  @media screen and (min-width: 769px) {
+    grid-template-columns: repeat(12, 1fr);
+  }
+}
+
+.Cell {
+  height: 100%;
+  background-color: var(--p-surface);
+}

--- a/polaris-react/.storybook/GridOverlay/GridOverlay.tsx
+++ b/polaris-react/.storybook/GridOverlay/GridOverlay.tsx
@@ -1,0 +1,26 @@
+import React, {useMemo, useState} from 'react';
+import debounce from 'lodash/debounce';
+import {EventListener} from '../../src';
+
+import styles from './GridOverlay.scss';
+
+const COLUMNS_SMALL = 4;
+const COLUMNS_LARGE = 12;
+
+export function GridOverlay() {
+  const [columns, setColumns] = useState(12);
+
+  const handleResize = debounce(
+    () => setColumns(window.innerWidth < 769 ? COLUMNS_SMALL : COLUMNS_LARGE),
+    50,
+  );
+
+  return (
+    <div className={styles.GridOverlay}>
+      {[...Array(columns).keys()].map((key) => (
+        <div key={key} className={styles.Cell} />
+      ))}
+      <EventListener event="resize" handler={handleResize} />
+    </div>
+  );
+}

--- a/polaris-react/.storybook/preview.js
+++ b/polaris-react/.storybook/preview.js
@@ -2,14 +2,17 @@ import React from 'react';
 import {withPerformance} from 'storybook-addon-performance';
 
 import {AppProvider} from '../src';
+import {GridOverlay} from './GridOverlay/GridOverlay';
 import enTranslations from '../locales/en.json';
 
 function StrictModeDecorator(Story, context) {
+  const gridOverlay = context.globals.grid === 'true' ? <GridOverlay /> : null;
   const Wrapper =
     context.globals.strictMode === 'true' ? React.StrictMode : React.Fragment;
 
   return (
     <Wrapper>
+      {gridOverlay}
       <Story {...context} />
     </Wrapper>
   );
@@ -33,6 +36,17 @@ export const globalTypes = {
       items: [
         {title: 'Disabled', value: 'false'},
         {title: 'Enabled', value: 'true'},
+      ],
+      showName: true,
+    },
+  },
+  grid: {
+    name: 'Grid overlay',
+    defaultValue: 'false',
+    toolbar: {
+      items: [
+        {title: 'Hide', value: 'false'},
+        {title: 'Show', value: 'true'},
       ],
       showName: true,
     },


### PR DESCRIPTION
### WHY are these changes introduced?

This adds our default grid as an overlay option to our stories. [Figma](https://www.figma.com/proto/tR4rQohYSzeRlN08gZystA/Layout-considerations?page-id=206%3A29294&node-id=279%3A26368&viewport=345%2C48%2C0.14&scaling=contain&starting-point-node-id=287%3A28470)

https://user-images.githubusercontent.com/6844391/163460691-c26dadc2-26bf-47f2-a1ad-c1f305feb4b7.mp4


