### PR TITLE
Updates changeset for `DataTable` update to fix malformatted `CHANGELOG.md`

### DIFF
--- a/.changeset/odd-games-cough.md
+++ b/.changeset/odd-games-cough.md
@@ -3,12 +3,4 @@
 'polaris.shopify.com': patch
 ---
 
-## '@shopify/polaris': patch
-
-- Updated `DataTable` to fix console warning about improperly nested HTML
-- Updated `DataTable` to ensure focus states remain on the same header element when switching between sticky and regular header.
-- Improved `DataTable` tooltip when using `truncate` prop.
-
-## 'polaris.shopify.com': patch
-
-- Added example for `DataTable` using fixed first column
+Updated `DataTable` to fix console warning about improperly nested HTML, ensure focus states remain on the same header element when switching between sticky and regular header and improved tooltip when using `truncate` prop.


### PR DESCRIPTION
[Second attempt](https://github.com/Shopify/polaris/pull/6774) at fixing `@shopify/polaris` and `polaris.shopify.com` changelog files by updating the changeset.

### WHY are these changes introduced?

Was using improper sub-headings in changeset.

### WHAT is this pull request doing?

Removing sub-headings in the changeset as they seem to be causing errors in the changelog generation.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)



### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
