### PR TITLE
Clean up breakpoint utilities after upgrade

### DIFF
--- a/polaris-react/src/styles/shared/_breakpoints.scss
+++ b/polaris-react/src/styles/shared/_breakpoints.scss
@@ -1,6 +1,3 @@
-/* stylelint-disable unit-disallowed-list */
-
-
 @function breakpoint($value, $inclusive: true) {
   $value-unit: unit($value);
   // Down media condition breakpoints are being subtracted by 0.05px to prevent

--- a/polaris-react/src/styles/shared/_breakpoints.scss
+++ b/polaris-react/src/styles/shared/_breakpoints.scss
@@ -16,13 +16,3 @@
     @error 'The $value passed into breakpoint() must be a pixel or em value. Got "#{$value}"';
   }
 }
-
-@function breakpoints-up($value) {
-  @return '(min-width: #{breakpoint($value)})';
-}
-
-@function breakpoints-down($value, $inclusive: false) {
-  @return '(max-width: #{breakpoint($value, $inclusive)})';
-}
-
-$page-max-width: $layout-width-primary-max + $layout-width-secondary-max + $layout-width-inner-spacing-base;

--- a/polaris-react/src/styles/shared/_page.scss
+++ b/polaris-react/src/styles/shared/_page.scss
@@ -1,3 +1,6 @@
+$page-max-width: $layout-width-primary-max + $layout-width-secondary-max +
+  $layout-width-inner-spacing-base;
+
 @mixin page-layout {
   margin: 0 auto;
   padding: 0;


### PR DESCRIPTION
### WHY are these changes introduced?

Clean up remaining breakpoint utilities after upgrade.


### WHAT is this pull request doing?

- Removing `breakpoints-up()`
- Removing `breakpoints-down()`
- Moving `$page-max-width` to `_page.scss`