### PR TITLE
Fix missing link

### DIFF
--- a/polaris.shopify.com/content/components/data-table/index.md
+++ b/polaris.shopify.com/content/components/data-table/index.md
@@ -53,7 +53,7 @@ Data tables should:
 - Include a summary row to surface the column totals.
 - Not include calculations within the summary row.
 - Wrap instead of truncate content. This is because if row titles start with the same word, they’ll all appear the same when truncated.
-- Not to be used for an actionable list of items that link to details pages. For this functionality, use the [resource list] component.
+- Not to be used for an actionable list of items that link to details pages. For this functionality, use the [resource list component](https://polaris.shopify.com/components/resource-list).
 
 ### Alignment
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes missing link

<img width="1036" alt="10-49-linhq-bni46" src="https://user-images.githubusercontent.com/6545515/184018069-0847c627-acb2-45a3-8675-86280ba1c55c.png">

and uses same link text as elsewhere on the page

<img width="1035" alt="10-50-4cufi-x6o5t" src="https://user-images.githubusercontent.com/6545515/184018075-7230f201-3d18-4a05-bdd3-4ecb90613f68.png">


### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
