### PR TITLE
feat: Update MediaCard to Polaris MD media conditions

### DIFF
--- a/polaris-react/src/components/MediaCard/MediaCard.scss
+++ b/polaris-react/src/components/MediaCard/MediaCard.scss
@@ -1,11 +1,5 @@
 @import '../../styles/common';
 
-$breakpoints-portrait-breakpoint-up: breakpoints-up(804px);
-$breakpoints-portrait-breakpoint-down: breakpoints-down(
-  804px,
-  $inclusive: true
-);
-
 .MediaCard {
   height: 100%;
   width: 100%;
@@ -16,7 +10,7 @@ $breakpoints-portrait-breakpoint-down: breakpoints-down(
     flex-flow: column nowrap;
   }
 
-  @media #{$breakpoints-portrait-breakpoint-down} {
+  @media #{$p-breakpoints-md-down} {
     flex-flow: column nowrap;
   }
 }
@@ -27,6 +21,12 @@ $breakpoints-portrait-breakpoint-down: breakpoints-down(
   &:not(.portrait) {
     flex-basis: 40%;
 
+    @media #{$p-breakpoints-md-up} {
+      border-top-right-radius: 0;
+      border-top-left-radius: var(--p-border-radius-2);
+      border-bottom-left-radius: var(--p-border-radius-2);
+    }
+
     &.sizeSmall {
       flex-basis: 33%;
     }
@@ -35,13 +35,6 @@ $breakpoints-portrait-breakpoint-down: breakpoints-down(
   @media #{$p-breakpoints-sm-up} {
     border-top-left-radius: var(--p-border-radius-2);
     border-top-right-radius: var(--p-border-radius-2);
-  }
-  @media #{$breakpoints-portrait-breakpoint-up} {
-    &:not(.portrait) {
-      border-top-right-radius: 0;
-      border-top-left-radius: var(--p-border-radius-2);
-      border-bottom-left-radius: var(--p-border-radius-2);
-    }
   }
 }
 
@@ -83,7 +76,7 @@ $breakpoints-portrait-breakpoint-down: breakpoints-down(
     padding-top: var(--p-space-8);
   }
 
-  @media #{$breakpoints-portrait-breakpoint-down} {
+  @media #{$p-breakpoints-md-down} {
     padding-top: var(--p-space-8);
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?
Part of #5714  

### WHAT is this pull request doing?
Updating `MediaCard` to use Polaris MD media conditions.

#### Checklist
- What Polaris media condition was used?

  | From | To |
  | --- | --- |
  | `@include breakpoint-before($portrait-breakpoint, inclusive)` | `@media #{$p-breakpoints-md-down}` |
  | `@include breakpoint-after($portrait-breakpoint, inclusive)` | `@media #{$p-breakpoints-md-up}` |

- Did the breakpoint value change? `Yes`

| Media condition | Value From | Value To | Change? |
  | --- | --- | --- | --- |
  | `@include breakpoint-before($portrait-breakpoint, inclusive)` | `804px` | `767.95px` | `Yes` |
  | `@include breakpoint-after($portrait-breakpoint, inclusive)` | `804px` | `768px` | `Yes` |

- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `No`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `Yes`
  - Search pattern: `breakpoint-(before|after).+portrait-breakpoint`
 
- Is the layout using a mobile first strategy?
 
| Media condition | Mobile first? |
  | --- | --- | 
  | `@include breakpoint-before($portrait-breakpoint, inclusive)` | `No` |
  | `@include breakpoint-after($portrait-breakpoint, inclusive)` | `Yes` |

 
#### Before/After Examples
**Before**

https://user-images.githubusercontent.com/21976492/175175380-eac628b9-058e-4ab9-ba3d-00d22b46de12.mp4



**After**


https://user-images.githubusercontent.com/21976492/175175704-b55f410f-01ed-4b97-b724-1964dbd4d008.mp4







