### PR TITLE
[AccountConnection] Change action type to LoadableAction

### DIFF
--- a/polaris-react/src/components/AccountConnection/AccountConnection.tsx
+++ b/polaris-react/src/components/AccountConnection/AccountConnection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import type {Action} from '../../types';
+import type {LoadableAction} from '../../types';
 import {Avatar} from '../Avatar';
 import {buttonFrom} from '../Button';
 import {Card} from '../Card';
@@ -24,7 +24,7 @@ export interface AccountConnectionProps {
   /** Set if the account is connected */
   connected?: boolean;
   /** Action for account connection */
-  action?: Action;
+  action?: LoadableAction;
 }
 
 export function AccountConnection({


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #6814 by adding type-safe support for the `loadable` prop on `AccountConnectionProps["action"]`.

This is important because clicking "connect" should trigger an external API request, and if this takes time to complete, the user should be informed. Setting `loading: true` disables the button and gives visual feedback.

(The best action type would also support `disabled`, so that the button could be disabled for 1 second before switching to a loading state; this PR keeps it simple for now, to avoid introducing any new types.)

### WHAT is this pull request doing?

It's just adding type safety for an existing capability:

<img width="642" alt="image" src="https://user-images.githubusercontent.com/1505561/182165321-5a05ad37-1175-42fa-970d-6e1ef03df020.png">