### PR TITLE
[polaris.shopify.com] fix: Header component needs to pass a ref to the Hamburger button

### DIFF
--- a/.changeset/fuzzy-mails-draw.md
+++ b/.changeset/fuzzy-mails-draw.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+forwarded the ref of the button component to be used by other components

--- a/polaris.shopify.com/src/components/Button/Button.tsx
+++ b/polaris.shopify.com/src/components/Button/Button.tsx
@@ -15,22 +15,26 @@ interface LinkButtonProps extends Props, PropsWithChildren<LinkProps> {
   download?: boolean;
 }
 
-function Button({ small, pill, primary, children, ...rest }: ButtonProps) {
-  return (
-    <button
-      className={className(
-        styles.Button,
-        small && styles.small,
-        pill && styles.pill,
-        primary && styles.primary
-      )}
-      {...rest}
-      type="button"
-    >
-      {children}
-    </button>
-  );
-}
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ small, pill, primary, children, ...rest }, ref) => {
+    return (
+      <button
+        className={className(
+          styles.Button,
+          small && styles.small,
+          pill && styles.pill,
+          primary && styles.primary
+        )}
+        {...rest}
+        type="button"
+        ref={ref}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+Button.displayName = "Button";
 
 export function LinkButton({
   small,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The Header component uses a ref to the 🍔 button to focus it when a user closes the side navigation menu using the keyboard

If we do not forward ref the Button component, React throws this error in the console

<img width="630" alt="Screenshot 2022-06-14 at 12 17 39" src="https://user-images.githubusercontent.com/6597467/173576279-03070852-4d96-479a-8bd3-01c69d853a0b.png">

### WHAT is this pull request doing?

It adds `React.forwardRef` to the Button component of polaris.shopify.com

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
