### PR TITLE
Migrate static breakpoint mixins

### DIFF
--- a/.changeset/light-starfishes-vanish.md
+++ b/.changeset/light-starfishes-vanish.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Add migration for legacy static breakpoint mixins

--- a/.changeset/light-starfishes-vanish.md
+++ b/.changeset/light-starfishes-vanish.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/polaris-migrator': patch
+'@shopify/polaris-migrator': minor
 ---
 
 Add migration for legacy static breakpoint mixins

--- a/.changeset/old-badgers-melt.md
+++ b/.changeset/old-badgers-melt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': minor
+---
+
+Add legacy Sass API migrations

--- a/.changeset/old-badgers-melt.md
+++ b/.changeset/old-badgers-melt.md
@@ -1,5 +1,0 @@
----
-'@shopify/polaris-migrator': minor
----
-
-Add legacy Sass API migrations

--- a/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/replace-static-breakpoint-mixins.ts
+++ b/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/replace-static-breakpoint-mixins.ts
@@ -1,0 +1,47 @@
+import {FileInfo} from 'jscodeshift';
+import postcss, {Plugin} from 'postcss';
+
+/** Mapping of static breakpoint mixins from old to new */
+const staticBreakpointMixins = {
+  'page-content-when-partially-condensed': '#{$p-breakpoints-md-down}',
+  'page-content-when-not-partially-condensed': '#{$p-breakpoints-md-up}',
+  'page-content-when-fully-condensed': '#{$p-breakpoints-sm-down}',
+  'page-content-when-not-fully-condensed': '#{$p-breakpoints-sm-up}',
+  'page-content-when-layout-stacked': '#{$p-breakpoints-md-down}',
+  'page-content-when-layout-not-stacked': '#{$p-breakpoints-md-up}',
+  'page-before-resource-list-small': '#{$p-breakpoints-sm-down}',
+  'page-after-resource-list-small': '#{$p-breakpoints-sm-up}',
+  'page-when-not-max-width': '#{$p-breakpoints-lg-down}',
+  'when-typography-condensed': '#{$p-breakpoints-md-down}',
+  'when-typography-not-condensed': '#{$p-breakpoints-md-up}',
+  'frame-when-nav-hidden': '#{$p-breakpoints-md-down}',
+  'frame-when-nav-displayed': '#{$p-breakpoints-md-up}',
+  'frame-with-nav-when-not-max-width': '#{$p-breakpoints-xl-down}',
+  'after-topbar-sheet': '#{$p-breakpoints-sm-up}',
+};
+
+const isStaticBreakpointMixin = (
+  mixinName: unknown,
+): mixinName is keyof typeof staticBreakpointMixins =>
+  Object.keys(staticBreakpointMixins).includes(mixinName as string);
+
+const plugin = (): Plugin => ({
+  postcssPlugin: 'ReplaceStaticBreakpointMixins',
+  AtRule(atRule) {
+    if (atRule.name !== 'include') return;
+
+    // Extract mixin name e.g. name from `@include name;` or `@include name();`
+    const mixinName = atRule.params.match(/^([a-zA-Z-]+)/)?.[1];
+
+    if (!isStaticBreakpointMixin(mixinName)) return;
+
+    atRule.name = 'media';
+    atRule.params = staticBreakpointMixins[mixinName];
+  },
+});
+
+export default function replaceStaticBreakpointMixins(fileInfo: FileInfo) {
+  return postcss(plugin()).process(fileInfo.source, {
+    syntax: require('postcss-scss'),
+  }).css;
+}

--- a/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/replace-static-breakpoint-mixins.ts
+++ b/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/replace-static-breakpoint-mixins.ts
@@ -35,8 +35,10 @@ const plugin = (): Plugin => ({
 
     if (!isStaticBreakpointMixin(mixinName)) return;
 
-    atRule.name = 'media';
-    atRule.params = staticBreakpointMixins[mixinName];
+    atRule.assign({
+      name: 'media',
+      params: staticBreakpointMixins[mixinName],
+    });
   },
 });
 

