### PR TITLE
Use FunctionComponent instead of deprecated types

### DIFF
--- a/polaris-icons/CHANGELOG.md
+++ b/polaris-icons/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Types are now React 18 compatible ([#5704](https://github.com/Shopify/polaris/pull/5704))
 
 ## 4.19.1 - 2022-04-21
 

--- a/polaris-icons/rollup.config.js
+++ b/polaris-icons/rollup.config.js
@@ -29,7 +29,7 @@ function generateTypesFile(iconExports) {
   return iconExports
     .map(
       (exportName) =>
-        `export declare const ${exportName}: React.SFC<React.SVGProps<SVGSVGElement>>;`,
+        `export declare const ${exportName}: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;`,
     )
     .join('\n');
 }

--- a/polaris-react/UNRELEASED.md
+++ b/polaris-react/UNRELEASED.md
@@ -21,6 +21,7 @@ Use [the changelog guidelines](/documentation/Versioning%20and%20changelog.md) t
 - Used prop-provided `selectable` value in `IndexTable` ([#5661](https://github.com/Shopify/polaris/pull/5661))
 - Fixed passing inline styles to the root element of the `CustomProperties` component ([#5661](https://github.com/Shopify/polaris/pull/5661))
 - Replaced incorrect usage of `aria-expanded` on `Collapsible` with `aria-hidden` ([#5661](https://github.com/Shopify/polaris/pull/5661))
+- Removed usage of deprecated and removed in v18 React types ([#5704](https://github.com/Shopify/polaris/pull/5704))
 
 ### Documentation
 

--- a/polaris-react/src/components/Banner/tests/Banner.test.tsx
+++ b/polaris-react/src/components/Banner/tests/Banner.test.tsx
@@ -295,7 +295,7 @@ describe('<Banner />', () => {
 
   describe('context', () => {
     it('passes the within banner context', () => {
-      const Child: React.SFC = (_props) => {
+      const Child: React.FunctionComponent = (_props) => {
         return (
           <BannerContext.Consumer>
             {(BannerContext) => {

--- a/polaris-react/src/components/Thumbnail/Thumbnail.tsx
+++ b/polaris-react/src/components/Thumbnail/Thumbnail.tsx
@@ -15,7 +15,7 @@ export interface ThumbnailProps {
    */
   size?: Size;
   /** URL for the image */
-  source: string | React.SFC<React.SVGProps<SVGSVGElement>>;
+  source: string | React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
   /** Alt text for the thumbnail image */
   alt: string;
   /** Transparent background */

--- a/polaris-react/src/utilities/components.tsx
+++ b/polaris-react/src/utilities/components.tsx
@@ -99,7 +99,7 @@ function hotReloadComponentCheck(
 ) {
   const componentName = AComponent.name;
   const anotherComponentName = (
-    AnotherComponent as React.StatelessComponent<any>
+    AnotherComponent as React.FunctionComponent<any>
   ).displayName;
 
   return (


### PR DESCRIPTION
### WHY are these changes introduced?

Preparing for React v18 support

SFC and StatelessComponent have been removed in react v18's types.

This should fix polaris-icons' react 18 support.

This doesn't go all the way to full v18 support in polaris-react, there's still some other breaking changes to fix up as detailed in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210, but this is a start.

### WHAT is this pull request doing?

Replace usage of `SFC` and `StatelessComponent` with `FunctionComponent`
