### PR TITLE
Large edit of Contribution section

### DIFF
--- a/.changeset/sixty-schools-taste.md
+++ b/.changeset/sixty-schools-taste.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Large edit of /contributing

--- a/polaris.shopify.com/content/contributing/code-of-conduct/index.md
+++ b/polaris.shopify.com/content/contributing/code-of-conduct/index.md
@@ -23,7 +23,7 @@ Examples of unacceptable behavior by participants include:
 - The use of sexualized language or imagery and unwelcome sexual attention or advances
 - Trolling, insulting/derogatory comments, and personal or political attacks
 - Public or private harassment
-- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Publishing others’ private information, such as a physical or electronic address, without explicit permission
 - Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Our responsibilities
@@ -40,7 +40,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at polaris@shopify.com. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.
 
 ## Attribution
 

--- a/polaris.shopify.com/content/contributing/components/index.md
+++ b/polaris.shopify.com/content/contributing/components/index.md
@@ -15,11 +15,11 @@ keywords:
   - open source
 ---
 
-Bug fixes can be as simple as removing a typo, or as complex as refactoring a component to address a performance or accessibility issue. Enhancements usually add to or update the props of an existing component to extend its functionality or presentation. New patterns can be contributed by simply adding a new example to an existing component's documentation, or by adding new components or utilities. Often component contributions are a mix of these.
+Bug fixes can be as simple as removing a typo, or as complex as refactoring a component to address a performance or accessibility issue. Enhancements usually add to or update the props of an existing component to extend its functionality or presentation. New patterns can be contributed by simply adding a new example to an existing component’s documentation, or by adding new components or utilities. Often component contributions are a mix of these.
 
