### PR TITLE
[Avatar] Improve default style class selection by using the entire name instead of just the first letter

### DIFF
--- a/.changeset/twelve-glasses-count.md
+++ b/.changeset/twelve-glasses-count.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Improve default style class selection of `Avatar` by using the entire name instead of just the first letter

--- a/polaris-react/src/components/Avatar/Avatar.tsx
+++ b/polaris-react/src/components/Avatar/Avatar.tsx
@@ -19,6 +19,26 @@ enum Status {
 
 export const STYLE_CLASSES = ['one', 'two', 'three', 'four', 'five'];
 
+/**
+ * Computes a rudimentary hash from a string by xoring the character codes
+ * of all characters
+ */
+function xorHash(str: string) {
+  let hash = 0;
+
+  for (const char of str) {
+    hash ^= char.charCodeAt(0);
+  }
+
+  return hash;
+}
+
+function styleClass(name?: string) {
+  return name
+    ? STYLE_CLASSES[xorHash(name) % STYLE_CLASSES.length]
+    : STYLE_CLASSES[0];
+}
+
 export interface AvatarProps {
   /**
    * Size of avatar
@@ -56,15 +76,6 @@ export function Avatar({
 }: AvatarProps) {
   const i18n = useI18n();
   const isAfterInitialMount = useIsAfterInitialMount();
-
-  // WARNING: This approach of utilizing the first letter of the name to generate the icon styling within the Avatar component also exists in one other repository:
-  // https://github.com/Shopify/mobile/blob/main/src/foundations/polaris/components/Avatar/utilities/getStyleClassFromName.ts
-  // Please ensure they stay in sync by making changes in both places.
-  function styleClass(name?: string) {
-    return name
-      ? STYLE_CLASSES[name.charCodeAt(0) % STYLE_CLASSES.length]
-      : STYLE_CLASSES[0];
-  }
 
   const [status, setStatus] = useState<Status>(Status.Pending);
 


### PR DESCRIPTION
### WHY are these changes introduced?

Because the default style selection is based on only the first letter of the name, there's little variance for cases where names in a given set may all start with the same letter (common to the language, variations within a set of names where only the suffix changes, etc.)

In Shopify Admin (both [web][1] and [mobile][2]), we are currently using the last letter of a shop's name to add colour variance to shops (e.g. when an organization may have multiple shops whose names start with the same letter).

[1]: https://github.com/Shopify/web/blob/6a845022808550dd36cf8e2fbdf553f1431965c7/app/foundation/Frame/components/AppSearch/components/Rows/Rows.tsx#L107
[2]: https://github.com/Shopify/mobile/blob/4f810ff2a6089731047965bfe32b5739058b429b/src/foundations/polaris/components/Avatar/utilities/getStyleClassFromName.ts#L14-L19

### WHAT is this pull request doing?

By using the entire name, there's more guarantee of variance. A very performant way to get a rudimentary hash out of a string is just xoring the character codes.

```
['Aba', 'Abb', 'Bba'].map(xorHash)
// [66, 65, 65]
```

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
