### PR TITLE
fix: Polaris tokens ESM interoperability

### DIFF
--- a/polaris-tokens/package.json
+++ b/polaris-tokens/package.json
@@ -3,12 +3,12 @@
   "version": "5.0.0",
   "description": "",
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     },
     "./json/*": "./dist/json/*",

--- a/polaris-tokens/rollup.config.js
+++ b/polaris-tokens/rollup.config.js
@@ -16,12 +16,13 @@ const rollupOptions = {
   output: [
     {
       format: /** @type {const} */ ('cjs'),
+      entryFileNames: '[name][assetExtname].js',
       dir: path.dirname(pkg.main),
       preserveModules: true,
     },
     {
       format: /** @type {const} */ ('es'),
-      entryFileNames: '[name].mjs',
+      entryFileNames: '[name][assetExtname].mjs',
       dir: path.dirname(pkg.module),
       preserveModules: true,
     },

--- a/polaris-tokens/rollup.config.js
+++ b/polaris-tokens/rollup.config.js
@@ -21,6 +21,7 @@ const rollupOptions = {
     },
     {
       format: /** @type {const} */ ('es'),
+      entryFileNames: '[name].mjs',
       dir: path.dirname(pkg.module),
       preserveModules: true,
     },


### PR DESCRIPTION
This PR fixes and issue with ESM interoperability in  `@shopify/polaris-tokens`. While we were already exporting dual ESM/CJS builds, Node.js was unable to infer what module system to use from the output paths alone. Therefore, all `dist/esm/*` files have been updated to use `.mjs` extensions and `dist/cjs/*` files will continue to use `.js`

![image](https://user-images.githubusercontent.com/32409546/166301064-2abe38e9-4e26-4a42-9f74-e4d7e8b66a77.png)