### PR TITLE
Fixed typo in "Shipping your contribution"

### DIFF
--- a/.changeset/gorgeous-apes-tease.md
+++ b/.changeset/gorgeous-apes-tease.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed a "your" -> "you are" typo

--- a/polaris.shopify.com/content/contributing/shipping-your-contribution.md
+++ b/polaris.shopify.com/content/contributing/shipping-your-contribution.md
@@ -84,7 +84,7 @@ yarn turbo run dev --filter=@shopify/polaris
 # Open https://localhost:6006 to test Storybook examples and Playground sandboxes
 ```
 
-If your adding or editing documentation, ensure your content displays as expected on the style guide website:
+If you are adding or editing documentation, ensure your content displays as expected on the style guide website:
 
 ```bash
 yarn turbo run dev --filter=polaris.shopify.com


### PR DESCRIPTION
### WHY are these changes introduced?

There is a typo on this page: [https://polaris.shopify.com/contributing/shipping-your-contribution#open-your-first-pr](https://polaris.shopify.com/contributing/shipping-your-contribution#open-your-first-pr)

_If **your** adding or editing documentation, ensure your content displays as expected on the style guide website:_
should be
_If **you are** adding [...]_

### WHAT is this pull request doing?

Fixed typo