### PR TITLE
[polaris.shopify.com reboot] Hide/fix broken examples

### DIFF
--- a/.changeset/tender-pans-juggle.md
+++ b/.changeset/tender-pans-juggle.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix broken examples

--- a/polaris.shopify.com/content/components/banner.md
+++ b/polaris.shopify.com/content/components/banner.md
@@ -55,20 +55,20 @@ examples:
     description: >-
       Default to using toasts for success messages, unless the feedback is
       delayed, persistent, or has a call to actionInclude next steps if
-      applicableundefinedundefined
+      applicable
   - fileName: banner-warning.tsx
     title: Warning banners
     description: >-
       Use to display information that needs attention or that merchants need to
       take action onSeeing these banners can be stressful for merchants so be
-      cautious about using themundefinedundefined
+      cautious about using them
   - fileName: banner-critical.tsx
     title: Critical banners
     description: >-
       Use to communicate problems that have to be resolved immediately for
       merchants to complete a taskFor example, you will show this banner for
       orders with high fraud riskSeeing these banners can be stressful for
-      merchants so be cautious about using themundefinedundefined
+      merchants so be cautious about using them
   - fileName: banner-in-a-modal.tsx
     title: Banner in a modal
     description: >-

--- a/polaris.shopify.com/content/components/card.md
+++ b/polaris.shopify.com/content/components/card.md
@@ -37,14 +37,14 @@ examples:
       items to a card containing a long list, or enter a customer’s new
       address.Use for less important card actions, or actions merchants may do
       before reviewing the contents of the card.Use an icon for the action, if
-      possibleInclude no more than 2 actionsundefinedundefined
+      possibleInclude no more than 2 actions
   - fileName: card-with-footer-actions.tsx
     title: Card with footer actions
     description: >-
       Use footer actions for a card’s most important actions, or actions
       merchants should do after reviewing the contents of the card.Use buttons
       with labelsIf you have more than 2 actions, consider using an overflow
-      menu on the cardundefinedundefined
+      menu on the card
   - fileName: card-with-multiple-footer-actions.tsx
     title: Card with multiple footer actions
   - fileName: card-with-custom-footer-actions.tsx

--- a/polaris.shopify.com/content/components/date-picker.md
+++ b/polaris.shopify.com/content/components/date-picker.md
@@ -43,8 +43,7 @@ examples:
 
 # Date picker
 
-Date pickers let merchants choose dates from a visual calendar that’s
-consistently applied wherever dates need to be selected across Shopify.
+Date pickers let merchants choose dates from a visual calendar that’s consistently applied wherever dates need to be selected across Shopify.
 
 ---
 

--- a/polaris.shopify.com/content/components/keyboard-accessories.md
+++ b/polaris.shopify.com/content/components/keyboard-accessories.md
@@ -11,16 +11,16 @@ keywords:
   - ios
   - android
 examples:
-  - fileName: keyboard-accessories-with-actions.tsx
-    title: Keyboard accessories with actions
-    description: >-
-      Use the action accessories to add actions that are relevant to what
-      merchants are entering on the screen.
-  - fileName: keyboard-accessories-with-text-field.tsx
-    title: Keyboard accessories with text field
-    description: >-
-      Use to make message entry easier in messaging and chat-based
-      products.
+  # - fileName: keyboard-accessories-with-actions.tsx
+  #   title: Keyboard accessories with actions
+  #   description: >-
+  #     Use the action accessories to add actions that are relevant to what
+  #     merchants are entering on the screen.
+  # - fileName: keyboard-accessories-with-text-field.tsx
+  #   title: Keyboard accessories with text field
+  #   description: >-
+  #     Use to make message entry easier in messaging and chat-based
+  #     products.
 ---
 
 # Keyboard accessories

--- a/polaris.shopify.com/content/components/modal.md
+++ b/polaris.shopify.com/content/components/modal.md
@@ -58,12 +58,12 @@ examples:
     title: Modal with activator ref
   - fileName: modal-without-an-activator-prop.tsx
     title: Modal without an activator prop
-  - fileName: modal-warning.tsx
-    title: Warning modal
-    description: >-
-      Use to make it clear to the merchant that the action is potentially
-      dangerous. Only use this option when the merchant is about to perform an
-      action that can’t be undone or is difficult to undo.
+  # - fileName: modal-warning.tsx
+  #   title: Warning modal
+  #   description: >-
+  #     Use to make it clear to the merchant that the action is potentially
+  #     dangerous. Only use this option when the merchant is about to perform an
+  #     action that can’t be undone or is difficult to undo.
 ---
 
 # Modal

