### PR TITLE
[Avatar] Fix flakey visual test

### DIFF
--- a/polaris-react/src/components/Avatar/Avatar.stories.tsx
+++ b/polaris-react/src/components/Avatar/Avatar.stories.tsx
@@ -50,7 +50,7 @@ export function ExternalImage() {
     <Avatar
       name="External image"
       shape="square"
-      source="https://picsum.photos/200"
+      source="https://i.picsum.photos/id/696/200/200.jpg?hmac=JE4lFckorKxM41-eM1nTxXjpOeCf3aZkAxrLl3ZAYI0"
     />
   );
 }


### PR DESCRIPTION
`https://picsum.photos/200` returns a random image on each fetch and chromatic was flagging this as a change on [every run ](https://www.chromatic.com/build?appId=5d559397bae39100201eedc1&number=13841)