### PR TITLE
[Box] Update description of alpha page in style guide

### DIFF
--- a/.changeset/mighty-timers-flash.md
+++ b/.changeset/mighty-timers-flash.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Updated alpha `Box` page to remove sentence regarding usage in existing components

--- a/polaris.shopify.com/content/components/box/index.md
+++ b/polaris.shopify.com/content/components/box/index.md
@@ -1,6 +1,6 @@
 ---
 title: Box
-description: Box is the most primitive layout component. Box has a set of padding options. Use it to render an individual item. Box can be used in components such as Toast, ContextualSaveBar, and Banner.
+description: Box is the most primitive layout component. Box has a set of padding options. Use it to render an individual item.
 category: Structure
 keywords:
   - layout


### PR DESCRIPTION
### WHY are these changes introduced?

Removes unclear wording from alpha `Box` page about its usage in existing Polaris components.

### WHAT is this pull request doing?
Updated alpha page:
    <details>
      <summary>Alpha Box — new</summary>
      <img src="https://user-images.githubusercontent.com/26749317/193900385-5ecd889f-f517-446c-8039-965cd89a9c67.png" alt="Alpha Box — new">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
