### PR TITLE
[polaris.shopify.com] Update type alignment guidance

### DIFF
--- a/.changeset/young-frogs-heal.md
+++ b/.changeset/young-frogs-heal.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Update typography guidance to clarify number alignment

--- a/.changeset/young-frogs-heal.md
+++ b/.changeset/young-frogs-heal.md
@@ -2,4 +2,4 @@
 'polaris.shopify.com': patch
 ---
 
-Update typography guidance to clarify number alignment
+Updated typography guidance to clarify number alignment

--- a/polaris.shopify.com/content/foundations/design/typography/index.md
+++ b/polaris.shopify.com/content/foundations/design/typography/index.md
@@ -58,7 +58,7 @@ Line length describes the width of the content. For longer body text, the recomm
 
 ![A diagram showing the ideal line length for text](/images/foundations/design/typography/text-line-length@2x.png)
 
-### Right align numbers
+### Right align tabular numbers
 
 Right align numbers when they're inside a table. This keeps the decimal in the same place and makes numerical data easier to read and compare.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -217,7 +217,7 @@
   dependencies:
     "@babel/types" "^7.16.7"
 
-"@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.18.9":
+"@babel/helper-function-name@^7.16.7", "@babel/helper-function-name@^7.18.9", "@babel/helper-function-name@^7.19.0":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz#941574ed5390682e872e52d3f38ce9d1bef4648c"
   integrity sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==


### PR DESCRIPTION
Updating the "Right align numbers" section to "Right align tabular numbers" to clarify when it's appropriate to use right alignment.

| before | after |
|---|---|
| <img width="881" alt="Screen Shot 2022-09-14 at 8 47 01 AM" src="https://user-images.githubusercontent.com/8629173/190201860-5c9ad75e-ee8f-4426-bffb-b5931e565dfc.png"> | <img width="867" alt="Screen Shot 2022-09-14 at 8 47 08 AM" src="https://user-images.githubusercontent.com/8629173/190201960-2fb61f91-f4ef-4648-a888-fdfc4141b983.png"> |