### PR TITLE
Enable namespace option for Sass spacing migration

### DIFF
--- a/.changeset/swift-donuts-destroy.md
+++ b/.changeset/swift-donuts-destroy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Enable namespace option for Sass spacing migration

--- a/polaris-migrator/src/migrate.ts
+++ b/polaris-migrator/src/migrate.ts
@@ -43,8 +43,6 @@ export async function migrate(
     console.log(chalk.green('Running migration:'), migration);
 
     await jscodeshift.run(migrationFile, filepaths, {
-      dry: options.dry,
-      print: options.print,
       babel: true,
       ignorePattern: ['**/node_modules/**', '**/.next/**', '**/build/**'],
       extensions: 'tsx,ts,jsx,js',
@@ -53,6 +51,7 @@ export async function migrate(
       runInBand: true,
       silent: false,
       stdin: false,
+      ...options,
     });
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/polaris-migrator/src/migrations/replace-sass-spacing/replace-sass-spacing.ts
+++ b/polaris-migrator/src/migrations/replace-sass-spacing/replace-sass-spacing.ts
@@ -1,4 +1,4 @@
-import type {FileInfo} from 'jscodeshift';
+import type {FileInfo, API, Options} from 'jscodeshift';
 import postcss, {Plugin} from 'postcss';
 import valueParser, {Node, FunctionNode} from 'postcss-value-parser';
 
@@ -18,10 +18,6 @@ const spacingMap = {
 const isSpacing = (spacing: unknown): spacing is keyof typeof spacingMap =>
   Object.keys(spacingMap).includes(spacing as string);
 
-function isSpacingFn(node: Node): node is FunctionNode {
-  return node.type === 'function' && node.value === 'spacing';
-}
-
 function isNumericOperator(node: Node): boolean {
   return (
     node.value === '+' ||
@@ -34,57 +30,73 @@ function isNumericOperator(node: Node): boolean {
 
 const processed = Symbol('processed');
 
-const plugin = (): Plugin => ({
-  postcssPlugin: 'ReplaceSassSpacing',
-  Declaration(decl) {
-    // @ts-expect-error - Skip if processed so we don't process it again
-    if (decl[processed]) return;
+interface PluginOptions extends Options {
+  namespace?: string;
+}
 
-    const parsed = valueParser(decl.value);
+const plugin = (options: PluginOptions = {}): Plugin => {
+  const namespace = options?.namespace || '';
+  const functionName = namespace ? `${namespace}.spacing` : 'spacing';
+  const isSpacingFn = (node: Node): node is FunctionNode => {
+    return node.type === 'function' && node.value === functionName;
+  };
 
-    let containsSpacingFn = false;
-    let containsCalculation = false;
+  return {
+    postcssPlugin: 'ReplaceSassSpacing',
+    Declaration(decl) {
+      // @ts-expect-error - Skip if processed so we don't process it again
+      if (decl[processed]) return;
 
-    parsed.walk((node) => {
-      if (isSpacingFn(node)) containsSpacingFn = true;
-      if (isNumericOperator(node)) containsCalculation = true;
+      const parsed = valueParser(decl.value);
 
-      if (!isSpacingFn(node)) return;
+      let containsSpacingFn = false;
+      let containsCalculation = false;
 
-      const spacing = node.nodes[0]?.value ?? '';
+      parsed.walk((node) => {
+        if (isSpacingFn(node)) containsSpacingFn = true;
+        if (isNumericOperator(node)) containsCalculation = true;
 
-      if (!isSpacing(spacing)) return;
-      const spacingCustomProperty = spacingMap[spacing];
+        if (!isSpacingFn(node)) return;
 
-      node.value = 'var';
-      node.nodes = [
-        {
-          type: 'word',
-          value: spacingCustomProperty,
-          sourceIndex: node.nodes[0]?.sourceIndex ?? 0,
-          sourceEndIndex: spacingCustomProperty.length,
-        },
-        ...node.nodes.slice(1),
-      ];
-    });
+        const spacing = node.nodes[0]?.value ?? '';
 
-    if (containsSpacingFn && containsCalculation) {
-      // Insert comment if the declaration value contains calculations
-      decl.before(postcss.comment({text: POLARIS_MIGRATOR_COMMENT}));
-      decl.before(
-        postcss.comment({text: `${decl.prop}: ${parsed.toString()};`}),
-      );
-    } else {
-      decl.value = parsed.toString();
-    }
+        if (!isSpacing(spacing)) return;
+        const spacingCustomProperty = spacingMap[spacing];
 
-    // @ts-expect-error - Mark the declaration as processed
-    decl[processed] = true;
-  },
-});
+        node.value = 'var';
+        node.nodes = [
+          {
+            type: 'word',
+            value: spacingCustomProperty,
+            sourceIndex: node.nodes[0]?.sourceIndex ?? 0,
+            sourceEndIndex: spacingCustomProperty.length,
+          },
+          ...node.nodes.slice(1),
+        ];
+      });
 
-export default function replaceSassSpacing(file: FileInfo) {
-  return postcss(plugin()).process(file.source, {
+      if (containsSpacingFn && containsCalculation) {
+        // Insert comment if the declaration value contains calculations
+        decl.before(postcss.comment({text: POLARIS_MIGRATOR_COMMENT}));
+        decl.before(
+          postcss.comment({text: `${decl.prop}: ${parsed.toString()};`}),
+        );
+      } else {
+        decl.value = parsed.toString();
+      }
+
+      // @ts-expect-error - Mark the declaration as processed
+      decl[processed] = true;
+    },
+  };
+};
+
+export default function replaceSassSpacing(
+  file: FileInfo,
+  _: API,
+  options: Options,
+) {
+  return postcss(plugin(options)).process(file.source, {
     syntax: require('postcss-scss'),
   }).css;
 }

--- a/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-sass-spacing.test.ts
+++ b/polaris-migrator/src/migrations/replace-sass-spacing/tests/replace-sass-spacing.test.ts
@@ -1,12 +1,17 @@
 import {check} from '../../../utilities/testUtils';
 
 const migration = 'replace-sass-spacing';
-const fixtures = ['replace-spacing'];
+const fixtures = ['replace-spacing', 'with-namespace'];
 
 for (const fixture of fixtures) {
   check(__dirname, {
     fixture,
     migration,
     extension: 'scss',
+    options: {
+      namespace: fixture.includes('with-namespace')
+        ? 'legacy-polaris-v8'
+        : undefined,
+    },
   });
 }

--- a/polaris-migrator/src/migrations/replace-sass-spacing/tests/with-namespace.input.scss
+++ b/polaris-migrator/src/migrations/replace-sass-spacing/tests/with-namespace.input.scss
@@ -1,0 +1,11 @@
+@use 'global-styles/legacy-polaris-v8';
+
+.Card {
+  z-index: legacy-polaris-v8.z-index(content) + 1;
+  padding: legacy-polaris-v8.spacing(loose)
+    legacy-polaris-v8.spacing(extra-loose);
+  border-radius: var(--p-border-radius-2, legacy-polaris-v8.border-radius());
+  box-shadow: var(--p-shadow-card, legacy-polaris-v8.shadow());
+  margin: legacy-polaris-v8.spacing(tight) 0 0
+    (-1 * legacy-polaris-v8.spacing());
+}

--- a/polaris-migrator/src/migrations/replace-sass-spacing/tests/with-namespace.output.scss
+++ b/polaris-migrator/src/migrations/replace-sass-spacing/tests/with-namespace.output.scss
@@ -1,0 +1,13 @@
+@use 'global-styles/legacy-polaris-v8';
+
+.Card {
+  z-index: legacy-polaris-v8.z-index(content) + 1;
+  padding: var(--p-space-5) var(--p-space-8);
+  border-radius: var(--p-border-radius-2, legacy-polaris-v8.border-radius());
+  box-shadow: var(--p-shadow-card, legacy-polaris-v8.shadow());
+  /* polaris-migrator: This is a complex expression that we can't automatically convert. Please check this manually. */
+  /* margin: var(--p-space-2) 0 0
+    (-1 * var(--p-space-4)); */
+  margin: legacy-polaris-v8.spacing(tight) 0 0
+    (-1 * legacy-polaris-v8.spacing());
+}

--- a/polaris-migrator/src/utilities/testUtils.ts
+++ b/polaris-migrator/src/utilities/testUtils.ts
@@ -19,11 +19,12 @@ interface TestArgs {
   fixture: string;
   migration: string;
   extension?: string;
+  options?: {[option: string]: any};
 }
 
 export function check(
   dirName: string,
-  {fixture, migration, extension = 'tsx'}: TestArgs,
+  {fixture, migration, extension = 'tsx', options = {}}: TestArgs,
 ) {
   describe(migration, () => {
     it(fixture, async () => {
@@ -37,7 +38,9 @@ export function check(
       );
       // Assumes transform is one level up from tests directory
       const module = await import(path.join(dirName, '..', migration));
-      const output = applyTransform({...module, parser: 'tsx'}, {}, {source});
+      const output = applyTransform({...module, parser: 'tsx'}, options, {
+        source,
+      });
 
       // Format output and expected with prettier for white spaces and line breaks consistency
       expect(prettier.format(output, {parser})).toBe(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

This change prepares the Sass spacing migration to handle updating the `spacing` function with a namespace prefix. This is in preparation for the switch from `node-sass` to `sass-embedded`.

### Usage

Default (no namespace)

```sh
npx @shopify/polaris-migrator replace-sass-spacing "./**/*.scss"
```

With namespace

```
npx @shopify/polaris-migrator replace-sass-spacing "./**/*.scss" --namespace="legacy-polaris-v8"
```
