### PR TITLE
[Modal] Fix spacing when title is hidden

### DIFF
--- a/.changeset/modern-rats-divide.md
+++ b/.changeset/modern-rats-divide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Fixed the padding of the close button in the `Modal` component when the title is hidden ([#5279](https://github.com/Shopify/polaris-react/pull/5280))

--- a/.changeset/modern-rats-divide.md
+++ b/.changeset/modern-rats-divide.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Fixed the padding of the close button in the `Modal` component when the title is hidden ([#5279](https://github.com/Shopify/polaris-react/pull/5280))
+Fixed the close button overlaying `Modal` content when `titleHidden` is `true` ([#6223](https://github.com/Shopify/polaris/pull/6223))

--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -145,7 +145,7 @@ export const Modal: React.FunctionComponent<ModalProps> & {
       );
 
     const content = sectioned
-      ? wrapWithComponent(children, Section, {})
+      ? wrapWithComponent(children, Section, {titleHidden})
       : children;
 
     const body = loading ? (

--- a/polaris-react/src/components/Modal/README.md
+++ b/polaris-react/src/components/Modal/README.md
@@ -651,7 +651,7 @@ function ModalWithoutTitleExample() {
           },
         ]}
       >
-        <Modal.Section>
+        <Modal.Section titleHidden>
           <TextContainer>
             <p>
               Use Instagram posts to share your products with millions of

--- a/polaris-react/src/components/Modal/components/CloseButton/CloseButton.scss
+++ b/polaris-react/src/components/Modal/components/CloseButton/CloseButton.scss
@@ -20,4 +20,8 @@
   &:focus:not(:active) {
     @include focus-ring($style: 'focused');
   }
+
+  &.titleHidden {
+    margin: var(--p-space-2);
+  }
 }

--- a/polaris-react/src/components/Modal/components/CloseButton/CloseButton.tsx
+++ b/polaris-react/src/components/Modal/components/CloseButton/CloseButton.tsx
@@ -1,22 +1,27 @@
 import React from 'react';
 import {MobileCancelMajor} from '@shopify/polaris-icons';
 
+import {classNames} from '../../../../utilities/css';
 import {useI18n} from '../../../../utilities/i18n';
 import {Icon} from '../../../Icon';
 
 import styles from './CloseButton.scss';
 
 export interface CloseButtonProps {
+  titleHidden?: boolean;
   onClick(): void;
 }
 
-export function CloseButton({onClick}: CloseButtonProps) {
+export function CloseButton({titleHidden = false, onClick}: CloseButtonProps) {
   const i18n = useI18n();
 
   return (
     <button
       onClick={onClick}
-      className={styles.CloseButton}
+      className={classNames(
+        styles.CloseButton,
+        titleHidden && styles.titleHidden,
+      )}
       aria-label={i18n.translate('Polaris.Common.close')}
     >
       <Icon source={MobileCancelMajor} color="base" />

--- a/polaris-react/src/components/Modal/components/Header/Header.scss
+++ b/polaris-react/src/components/Modal/components/Header/Header.scss
@@ -10,8 +10,10 @@
 
 .titleHidden {
   position: absolute;
-  right: var(--p-space-2);
+  right: 0;
   z-index: 1;
+  padding-top: var(--p-space-4);
+  padding-right: var(--p-space-5);
 
   .Title {
     display: none;

--- a/polaris-react/src/components/Modal/components/Header/Header.scss
+++ b/polaris-react/src/components/Modal/components/Header/Header.scss
@@ -12,8 +12,9 @@
   position: absolute;
   right: 0;
   z-index: 1;
-  padding-top: var(--p-space-4);
-  padding-right: var(--p-space-5);
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
 
   .Title {
     display: none;

--- a/polaris-react/src/components/Modal/components/Header/Header.tsx
+++ b/polaris-react/src/components/Modal/components/Header/Header.tsx
@@ -22,7 +22,7 @@ export function Header({id, titleHidden, children, onClose}: HeaderProps) {
           {children}
         </DisplayText>
       </div>
-      <CloseButton onClick={onClose} />
+      <CloseButton titleHidden={titleHidden} onClick={onClose} />
     </div>
   );
 }

--- a/polaris-react/src/components/Modal/components/Section/Section.scss
+++ b/polaris-react/src/components/Modal/components/Section/Section.scss
@@ -1,5 +1,7 @@
 @import '../../../../styles/common';
 
+$close-button-width: calc(var(--p-space-12) + var(--p-space-1));
+
 .Section {
   flex: 0 0 auto;
   padding: var(--p-space-5);
@@ -14,5 +16,9 @@
 
   &.flush {
     padding: 0;
+  }
+
+  &.titleHidden {
+    padding-right: $close-button-width;
   }
 }

--- a/polaris-react/src/components/Modal/components/Section/Section.tsx
+++ b/polaris-react/src/components/Modal/components/Section/Section.tsx
@@ -8,17 +8,20 @@ export interface SectionProps {
   children?: React.ReactNode;
   flush?: boolean;
   subdued?: boolean;
+  titleHidden?: boolean;
 }
 
 export function Section({
   children,
   flush = false,
   subdued = false,
+  titleHidden = false,
 }: SectionProps) {
   const className = classNames(
     styles.Section,
     flush && styles.flush,
     subdued && styles.subdued,
+    titleHidden && styles.titleHidden,
   );
 
   return <section className={className}>{children}</section>;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Picks up where #5280 started in fixing #5279  <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

When `titleHidden` is `true`, currently `Header` gets reduced to the width of `CloseButton` and the body doesn't account for its width. This leaves potential for the body content to sit underneath `CloseButton`, as demo'd in the table below.

This PR takes the approach of accounting for `titleHidden` in `CloseButton` and `Section`.

|Before|After|Section spacing increase when `titleHidden=true`|
|---|---|---|
|<img width="642" alt="Screen Shot 2022-06-17 at 8 58 29 AM" src="https://user-images.githubusercontent.com/18447883/174303122-4494c4ef-d15d-4570-a3b1-1bc97b3eeaa2.png">|<img width="643" alt="Screen Shot 2022-06-17 at 8 50 04 AM" src="https://user-images.githubusercontent.com/18447883/174301694-2b79e941-e127-461c-9c7f-f16343c7ea69.png">|<img width="631" alt="Screen Shot 2022-06-17 at 8 49 21 AM" src="https://user-images.githubusercontent.com/18447883/174301725-214be32d-8945-4824-b44d-b95e3b39058a.png">|
|<img width="374" alt="Screen Shot 2022-06-17 at 8 58 47 AM" src="https://user-images.githubusercontent.com/18447883/174303156-7e0f9e9b-982a-4ab8-9a7b-c8b2895f66f3.png">|<img width="375" alt="Screen Shot 2022-06-17 at 8 49 55 AM" src="https://user-images.githubusercontent.com/18447883/174301760-0728924c-ec11-4997-9383-56fbe83a9161.png">|<img width="376" alt="Screen Shot 2022-06-17 at 8 49 44 AM" src="https://user-images.githubusercontent.com/18447883/174301783-7d1956fb-7958-4010-a59a-60509c3e6646.png">|


<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {Page, Modal, Button, TextContainer} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <ModalWithoutTitleExample />
    </Page>
  );
}

function ModalWithoutTitleExample() {
  const [active, setActive] = useState(true);

  const handleChange = useCallback(() => setActive(!active), [active]);

  const activator = <Button onClick={handleChange}>Open</Button>;

  return (
    <div style={{height: '500px'}}>
      <Modal
        titleHidden
        title="Reach more shoppers with Instagram product tags"
        activator={activator}
        open={active}
        onClose={handleChange}
        primaryAction={{
          content: 'Add Instagram',
          onAction: handleChange,
        }}
        secondaryActions={[
          {
            content: 'Learn more',
            onAction: handleChange,
          },
        ]}
      >
        <Modal.Section titleHidden>
          <TextContainer>
            <p>
              Use Instagram posts to share your products with millions of people
              if that is, you know, what you feel like doing or whatever. Let
              shoppers buy from your store without leaving Instagram.
            </p>
          </TextContainer>
        </Modal.Section>
      </Modal>
    </div>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
