### PR TITLE
Add range media query for larger tap target on small screen

### DIFF
--- a/.changeset/khaki-baboons-draw.md
+++ b/.changeset/khaki-baboons-draw.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Update rangeslider height to 44px in small screens

--- a/polaris-react/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/polaris-react/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -28,7 +28,7 @@
   }
 
   @media #{$p-breakpoints-sm-down} {
-    height: 44px;
+    min-height: 44px;
   }
 }
 

--- a/polaris-react/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/polaris-react/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -26,6 +26,10 @@
   &::after {
     @include track-dashed;
   }
+
+  @media #{$p-breakpoints-sm-down} {
+    height: 44px;
+  }
 }
 
 .disabled {

--- a/polaris-react/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
+++ b/polaris-react/src/components/RangeSlider/components/SingleThumb/SingleThumb.scss
@@ -28,7 +28,7 @@
   }
 
   @media #{$p-breakpoints-sm-down} {
-    min-height: 44px;
+    height: 44px;
   }
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Contributes to [#14004](https://github.com/Shopify/online-store-web/issues/14004) in online-store-web

We believe increasing the tap target to the range slider in mobile will provide easier accessibility on smaller screens.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds a media query that increases the height of the SingleThumb slider to 44px for easier accessibility on a small screen.

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

Before:
<img width="401" alt="Screen Shot 2022-09-20 at 3 15 12 PM" src="https://user-images.githubusercontent.com/69861203/191344987-f647cef2-077f-428b-aadc-90c5df38a3e3.png">


After: 
<img width="401" alt="Screen Shot 2022-09-20 at 3 15 26 PM" src="https://user-images.githubusercontent.com/69861203/191345028-d2d765fd-28a8-4898-a80d-3666a1e97809.png">

### 🎩 Instructions

Spin link: https://shop1.shopify.rangesliderchanges.rana-jurjus.us.spin.dev/admin/themes/1/editor

1. Make sure you are in mobile web view (dev tools)
2. In the sections footer, select a section that has rangesliders (collage for example)
3. Ensure the rangeslider is a height of 44px and nothing looks out of the ordinary.
4. For more dense rangeslider examples, click the ... in the header in mobile and select theme settings
5. Select Layout and make sure the height is 44px and everything looks ok

### 🎩 checklist

- [X] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [X] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [X] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [X] Updated the component's `README.md` with documentation changes (changeset added)

