### PR TITLE
[Layout] Clean up and align to grid

### DIFF
--- a/polaris-react/.storybook/GridOverlay/GridOverlay.scss
+++ b/polaris-react/.storybook/GridOverlay/GridOverlay.scss
@@ -7,9 +7,9 @@
   bottom: 0;
   right: 0;
   display: grid;
-  gap: var(--p-space-3);
+  gap: var(--p-space-4);
   grid-template-columns: repeat(4, 1fr);
-  padding: 0 var(--p-space-3);
+  padding: 0 var(--p-space-4);
   margin: 0 auto;
   background-color: var(--p-action-critical);
   opacity: 0.25;

--- a/polaris-react/.storybook/GridOverlay/GridOverlay.tsx
+++ b/polaris-react/.storybook/GridOverlay/GridOverlay.tsx
@@ -1,5 +1,4 @@
-import React, {useEffect, useState} from 'react';
-import debounce from 'lodash/debounce';
+import React, {useState} from 'react';
 import {EventListener} from '../../src';
 import {classNames} from '../../src/utilities/css';
 
@@ -22,16 +21,15 @@ export function GridOverlay({inFrame, maxWidth, layer, children}: Props) {
     window.innerWidth < BREAKPOINT ? COLUMNS_SMALL : COLUMNS_LARGE,
   );
 
-  const handleResize = debounce(() => {
+  const handleResize = () =>
     setColumns(window.innerWidth < BREAKPOINT ? COLUMNS_SMALL : COLUMNS_LARGE);
-  }, 50);
 
   const className = classNames(styles.GridOverlay, inFrame && styles.inFrame);
 
   const style = {
     maxWidth,
     zIndex: layer === 'above' || inFrame ? 1 : -1,
-  } as unknown as React.CSSProperties;
+  } as React.CSSProperties;
 
   return (
     <div className={className} style={style}>

--- a/polaris-react/src/components/Layout/Layout.scss
+++ b/polaris-react/src/components/Layout/Layout.scss
@@ -4,41 +4,21 @@ $secondary-basis: layout-width(secondary, min);
 $primary-basis: layout-width(primary, min);
 $one-half-basis: layout-width(one-half-width, base);
 $one-third-basis: layout-width(one-third-width, base);
-$relative-size: $primary-basis / $secondary-basis;
 
 .Layout {
   display: flex;
   flex-wrap: wrap;
+  gap: var(--p-space-4);
   justify-content: center;
   align-items: flex-start;
-  margin-top: calc(-1 * var(--p-space-4));
-  margin-left: calc(-1 * var(--p-space-5));
-
-  @media print {
-    body & {
-      font-size: var(--p-font-size-1);
-      line-height: var(--p-line-height-1);
-    }
-
-    a,
-    button {
-      color: var(--p-text);
-    }
-  }
 }
 
 .Section {
-  flex: $relative-size $relative-size $primary-basis;
-  min-width: 51%;
-
-  @media print {
-    flex: 2 2 360px;
-  }
+  flex: 2 2 $primary-basis;
 }
 
 .Section-secondary {
   flex: 1 1 $secondary-basis;
-  min-width: 0;
 }
 
 .Section-fullWidth {
@@ -47,25 +27,18 @@ $relative-size: $primary-basis / $secondary-basis;
 
 .Section-oneHalf {
   flex: 1 1 $one-half-basis;
-  min-width: 0;
 }
 
 .Section-oneThird {
   flex: 1 1 $one-third-basis;
-  min-width: 0;
 }
 
 .AnnotatedSection {
-  min-width: 0;
   flex: 1 1 100%;
 }
 
 .Section,
 .AnnotatedSection {
-  max-width: calc(100% - var(--p-space-5));
-  margin-top: var(--p-space-4);
-  margin-left: var(--p-space-5);
-
   + .AnnotatedSection {
     @include page-content-when-not-fully-condensed {
       padding-top: var(--p-space-4);
@@ -77,12 +50,10 @@ $relative-size: $primary-basis / $secondary-basis;
 .AnnotationWrapper {
   display: flex;
   flex-wrap: wrap;
-  margin-top: calc(-1 * var(--p-space-4));
-  margin-left: calc(-1 * var(--p-space-5));
 }
 
 .AnnotationContent {
-  flex: $relative-size $relative-size $primary-basis;
+  flex: 2 2 $primary-basis;
 }
 
 .Annotation {
@@ -96,14 +67,6 @@ $relative-size: $primary-basis / $secondary-basis;
   @include page-content-when-layout-not-stacked {
     padding: var(--p-space-5) var(--p-space-5) var(--p-space-5) 0;
   }
-}
-
-.Annotation,
-.AnnotationContent {
-  min-width: 0;
-  max-width: calc(100% - var(--p-space-5));
-  margin-top: var(--p-space-4);
-  margin-left: var(--p-space-5);
 }
 
 .AnnotationDescription {

--- a/polaris-react/src/styles/foundation/_layout.scss
+++ b/polaris-react/src/styles/foundation/_layout.scss
@@ -15,8 +15,8 @@ $layout-width-data: (
     max: 662px,
   ),
   secondary: (
-    min: 240px,
-    max: 320px,
+    min: 236px,
+    max: 324px,
   ),
   one-half-width: (
     base: 450px,

--- a/polaris-react/src/styles/shared/_page.scss
+++ b/polaris-react/src/styles/shared/_page.scss
@@ -4,7 +4,11 @@
   max-width: $page-max-width;
 
   @include page-content-when-not-fully-condensed {
-    padding: 0 var(--p-space-6);
+    padding: 0 var(--p-space-4);
+  }
+
+  @include page-content-when-not-partially-condensed {
+    padding: 0 var(--p-space-8);
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Part 1 of https://github.com/Shopify/polaris/issues/5553. This gets us closer to the grid using flex.
Part 2 will be handled by fully switching to css grid in https://github.com/Shopify/polaris/pull/5565 but will be pointed to v10

https://user-images.githubusercontent.com/6844391/165624246-47d4d9a8-114b-4818-bed3-f35561dff56d.mp4

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Card, Page, Layout} from '../src';

export function Playground() {
  return (
    <Page title="Playground" fullWidth>
      <Layout>
        <Layout.Section fullWidth>
          <Card sectioned>Full width</Card>
        </Layout.Section>
        <Layout.Section secondary>
          <Card sectioned>Secondary</Card>
          <Card sectioned>Secondary</Card>
          <Card sectioned>Secondary</Card>
        </Layout.Section>
        <Layout.Section>
          <Card sectioned>Default</Card>
          <Card sectioned>Default</Card>
        </Layout.Section>

        <Layout.Section columns={{small: 2, large: 4}}>
          <Card sectioned>2 col mobile 4 col desk</Card>
        </Layout.Section>
        <Layout.Section columns={{small: 1, large: 8}}>
          <Card sectioned>1 col mobile 8 col desk</Card>
        </Layout.Section>
        <Layout.Section columns={{small: 1, large: 6}}>
          <Card sectioned>1 col mobile 6 col desk</Card>
        </Layout.Section>
        <Layout.Section columns={{small: 2, large: 6}}>
          <Card sectioned>2 col mobile 6 col desk</Card>
        </Layout.Section>

        <Layout.Section>
          <Card sectioned>Default</Card>
          <Card sectioned>Default</Card>
          <Card sectioned>Default</Card>
        </Layout.Section>
        <Layout.Section secondary>
          <Card sectioned>Secondary</Card>
          <Card sectioned>Secondary</Card>
        </Layout.Section>
      </Layout>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