--- a/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/replace-static-breakpoint-mixins.ts
+++ b/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/replace-static-breakpoint-mixins.ts
@@ -31,7 +31,7 @@ const plugin = (): Plugin => ({
     if (atRule.name !== 'include') return;
 
     // Extract mixin name e.g. name from `@include name;` or `@include name();`
-    const mixinName = atRule.params.match(/^([a-zA-Z-]+)/)?.[1];
+    const mixinName = atRule.params.match(/^([a-zA-Z0-9_-]+)/)?.[1];
 
     if (!isStaticBreakpointMixin(mixinName)) return;
 

--- a/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/tests/replace-static-breakpoint-mixins.input.scss
+++ b/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/tests/replace-static-breakpoint-mixins.input.scss
@@ -1,0 +1,118 @@
+.root {
+  @include page-content-when-partially-condensed {
+    padding-bottom: spacing(loose);
+
+    &.Active {
+      border-bottom: rem(3px) solid color('ink');
+    }
+
+    @include page-content-when-not-partially-condensed {
+      padding: 0 spacing(extra-loose);
+    }
+  }
+
+  @include page-content-when-fully-condensed {
+    margin: 0 spacing(loose) spacing(tight);
+  }
+
+  @include page-content-when-not-fully-condensed {
+    border-radius: spacing(tight);
+  }
+
+  @include page-when-not-max-width {
+    border-radius: spacing(tight);
+  }
+
+  @include page-content-when-layout-stacked {
+    @include stacked-elements;
+  }
+
+  @include page-content-when-layout-not-stacked {
+    border-radius: spacing(tight);
+  }
+
+  @include page-after-resource-list-small {
+    border-radius: spacing(tight);
+  }
+
+  @include page-before-resource-list-small {
+    border-radius: spacing(tight);
+  }
+
+  @include after-topbar-sheet {
+    max-width: $content-max-width + (2 * spacing(extra-loose));
+
+    > li {
+      margin-right: spacing();
+    }
+
+    &.TwoColumn > li {
+      flex: 0 calc(50% - #{spacing(extra-loose)});
+    }
+  }
+
+  @include frame-with-nav-when-not-max-width {
+    padding: spacing(tight) 0;
+  }
+
+  @mixin global-nav-offset {
+    @include frame-when-nav-displayed {
+      left: $global-nav-width;
+      width: calc(100% - #{$global-nav-width});
+    }
+  }
+
+  .Large {
+    @include frame-when-nav-displayed {
+      width: $sheet-desktop-width-large;
+    }
+  }
+
+  @include frame-when-nav-displayed {
+    @include breakpoint-after(
+      layout-width(page-content, not-condensed) + layout-width(nav)
+    ) {
+      @content;
+    }
+  }
+
+  @include frame-when-nav-hidden {
+    @include stick-to-bottom-container;
+  }
+
+  .MinimizableVideoToolbar {
+    &.Inline {
+      @include frame-when-nav-hidden {
+        display: none;
+      }
+    }
+  }
+
+  @include frame-when-nav-hidden {
+    @include page-content-when-not-partially-condensed {
+      width: rem(200px);
+    }
+  }
+
+  @mixin breakpoint-tablet-not-condensed {
+    @include frame-when-nav-hidden {
+      @include page-content-when-not-partially-condensed {
+        @content;
+      }
+    }
+
+    @include frame-when-nav-displayed {
+      @include breakpoint-after(
+        layout-width(page-content, not-condensed) + layout-width(nav)
+      ) {
+        @content;
+      }
+    }
+  }
+
+  > *:not(:last-child) {
+    @include when-typography-condensed {
+      margin-bottom: var(--p-space-4);
+    }
+  }
+}

--- a/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/tests/replace-static-breakpoint-mixins.output.scss
+++ b/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/tests/replace-static-breakpoint-mixins.output.scss
@@ -1,0 +1,118 @@
+.root {
+  @media #{$p-breakpoints-md-down} {
+    padding-bottom: spacing(loose);
+
+    &.Active {
+      border-bottom: rem(3px) solid color('ink');
+    }
+
+    @media #{$p-breakpoints-md-up} {
+      padding: 0 spacing(extra-loose);
+    }
+  }
+
+  @media #{$p-breakpoints-sm-down} {
+    margin: 0 spacing(loose) spacing(tight);
+  }
+
+  @media #{$p-breakpoints-sm-up} {
+    border-radius: spacing(tight);
+  }
+
+  @media #{$p-breakpoints-lg-down} {
+    border-radius: spacing(tight);
+  }
+
+  @media #{$p-breakpoints-md-down} {
+    @include stacked-elements;
+  }
+
+  @media #{$p-breakpoints-md-up} {
+    border-radius: spacing(tight);
+  }
+
+  @media #{$p-breakpoints-sm-up} {
+    border-radius: spacing(tight);
+  }
+
+  @media #{$p-breakpoints-sm-down} {
+    border-radius: spacing(tight);
+  }
+
+  @media #{$p-breakpoints-sm-up} {
+    max-width: $content-max-width + (2 * spacing(extra-loose));
+
+    > li {
+      margin-right: spacing();
+    }
+
+    &.TwoColumn > li {
+      flex: 0 calc(50% - #{spacing(extra-loose)});
+    }
+  }
+
+  @media #{$p-breakpoints-xl-down} {
+    padding: spacing(tight) 0;
+  }
+
+  @mixin global-nav-offset {
+    @media #{$p-breakpoints-md-up} {
+      left: $global-nav-width;
+      width: calc(100% - #{$global-nav-width});
+    }
+  }
+
+  .Large {
+    @media #{$p-breakpoints-md-up} {
+      width: $sheet-desktop-width-large;
+    }
+  }
+
+  @media #{$p-breakpoints-md-up} {
+    @include breakpoint-after(
+      layout-width(page-content, not-condensed) + layout-width(nav)
+    ) {
+      @content;
+    }
+  }
+
+  @media #{$p-breakpoints-md-down} {
+    @include stick-to-bottom-container;
+  }
+
+  .MinimizableVideoToolbar {
+    &.Inline {
+      @media #{$p-breakpoints-md-down} {
+        display: none;
+      }
+    }
+  }
+
+  @media #{$p-breakpoints-md-down} {
+    @media #{$p-breakpoints-md-up} {
+      width: rem(200px);
+    }
+  }
+
+  @mixin breakpoint-tablet-not-condensed {
+    @media #{$p-breakpoints-md-down} {
+      @media #{$p-breakpoints-md-up} {
+        @content;
+      }
+    }
+
+    @media #{$p-breakpoints-md-up} {
+      @include breakpoint-after(
+        layout-width(page-content, not-condensed) + layout-width(nav)
+      ) {
+        @content;
+      }
+    }
+  }
+
+  > *:not(:last-child) {
+    @media #{$p-breakpoints-md-down} {
+      margin-bottom: var(--p-space-4);
+    }
+  }
+}

