### PR TITLE
Add @markdoc/next.js to test rendering Markdown in Next.js site

### DIFF
--- a/polaris.shopify.com/next.config.js
+++ b/polaris.shopify.com/next.config.js
@@ -1,7 +1,9 @@
 /* eslint-disable require-await */
 /** @type {import('next').NextConfig} */
 
-const nextConfig = {
+const withMarkdoc = require('@markdoc/next.js');
+
+const nextConfig = withMarkdoc({ mode: 'server' })({
   reactStrictMode: true,
   eslint: {
     ignoreDuringBuilds: true,
@@ -29,6 +31,7 @@ const nextConfig = {
       },
     ];
   },
-};
+  pageExtensions: ['tsx', 'md']
+});
 
 module.exports = nextConfig;

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.5.0",
+    "@markdoc/next.js": "^0.1.2",
     "@shopify/polaris": "*",
     "@shopify/polaris-tokens": "*",
     "@shopify/polaris-icons": "*",

--- a/polaris.shopify.com/src/pages/docs/getting-started.md
+++ b/polaris.shopify.com/src/pages/docs/getting-started.md
@@ -1,0 +1,6 @@
+---
+title: Get started with Markdoc
+description: How to get started with Markdoc
+---
+
+# Get started with Markdoc

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,6 +2264,19 @@
   resolved "https://registry.yarnpkg.com/@luigiminardim/storybook-addon-globals-controls/-/storybook-addon-globals-controls-0.1.3.tgz#8be7f1d8f25a51dd94eab8dae27c73f67c7abdd2"
   integrity sha512-gRwZue2pzGKkdliOnpnByG/fZh2bmhQ9DY9O62Ppk9nJSgHsQbhsv87yjjldqayd88ZYkg2u5jHv5VgYRubI8A==
 
+"@markdoc/markdoc@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@markdoc/markdoc/-/markdoc-0.1.1.tgz#40823d242a5e4ee07471d64edd15c203b6290dc7"
+  integrity sha512-ak7lacwM9fY99U+b9+IQ02qkcdc8Of0OPIWUdWNHW8zdmWam0fNRYoKWVR1B5OvdWDauYN3u0+ZbR9cds3oChw==
+
+"@markdoc/next.js@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@markdoc/next.js/-/next.js-0.1.2.tgz#640d607acfe04d8e669a695449fcea4a74eb2984"
+  integrity sha512-MkcJ0VG7WVQHF11fYPN4ZLoFHTaM7bjUZut32PP8k87Lyv/Mcp7EXtLwFdmJ4pwNXNDbiRoAHP0F2J1GAfgMzQ==
+  dependencies:
+    "@markdoc/markdoc" "0.1.1"
+    js-yaml "^4.1.0"
+
 "@mdx-js/loader@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-1.6.22.tgz#d9e8fe7f8185ff13c9c8639c048b123e30d322c4"


### PR DESCRIPTION
Huston, we have [Markdoc](https://markdoc.io/) 🧑‍🚀 🚀 

> Note: We may want to consider wrapping the `Page` component to provide layout for the markdown pages as well. See the [Next.js Layout section](https://markdoc.io/docs/nextjs#layouts).

| Getting Started page example |
| --- |
| <img width="868" alt="Screen Shot 2022-05-16 at 7 22 20 PM" src="https://user-images.githubusercontent.com/11774595/168710281-f08dd00d-f3c8-430a-bceb-9cb5c5a3c646.png"> |
