### PR TITLE
feat: Update SkeletonPage to use Polaris LG media conditions

### DIFF
--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
@@ -74,7 +74,7 @@ $skeleton-display-text-max-width: 120px;
     min-width: $primary-action-button-width;
   }
 
-  @media #{$breakpoints-page-content-when-layout-stacked-down} {
+  @media #{$p-breakpoints-lg-down} {
     margin-top: var(--p-space-4);
     margin-bottom: calc(-1 * var(--p-space-2));
   }

--- a/polaris-react/src/styles/shared/_breakpoints.scss
+++ b/polaris-react/src/styles/shared/_breakpoints.scss
@@ -30,7 +30,6 @@ $page-max-width: $layout-width-primary-max + $layout-width-secondary-max + $layo
 $not-condensed-content: breakpoint($layout-width-page-content-not-condensed);
 
 $breakpoints-page-content-when-layout-not-stacked-up: breakpoints-up(800px);
-$breakpoints-page-content-when-layout-stacked-down: breakpoints-down(1040px, $inclusive: true);
 
 $breakpoints-page-content-when-partially-condensed-down: breakpoints-down(984px, $inclusive: true);
 


### PR DESCRIPTION
### WHY are these changes introduced?
Part of #5716 

### WHAT is this pull request doing?
Updating `SkeletonPage` to use Polaris LG media conditions.

#### Checklist
- What Polaris media condition was used?
  - From: `@include page-content-when-layout-stacked`
  - To: `$p-breakpoints-lg-down`
- Did the breakpoint value change? `Yes`
  - From: `1040px`
  - To: `1039.95px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `No`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `page-content-when-layout-stacked`
- Is the layout using a mobile first strategy? `No`
 
#### Before/After Examples
**Before**

https://user-images.githubusercontent.com/21976492/175161929-8a73b1cd-6729-4988-b6ba-504dd3763885.mp4

**After**

https://user-images.githubusercontent.com/21976492/175162011-0441a644-38d0-4b7f-aa3b-c189d65d88c4.mp4




