### PR TITLE
feat: Update TopBar to Polaris XL media conditions

### DIFF
--- a/polaris-react/src/components/TopBar/TopBar.scss
+++ b/polaris-react/src/components/TopBar/TopBar.scss
@@ -3,7 +3,6 @@
 
 $icon-size: 20px;
 
-$breakpoints-context-control-expand-up: breakpoints-up(1400px);
 $breakpoints-page-left-alignment-down: breakpoints-down(
   1238px,
   $inclusive: true
@@ -62,7 +61,7 @@ $breakpoints-page-left-alignment-down: breakpoints-down(
     display: block;
   }
 
-  @media #{$breakpoints-context-control-expand-up} {
+  @media #{$p-breakpoints-xl-up} {
     width: $layout-width-nav-base;
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?
Part of #5808    

### WHAT is this pull request doing?
Updating `TopBar` to use Polaris XL media conditions.

#### Checklist
- What Polaris media condition was used?
  - From: `@include breakpoint-after($context-control-expand-after)`
  - To: `@media #{$p-breakpoints-xl-up}`
- Did the breakpoint value change? `Yes`
  - From: `1400px`
  - To: `1440px`
- Was the breakpoint variable, function, or mixin used elsewhere in Polaris? `No`
- Was the breapoint variable, function, or mixin used elsewhere in Web? `No`
  - Search pattern: `breakpoint-after.+context-control-expand-after`
- Is the layout using a mobile first strategy? `Yes`
 
#### Before/After Examples
Couldn't find any visual examples of the change. 


