### PR TITLE
[ActionList] Fix spacing above action list title when first in mobile action menu popover

### DIFF
--- a/.changeset/swift-dryers-switch.md
+++ b/.changeset/swift-dryers-switch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Fixed spacing above action group titles when they are the first element in a Page's action list menu on mobile

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -35,10 +35,10 @@
 .Title {
   @include text-style-subheading;
   padding: var(--p-space-1) var(--p-space-4) var(--p-space-3) var(--p-space-4);
+}
 
-  &.firstSectionWithTitle {
-    padding-top: var(--p-space-3);
-  }
+.Section:first-child .Title {
+  padding-top: var(--p-space-3);
 }
 
 .Item {

--- a/polaris-react/src/components/ActionList/ActionList.scss
+++ b/polaris-react/src/components/ActionList/ActionList.scss
@@ -34,11 +34,11 @@
 
 .Title {
   @include text-style-subheading;
-  padding: var(--p-space-1) var(--p-space-4) var(--p-space-3) var(--p-space-4);
+  padding: var(--p-space-3) var(--p-space-4) var(--p-space-3) var(--p-space-4);
 }
 
-.Section:first-child .Title {
-  padding-top: var(--p-space-3);
+.Section:not(:first-child) .Title {
+  padding-top: var(--p-space-1);
 }
 
 .Item {

--- a/polaris-react/src/components/ActionList/ActionList.tsx
+++ b/polaris-react/src/components/ActionList/ActionList.tsx
@@ -50,7 +50,6 @@ export function ActionList({
     return section.items.length > 0 ? (
       <Section
         key={section.title || index}
-        firstSection={index === 0}
         section={section}
         hasMultipleSections={hasMultipleSections}
         actionRole={actionRole}

--- a/polaris-react/src/components/ActionList/components/Section/Section.tsx
+++ b/polaris-react/src/components/ActionList/components/Section/Section.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import {classNames} from '../../../../utilities/css';
 import {Item} from '../Item';
 import type {
   ActionListItemDescriptor,

--- a/polaris-react/src/components/ActionList/components/Section/Section.tsx
+++ b/polaris-react/src/components/ActionList/components/Section/Section.tsx
@@ -15,8 +15,6 @@ export interface SectionProps {
   hasMultipleSections: boolean;
   /** Defines a specific role attribute for each action in the list */
   actionRole?: 'option' | 'menuitem' | string;
-  /** Whether or not the section is the first to appear */
-  firstSection?: boolean;
   /** Callback when any item is clicked or keypressed */
   onActionAnyItem?: ActionListItemDescriptor['onAction'];
 }
@@ -25,7 +23,6 @@ export function Section({
   section,
   hasMultipleSections,
   actionRole,
-  firstSection,
   onActionAnyItem,
 }: SectionProps) {
   const handleAction = (itemOnAction: ActionListItemDescriptor['onAction']) => {
@@ -54,10 +51,7 @@ export function Section({
   );
 
   const className = section.title ? undefined : styles['Section-withoutTitle'];
-  const titleClassName = classNames(
-    styles.Title,
-    firstSection && styles.firstSectionWithTitle,
-  );
+  const titleClassName = classNames(styles.Title);
 
   const titleMarkup = section.title ? (
     <p className={titleClassName}>{section.title}</p>

--- a/polaris-react/src/components/ActionList/components/Section/Section.tsx
+++ b/polaris-react/src/components/ActionList/components/Section/Section.tsx
@@ -51,10 +51,9 @@ export function Section({
   );
 
   const className = section.title ? undefined : styles['Section-withoutTitle'];
-  const titleClassName = classNames(styles.Title);
 
   const titleMarkup = section.title ? (
-    <p className={titleClassName}>{section.title}</p>
+    <p className={styles.Title}>{section.title}</p>
   ) : null;
 
   let sectionRole;

--- a/polaris-react/src/components/ActionList/tests/ActionList.test.tsx
+++ b/polaris-react/src/components/ActionList/tests/ActionList.test.tsx
@@ -87,41 +87,6 @@ describe('<ActionList />', () => {
     });
   });
 
-  it('passes firstSection=true to the first Section', () => {
-    const actionList = mountWithApp(
-      <ActionList
-        sections={[
-          {title: 'One', items: [{content: 'First section'}]},
-          {title: 'Two', items: [{content: 'Second section'}]},
-        ]}
-        onActionAnyItem={mockOnActionAnyItem}
-        actionRole="option"
-      />,
-    );
-
-    const {firstSection} = actionList.find(Section)!.props;
-
-    expect(firstSection).toBe(true);
-  });
-
-  it('passes firstSection=false to sections that are not the first', () => {
-    const actionList = mountWithApp(
-      <ActionList
-        sections={[
-          {title: 'One', items: [{content: 'First section'}]},
-          {title: 'Two', items: [{content: 'Second section'}]},
-        ]}
-        onActionAnyItem={mockOnActionAnyItem}
-        actionRole="option"
-      />,
-    );
-
-    const sections = actionList.findAll(Section);
-    const {firstSection} = sections[sections.length - 1].props;
-
-    expect(firstSection).toBe(false);
-  });
-
   it('renders a ul with sections', () => {
     const actionList = mountWithApp(
       <ActionList


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/5877

When a page has action groups but no secondary actions, there is not enough spacing above the title of the first action group in the action list popover on mobile.

I can't reproduce the problem in an `ActionList` in isolation; it only seems to be present in a `Page`.

### WHAT is this pull request doing?

There was a [previous PR](https://github.com/Shopify/polaris/pull/4355) that fixed this last August by adding a `firstSection` class to the first section of the action list using the `index` when mapping across `finalSections`. However this solution is not reliable as-is because the item at the index of `0` is not always rendered.

Instead of fixing the logic, I decided to go for a CSS solution.

First, set the `padding-top` for every action list title to the increased amount.

Then, select all titles that are in sections that are not the first section and set their `padding-top` to the smaller amount.

I had originally done this by just selecting `.Section:first-child .Title` and setting its `padding-top` to the increased amount, but that broke the case where an action list is not sectioned (has only one item in its `actionGroups` array).

#### Before this PR

![The first section has a title which does not have enough spacing above it.](https://user-images.githubusercontent.com/7571219/169616405-6cb39ed2-6e49-4c9c-ace7-dfcb1805ddd5.png)

![The first section does not have title and all spacing is correct.](https://user-images.githubusercontent.com/7571219/169616471-8253d34d-7bdc-4914-8d90-3e90112989c1.png)

#### After this PR

![The first section has a title and it has enough spacing above it.](https://user-images.githubusercontent.com/7571219/169616523-dabcf153-5323-4e58-9b3f-7f74b2ab9b3a.png)

![The first section does not have a title and all spacing is correct. There is no change in this scenario after this PR.](https://user-images.githubusercontent.com/7571219/169616588-60083c4a-861b-4d65-a0d1-88a5eaeaab7b.png)

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

This can be tophatted by viewing the `Page/Page with action groups` story in Storybook at a mobile screen size and expanding the action list menu.

You can also verify this does not break the `ActionList` component in isolation by viewing the `Action list/Action list with destructive item` and `Action list/Sectioned action list` stories.

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
