### PR TITLE
Improve examples browser

### DIFF
--- a/.changeset/large-windows-judge.md
+++ b/.changeset/large-windows-judge.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Improved design of examples browser

--- a/polaris.shopify.com/content/components/account-connection.md
+++ b/polaris.shopify.com/content/components/account-connection.md
@@ -23,10 +23,7 @@ examples:
 
 # Account connection
 
-The account connection component is used so merchants can connect or disconnect
-their store to various accounts. For example, if merchants want to use the
-Facebook sales channel, they need to connect their Facebook
-account to their Shopify store.
+The account connection component is used so merchants can connect or disconnect their store to various accounts. For example, if merchants want to use the Facebook sales channel, they need to connect their Facebook account to their Shopify store.
 
 ---
 

--- a/polaris.shopify.com/content/components/avatar.md
+++ b/polaris.shopify.com/content/components/avatar.md
@@ -38,8 +38,7 @@ examples:
 
 # Avatar
 
-Avatars are used to show a thumbnail representation of an individual or
-business in the interface.
+Avatars are used to show a thumbnail representation of an individual or business in the interface.
 
 ---
 

--- a/polaris.shopify.com/content/components/callout-card.md
+++ b/polaris.shopify.com/content/components/callout-card.md
@@ -41,9 +41,7 @@ examples:
 
 # Callout card
 
-Callout cards are used to encourage merchants to take an action related to a
-new feature or opportunity. They are most commonly displayed in the
-sales channels section of Shopify.
+Callout cards are used to encourage merchants to take an action related to a new feature or opportunity. They are most commonly displayed in the sales channels section of Shopify.
 
 ---
 

--- a/polaris.shopify.com/content/components/color-picker.md
+++ b/polaris.shopify.com/content/components/color-picker.md
@@ -30,9 +30,7 @@ examples:
 
 # Color picker
 
-The color picker is used to let merchants select a color visually. For
-example, merchants use the color picker to customize the accent color of the
-email templates for their shop.
+The color picker is used to let merchants select a color visually. For example, merchants use the color picker to customize the accent color of the email templates for their shop.
 
 ---
 

--- a/polaris.shopify.com/content/components/display-text.md
+++ b/polaris.shopify.com/content/components/display-text.md
@@ -53,9 +53,7 @@ examples:
 
 # Display text
 
-Display styles make a bold visual statement. Use them to create impact when the
-main goal is visual storytelling. For example, use display text to convince or
-reassure merchants such as in marketing content or to capture attention during onboarding.
+Display styles make a bold visual statement. Use them to create impact when the main goal is visual storytelling. For example, use display text to convince or reassure merchants such as in marketing content or to capture attention during onboarding.
 
 ---
 

--- a/polaris.shopify.com/content/components/option-list.md
+++ b/polaris.shopify.com/content/components/option-list.md
@@ -32,11 +32,7 @@ examples:
 
 # Option list
 
