### PR TITLE
[TexField] Allow parent elements to listen to click events

### DIFF
--- a/.changeset/quiet-pots-doubt.md
+++ b/.changeset/quiet-pots-doubt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Conditionally calls `event.stopPropagation` on `TextField` component

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -629,7 +629,9 @@ export function TextField({
   }
 
   function handleClickChild(event: React.MouseEvent) {
-    event.stopPropagation();
+    if (inputRef.current !== event.target) {
+      event.stopPropagation();
+    }
 
     if (
       isPrefixOrSuffix(event.target) ||

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -84,6 +84,53 @@ describe('<TextField />', () => {
     });
   });
 
+  describe('click events', () => {
+    describe('when a click event occurs on the input', () => {
+      it('bubbles up to the parent element', () => {
+        const onClick = jest.fn();
+        const event = new MouseEvent('click', {
+          view: window,
+          bubbles: true,
+          cancelable: true,
+        });
+        const textField = mountWithApp(
+          <div onClick={onClick}>
+            <TextField type="text" label="TextField" autoComplete="off" />
+          </div>,
+        );
+
+        textField.find('input')!.domNode?.dispatchEvent(event);
+        expect(onClick).toHaveBeenCalled();
+      });
+
+      describe('when a click event occurs in an element other than the input', () => {
+        it('does not bubble up to the parent element', () => {
+          const onClick = jest.fn();
+          const children = 'vertical-content-children';
+          const event = new MouseEvent('click', {
+            view: window,
+            bubbles: true,
+            cancelable: true,
+          });
+          const verticalContent = <span>{children}</span>;
+          const textField = mountWithApp(
+            <div onClick={onClick}>
+              <TextField
+                type="text"
+                label="TextField"
+                autoComplete="off"
+                verticalContent={verticalContent}
+              />
+            </div>,
+          );
+
+          textField.find('span', {children})!.domNode?.dispatchEvent(event);
+          expect(onClick).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
   describe('onChange()', () => {
     it('is called with the new value', () => {
       const spy = jest.fn();


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/6117

As pointed out by Amy on this [issue](https://github.com/Shopify/polaris/issues/6117) as of Polaris 9.12.0 we no longer bubble up click events emitted on `TextField` and parent elements can no longer depend on interactions.

This change was introduced [here](https://github.com/Shopify/polaris/commit/e519016562c8caa70ae4e9e5210b660a0b9a112c#diff-b3c67fa075f17d88f8c43be7df7456856ae03cb49912c84f23560ddaf30d4fa4R632) and the [bug](https://shopify.slack.com/archives/C032T3AAV0T/p1654885261819359) was reported by a merchant who could no longer operate on the newly built bulk editor (see [this issue](https://github.com/Shopify/web/issues/66549) for more details)

### WHAT is this pull request doing?

This PR will conditionally call `stopPropagation` when click events are captured by `TextField` and parent elements.

Following [this](https://github.com/Shopify/polaris/pull/5957#discussion_r886199308) comment I believe we still want that behavior if a click event happens outside of the `input` element (i.e `verticalContent`).


For comparison here are two examples of before and after:

```tsx
<div onClick={(event) => console.log("Propagated event", event)}>
  <TextField label="Store name" autoComplete="off" />
</div>
```

**Before**

https://user-images.githubusercontent.com/2286385/174068533-2491a9b0-d0c3-4bd5-8853-5fe1d368bdad.mov

**After**

https://user-images.githubusercontent.com/2286385/174068507-9b2a5fca-edcf-4ee2-8b63-cc713c7e4809.mov

I also create a [snapshopt](https://github.com/Shopify/polaris/pull/6129#issuecomment-1156432854) with these changes and deployed it to stagging and could confirm that it fixes the merchant's issue.

https://user-images.githubusercontent.com/2286385/174069637-006aff3a-3a4c-4460-97af-eb13706774f8.mov

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from "react";

import { Badge, Page, Stack, TextField } from "../src";

export function Playground() {
  return (
    <Page title="Playground">
      <Stack vertical>
        <div onClick={(event) => console.log("Propagated event", event)}>
          <TextField label="Store name" autoComplete="off" />
        </div>
        <div
          onClick={(event) =>
            console.log("Propagated event / verticalContent", event)
          }
        >
          <TextField
            label="Store name"
            autoComplete="off"
            verticalContent={<Badge>Buyer</Badge>}
          />
        </div>
      </Stack>
    </Page>
  );
}
```


</details>

There should be two `TextField`s rendered in your playground and one of them contains a `Badge` as its `verticalContent` prop.

- Open your console and click on the first `TextField`
- You should see a log indicating that the click event bubbled up to its parent
- On the second `TextField` click right on the `Badge`
- You should not see any logs indicating that the click event bubbled up
- Now on the second `TextField` click right over the input itself
- You should see a log indicating that the click event bubbled up to its parent

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
