### PR TITLE
[Actions] Fix rolled up action groups to include section title.

### DIFF
--- a/.changeset/rare-monkeys-judge.md
+++ b/.changeset/rare-monkeys-judge.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+---
+
+- Fixed rolled up action groups to include section title.
+- Fixed action items inside action groups to be disabled if the action group is disabled.

--- a/polaris-react/src/components/ActionMenu/ActionMenu.tsx
+++ b/polaris-react/src/components/ActionMenu/ActionMenu.tsx
@@ -66,6 +66,9 @@ function convertGroupToSection({
 }: MenuGroupDescriptor): ActionListSection {
   return {
     title,
-    items: disabled ? [] : actions,
+    items: actions.map((action) => ({
+      ...action,
+      disabled: disabled || action.disabled,
+    })),
   };
 }

--- a/polaris-react/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
+++ b/polaris-react/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback} from 'react';
 
-import type {MenuGroupDescriptor} from '../../../../types';
+import type {ActionListSection, MenuGroupDescriptor} from '../../../../types';
 import {ActionList} from '../../../ActionList';
 import {Popover} from '../../../Popover';
 import {SecondaryAction} from '../SecondaryAction';
@@ -20,6 +20,8 @@ export interface MenuGroupProps extends MenuGroupDescriptor {
   onClose(title: string): void;
   /** Callback for getting the offsetWidth of the MenuGroup */
   getOffsetWidth?(width: number): void;
+  /** Collection of sectioned action items */
+  sections?: readonly ActionListSection[];
 }
 
 export function MenuGroup({
@@ -34,6 +36,7 @@ export function MenuGroup({
   onClose,
   onOpen,
   getOffsetWidth,
+  sections,
 }: MenuGroupProps) {
   const handleClose = useCallback(() => {
     onClose(title);
@@ -80,7 +83,11 @@ export function MenuGroup({
       onClose={handleClose}
       hideOnPrint
     >
-      <ActionList items={actions} onActionAnyItem={handleClose} />
+      <ActionList
+        items={actions}
+        sections={sections}
+        onActionAnyItem={handleClose}
+      />
       {details && <div className={styles.Details}>{details}</div>}
     </Popover>
   );

--- a/polaris-react/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
+++ b/polaris-react/src/components/ActionMenu/components/MenuGroup/tests/MenuGroup.test.tsx
@@ -55,6 +55,32 @@ describe('<MenuGroup />', () => {
       });
     });
 
+    it('passes `sections` into the <ActionList />', () => {
+      const mockActions = [
+        {content: 'mock action 1'},
+        {content: 'mock action 2'},
+      ];
+      const mockSections = [
+        {title: 'section 1', items: [{content: 'mock section 1'}]},
+        {title: 'section 2', items: [{content: 'mock section 2'}]},
+      ];
+      const wrapper = mountWithApp(
+        <MenuGroup
+          {...mockProps}
+          actions={mockActions}
+          sections={mockSections}
+        />,
+      );
+      const popoverContents = mountWithApp(
+        <div>{wrapper.find(Popover)!.prop('children')}</div>,
+      );
+
+      expect(popoverContents).toContainReactComponent(ActionList, {
+        items: mockActions,
+        sections: mockSections,
+      });
+    });
+
     it('triggers `onOpen` when `onClick` is not defined', () => {
       const onOpenSpy = jest.fn();
       const wrapper = mountWithApp(

--- a/polaris-react/src/components/ActionMenu/tests/ActionMenu.test.tsx
+++ b/polaris-react/src/components/ActionMenu/tests/ActionMenu.test.tsx
@@ -84,11 +84,16 @@ describe('<ActionMenu />', () => {
       });
     });
 
-    it('hides disabled action group items when `rollup` is `true`', () => {
+    it('shows action group items as disabled when `rollup` is `true` and action group is disabled', () => {
       const convertedSections = mockGroupsWithDisabledGroup.map((group) => {
         return {
           title: group.title,
-          items: group.disabled ? [] : group.actions,
+          items: group.disabled
+            ? group.actions.map((action) => ({
+                ...action,
+                disabled: group.disabled,
+              }))
+            : group.actions,
         };
       });
       const wrapper = mountWithApp(


### PR DESCRIPTION
### WHY are these changes introduced?

- We have two components rendering action groups: the [RollupActions](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/ActionMenu/ActionMenu.tsx#L44) component renders them when the [navigation is collapsed](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/Page/components/Header/Header.tsx#L147) (which happens for the mobile view), and the [Actions](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/ActionMenu/ActionMenu.tsx#L50) component that handles every other case.
  - In the case of `RollupActions`, we are currently passing [sections](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/ActionMenu/ActionMenu.tsx#L47), which allows for rendering an `ActionList` component that divides the action groups with their own titles. However, these sections are not being used for the `Actions` component, as we are only passing the actions within the group when they are being rolled up. Note that the `Actions` component is rendering the `MenuGroup` component which is rendering the [ActionList](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/ActionMenu/components/MenuGroup/MenuGroup.tsx#L83) component without sections.
  - Another inconsistency: for `RollupActions` we are currently hiding (not showing) the action items inside an action group if the action group is disabled (look [here](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/ActionMenu/ActionMenu.tsx#L69)). And again, this is something that is not happening for the `Actions` component, and it is not desirable given that users could access these action items (when they are rolled up) even when the action group is disabled.
  
Please look at the Before and After videos below to understand the current behavior with their fixes.

### WHAT is this pull request doing?

This PR is doing two things to have consistency across `RollupActions` and `Actions` components:
- Fixing rolled up action groups to include section title.
- Fixing action items inside action groups to be disabled if the action group is disabled. We also keep the disabled behavior even when the action group is rolled up into another action group.
  - One thing to note for this second fix is that I think it is better to disable the action items inside action groups when the action group is disabled, when compared to the solution of not showing the action items at all (hiding them). The main reason is because it adds a little bit of more flexibility: i.e. if we want to hide the action items, we could easily just not pass them to the component from the implementation side, but if we decide to hide them here, then there is nothing we can do about it on the implementation side.

### How to 🎩 <a href="#test-section" id="test-section">#</a>

Compare this branch against `main` using the Playground for the `Page` component. You should get results similar to the following videos:

- Before:

https://user-images.githubusercontent.com/16692690/171927801-0a48b385-adcb-4873-8de6-6feee8a931bc.mov

- After:

https://user-images.githubusercontent.com/16692690/171927838-ef811ac0-529b-4c98-8fe1-577c5078833a.mov


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