--- a/polaris.shopify.com/content/components/page.md
+++ b/polaris.shopify.com/content/components/page.md
@@ -31,9 +31,9 @@ examples:
       Use for detail pages, which should have pagination and breadcrumbs, and
       also often have several actions.Use for detail pages, which should have
       breadcrumbs, and also often have several actions.Use for building any page
-      on Android.undefinedUse for detail pages, which should have breadcrumbs,
+      on Android. Use for detail pages, which should have breadcrumbs,
       and also often have several actions.Use for building any page on
-      iOS.undefined
+      iOS.
   - fileName: page-with-custom-primary-action.tsx
     title: Page with custom primary action
     description: Use to create a custom primary action.

--- a/polaris.shopify.com/content/components/pagination.md
+++ b/polaris.shopify.com/content/components/pagination.md
@@ -36,11 +36,11 @@ examples:
     description: >-
       Add a label between navigation buttons to provide more context of the
       content being viewed by the user.
-  - fileName: pagination-infinite-scroll.tsx
-    title: Infinite scroll
-    description: >-
-      Use for lists longer than 25 items. In mobile apps it’s natural to scroll
-      to the bottom of the screen to load more items.
+  # - fileName: pagination-infinite-scroll.tsx
+  #   title: Infinite scroll
+  #   description: >-
+  #     Use for lists longer than 25 items. In mobile apps it’s natural to scroll
+  #     to the bottom of the screen to load more items.
 ---
 
 # Pagination

--- a/polaris.shopify.com/content/components/popover.md
+++ b/polaris.shopify.com/content/components/popover.md
@@ -46,11 +46,11 @@ examples:
     description: >-
       Use to present merchants with a list that dynamically loads more items on
       scroll or arrow down.
-  - fileName: popover-action-sheet.tsx
-    title: Action sheet
-    description: >-
-      Use when you have few actions that affects the whole page. Action sheets
-      doesn’t support icons or additional information.undefined
+  # - fileName: popover-action-sheet.tsx
+  #   title: Action sheet
+  #   description: >-
+  #     Use when you have few actions that affects the whole page. Action sheets
+  #     doesn’t support icons or additional information.
 ---
 
 # Popover

--- a/polaris.shopify.com/content/components/radio-button.md
+++ b/polaris.shopify.com/content/components/radio-button.md
@@ -23,11 +23,11 @@ examples:
     description: >-
       Use radio buttons where merchants must make a single
       selection.
-  - fileName: radio-button-toggle.tsx
-    title: Toggle
-    description: >-
-      Use toggles when merchants need to make a binary choice (on or
-      off).
+  # - fileName: radio-button-toggle.tsx
+  #   title: Toggle
+  #   description: >-
+  #     Use toggles when merchants need to make a binary choice (on or
+  #     off).
 ---
 
 # Radio button

--- a/polaris.shopify.com/content/components/range-slider.md
+++ b/polaris.shopify.com/content/components/range-slider.md
@@ -16,7 +16,7 @@ keywords:
 examples:
   - fileName: range-slider-default.tsx
     title: Default range slider
-    description: undefinedundefined
+    description:
   - fileName: range-slider-min-and-max-control.tsx
     title: Min and max range control
     description: >-

--- a/polaris.shopify.com/content/components/section-header.md
+++ b/polaris.shopify.com/content/components/section-header.md
@@ -16,17 +16,17 @@ keywords:
   - android
   - ios
 examples:
-  - fileName: section-header-default.tsx
-    title: Default
-    description: >-
-      Use to group related content together, for example orders received on the
-      same day.
-  - fileName: section-header-fixed.tsx
-    title: Fixed
-    description: >-
-      Use if your list section could be longer than the height of the screen.
-      For example you may need fixed section headers for a list of orders,
-      because merchants may receive many orders in one day.undefined
+  # - fileName: section-header-default.tsx
+  #   title: Default
+  #   description: >-
+  #     Use to group related content together, for example orders received on the
+  #     same day.
+  # - fileName: section-header-fixed.tsx
+  #   title: Fixed
+  #   description: >-
+  #     Use if your list section could be longer than the height of the screen.
+  #     For example you may need fixed section headers for a list of orders,
+  #     because merchants may receive many orders in one day.
 ---
 
 # Section header

--- a/polaris.shopify.com/content/components/select.md
+++ b/polaris.shopify.com/content/components/select.md
@@ -31,8 +31,8 @@ examples:
     description: >-
       Presents a classic dropdown menu or equivalent picker as determined by
       merchants’ browsers.The iOS picker expands in-line. Merchants scroll to
