### PR TITLE
Adding clarification for `About` native section

### DIFF
--- a/polaris.shopify.com/content/foundations/foundations/about-polaris/index.md
+++ b/polaris.shopify.com/content/foundations/foundations/about-polaris/index.md
@@ -23,7 +23,9 @@ The web version of the Shopify admin is available for desktop and mobile web. Po
 
 ### Native
 
-The Shopify admin is also available as iOS and Android apps. Polaris components are available as native user interface (UI) elements built with React Native. Because the iOS and Android apps also make use of embedded web views for parts of the admin, Polaris web components are used in these cases.
+The Shopify admin is also available as iOS and Android apps. Polaris components are available as native user interface (UI) elements built with React Native. The Polaris React Native components are only available to Shopify employees building the admin iOS and Android apps.
+
+Because the iOS and Android apps also make use of embedded web views for parts of the admin, Polaris web components are used in these cases.
 
 ### Shopify apps
 

--- a/polaris.shopify.com/content/foundations/foundations/about-polaris/index.md
+++ b/polaris.shopify.com/content/foundations/foundations/about-polaris/index.md
@@ -23,7 +23,7 @@ The web version of the Shopify admin is available for desktop and mobile web. Po
 
 ### Native
 
-The Shopify admin is also available as iOS and Android apps. Polaris components are available as native user interface (UI) elements built with React Native. The Polaris React Native components are only available to Shopify employees building the admin iOS and Android apps.
+The Shopify admin is also available as iOS and Android apps. Polaris components are available as native user interface (UI) elements built with React Native. The Polaris React Native components are currently only available to Shopify employees building the admin iOS and Android apps.
 
 Because the iOS and Android apps also make use of embedded web views for parts of the admin, Polaris web components are used in these cases.
 


### PR DESCRIPTION
specifying that Polaris for mobile is only available for shopify employeers