### PR TITLE
[TextField] Allow click event on spinner (stepper in number type) 

### DIFF
--- a/.changeset/late-turkeys-teach.md
+++ b/.changeset/late-turkeys-teach.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': major
+---
+
+Allow click events for spinner in [TextField]

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -239,6 +239,7 @@ export function TextField({
   const suffixRef = useRef<HTMLDivElement>(null);
   const verticalContentRef = useRef<HTMLDivElement>(null);
   const buttonPressTimer = useRef<number>();
+  const spinnerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const input = inputRef.current;
@@ -405,6 +406,7 @@ export function TextField({
         onChange={handleNumberChange}
         onMouseDown={handleButtonPress}
         onMouseUp={handleButtonRelease}
+        ref={spinnerRef}
       />
     ) : null;
 
@@ -585,11 +587,28 @@ export function TextField({
     event.preventDefault();
   }
 
+  function isInput(target: HTMLElement | EventTarget) {
+    return (
+      target instanceof HTMLElement &&
+      inputRef.current &&
+      (inputRef.current.contains(target) ||
+        inputRef.current.contains(document.activeElement))
+    );
+  }
+
   function isPrefixOrSuffix(target: Element | EventTarget) {
     return (
       target instanceof Element &&
       ((prefixRef.current && prefixRef.current.contains(target)) ||
         (suffixRef.current && suffixRef.current.contains(target)))
+    );
+  }
+
+  function isSpinner(target: Element | EventTarget) {
+    return (
+      target instanceof Element &&
+      spinnerRef.current &&
+      spinnerRef.current.contains(target)
     );
   }
 
@@ -599,15 +618,6 @@ export function TextField({
       verticalContentRef.current &&
       (verticalContentRef.current.contains(target) ||
         verticalContentRef.current.contains(document.activeElement))
-    );
-  }
-
-  function isInput(target: HTMLElement | EventTarget) {
-    return (
-      target instanceof HTMLElement &&
-      inputRef.current &&
-      (inputRef.current.contains(target) ||
-        inputRef.current.contains(document.activeElement))
     );
   }
 
@@ -629,7 +639,7 @@ export function TextField({
   }
 
   function handleClickChild(event: React.MouseEvent) {
-    if (inputRef.current !== event.target) {
+    if (!isInput(event.target) && !isSpinner(event.target)) {
       event.stopPropagation();
     }
 

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -573,6 +573,41 @@ export function TextField({
     </Labelled>
   );
 
+  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    onChange && onChange(event.currentTarget.value, id);
+  }
+
+  function handleClick({target}: React.MouseEvent) {
+    if (
+      isPrefixOrSuffix(target) ||
+      isVerticalContent(target) ||
+      isInput(target) ||
+      isSpinner(target) ||
+      focus
+    ) {
+      return;
+    }
+
+    inputRef.current?.focus();
+  }
+
+  function handleClickChild(event: React.MouseEvent) {
+    if (!isSpinner(event.target) && !isInput(event.target)) {
+      event.stopPropagation();
+    }
+
+    if (
+      isPrefixOrSuffix(event.target) ||
+      isVerticalContent(event.target) ||
+      isInput(event.target) ||
+      focus
+    ) {
+      return;
+    }
+
+    setFocus(true);
+  }
+
   function handleClearButtonPress() {
     onClearButtonClick && onClearButtonClick(id);
   }
@@ -620,40 +655,12 @@ export function TextField({
         verticalContentRef.current.contains(document.activeElement))
     );
   }
+}
 
-  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
-    onChange && onChange(event.currentTarget.value, id);
-  }
+function getRows(multiline?: boolean | number) {
+  if (!multiline) return undefined;
 
-  function handleClick({target}: React.MouseEvent) {
-    if (
-      isPrefixOrSuffix(target) ||
-      isVerticalContent(target) ||
-      isInput(target) ||
-      focus
-    ) {
-      return;
-    }
-
-    inputRef.current?.focus();
-  }
-
-  function handleClickChild(event: React.MouseEvent) {
-    if (!isInput(event.target) && !isSpinner(event.target)) {
-      event.stopPropagation();
-    }
-
-    if (
-      isPrefixOrSuffix(event.target) ||
-      isVerticalContent(event.target) ||
-      isInput(event.target) ||
-      focus
-    ) {
-      return;
-    }
-
-    setFocus(true);
-  }
+  return typeof multiline === 'number' ? multiline : 1;
 }
 
 function normalizeAriaMultiline(multiline?: boolean | number) {
@@ -662,10 +669,4 @@ function normalizeAriaMultiline(multiline?: boolean | number) {
   return Boolean(multiline) || multiline > 0
     ? {'aria-multiline': true}
     : undefined;
-}
-
-function getRows(multiline?: boolean | number) {
-  if (!multiline) return undefined;
-
-  return typeof multiline === 'number' ? multiline : 1;
 }

--- a/polaris-react/src/components/TextField/components/Spinner/Spinner.tsx
+++ b/polaris-react/src/components/TextField/components/Spinner/Spinner.tsx
@@ -12,6 +12,7 @@ export interface SpinnerProps {
   onMouseDown(onChange: HandleStepFn): void;
   onMouseUp(): void;
 }
+
 export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
   function Spinner({onChange, onClick, onMouseDown, onMouseUp}, ref) {
     function handleStep(step: number) {

--- a/polaris-react/src/components/TextField/components/Spinner/Spinner.tsx
+++ b/polaris-react/src/components/TextField/components/Spinner/Spinner.tsx
@@ -12,51 +12,46 @@ export interface SpinnerProps {
   onMouseDown(onChange: HandleStepFn): void;
   onMouseUp(): void;
 }
+export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
+  function Spinner({onChange, onClick, onMouseDown, onMouseUp}, ref) {
+    function handleStep(step: number) {
+      return () => onChange(step);
+    }
 
-export function Spinner({
-  onChange,
-  onClick,
-  onMouseDown,
-  onMouseUp,
-}: SpinnerProps) {
-  function handleStep(step: number) {
-    return () => onChange(step);
-  }
+    function handleMouseDown(onChange: HandleStepFn) {
+      return (event: React.MouseEvent) => {
+        if (event.button !== 0) return;
+        onMouseDown(onChange);
+      };
+    }
 
-  function handleMouseDown(onChange: HandleStepFn) {
-    return (event: React.MouseEvent) => {
-      if (event.button !== 0) return;
-      onMouseDown(onChange);
-    };
-  }
-
-  return (
-    <div className={styles.Spinner} onClick={onClick} aria-hidden>
-      <div
-        role="button"
-        className={styles.Segment}
-        tabIndex={-1}
-        onClick={handleStep(1)}
-        onMouseDown={handleMouseDown(handleStep(1))}
-        onMouseUp={onMouseUp}
-      >
-        <div className={styles.SpinnerIcon}>
-          <Icon source={CaretUpMinor} />
+    return (
+      <div className={styles.Spinner} onClick={onClick} aria-hidden ref={ref}>
+        <div
+          role="button"
+          className={styles.Segment}
+          tabIndex={-1}
+          onClick={handleStep(1)}
+          onMouseDown={handleMouseDown(handleStep(1))}
+          onMouseUp={onMouseUp}
+        >
+          <div className={styles.SpinnerIcon}>
+            <Icon source={CaretUpMinor} />
+          </div>
+        </div>
+        <div
+          role="button"
+          className={styles.Segment}
+          tabIndex={-1}
+          onClick={handleStep(-1)}
+          onMouseDown={handleMouseDown(handleStep(-1))}
+          onMouseUp={onMouseUp}
+        >
+          <div className={styles.SpinnerIcon}>
+            <Icon source={CaretDownMinor} />
+          </div>
         </div>
       </div>
-
-      <div
-        role="button"
-        className={styles.Segment}
-        tabIndex={-1}
-        onClick={handleStep(-1)}
-        onMouseDown={handleMouseDown(handleStep(-1))}
-        onMouseUp={onMouseUp}
-      >
-        <div className={styles.SpinnerIcon}>
-          <Icon source={CaretDownMinor} />
-        </div>
-      </div>
-    </div>
-  );
-}
+    );
+  },
+);

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -85,49 +85,62 @@ describe('<TextField />', () => {
   });
 
   describe('click events', () => {
-    describe('when a click event occurs on the input', () => {
-      it('bubbles up to the parent element', () => {
-        const onClick = jest.fn();
-        const event = new MouseEvent('click', {
-          view: window,
-          bubbles: true,
-          cancelable: true,
-        });
-        const textField = mountWithApp(
-          <div onClick={onClick}>
-            <TextField type="text" label="TextField" autoComplete="off" />
-          </div>,
-        );
-
-        textField.find('input')!.domNode?.dispatchEvent(event);
-        expect(onClick).toHaveBeenCalled();
+    it('bubbles up to the parent element when it occurs in the input', () => {
+      const onClick = jest.fn();
+      const event = new MouseEvent('click', {
+        view: window,
+        bubbles: true,
+        cancelable: true,
       });
+      const textField = mountWithApp(
+        <div onClick={onClick}>
+          <TextField type="text" label="TextField" autoComplete="off" />
+        </div>,
+      );
 
-      describe('when a click event occurs in an element other than the input', () => {
-        it('does not bubble up to the parent element', () => {
-          const onClick = jest.fn();
-          const children = 'vertical-content-children';
-          const event = new MouseEvent('click', {
-            view: window,
-            bubbles: true,
-            cancelable: true,
-          });
-          const verticalContent = <span>{children}</span>;
-          const textField = mountWithApp(
-            <div onClick={onClick}>
-              <TextField
-                type="text"
-                label="TextField"
-                autoComplete="off"
-                verticalContent={verticalContent}
-              />
-            </div>,
-          );
+      textField.find('input')!.domNode?.dispatchEvent(event);
+      expect(onClick).toHaveBeenCalled();
+    });
 
-          textField.find('span', {children})!.domNode?.dispatchEvent(event);
-          expect(onClick).not.toHaveBeenCalled();
-        });
+    it('bubbles up to the parent element when it occurs in the spinner', () => {
+      const onClick = jest.fn();
+      const event = new MouseEvent('click', {
+        view: window,
+        bubbles: true,
+        cancelable: true,
       });
+      const textField = mountWithApp(
+        <div onClick={onClick}>
+          <TextField type="number" label="TextField" autoComplete="off" />
+        </div>,
+      );
+
+      textField.find(Spinner)!.domNode?.dispatchEvent(event);
+      expect(onClick).toHaveBeenCalled();
+    });
+
+    it('does not bubble up to the parent element when it occurs in an element other than the input', () => {
+      const onClick = jest.fn();
+      const children = 'vertical-content-children';
+      const event = new MouseEvent('click', {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+      });
+      const verticalContent = <span>{children}</span>;
+      const textField = mountWithApp(
+        <div onClick={onClick}>
+          <TextField
+            type="text"
+            label="TextField"
+            autoComplete="off"
+            verticalContent={verticalContent}
+          />
+        </div>,
+      );
+
+      textField.find('span', {children})!.domNode?.dispatchEvent(event);
+      expect(onClick).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
co-author: @weslleyaraujo 
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/6725
Part of https://github.com/Shopify/inventory-states-ux/issues/524
Follow up to https://github.com/Shopify/polaris/pull/6129 https://github.com/Shopify/web/pull/68974

As of Polaris 9.12.0, we no longer bubble up click events emitted on `TextField` and parent elements can no longer depend on interactions. This change was introduced [here](https://github.com/Shopify/polaris/commit/e519016562c8caa70ae4e9e5210b660a0b9a112c#diff-b3c67fa075f17d88f8c43be7df7456856ae03cb49912c84f23560ddaf30d4fa4R632). 

Click events do not bubble for the `Spinner`[(see here)](https://github.com/Shopify/polaris/blob/5981b1ba3b972f41a787d51e9881faccf7cd467c/polaris-react/src/components/TextField/TextField.tsx#L403) portion of the Textfield.  The spinner is the 🔼 and 🔽 when the `type='number'`.  **_This is problematic for when we need to implement onClick events around the TextField_**. This current [monorail schema](https://github.com/Shopify/monorail/blob/062ccd893702ef5804ebd36022d7d43666564429/schemas/admin_product_inventory_available_save_button_click/1.0.yml) measures whether or not a merchant used the stepper / spinner to adjust their inventory quantity. The `event.stopPropagation()` no longer allows us to capture this data 😢 and will always return false. 

### WHAT is this pull request doing?

This PR will conditionally call stopPropagation when click events are captured by TextField and parent elements.

If it is either the `spinner` or an `input`, it will no longer call the `stopPropagation`. 


### BEFORE

https://user-images.githubusercontent.com/43223543/180799925-71a9ae49-105f-490b-a6e5-60c263e1805a.mp4

### AFTER

https://user-images.githubusercontent.com/43223543/180799916-97a90764-786a-4664-accb-6cf385ee804e.mp4



### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)


<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Badge, Page, Stack, TextField} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      <Stack vertical>
        <div
          onClick={(event) =>
            console.log('Propagated event for the stepper / Spinner', event)
          }
        >
          <TextField
            label="Working Stepper Event"
            autoComplete="off"
            type="number"
          />
        </div>
        <div
          onClick={(event) =>
            console.log('Propagated event / verticalContent', event)
          }
        >
          <TextField
            label="Vertical Content"
            autoComplete="off"
            verticalContent={<Badge>Buyer</Badge>}
          />
        </div>
      </Stack>
    </Page>
  );
}

```


</details>


There should be two `TextField`s rendered in your playground and one of them contains a `Badge` as its `verticalContent` prop.

- Open your console and click the spinner on the first `TextField`
- You should see a log indicating that the click event bubbled up to its parent 🥳 
- On the second `TextField` click directly on the `Badge` (not the input field)
- You should not see any logs indicating that the click event bubbled up (unless you clicked on the input field)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
