### PR TITLE
[FullscreenBar] Add this component for use in Fullscreen apps

### DIFF
--- a/.changeset/gold-donkeys-work.md
+++ b/.changeset/gold-donkeys-work.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added new FullscreenBar component which provides a uniformly styled Back button to exit Fullscreen mode.

--- a/polaris-react/.storybook/polaris-readme-loader.js
+++ b/polaris-react/.storybook/polaris-readme-loader.js
@@ -94,6 +94,7 @@ import {
   Form,
   FormLayout,
   Frame,
+  FullscreenBar,
   Heading,
   Icon,
   Image,

--- a/polaris-react/locales/en.json
+++ b/polaris-react/locales/en.json
@@ -144,6 +144,10 @@
         "closeMobileNavigationLabel": "Close navigation"
       }
     },
+    "FullscreenBar": {
+      "back": "Back",
+      "accessibilityLabel": "Exit fullscreen mode"
+    },
     "Filters": {
       "moreFilters": "More filters",
       "moreFiltersWithCount": "More filters ({count})",

--- a/polaris-react/src/components/FullscreenBar/FullscreenBar.scss
+++ b/polaris-react/src/components/FullscreenBar/FullscreenBar.scss
@@ -1,0 +1,26 @@
+@import '../../styles/common';
+
+.FullscreenBar {
+  position: relative;
+  display: flex;
+  height: top-bar-height();
+  box-shadow: var(--p-shadow-top-bar);
+  background-color: var(--p-surface);
+}
+
+.BackAction {
+  display: flex;
+  flex: 0 1 auto;
+  align-items: center;
+  padding-left: var(--p-space-3);
+  padding-right: var(--p-space-3);
+  border-width: 0;
+  border-right: var(--p-border-base);
+  background-color: var(--p-surface);
+  font-weight: var(--p-font-weight-medium);
+  cursor: pointer;
+}
+
+.BackAction :first-child {
+  padding-right: var(--p-space-05);
+}

--- a/polaris-react/src/components/FullscreenBar/FullscreenBar.scss
+++ b/polaris-react/src/components/FullscreenBar/FullscreenBar.scss
@@ -3,7 +3,7 @@
 .FullscreenBar {
   position: relative;
   display: flex;
-  height: top-bar-height();
+  height: $top-bar-height;
   box-shadow: var(--p-shadow-top-bar);
   background-color: var(--p-surface);
 }

--- a/polaris-react/src/components/FullscreenBar/FullscreenBar.tsx
+++ b/polaris-react/src/components/FullscreenBar/FullscreenBar.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {ExitMajor} from '@shopify/polaris-icons';
+
+import {Icon} from '../Icon';
+import {useI18n} from '../../utilities/i18n';
+
+import styles from './FullscreenBar.scss';
+
+export interface FullscreenBarProps {
+  /** Callback when back button is clicked */
+  onAction: () => void;
+  /** Render child elements */
+  children?: React.ReactNode;
+}
+
+export function FullscreenBar({onAction, children}: FullscreenBarProps) {
+  const i18n = useI18n();
+
+  return (
+    <div className={styles.FullscreenBar}>
+      <button
+        className={styles.BackAction}
+        onClick={onAction}
+        aria-label={i18n.translate('Polaris.FullscreenBar.accessibilityLabel')}
+      >
+        <Icon source={ExitMajor} />
+        {i18n.translate('Polaris.FullscreenBar.back')}
+      </button>
+      {children}
+    </div>
+  );
+}

--- a/polaris-react/src/components/FullscreenBar/README.md
+++ b/polaris-react/src/components/FullscreenBar/README.md
@@ -1,0 +1,106 @@
+---
+name: Fullscreen bar
+category: Navigation
+keywords:
+  - topbar
+  - top bar
+  - header
+  - bar
+  - app
+---
+
+# Fullscreen bar
+
+The Fullscreen bar is a header component that should be presented at the top of an app when it is in fullscreen mode. This is designed to ensure
+a uniform placement for a button to exit that mode. The Fullscreen bar can be customized by adding `children`.
+
+---
+
+## Best practices
+
+The Fullscreen bar component should:
+
+- Be presented when an App is in fullscreen mode as a means of exiting that mode.
+- Fire an action to exit fullscreen mode.
+
+---
+
+## Examples
+
+### Fullscreen bar with children
+
+Use to provide structure for the top of an application while in fullscreen mode.
+
+```jsx
+function FullscreenBarExample() {
+  const [isFullscreen, setFullscreen] = useState(true);
+
+  const handleActionClick = useCallback(() => {
+    setFullscreen(false);
+  }, []);
+
+  const fullscreenBarMarkup = (
+    <FullscreenBar onAction={handleActionClick}>
+      <div
+        style={{
+          display: 'flex',
+          flexGrow: 1,
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          paddingLeft: '1rem',
+        }}
+      >
+        <DisplayText>Content</DisplayText>
+        <Button onClick={() => {}}>User Action 1</Button>
+      </div>
+    </FullscreenBar>
+  );
+
+  return (
+    <div style={{height: '250px'}}>
+      {isFullscreen && fullscreenBarMarkup}
+      <div style={{padding: '1rem'}}>
+        {!isFullscreen && (
+          <Button onClick={() => setFullscreen(true)}>Go Fullscreen</Button>
+        )}
+        <DisplayText size="small">Page content</DisplayText>
+      </div>
+    </div>
+  );
+}
+```
+
+### Fullscreen bar no children
+
+Use this default to show ONLY the Back button.
+
+```jsx
+function FullscreenBarExample() {
+  const [isFullscreen, setFullscreen] = useState(true);
+
+  const handleActionClick = useCallback(() => {
+    setFullscreen(false);
+  }, []);
+
+  const fullscreenBarMarkup = <FullscreenBar onAction={handleActionClick} />;
+
+  return (
+    <div style={{height: '250px'}}>
+      {isFullscreen && fullscreenBarMarkup}
+      <div style={{padding: '1rem'}}>
+        {!isFullscreen && (
+          <Button onClick={() => setFullscreen(true)}>Go Fullscreen</Button>
+        )}
+        <DisplayText size="small">Page content</DisplayText>
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+## Related components
+
+- To provide quick, at-a-glance feedback on the outcome of an action, use the [toast](https://polaris.shopify.com/components/feedback-indicators/toast) component.
+- To indicate to merchants that a page is loading or an upload is processing, use the [loading](https://polaris.shopify.com/components/feedback-indicators/loading) component.

--- a/polaris-react/src/components/FullscreenBar/index.ts
+++ b/polaris-react/src/components/FullscreenBar/index.ts
@@ -1,0 +1,1 @@
+export * from './FullscreenBar';

--- a/polaris-react/src/components/FullscreenBar/tests/FullscreenBar.test.tsx
+++ b/polaris-react/src/components/FullscreenBar/tests/FullscreenBar.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+import {FullscreenBar} from '../FullscreenBar';
+
+describe('<FullscreenBar />', () => {
+  it('renders its children', () => {
+    const text = 'My App Info';
+    const bar = mountWithApp(
+      <FullscreenBar onAction={() => {}}>{text}</FullscreenBar>,
+    );
+
+    expect(bar).toContainReactText(text);
+  });
+
+  it('fires onAction when clicked', () => {
+    const mockOnAction = jest.fn();
+    const bar = mountWithApp(<FullscreenBar onAction={mockOnAction} />);
+
+    bar.find('button')!.trigger('onClick');
+    expect(mockOnAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -175,6 +175,9 @@ export {
 } from './components/Frame';
 export type {FrameProps} from './components/Frame';
 
+export {FullscreenBar} from './components/FullscreenBar';
+export type {FullscreenBarProps} from './components/FullscreenBar';
+
 export {Heading} from './components/Heading';
 export type {HeadingProps} from './components/Heading';
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #5664

We are rolling out Fullscreen mode in Apps (first and third-party) in App Bridge.  We want to give App developers an easy way to be conformant with our requirements on Fullscreen.  If they are in that mode, they MUST provide a navigation bar with a back button to exit.

### WHAT is this pull request doing?

This PR adds a top bar with uniformed styling on a Back button to exit Fullscreen mode.  It can contain children so that the App developer can customize the rest of the bar to their needs.

<img width="749" alt=" Fullscreen bar - Fullscreen bar with children ⋅ Storybook 2022-05-02 16-26-04" src="https://user-images.githubusercontent.com/419924/166342028-7972797b-61ad-4df3-9955-e1276f9b2230.png">

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md)

You can test this component locally in Storybook:
[Fullscreen bar](http://localhost:6006/?path=/story/all-components-fullscreen-bar--fullscreen-bar-with-children)

or in a Spin instance: https://shop1.shopify.fsbar.cameron-dawson.us.spin.dev/admin/email_templates/order_confirmation/edit
* Check toward the top of the page to see it.  Click the Back button for a Toast to pop up.


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