-Start planning your contribution as early as possible to account for the scope in your timeline. To get help with the strategy for your contribution early on, start a [discussion](https://github.com/Shopify/polaris/discussions/new) with the Polaris community. If you have a smaller question, reach out in #polaris if you work at Shopify, or the [Shopify Partners Slack](http://shopifypartners.slack.com) if you're an open source contributor. Once you've decided on the best way to solve the problem, submit a [feature proposal](https://github.com/Shopify/polaris/issues/new?assignees=&labels=Feature+request&template=FEATURE_REQUEST.md) or [bug report](https://github.com/Shopify/polaris/issues/new?assignees=&labels=%F0%9F%90%9BBug&template=ISSUE.md) issue. Then contribute the change by shipping a pull request.
+Start planning your contribution as early as possible to account for the scope in your timeline. To get help with the strategy for your contribution early on, start a [discussion](https://github.com/Shopify/polaris/discussions/new) with the Polaris community. If you have a smaller question, reach out in #polaris if you work at Shopify, or the [Shopify Partners Slack](http://shopifypartners.slack.com) if you’re an open source contributor. Once you’ve decided on the best way to solve the problem, submit a [feature proposal](https://github.com/Shopify/polaris/issues/new?assignees=&labels=Feature+request&template=FEATURE_REQUEST.md) or [bug report](https://github.com/Shopify/polaris/issues/new?assignees=&labels=%F0%9F%90%9BBug&template=ISSUE.md) issue. Then contribute the change by shipping a pull request.
 
-Often the changes you make to a component's code impact the [documentation](/contributing/documentation) and [Figma UI Kit](/contributing/figma-ui-kit). If you work at Shopify, component contributions should be a team effort across disciplines. If you're an open source contributor, we'll work with you to update the Figma UI Kit once you [create an issue](https://github.com/Shopify/polaris/issues/new/choose) or [open a pull request](/contributing/shipping-your-contribution#open-your-first-pr) in the `Shopify/polaris` repo.
+Often the changes you make to a component’s code impact the [documentation](/contributing/documentation) and [Figma UI Kit](/contributing/figma-ui-kit). If you work at Shopify, component contributions should be a team effort across disciplines. If you’re an open source contributor, we’ll work with you to update the Figma UI Kit once you [create an issue](https://github.com/Shopify/polaris/issues/new/choose) or [open a pull request](/contributing/shipping-your-contribution#open-your-first-pr) in the `Shopify/polaris` repo.
 
 ## Update props
 
@@ -35,7 +35,7 @@ Components should be performant, accessible, and maintainable. When contributing
 - Address a pain point in the merchant experience
 - Reduce complexity of the source code
 
-If a component isn't flexible enough to meet your project's requirements, or you're unsure whether a component is right for your use case, submit an [issue](https://github.com/Shopify/polaris/issues/new?assignees=&labels=Feature+request&template=FEATURE_REQUEST.md) or [open a pull request](/contributing/shipping-your-contribution#open-your-first-pr) outlining the problem and the approach you're thinking about. We're happy to collaborate to find a solution.
+If a component isn’t flexible enough to meet your project’s requirements, or you’re unsure whether a component is right for your use case, submit an [issue](https://github.com/Shopify/polaris/issues/new?assignees=&labels=Feature+request&template=FEATURE_REQUEST.md) or [open a pull request](/contributing/shipping-your-contribution#open-your-first-pr) outlining the problem and the approach you’re thinking about. We’re happy to collaborate to find a solution.
 
 ### How to contribute
 
@@ -57,13 +57,13 @@ To add or update a prop:
 
 ### Considerations
 
-Bug fixes are high impact contributions that ensure we deliver a reliable, crafted experience to merchants. Whether you're a seasoned contributor or looking to make your first pull request, there's a bug report open for every level of experience.
+Bug fixes are high impact contributions that ensure we deliver a reliable, crafted experience to merchants. Whether you’re a seasoned contributor or looking to make your first pull request, there’s a bug report open for every level of experience.
 
-If you're just getting started with contributing to Polaris React, look for issues that are:
+If you’re just getting started with contributing to Polaris React, look for issues that are:
 
 - Labeled as a [good first issue](https://github.com/Shopify/polaris/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+first+issue%22)
 - Not yet assigned to someone
-- Haven't been updated in two or more weeks
+- Haven’t been updated in two or more weeks
 
 ### How to contribute
 
@@ -95,7 +95,7 @@ When exploring the potential for improving the look, feel, and or experience of 
 
 ### Case study
 
-In the years since Polaris launched in 2017, we've learned a lot from the Shopify and design system communities. As the system's matured, we've found that many of the components should evolve toward [composition over configuration](https://maecapozzi.com/blog/composition-vs-configuration/). Many props is a signal that a component is solving too many problems or is too opinionated. When that's the case, there's an opportunity to refactor the component or build a new component to better meet merchant needs.
+In the years since Polaris launched in 2017, we’ve learned a lot from the Shopify and design system communities. As the system’s matured, we’ve found that many of the components should evolve toward [composition over configuration](https://maecapozzi.com/blog/composition-vs-configuration/). Many props is a signal that a component is solving too many problems or is too opinionated. When that’s the case, there’s an opportunity to refactor the component or build a new component to better meet merchant needs.
 
 For example, `Autocomplete` implements [the combobox with list pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/). When the Deliver team looked into fixing bugs in the component, they decided it would benefit from being broken down into two new components. They contributed `Combobox` and `Listbox` and refactored `Autocomplete` to use them. This reduced complexity and made `Autocomplete` easier to maintain.
 

--- a/polaris.shopify.com/content/contributing/designing-with-a-system/index.md
+++ b/polaris.shopify.com/content/contributing/designing-with-a-system/index.md
@@ -8,15 +8,15 @@ keywords:
 
 ![Illustration of dozens of chairs of the same kind and a single chair of a diverent kind.](/images/contributing/designing-with-a-system/01.png)
 
-At Shopify, we often say, "Polaris is the floor, not the ceiling." The design system provides you with building blocks, and it's up to you to construct them in a way that best meets your user's needs. The idea behind Polaris not being a ceiling is that you shouldn't limit your ideas to fit into existing system pieces too early. Zoom out, figure out the best design solution to the problem, and then see if Polaris has all the pieces for you to design that solution. If there's a gap, then [contribute](https://polaris.shopify.com/contributing) to the system to make it better.
+At Shopify, we often say, “Polaris is the floor, not the ceiling.” The design system provides you with building blocks, and it’s up to you to construct them in a way that best meets your user’s needs. The idea behind Polaris not being a ceiling is that you shouldn’t limit your ideas to fit into existing system pieces too early. Zoom out, figure out the best design solution to the problem, and then see if Polaris has all the pieces for you to design that solution. If there’s a gap, then [contribute](https://polaris.shopify.com/contributing) to the system to make it better.
 
 ## Zoom out
 
-No matter what problem you're solving, zooming out allows you to get a better understanding of the problem, and its sphere of influence. A problem rarely exists in isolation, so understanding context and contributing factors is key before getting into solutions. Practically speaking, this means that you should understand the product as a whole, not just the product area you're working on.
+No matter what problem you’re solving, zooming out allows you to get a better understanding of the problem, and its sphere of influence. A problem rarely exists in isolation, so understanding context and contributing factors is key before getting into solutions. Practically speaking, this means that you should understand the product as a whole, not just the product area you’re working on.
 
 For instance, if you work on Orders, you should have a holistic understanding of the Shopify admin so you can leverage existing patterns and mental models. You can also gain context and empathy for merchants through research.
 
-Merchants don't care about Shopify's internal organization. They use the admin as a whole, so we must design with the whole experience in mind.
+Merchants don’t care about Shopify’s internal organization. They use the admin as a whole, so we must design with the whole experience in mind.
 
 ![Illustration of three tag autocomplete inputs implementing the same pattern, but using different components.](/images/contributing/designing-with-a-system/02.png)
 
@@ -24,7 +24,7 @@ The Deliver team identified a need to consolidate 6 different tag components wit
 
 ## Explore freely
 
-When you understand the product as a whole, you should be well equipped to explore without constraints. That means don't start from our UI kit, component library, or patterns you see in the product---start with a blank sheet of paper instead. Solve the problem, preferably in more than one way, before you start worrying about consistency.
+When you understand the product as a whole, you should be well equipped to explore without constraints. That means don’t start from our UI kit, component library, or patterns you see in the product---start with a blank sheet of paper instead. Solve the problem, preferably in more than one way, before you start worrying about consistency.
 
 ![Illustration of three different ways to improve the design and experience of the tag autocomplete input.](/images/contributing/designing-with-a-system/03.png)
 

--- a/polaris.shopify.com/content/contributing/documentation/index.md
+++ b/polaris.shopify.com/content/contributing/documentation/index.md
@@ -11,7 +11,7 @@ Shopify teams create documentation for polaris.shopify.com, but open source cont
 
 To write effectively as a Shopify employee, use a cross-discipline lens. Make sure your content meets both UX and development needs. Before starting, check out our [style guide to the style guide](https://docs.google.com/document/d/1zVDsHIWhoir2svRjdtSdRbD_ruTz3K1nAJcQLGPVQwM/edit#heading=h.ni67tdntu9cr).
 
-Most documentation about the design system is meant for polaris.shopify.com. However, there may be a reason for the content to live elsewhere. If you're not sure if something should live on this site, the Polaris team can help you figure that out.
+Most documentation about the design system is meant for polaris.shopify.com. However, there may be a reason for the content to live elsewhere. If you’re not sure if something should live on this site, the Polaris team can help you figure that out.
 
 ## Making copy edits
 
@@ -19,7 +19,7 @@ Edits related to spelling, grammar, punctuation, or other typos should happen qu
 
 To fix any copy issues on polaris.shopify.com, [open a pull request](/contributing/shipping-your-contribution#open-your-first-pr) in the [Shopify/polaris repo](https://github.com/Shopify/polaris) GitHub repo.
 
-Note: If you find copy issues in other Polaris resources, follow the steps for that resource's contribution guidelines.
+Note: If you find copy issues in other Polaris resources, follow the steps for that resource’s contribution guidelines.
 
 ## Updating documentation
 
@@ -36,16 +36,18 @@ New documentation in Polaris can range from component documentation, to content 
 
 To create new documentation:
 
-1. Book office hours with Polaris to share your rationale for why you think this addition would improve the design system.
-2. Once the Polaris team provides feedback, draft the content in Google docs for easy collaboration. We recommend writing in [Markdown](https://www.markdownguide.org/cheat-sheet/), or converting your file to Markdown when finished.
+1. Reach out to the Polaris team and we can help you:
+- strategize where to add the documentation
+- offer strategies and templates for drafting your documentation
+- provide asynchronous feedback
+- offer ad hoc pair writing session when you get stuck
+2. Draft the content in Google docs for easy collaboration. We recommend writing in [Markdown](https://www.markdownguide.org/cheat-sheet/), or converting your file to Markdown when finished.
 3. Get feedback from subject matter experts, or someone with high context around your changes (team member, manager, etc.).
-4. Reach out to the Polaris team again to review your changes for style guide alignment.
-   <br /> If on review of the initial proposal the Polaris team suggests that the content should live somewhere besides the Polaris site, you don't need to have the content reviewed for style guide alignment.
-5. [Open a pull request](/contributing/shipping-your-contribution#open-your-first-pr) in the [Shopify/polaris repo](https://github.com/Shopify/polaris) GitHub repo.
+4. [Open a pull request](/contributing/shipping-your-contribution#open-your-first-pr) in the [Shopify/polaris repo](https://github.com/Shopify/polaris) GitHub repo.
 
 ## Removing documentation
 
-It's important that inaccurate or outdated information be removed as soon as possible. This helps maintain high trust in Polaris as a source of truth for design system guidance.
+It’s important that inaccurate or outdated information be removed as soon as possible. This helps maintain high trust in Polaris as a source of truth for design system guidance.
 
 To remove documentation:
 

--- a/polaris.shopify.com/content/contributing/figma-ui-kit/index.md
+++ b/polaris.shopify.com/content/contributing/figma-ui-kit/index.md
@@ -9,17 +9,17 @@ keywords:
 
 Any designer that works at Shopify can contribute to the Figma UI Kit. If you find a bug to fix or your team is contributing new patterns or variants to Polaris React components, we want you to feel empowered to contribute.
 
-Components, features, or patterns shouldn't be added to the Figma UI Kit if they are not part of Polaris React, as our goal is to keep Figma in sync with the code base. Only contributing changes to the Figma UI Kit when there's a counterpart in Polaris React prevents confusion and keeps tooling in sync across resources.
+Components, features, or patterns shouldn’t be added to the Figma UI Kit if they are not part of Polaris React, as our goal is to keep Figma in sync with the code base. Only contributing changes to the Figma UI Kit when there’s a counterpart in Polaris React prevents confusion and keeps tooling in sync across resources.
 
 1. Submit an issue in the [Shopify/polaris](https://github.com/Shopify/polaris/issues/new) GitHub repo, or assign yourself to [an existing issue](https://github.com/Shopify/polaris/labels/Figma%20UI%20Kit). Make sure to:
    1. Assign yourself to the issue so it’s clear who is doing the work.
    2. Add the "Figma UI Kit" label so we can easily find the issue.
    3. Use a descriptive title.
-   4. Describe the change you're making in the issue itself.
+   4. Describe the change you’re making in the issue itself.
 2. Create a branch in the Polaris Components Figma library.
-   <br /> - Give your branch a descriptive name, ideally using the GitHub issue number so it's easy to track.
+   <br /> - Give your branch a descriptive name, ideally using the GitHub issue number so it’s easy to track.
    <br /> - For example, "[4963] Navigation design changes"
 3. Make the necessary changes in the new branch.
 4. Document all changes in the “Release Notes” page within the UI kit.
-5. Add a design reviewer from the Polaris team to review the changes on your branch. If you aren't sure who to add, share the link to your Figma branch and ask for review in the #polaris Slack channel.
+5. Add a design reviewer from the Polaris team to review the changes on your branch. If you aren’t sure who to add, share the link to your Figma branch and ask for review in the #polaris Slack channel.
 6. Once reviewed and approved, the Polaris designer will merge your changes into the main branch and publish the updates.

--- a/polaris.shopify.com/content/contributing/icons/index.md
+++ b/polaris.shopify.com/content/contributing/icons/index.md
@@ -10,7 +10,7 @@ keywords:
 
 Polaris Icons are important visual aids that help merchants understand actions and concepts across the Shopify Admin. Whether your team needs to add, modify, or deprectate an icon, all designers and developers that work at Shopify are welcome to contribute.
 
-Before proposing a new icon, search the [icon explorer](https://polaris.shopify.com/icons). If the icon you're looking for isn't included, create a proposal for the new icon and work with your team to add it. Any additions or changes should also be reflected in the [Figma UI Kit](/contributing/figma-ui-kit).
+Before proposing a new icon, search the [icon explorer](https://polaris.shopify.com/icons). If the icon you’re looking for isn’t included, create a proposal for the new icon and work with your team to add it. Any additions or changes should also be reflected in the [Figma UI Kit](/contributing/figma-ui-kit).
 
 To learn about best practices for designing and using Polaris icons, read the [icon design guidelines](https://polaris.shopify.com/design/icons). If you have initial questions or need help, reach out in the [#polaris](https://shopify.slack.com/archives/C4Y8N30KD) Slack channel. If you want to start a more in-depth conversation with the system community before opening an issue, start a [GitHub discussion](https://github.com/Shopify/polaris/discussions/new).
 

--- a/polaris.shopify.com/content/contributing/illustrations/index.md
+++ b/polaris.shopify.com/content/contributing/illustrations/index.md
@@ -8,6 +8,4 @@ keywords:
   - add
 ---
 
-Illustration contributions are welcome from any designer working at Shopify.
-
-Each illustration must be submitted for feedback from an illustrator in #illustration-guild on Slack. Polaris only supports illustrations within the Shopify Admin product and not marketing assets.
+Reusing illustrations should be avoided in product. New illustration contributions are welcome from any designer working at Shopify. They can be submitted for feedback to the #illustration-guild on Slack. Polaris only supports illustrations within the Shopify admin product and not marketing assets.

--- a/polaris.shopify.com/content/contributing/index.md
+++ b/polaris.shopify.com/content/contributing/index.md
@@ -1,10 +1,12 @@
 ---
 title: Contributing to Polaris
-description: Polaris exists to make a product worked on by many, feel like it was created by one person. The design system needs to stay in sync with new solutions so merchants always have a seamless experience. This is why Polaris thrives on contribution and community support. Anyone, regardless of discipline, is encouraged to contribute. No contribution is too small. We welcome everything from bug fixes or new components, to new UX guidelines. So if you find something to contribute, we hope you feel empowered to go for it. The Polaris team is here to help you along the way.
+description: Polaris exists to make a product worked on by many, feel like it was created by one person. The design system needs to stay in sync with new solutions so merchants always have a seamless experience. This is why Polaris thrives on contribution and community support. 
 keywords:
   - how to contribute to polaris
   - contribution
 ---
+
+Anyone, regardless of discipline, is encouraged to contribute. No contribution is too small. We welcome everything from bug fixes or new components, to new UX guidelines. So if you find something to contribute, we hope you feel empowered to go for it. The Polaris team is here to help you along the way.
 
 ## Who can contribute
 
@@ -12,7 +14,7 @@ Contribution to Polaris looks different depending on whether you work at Shopify
 
 ## When to contribute
 
-Contributions can seem intimidating, but they don't have to be! Here are some common scenarios for deciding when to contribute:
+Contributions can seem intimidating, but they don’t have to be! Here are some common scenarios for deciding when to contribute:
 
 | Use the system                                                               | Extend the system                                                                       | Build a custom solution                                                                         |     |     |
 | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | --- | --- |

--- a/polaris.shopify.com/content/contributing/shipping-your-contribution/index.md
+++ b/polaris.shopify.com/content/contributing/shipping-your-contribution/index.md
@@ -11,7 +11,7 @@ keywords:
 
 ## Project details
 
-### How it's structured
+### How it’s structured
 
 The Shopify/polaris GitHub repository is structured as a monorepo, which means it’s a single repository with multiple projects. The monorepo includes:
 
@@ -38,7 +38,7 @@ Every Polaris project is a little different, but in general we build with JavaSc
 
 ## Get set up
 
-To contribute to Polaris components, icons, or documentation, you’ll need to use your preferred `git` interface to commit and push up your changes. Whether that's the command line in your favorite terminal, or in GitHub Desktop is entirely up to you. For this guide, we'll illustrate the steps with terminal commands.
+To contribute to Polaris components, icons, or documentation, you’ll need to use your preferred `git` interface to commit and push up your changes. Whether that’s the command line in your favorite terminal, or in GitHub Desktop is entirely up to you. For this guide, we’ll illustrate the steps with terminal commands.
 
 ### 1. Download the repo
 
@@ -72,7 +72,7 @@ git checkout -b new-branch-name
 
 As you work, commit and test your changes:
 
-If your changes affect Polaris React components, you'll need to test the examples and documentation of affected components. For more thorough testing edit the sandbox files found in the `/polaris-react/playground` directory.
+If your changes affect Polaris React components, you’ll need to test the examples and documentation of affected components. For more thorough testing edit the sandbox files found in the `/polaris-react/playground` directory.
 
 ```bash
 yarn turbo run dev --filter=@shopify/polaris
@@ -89,7 +89,7 @@ yarn turbo run dev --filter=polaris.shopify.com
 
 ### 2. Commit your changes
 
-Save the changes you've made to your branch.
+Save the changes you’ve made to your branch.
 
 ```bash
 git commit -m “descriptive message”

--- a/polaris.shopify.com/content/contributing/when-to-contribute-new-patterns/index.md
+++ b/polaris.shopify.com/content/contributing/when-to-contribute-new-patterns/index.md
@@ -8,7 +8,7 @@ keywords:
   - contribution guide
 ---
 
-To help you figure this out, start by plotting out where each solution fits in this "perfect vs consistent" framework. Rate the solutions according to:
+To help you figure this out, start by plotting out where each solution fits in this “perfect vs consistent” framework. Rate the solutions according to:
 
 - Consistency with the rest of the product (x axis)
 - How appropriate the solution is for your specific situation (y axis)
@@ -41,4 +41,4 @@ When both are appropriate and there’s not a massive difference in value, consi
 
 The key here is to zoom out. When we’re [designing for scale](https://polaris.shopify.com/contributing/designing-with-a-system), we need to think broader and look at our specific problem area as a small part of a larger system. So spend some time figuring out if your solution is unique, or if it has potential to solve other problems. This is why it’s important to have good awareness of the whole experience before you start, and why it’s important to contribute back to the system if you land on a solution that would benefit others.
 
-For initial questions about contribution, reach out in [#polaris](https://shopify.slack.com/archives/C4Y8N30KD) if you work at Shopify, or the [Shopify Partners Slack](http://shopifypartners.slack.com) if you're an open source contributor. To get help with the strategy for a larger contribution, start a [GitHub discussion](https://github.com/Shopify/polaris/discussions/new) with the system community.
+For initial questions about contribution, reach out in [#polaris](https://shopify.slack.com/archives/C4Y8N30KD) if you work at Shopify, or the [Shopify Partners Slack](http://shopifypartners.slack.com) if you’re an open source contributor. To get help with the strategy for a larger contribution, start a [GitHub discussion](https://github.com/Shopify/polaris/discussions/new) with the system community.

--- a/polaris.shopify.com/content/contributing/working-with-the-polaris-team/index.md
+++ b/polaris.shopify.com/content/contributing/working-with-the-polaris-team/index.md
@@ -11,7 +11,7 @@ keywords:
 
 Through supporting teams, we’ve learned what works well, and not so well. We’ve outlined these things so that you can create a successful plan. This guide goes into detail, but here are the highlights.
 
-## TL;dr
+## Tl;dr
 
 Think about your system needs in the prototype phase of your project so your team can plan for [quality](/contributing/quality-contributions) systems [contributions](/contributing) ahead of the build phase. The Polaris team is here to help you with planning, but we can’t be pulled in last minute to unblock.
 
@@ -36,7 +36,7 @@ Things don’t always go according to plan. If a team is still learning how to p
 
 ## Collaborations for system contributions
 
-When an opportunity for a collaboration related to a system contribution comes up, we’ll add it to our [backlog](https://github.com/orgs/Shopify/projects/2250/views/5) for triaging. Collaboration opportunities can be worked on through cross-product team pairings and don't always have to be with Polaris.
+When an opportunity for a collaboration related to a system contribution comes up, we’ll add it to our [backlog](https://github.com/orgs/Shopify/projects/2250/views/5) for triaging. Collaboration opportunities can be worked on through cross-product team pairings and don’t always have to be with Polaris.
 
 ### Triaging considerations
 
@@ -61,7 +61,7 @@ If the Polaris team is the main collaborator on a system contribution, the Polar
 
 - pair with the contributor(s) asynchronously, or when it’s more efficient, through ad hoc video calls
 - direct internal contributors to the #admin-ux community if extra feedback is needed on the solution being explored
-- offer systems coaching to the subject matter experts with the most context on the merchant problem that's being solved
+- offer systems coaching to the subject matter experts with the most context on the merchant problem that’s being solved
 - help the contributor with any systems tooling related to shipping the solution
 
 ## Polaris on-call support
@@ -96,7 +96,7 @@ Polaris is an open source project used by Shopify employees, and Shopify Partner
 
 | Contribution type                                                                | Team response                                                                                                                                                                                                                                | How you can help                                                                                                                                                                                                                                                                                       |
 | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Bug report                                                                       | Prioritized against our backlog and roadmap. If there's a clear or urgent need for a fix we'll add it to our backlog.                                                                                                                        | Leave comments with additional information on how to reproduce the bug and how it's affecting your use case.<br/><br/> If you're interested in a fix, [upvote](https://github.com/Shopify/polaris/issues/new?assignees=&labels=%F0%9F%90%9BBug&template=ISSUE.md) the bug report to let the team know. |
-| Feature request                                                                  | For now, feature requests will be closed and reviewed against our existing backlog and roadmap. We'll evaluate interest in the request and prioritize it for development if there is enough interest and alignment with our product roadmap. | If you're interested in the feature please upvote the request in [GitHub](https://github.com/Shopify/polaris/issues/new?assignees=&labels=Feature+request&template=FEATURE_REQUEST.md) to let the team know.                                                                                           |
+| Bug report                                                                       | Prioritized against our backlog and roadmap. If there’s a clear or urgent need for a fix we’ll add it to our backlog.                                                                                                                        | Leave comments with additional information on how to reproduce the bug and how it’s affecting your use case.<br/><br/> If you’re interested in a fix, [upvote](https://github.com/Shopify/polaris/issues/new?assignees=&labels=%F0%9F%90%9BBug&template=ISSUE.md) the bug report to let the team know. |
+| Feature request                                                                  | For now, feature requests will be closed and reviewed against our existing backlog and roadmap. We’ll evaluate interest in the request and prioritize it for development if there is enough interest and alignment with our product roadmap. | If you’re interested in the feature please upvote the request in [GitHub](https://github.com/Shopify/polaris/issues/new?assignees=&labels=Feature+request&template=FEATURE_REQUEST.md) to let the team know.                                                                                           |
 | Pull request                                                                     | Will review [PRs](https://github.com/Shopify/polaris/pulls) for system alignment, user need, and contribution quality.                                                                                                                       | Leave comments for code review.<br/><br/> Upvote the request in [GitHub](https://github.com/Shopify/polaris/discussions/6750) to express interest and let the team know you want this feature.                                                                                                         |
 | Start a [GitHub discussion](https://github.com/Shopify/polaris/discussions/6750) | Review discussions and close or respond as needed                                                                                                                                                                                            | Participate in a discussion to express interest or share your opinion.                                                                                                                                                                                                                                 |


### PR DESCRIPTION
Made some sweeping edits to the contribution guidelines. Started with updating the outdated documentation contribution guidelines but caught a bunch more stuff as I clicked through the different sections:
- updated apostrophes to curly style
- updated the documentation contribution guidelines (removed mention of office hours, etc)
- trying to fix this **bug** where the keywords are showing up in the content:

<img width="635" alt="Screen Shot 2022-09-01 at 10 07 57 AM" src="https://user-images.githubusercontent.com/18617698/187972749-cb40fc58-5f12-46d6-877f-98511538bc69.png">

- made intro description less bulky looking by moving part of the paragraph down. Make this:
<img width="633" alt="Screen Shot 2022-09-01 at 10 11 40 AM" src="https://user-images.githubusercontent.com/18617698/187973063-55f01674-5b33-4101-981b-932842dc0753.png">

Look more like this:
<img width="613" alt="Screen Shot 2022-09-01 at 10 11 52 AM" src="https://user-images.githubusercontent.com/18617698/187973094-c3d7010d-f300-4beb-aabd-ce2f43a1d4b4.png">
