### PR TITLE
Support nodejs v14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: ['14.17.0', '16']
+        node_version: ['14.17.0', '16.13.0']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,16 @@ on:
 
 jobs:
   test:
-    name: Test ${{ matrix.node }}
+    name: Test with node v${{ matrix.node_version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.17.0', '16']
+        node_version: ['14.17.0', '16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node_version: ${{ matrix.node_version }}
           cache: yarn
 
       - uses: actions/cache@v2
@@ -29,9 +29,9 @@ jobs:
             polaris-react/.loom
             polaris-react/build/ts/latest
             polaris.shopify.com/.next/cache
-          key: ${{ runner.os }}-node${{ matrix.node-version }}-test-v1-${{ github.sha }}
+          key: ${{ runner.os }}-node${{ matrix.node_version }}-test-v1-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-node${{ matrix.node-version }}-test-v1-
+            ${{ runner.os }}-node${{ matrix.node_version }}-test-v1-
 
       - run: yarn --frozen-lockfile
       - run: yarn workspace @shopify/polaris run validate-tokens

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   test:
-    name: 'Test'
+    name: Test ${{ matrix.node }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['16.13.0']
+        node-version: ['14.13.1', '16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['14.13.1', '16']
+        node-version: ['14.17.0', '16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/documentation/Nodejs support.md
+++ b/documentation/Nodejs support.md
@@ -12,7 +12,7 @@ We install dependencies, build the library and run tests across the two supporte
 
 ## Where do we put Node.js versions?
 
-The `package.json` engines.
+The `package.json` engines. This should match the `.github/workflows/ci.yml` and list all supported versions.
 
 ```json
 "engines": {
@@ -20,19 +20,21 @@ The `package.json` engines.
 },
 ```
 
-The `dev.yml` file which creates a local development environment.
 
-```yml
-version: v16.13.0
-```
-
-The GitHub actions `.github/workflows/ci.yml` file:
+The GitHub actions `.github/workflows/ci.yml` file. This should match the `package.json` and list all supported versions.
 
 ```yml
 node_version: ['14.17.0', '16']
 ```
 
-The `.nvmrc` file:
+The `dev.yml` file which creates a local development environment. This should match the `.nvmrc` file.
+
+```yml
+version: v16.13.0
+```
+
+
+The `.nvmrc` file for local development. This should match the `dev.yml` file.
 ```
 v16.13.0
 ```

--- a/documentation/Nodejs support.md
+++ b/documentation/Nodejs support.md
@@ -23,13 +23,16 @@ The `package.json` engines.
 The `dev.yml` file which creates a local development environment.
 
 ```yml
-up:
-  - node:
-      yarn: v1.22.18
+version: v16.13.0
 ```
 
 The GitHub actions `.github/workflows/ci.yml` file:
 
 ```yml
 node_version: ['14.17.0', '16']
+```
+
+The `.nvmrc` file:
+```
+v16.13.0
 ```

--- a/documentation/Nodejs support.md
+++ b/documentation/Nodejs support.md
@@ -1,0 +1,35 @@
+# NodeJS support
+
+`@shopify/polaris` supports the [last two long term support (LTS) versions](https://nodejs.org/en/about/releases/) of NodeJS. This matches our approach for the [Shopify CLI](https://github.com/Shopify/shopify-cli) a tool used by developers to quickly create applications that uses Polaris.
+
+## Local development
+
+We use the latest long term support version of nodejs for local development.
+
+## Continuous Integration
+
+We install dependencies, build the library and run tests across the two supported NodeJS versions.
+
+## Where do we put Node.js versions?
+
+The `package.json` engines.
+
+```json
+"engines": {
+  "node": "^14.17.0 || ^16.13.0"
+},
+```
+
+The `dev.yml` file which creates a local development environment.
+
+```yml
+up:
+  - node:
+      yarn: v1.22.18
+```
+
+The GitHub actions `.github/workflows/ci.yml` file:
+
+```yml
+node_version: ['14.17.0', '16']
+```

--- a/documentation/Nodejs support.md
+++ b/documentation/Nodejs support.md
@@ -24,7 +24,7 @@ The `package.json` engines. This should match the `.github/workflows/ci.yml` and
 The GitHub actions `.github/workflows/ci.yml` file. This should match the `package.json` and list all supported versions.
 
 ```yml
-node_version: ['14.17.0', '16']
+node_version: ['14.17.0', '16.13.0']
 ```
 
 The `dev.yml` file which creates a local development environment. This should match the `.nvmrc` file.

--- a/documentation/Nodejs support.md
+++ b/documentation/Nodejs support.md
@@ -20,7 +20,6 @@ The `package.json` engines. This should match the `.github/workflows/ci.yml` and
 },
 ```
 
-
 The GitHub actions `.github/workflows/ci.yml` file. This should match the `package.json` and list all supported versions.
 
 ```yml
@@ -33,8 +32,8 @@ The `dev.yml` file which creates a local development environment. This should ma
 version: v16.13.0
 ```
 
-
 The `.nvmrc` file for local development. This should match the `dev.yml` file.
+
 ```
 v16.13.0
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "polaris",
   "private": true,
   "engines": {
-    "node": "^14.13.1 || ^16.13.0"
+    "node": "^14.17.0 || ^16.13.0"
   },
   "workspaces": [
     "polaris-for-vscode",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "polaris",
   "private": true,
   "engines": {
-    "node": "^14.13.1 || ^16.0.0"
+    "node": "^14.13.1 || ^16.13.0"
   },
   "workspaces": [
     "polaris-for-vscode",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "polaris",
   "private": true,
   "engines": {
-    "node": ">=16.13.0"
+    "node": "^14.13.1 || ^16.0.0"
   },
   "workspaces": [
     "polaris-for-vscode",

--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -10,6 +10,8 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 
 - Added support for setting a `ReactNode` on the `PageActions` `secondaryActions` prop ([#5495](https://github.com/Shopify/polaris/pull/5495))
 
+- Added support for NodeJS v14 ([#5551](https://github.com/Shopify/polaris/pull/5551))
+
 ### Bug fixes
 
 ### Documentation

--- a/stylelint-polaris/package.json
+++ b/stylelint-polaris/package.json
@@ -26,9 +26,6 @@
     "stylelint"
   ],
   "main": "index.js",
-  "engines": {
-    "node": ">=16.13.0"
-  },
   "scripts": {
     "gen-polaris-data": "node ./scripts/gen-polaris-data.js",
     "build": "yarn gen-polaris-data",


### PR DESCRIPTION
### WHY are these changes introduced?

The Shopify CLI supports NodeJS v14. Polaris is a key part of this when using the CLI to create a new application. This adds back support and tests for NodeJS v14.

### WHAT is this pull request doing?

- [x] Creates a GitHub action for nodejs v14
- [x] Adds a minumum nodejs v14 to the package.json file