### PR TITLE
[polaris.shopify.com] Fix examples select

### DIFF
--- a/.changeset/fuzzy-actors-do.md
+++ b/.changeset/fuzzy-actors-do.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix dropdown on Examples page

--- a/polaris.shopify.com/src/components/Examples/Examples.tsx
+++ b/polaris.shopify.com/src/components/Examples/Examples.tsx
@@ -70,7 +70,7 @@ const Examples = (props: Props) => {
         label="Component example"
         id="Component-Example-Select"
         options={options}
-        selected={String(options[currentIndex])}
+        selected={options[currentIndex].value}
         onChange={handleSelection}
       />
       {description ? <p>{description}</p> : null}


### PR DESCRIPTION
#6430 accidentally introduced a bug on the examples page, causing the dropdown to break. This PR fixes that right up!