### PR TITLE
Add a changeset noting the deprecated `CustomProperties` component

### DIFF
--- a/.changeset/hot-teachers-rule.md
+++ b/.changeset/hot-teachers-rule.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+The `CustomProperties` component and the `colorScheme` prop in all components have been deprecated. Please see the [v9 to v10 migration guide](https://github.com/Shopify/polaris/blob/main/documentation/guides/migrating-from-v9-to-v10.md) for upgrade options.


### PR DESCRIPTION
… and `colorScheme` props

Related: #6014