-      select the item they want.undefinedThe Android menu is similar in behavior
-      to the web dropdown.undefined
+      select the item they want. The Android menu is similar in behavior
+      to the web dropdown.
   - fileName: select-with-inline-label.tsx
     title: Select with inline label
     description: >-

--- a/polaris.shopify.com/content/components/stepper.md
+++ b/polaris.shopify.com/content/components/stepper.md
@@ -13,16 +13,16 @@ keywords:
   - android
   - ios
 examples:
-  - fileName: stepper-default.tsx
-    title: Default stepper
-    description: >-
-      The stepper has two buttons, a minus and a plus button. It’s possible to
-      tap into the text field as well.
-  - fileName: stepper-disabled.tsx
-    title: Disabled stepper
-    description: >-
-      If you reach the bottom or top value, the appropriate button becomes
-      disabled.
+  # - fileName: stepper-default.tsx
+  #   title: Default stepper
+  #   description: >-
+  #     The stepper has two buttons, a minus and a plus button. It’s possible to
+  #     tap into the text field as well.
+  # - fileName: stepper-disabled.tsx
+  #   title: Disabled stepper
+  #   description: >-
+  #     If you reach the bottom or top value, the appropriate button becomes
+  #     disabled.
 ---
 
 # Stepper

--- a/polaris.shopify.com/content/components/text-field.md
+++ b/polaris.shopify.com/content/components/text-field.md
@@ -57,14 +57,14 @@ examples:
     title: Number field
     description: >-
       Use when input text should be a number.This will display the right
-      keyboard on mobile devices.undefinedThis will display the right keyboard
-      on mobile devices.undefined
+      keyboard on mobile devices. This will display the right keyboard
+      on mobile devices.
   - fileName: text-field-email-field.tsx
     title: Email field
     description: >-
       Use when the text input should be an email address.This will display the
-      right keyboard on mobile devices.undefinedThis will display the right
-      keyboard on mobile devices.undefined
+      right keyboard on mobile devices. This will display the right
+      keyboard on mobile devices.
   - fileName: text-field-multiline.tsx
     title: Multiline text field
     description: >-
@@ -116,15 +116,15 @@ examples:
       Use when a text field and several related fields make up a logical unit.If
       inputting weight as a number and a separate unit of measurement, use a
       text field with a selector (like “kg” or “lb”) as a connected
-      field.undefinedIf inputting weight as a number and a separate unit of
+      field. If inputting weight as a number and a separate unit of
       measurement, use a text field with a selector (like “kg” or “lb”) as a
-      connected field.undefined
-  - fileName: text-field-with-icon-action.tsx
-    title: Text field with icon action
-    description: >-
-      Use to let merchants take an action within the text field.For example, tap
-      on a barcode icon to launch the camera and scan barcode for the barcode
-      field. This helps merchants simplify their input.
+      connected field.
+  # - fileName: text-field-with-icon-action.tsx
+  #   title: Text field with icon action
+  #   description: >-
+  #     Use to let merchants take an action within the text field.For example, tap
+  #     on a barcode icon to launch the camera and scan barcode for the barcode
+  #     field. This helps merchants simplify their input.
   - fileName: text-field-with-validation-error.tsx
     title: Text field with validation error
     description: >-

--- a/polaris.shopify.com/content/components/toast.md
+++ b/polaris.shopify.com/content/components/toast.md
@@ -38,29 +38,29 @@ examples:
     description: >-
       Use when a merchant has the ability to act on the message. For example, to
       undo a change or retry an action.
-  - fileName: toast-default.tsx
-    title: Default toast
-    description: >-
-      Use default toast for informative and neutral feedback.undefinedOn iOS,
-      icons are available for cases where you want to re-inforce the
-      message.undefined
-  - fileName: toast-success.tsx
-    title: Success toast
-    description: >-
-      Use success toast to indicate that something was successful. For example,
-      a product was successfully updated.undefinedOn iOS, icons are available
-      for cases where you want to re-inforce the message.undefined
+  # - fileName: toast-default.tsx
+  #   title: Default toast
+  #   description: >-
+  #     Use default toast for informative and neutral feedback.On iOS,
+  #     icons are available for cases where you want to re-inforce the
+  #     message.
+  # - fileName: toast-success.tsx
+  #   title: Success toast
+  #   description: >-
+  #     Use success toast to indicate that something was successful. For example,
+  #     a product was successfully updated.On iOS, icons are available
+  #     for cases where you want to re-inforce the message.
   - fileName: toast-error.tsx
     title: Error toast
     description: >-
