### PR TITLE
[polaris.shopify.com] Set root font size as percentage

### DIFF
--- a/.changeset/poor-melons-warn.md
+++ b/.changeset/poor-melons-warn.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Set root font size as percentage

--- a/polaris.shopify.com/src/styles/globals.scss
+++ b/polaris.shopify.com/src/styles/globals.scss
@@ -124,10 +124,10 @@ video {
 }
 
 html {
-  font-size: 17px;
+  font-size: 106.25%;
 
   @media screen and (max-width: $breakpointMobile) {
-    font-size: 16px;
+    font-size: 100%;
   }
 }
 


### PR DESCRIPTION
Small fix to set root font size as a percentage so that user browser font size preferences are supported