### PR TITLE
[Custom properties] Add data- to p-color-scheme body attribute

### DIFF
--- a/.changeset/real-pants-look.md
+++ b/.changeset/real-pants-look.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Prefixed body attribute with data-

--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -98,7 +98,7 @@ export class AppProvider extends Component<AppProviderProps, State> {
     // Inlining the following custom properties to maintain backward
     // compatibility with the legacy ThemeProvider implementation.
     document.body.setAttribute(
-      'p-color-scheme',
+      'data-p-color-scheme',
       this.props.colorScheme || DEFAULT_COLOR_SCHEME,
     );
     document.body.style.backgroundColor = 'var(--p-background)';

--- a/polaris-react/src/components/CustomProperties/CustomProperties.tsx
+++ b/polaris-react/src/components/CustomProperties/CustomProperties.tsx
@@ -43,7 +43,7 @@ export function CustomProperties(props: CustomPropertiesProps) {
 
   return (
     <Component
-      p-color-scheme={colorScheme}
+      data-p-color-scheme={colorScheme}
       className={className}
       style={{color: 'var(--p-text)', ...style}}
     >

--- a/polaris-react/src/components/CustomProperties/tests/CustomProperties.test.tsx
+++ b/polaris-react/src/components/CustomProperties/tests/CustomProperties.test.tsx
@@ -6,7 +6,7 @@ import {mountWithApp} from 'tests/utilities';
 import {CustomProperties, DEFAULT_COLOR_SCHEME} from '../CustomProperties';
 
 interface ColorSchemeAttribute {
-  'p-color-scheme': ColorScheme;
+  'data-p-color-scheme': ColorScheme;
 }
 
 describe('<CustomProperties />', () => {
@@ -48,7 +48,7 @@ describe('<CustomProperties />', () => {
 
       expect(
         (customProperties.find('div')!.props as ColorSchemeAttribute)[
-          'p-color-scheme'
+          'data-p-color-scheme'
         ],
       ).toBe(DEFAULT_COLOR_SCHEME);
     });
@@ -60,7 +60,7 @@ describe('<CustomProperties />', () => {
 
       expect(
         (customProperties.find('div')!.props as ColorSchemeAttribute)[
-          'p-color-scheme'
+          'data-p-color-scheme'
         ],
       ).toBe('light');
     });
@@ -72,7 +72,7 @@ describe('<CustomProperties />', () => {
 
       expect(
         (customProperties.find('div')!.props as ColorSchemeAttribute)[
-          'p-color-scheme'
+          'data-p-color-scheme'
         ],
       ).toBe('dark');
     });


### PR DESCRIPTION
### WHY are these changes introduced?

p-color-scheme isn't a valid attribute for the body tag. 

### WHAT is this pull request doing?

Simply added the `data-` prefix.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