--- a/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/tests/replace-static-breakpoint-mixins.test.ts
+++ b/polaris-migrator/src/migrations/replace-static-breakpoint-mixins/tests/replace-static-breakpoint-mixins.test.ts
@@ -1,0 +1,12 @@
+import {check} from '../../../utilities/testUtils';
+
+const migration = 'replace-static-breakpoint-mixins';
+const fixtures = ['replace-static-breakpoint-mixins'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    migration,
+    extension: 'scss',
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,19 +156,6 @@
     browserslist "^4.20.2"
     semver "^6.3.0"
 
-"@babel/helper-create-class-features-plugin@^7.14.5", "@babel/helper-create-class-features-plugin@^7.16.7", "@babel/helper-create-class-features-plugin@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.19.0.tgz#bfd6904620df4e46470bae4850d66be1054c404b"
-  integrity sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.18.6"
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.19.0"
-    "@babel/helper-member-expression-to-functions" "^7.18.9"
-    "@babel/helper-optimise-call-expression" "^7.18.6"
-    "@babel/helper-replace-supers" "^7.18.9"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-
 "@babel/helper-create-class-features-plugin@^7.16.10", "@babel/helper-create-class-features-plugin@^7.17.6", "@babel/helper-create-class-features-plugin@^7.17.9", "@babel/helper-create-class-features-plugin@^7.18.6":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.9.tgz#d802ee16a64a9e824fcbf0a2ffc92f19d58550ce"
@@ -177,6 +164,19 @@
     "@babel/helper-annotate-as-pure" "^7.18.6"
     "@babel/helper-environment-visitor" "^7.18.9"
     "@babel/helper-function-name" "^7.18.9"
+    "@babel/helper-member-expression-to-functions" "^7.18.9"
+    "@babel/helper-optimise-call-expression" "^7.18.6"
+    "@babel/helper-replace-supers" "^7.18.9"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+
+"@babel/helper-create-class-features-plugin@^7.16.7", "@babel/helper-create-class-features-plugin@^7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.19.0.tgz#bfd6904620df4e46470bae4850d66be1054c404b"
+  integrity sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
     "@babel/helper-member-expression-to-functions" "^7.18.9"
     "@babel/helper-optimise-call-expression" "^7.18.6"
     "@babel/helper-replace-supers" "^7.18.9"
@@ -361,7 +361,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
   integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
 
-"@babel/helper-validator-option@^7.14.5", "@babel/helper-validator-option@^7.16.7", "@babel/helper-validator-option@^7.18.6":
+"@babel/helper-validator-option@^7.16.7", "@babel/helper-validator-option@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
   integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
@@ -1046,7 +1046,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
-"@babel/plugin-transform-typescript@^7.15.0", "@babel/plugin-transform-typescript@^7.16.7":
+"@babel/plugin-transform-typescript@^7.16.7", "@babel/plugin-transform-typescript@^7.18.6":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.19.0.tgz#50c3a68ec8efd5e040bde2cd764e8e16bc0cbeaf"
   integrity sha512-DOOIywxPpkQHXijXv+s9MDAyZcLp12oYRl3CMWZ6u7TjSoCBq/KqHR/nNFR3+i2xqheZxoF0H2XyL7B6xeSRuA==
@@ -1279,7 +1279,7 @@
     "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.16.0", "@babel/types@^7.18.10", "@babel/types@^7.19.0":
+"@babel/types@^7.18.10", "@babel/types@^7.19.0":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.0.tgz#75f21d73d73dc0351f3368d28db73465f4814600"
   integrity sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,7 +163,7 @@
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.18.6"
     "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
     "@babel/helper-member-expression-to-functions" "^7.18.9"
     "@babel/helper-optimise-call-expression" "^7.18.6"
     "@babel/helper-replace-supers" "^7.18.9"
@@ -217,7 +217,7 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
-"@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.18.9", "@babel/helper-function-name@^7.19.0":
+"@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.18.9":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
   integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==


### PR DESCRIPTION
Closes #7143, #7144, #7145, #7146, #7147

Add `replace-static-breakpoint-mixins` migration script.

Running `npx @shopify/polaris-migrator replace-static-breakpoint-mixins "**/*.scss"` will replace the following mixins with Polaris Breakpoint media queries:

| Before                                    | After                     |
| ----------------------------------------- | ------------------------- |
| page-content-when-partially-condensed     | #{$p-breakpoints-md-down} |
| page-content-when-not-partially-condensed | #{$p-breakpoints-md-up}   |
| page-content-when-fully-condensed         | #{$p-breakpoints-sm-down} |
| page-content-when-not-fully-condensed     | #{$p-breakpoints-sm-up}   |
| page-content-when-layout-stacked          | #{$p-breakpoints-md-down} |
| page-content-when-layout-not-stacked      | #{$p-breakpoints-md-up}   |
| page-before-resource-list-small           | #{$p-breakpoints-sm-down} |
| page-after-resource-list-small            | #{$p-breakpoints-sm-up}   |
| page-when-not-max-width                   | #{$p-breakpoints-lg-down} |
| when-typography-condensed                 | #{$p-breakpoints-md-down} |
| when-typography-not-condensed             | #{$p-breakpoints-md-up}   |
| frame-when-nav-hidden                     | #{$p-breakpoints-md-down} |
| frame-when-nav-displayed                  | #{$p-breakpoints-md-up}   |
| frame-with-nav-when-not-max-width         | #{$p-breakpoints-xl-down} |
| after-topbar-sheet                        | #{$p-breakpoints-sm-up}   |
