### PR TITLE
[IndexTable] Update to let padding apply to second cell

### DIFF
--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -240,7 +240,6 @@ $loading-panel-height: 53px;
   @include breakpoint-after($breakpoint-small) {
     position: sticky;
     z-index: var(--pc-index-table-sticky-cell);
-    padding: 0;
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes linked issue

### Screenies
|Before|After|
|-|-|
|<img width="449" alt="Screen Shot 2022-05-11 at 1 12 05 PM" src="https://user-images.githubusercontent.com/24610840/167909851-23229727-76f8-43ab-977e-19d36d3ecfe7.png">|<img width="342" alt="Screen Shot 2022-05-11 at 1 13 13 PM" src="https://user-images.githubusercontent.com/24610840/167909859-ac47979f-94b6-4f24-b7f3-7d8f91cd163b.png">|

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

```bash
# At root
$: yarn build
$: cd ../polaris-react
$: yarn dev
```

Any `IndexTable` example that can be collapsed should work, I used IndexTable with all of its elements


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
- [ ] For visual design changes, ping @ sarahill to update the Polaris UI kit

<!--
  When tophatting, please check the UNRELEASED entry for consistency, as per the [guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Versioning%20and%20changelog.md).
-->
