### PR TITLE
[polaris.shopify.com] Fix layout bug in components grid

### DIFF
--- a/.changeset/hungry-guests-sing.md
+++ b/.changeset/hungry-guests-sing.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix layout bug in CSS grid

--- a/polaris.shopify.com/src/components/ComponentGrid/ComponentGrid.module.scss
+++ b/polaris.shopify.com/src/components/ComponentGrid/ComponentGrid.module.scss
@@ -19,6 +19,7 @@
     border-radius: var(--border-radius-600);
     box-shadow: var(--card-shadow);
     overflow: hidden;
+    width: 100%;
 
     &:hover {
       box-shadow: var(--card-shadow-hover);


### PR DESCRIPTION
Before:

<img width="632" alt="Screen Shot 2022-07-07 at 7 00 47 PM" src="https://user-images.githubusercontent.com/875708/177829823-212ec833-95c9-41aa-8943-9d166f2aa19e.png">

After:

<img width="620" alt="Screen Shot 2022-07-07 at 7 01 07 PM" src="https://user-images.githubusercontent.com/875708/177829828-0817d250-4b9e-4e12-a821-bb7a7c66c009.png">
