### PR TITLE
[polaris.shopify.com][FullscreenBar] Make examples wider

### DIFF
--- a/.changeset/polite-tomatoes-remember.md
+++ b/.changeset/polite-tomatoes-remember.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Make wrapper of FullscreenBar's examples wider

--- a/polaris.shopify.com/src/pages/examples/fullscreen-bar-no-children.tsx
+++ b/polaris.shopify.com/src/pages/examples/fullscreen-bar-no-children.tsx
@@ -12,7 +12,7 @@ function FullscreenBarExample() {
   const fullscreenBarMarkup = <FullscreenBar onAction={handleActionClick} />;
 
   return (
-    <div style={{ height: "250px" }}>
+    <div style={{ height: "250px", width: "100%" }}>
       {isFullscreen && fullscreenBarMarkup}
       <div style={{ padding: "1rem" }}>
         {!isFullscreen && (

--- a/polaris.shopify.com/src/pages/examples/fullscreen-bar-with-children.tsx
+++ b/polaris.shopify.com/src/pages/examples/fullscreen-bar-with-children.tsx
@@ -27,7 +27,7 @@ function FullscreenBarExample() {
   );
 
   return (
-    <div style={{ height: "250px" }}>
+    <div style={{ height: "250px", width: "100%" }}>
       {isFullscreen && fullscreenBarMarkup}
       <div style={{ padding: "1rem" }}>
         {!isFullscreen && (


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes [#6277](https://github.com/Shopify/polaris/issues/6277)

<img width="848" alt="Screenshot 2022-06-22 at 15 09 51" src="https://user-images.githubusercontent.com/6597467/175036953-1e54ac9a-f27c-43e1-8bf8-eafe7097634d.png">


### WHAT is this pull request doing?

It adds `width: '100%'` to the div wrapping the examples

