### PR TITLE
[Popover] Use different helper for autofocus

### DIFF
--- a/.changeset/two-actors-lay.md
+++ b/.changeset/two-actors-lay.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Use different focus helper for the popover autofocus

--- a/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
+++ b/polaris-react/src/components/Popover/components/PopoverOverlay/PopoverOverlay.tsx
@@ -6,7 +6,7 @@ import {
   CustomProperties,
   CustomPropertiesProps,
 } from '../../../CustomProperties';
-import {findFirstFocusableNode} from '../../../../utilities/focus';
+import {findFirstKeyboardFocusableNode} from '../../../../utilities/focus';
 import {classNames} from '../../../../utilities/css';
 import {
   isElementOfType,
@@ -189,7 +189,9 @@ export class PopoverOverlay extends PureComponent<PopoverOverlayProps, State> {
         return;
       }
 
-      const focusableChild = findFirstFocusableNode(this.contentNode.current);
+      const focusableChild = findFirstKeyboardFocusableNode(
+        this.contentNode.current,
+      );
 
       if (focusableChild && autofocusTarget === 'first-node') {
         focusableChild.focus({


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #6593

The Popover component doesn't actually focus on the first node when you have something like an ActionList as the child. What happens is one of the wrapping divs of the action list gets focused instead of the first item of the list.

### WHAT is this pull request doing?

By changing `findFirstFocusableNode` -> `findFirstKeyboardFocusableNode` the first item will actually be focused correctly.

Before: 

https://user-images.githubusercontent.com/105817582/178350252-47505f67-32bb-4d24-b6ca-4592f91f7f0b.mov

After:

https://user-images.githubusercontent.com/105817582/178350266-e30fa3e7-9101-43c2-8084-376d250e2069.mov

### How to 🎩

Should see the change buy opening the popover component in storybooks. Should work with click or pressing enter when focused.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