-      undefinedOn iOS, icons are available for cases where you want to
-      re-inforce the message.undefined
-  - fileName: toast-with-action.tsx
-    title: With action
-    description: >-
-      Use action when merchants have the ability to act on the message. For
-      example, to undo a change or retry an action. Keep the action label short,
-      preferably 1 verb action.
+      On iOS, icons are available for cases where you want to
+      re-inforce the message.
+  # - fileName: toast-with-action.tsx
+  #   title: With action
+  #   description: >-
+  #     Use action when merchants have the ability to act on the message. For
+  #     example, to undo a change or retry an action. Keep the action label short,
+  #     preferably 1 verb action.
 ---
 
 # Toast

--- a/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
+++ b/polaris.shopify.com/src/components/CodeExample/CodeExample.module.scss
@@ -48,7 +48,7 @@
   font-family: "SF Mono", SFMono-Regular, ui-monospace, "DejaVu Sans Mono",
     Menlo, Consolas, monospace;
   white-space: pre;
-  padding: 0.4rem 0.1rem;
+  padding: 0.66rem 0.66rem;
   font-size: 13px;
   color: var(--text-strong);
   overflow: auto;

--- a/polaris.shopify.com/src/components/CodeExample/CodeExample.tsx
+++ b/polaris.shopify.com/src/components/CodeExample/CodeExample.tsx
@@ -12,7 +12,6 @@ interface Props {
 
 function CodeExample({ title, children }: Props) {
   const [copy, didJustCopy] = useCopyToClipboard(children);
-  const lines = children.split("\n");
 
   return (
     <div className={styles.CodeExample}>
@@ -44,13 +43,7 @@ function CodeExample({ title, children }: Props) {
         </Tooltip>
       </div>
 
-      <div className={styles.Code}>
-        {lines.map((line, i) => (
-          <div className={styles.Line} key={line}>
-            <span className={styles.LineNumber}>{i + 1}</span> {line}
-          </div>
-        ))}
-      </div>
+      <div className={styles.Code}>{children.toString().trim()}</div>
     </div>
   );
 }

--- a/polaris.shopify.com/src/components/Examples/Examples.tsx
+++ b/polaris.shopify.com/src/components/Examples/Examples.tsx
@@ -96,9 +96,7 @@ const Examples = (props: Props) => {
           <iframe src={exampleUrl} height="400px" width="100%" />
         </div>
       ) : (
-        <CodeExample language="typescript" title={`${title} Example`}>
-          {code}
-        </CodeExample>
+        <CodeExample language="typescript">{code}</CodeExample>
       )}
     </>
   );

--- a/polaris.shopify.com/src/pages/components/[component].tsx
+++ b/polaris.shopify.com/src/pages/components/[component].tsx
@@ -68,25 +68,27 @@ export const getStaticProps: GetStaticProps<
       body: readmeBody,
     };
 
-    const examples = data?.frontMatter?.examples.map((example: Example) => {
-      const examplePath = path.resolve(
-        process.cwd(),
-        `src/pages/examples/${example.fileName}`
-      );
-      let code = "";
+    const examples = (data?.frontMatter?.examples || []).map(
+      (example: Example) => {
+        const examplePath = path.resolve(
+          process.cwd(),
+          `src/pages/examples/${example.fileName}`
+        );
+        let code = "";
 
-      if (fs.existsSync(examplePath)) {
-        code = fs.readFileSync(examplePath, "utf-8");
-        code = code
-          .split("\n")
-          .filter((line) => !line.includes("withPolarisExample"))
-          .join("\n");
+        if (fs.existsSync(examplePath)) {
+          code = fs.readFileSync(examplePath, "utf-8");
+          code = code
+            .split("\n")
+            .filter((line) => !line.includes("withPolarisExample"))
+            .join("\n");
+        }
+
+        console.log("code is", code);
+
+        return { ...example, code };
       }
-
-      console.log("code is", code);
-
-      return { ...example, code };
-    });
+    );
     const props: Props = {
       ...data.frontMatter,
       examples,

--- a/polaris.shopify.com/src/pages/examples/video-thumbnail-basic.tsx
+++ b/polaris.shopify.com/src/pages/examples/video-thumbnail-basic.tsx
@@ -21,4 +21,4 @@ function VideoThumbnailExample() {
   );
 }
 
-export default withPolarisExample(() => <p />);
+export default withPolarisExample(() => <VideoThumbnailExample />);


### PR DESCRIPTION
- Hides examples that are not ready for prime time
- Makes site code accept "no examples" in readmes
- Removes the word "undefined" from some examples