-The option list component lets you create a list of grouped items that
-merchants can pick from. This can include single selection or multiple selection
-of options. Option list usually appears in a popover, and sometimes in a modal
-or a sidebar. Option lists are styled differently than
-[choice lists](https://polaris.shopify.com/components/forms/choice-list) and should not be used within a form, but as a standalone menu.
+The option list component lets you create a list of grouped items that merchants can pick from. This can include single selection or multiple selection of options. Option list usually appears in a popover, and sometimes in a modal or a sidebar. Option lists are styled differently than [choice lists](https://polaris.shopify.com/components/forms/choice-list) and should not be used within a form, but as a standalone menu.
 
 ---
 

--- a/polaris.shopify.com/content/components/radio-button.md
+++ b/polaris.shopify.com/content/components/radio-button.md
@@ -32,8 +32,7 @@ examples:
 
 # Radio button
 
-Use radio buttons to present each item in a list of options where merchants must
-make a single selection.
+Use radio buttons to present each item in a list of options where merchants must make a single selection.
 
 ---
 

--- a/polaris.shopify.com/content/components/setting-toggle.md
+++ b/polaris.shopify.com/content/components/setting-toggle.md
@@ -24,8 +24,7 @@ examples:
 
 # Setting toggle
 
-Use to give merchants control over a feature or option that can be turned
-on or off.
+Use to give merchants control over a feature or option that can be turned on or off.
 
 ---
 

--- a/polaris.shopify.com/content/components/stack.md
+++ b/polaris.shopify.com/content/components/stack.md
@@ -57,9 +57,7 @@ examples:
 
 # Stack
 
-Use to lay out a horizontal row of components or to achieve no-fuss vertical
-centering. A stack is made of flexible items that wrap each of the stack’s
-children. Options provide control of the wrapping, spacing, and relative size of the items in the stack.
+Use to lay out a horizontal row of components or to achieve no-fuss vertical centering. A stack is made of flexible items that wrap each of the stack’s children. Options provide control of the wrapping, spacing, and relative size of the items in the stack.
 
 ---
 

--- a/polaris.shopify.com/content/components/text-field.md
+++ b/polaris.shopify.com/content/components/text-field.md
@@ -171,8 +171,7 @@ examples:
 
 # Text field
 
-A text field is an input field that merchants can type into. It has a range of
-options and supports several text formats including numbers.
+A text field is an input field that merchants can type into. It has a range of options and supports several text formats including numbers.
 
 ---
 

--- a/polaris.shopify.com/content/components/tooltip.md
+++ b/polaris.shopify.com/content/components/tooltip.md
@@ -22,9 +22,7 @@ examples:
 
 # Tooltip
 
-Tooltips are floating labels that briefly explain the function of a user
-interface element. They can be triggered when merchants hover, focus, tap, or
-click.
+Tooltips are floating labels that briefly explain the function of a user interface element. They can be triggered when merchants hover, focus, tap, or click.
 
 ---
 

--- a/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
+++ b/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
@@ -1,15 +1,15 @@
 .CodeExample {
   border-radius: var(--border-radius-400);
   overflow: hidden;
-  border: 1px solid var(--border-color-light);
+  box-shadow: var(--card-shadow);
   line-height: 1.4;
 }
 
 .TitleBar {
   padding: 0.5rem 0.75em;
   background: var(--surface-subdued);
-  margin: 1px 1px 0 1px;
-  border-radius: var(--border-radius-600) var(--border-radius-600)
+  margin: 1px 1px 0 0.5px;
+  border-radius: var(--border-radius-400) var(--border-radius-400)
     var(--border-radius-300) var(--border-radius-300);
 
   .Title {
@@ -51,6 +51,7 @@
   padding: 0.4rem 0.1rem;
   font-size: 13px;
   color: var(--text-strong);
+  overflow: auto;
 }
 
 .LineNumber {

--- a/polaris.shopify.com/src/components/CodesandboxButton/CodesandboxButton.module.scss
+++ b/polaris.shopify.com/src/components/CodesandboxButton/CodesandboxButton.module.scss
@@ -1,0 +1,4 @@
+.Button {
+  background: transparent;
+  font-size: var(--font-size-100);
+}

--- a/polaris.shopify.com/src/components/CodesandboxButton/CodesandboxButton.tsx
+++ b/polaris.shopify.com/src/components/CodesandboxButton/CodesandboxButton.tsx
@@ -1,4 +1,5 @@
 import { getParameters } from "codesandbox/lib/api/define";
+import styles from "./CodesandboxButton.module.scss";
 
 const getAppCode = (code: string) => {
   const lineWithFunctionName = code
@@ -75,7 +76,9 @@ const CodesandboxButton = (props: Props) => {
     >
       <input type="hidden" name="parameters" value={parameters} />
       <input type="hidden" name="query" value="module=App.js" />
-      <button type="submit">Edit in Codesandbox</button>
+      <button type="submit" className={styles.Button}>
+        Edit in Codesandbox
+      </button>
     </form>
   );
 };

--- a/polaris.shopify.com/src/components/Examples/Examples.module.scss
+++ b/polaris.shopify.com/src/components/Examples/Examples.module.scss
@@ -9,12 +9,15 @@
     line-height: 2.5rem;
     padding-left: 0.75rem;
     padding-right: 0.75rem;
-    background-color: #f9f9f9;
-    color: #444444;
-    border: 1px solid var(--border-color);
+    background-color: var(--surface-subdued);
+    color: var(--text);
     border-radius: var(--border-radius-500);
     font-size: var(--font-size-400);
-    box-shadow: 0px -1px 0px 0px rgba(0, 0, 0, 0.07) inset;
+    box-shadow: 0 0 0 1px var(--border-color);
+
+    &:focus-visible {
+      box-shadow: var(--focus-outline);
+    }
   }
 }
 
@@ -35,47 +38,34 @@
 
 .Buttons {
   margin-top: 3rem;
-  margin-bottom: 2rem;
-  padding: 0 0.5rem;
-  width: 100%;
-}
-
-.ButtonsOverlayed {
-  position: absolute;
-  margin-top: 2rem;
-  margin-bottom: 0rem;
+  margin-bottom: 0.5rem;
+  display: flex;
+  justify-content: space-between;
 }
 
 .Button {
-  margin-left: 0.5rem;
   padding: 0.25rem 0.5rem;
-  border-radius: 5px;
+  border-radius: var(--border-radius-400);
   font-size: var(--font-size-100);
-  color: #000;
+  background-color: var(--surface-subdued);
+  color: var(--text);
   min-width: 40px;
-  background: none;
-
-  &:hover {
-    background: #f0f0f0;
-  }
+  box-shadow: var(--card-shadow);
 }
 
-.ButtonSelected {
-  background: #f0f0f0;
+.Button:not(.ButtonSelected) {
+  background: transparent;
+  box-shadow: none;
 }
 
 .ExampleFrame {
-  margin: 2rem 0 2rem;
+  margin-bottom: 2rem;
+  background: #fafafa;
+  border-radius: var(--border-radius-400);
+  overflow: hidden;
+  box-shadow: var(--card-shadow);
 }
 
 .SandboxButton {
   float: right;
-
-  button {
-    padding: 0.25rem 0.5rem;
-    border-radius: 5px;
-    font-size: var(--font-size-100);
-    color: #000;
-    background: #f0f0f0;
-  }
 }

--- a/polaris.shopify.com/src/components/Examples/Examples.tsx
+++ b/polaris.shopify.com/src/components/Examples/Examples.tsx
@@ -1,10 +1,10 @@
-import { getParameters } from "codesandbox/lib/api/define";
 import { ChangeEvent, useState } from "react";
 import styles from "./Examples.module.scss";
 import CodesandboxButton from "../CodesandboxButton";
 import CodeExample from "../CodeExample";
 import Image from "../Image";
 import iconChevronDown from "../../../public/chevron-down.svg";
+import Button from "../Button";
 
 export type Example = {
   code: string;
@@ -32,7 +32,7 @@ const Examples = (props: Props) => {
   if (!examples?.length) return null;
 
   return (
-    <div>
+    <>
       <h2 id="examples">Examples</h2>
       <div className={styles.SelectContainer}>
         <select onChange={handleSelection}>
@@ -57,28 +57,28 @@ const Examples = (props: Props) => {
           />
         </div>
       </div>
+
       {description ? <p>{description}</p> : null}
-      <div
-        className={`${styles.Buttons} ${
-          showPreview && styles.ButtonsOverlayed
-        }`}
-      >
-        <button
-          className={`${styles.Button} ${
-            showPreview ? styles.ButtonSelected : ""
-          }`}
-          onClick={() => setShowPreview(true)}
-        >
-          Preview
-        </button>
-        <button
-          className={`${styles.Button} ${
-            showPreview ? "" : styles.ButtonSelected
-          }`}
-          onClick={() => setShowPreview(false)}
-        >
-          Code
-        </button>
+
+      <div className={styles.Buttons}>
+        <div>
+          <button
+            className={`${styles.Button} ${
+              showPreview ? styles.ButtonSelected : ""
+            }`}
+            onClick={() => setShowPreview(true)}
+          >
+            Preview
+          </button>
+          <button
+            className={`${styles.Button} ${
+              showPreview ? "" : styles.ButtonSelected
+            }`}
+            onClick={() => setShowPreview(false)}
+          >
+            Code
+          </button>
+        </div>
         <CodesandboxButton className={styles.SandboxButton} code={code} />
       </div>
       {showPreview ? (
@@ -90,7 +90,7 @@ const Examples = (props: Props) => {
           {code}
         </CodeExample>
       )}
-    </div>
+    </>
   );
 };
 

--- a/polaris.shopify.com/src/components/Layout/Layout.module.scss
+++ b/polaris.shopify.com/src/components/Layout/Layout.module.scss
@@ -58,6 +58,7 @@
   .PostContent {
     flex: 1;
     position: relative;
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
- Adds a Polaris-colored background to the examples frame so that it doesn't flicker when loading examples 
- Puts buttons above the examples to prevent that they overlap the examples
- Fixes up readmes so that component descriptions render correctly

<img width="885" alt="Screen Shot 2022-06-22 at 12 48 51 AM" src="https://user-images.githubusercontent.com/875708/174909760-fa9b7dd1-b64f-488d-9f65-c4b5a46660f1.png">

