### PR TITLE
Refactor exported alias and scale types in `polaris-tokens`

### DIFF
--- a/.changeset/mean-elephants-nail.md
+++ b/.changeset/mean-elephants-nail.md
@@ -1,7 +1,5 @@
 ---
 '@shopify/polaris-tokens': patch
-'@shopify/polaris-migrator': minor
 ---
 
 Refactored exported alias and scale types in `breakpoints`, `depth`, `font`, `motion`, `shape`, `spacing`, and `zIndex`.
-Added `isKeyOf` to exports from `polaris-migrator` package.

--- a/.changeset/mean-elephants-nail.md
+++ b/.changeset/mean-elephants-nail.md
@@ -1,0 +1,7 @@
+---
+'@shopify/polaris-tokens': patch
+'@shopify/polaris-migrator': minor
+---
+
+Refactored exported alias and scale types in `breakpoints`, `depth`, `font`, `motion`, `shape`, `spacing`, and `zIndex`.
+Added `isKeyOf` to exports from `polaris-migrator` package.

--- a/polaris-migrator/src/index.ts
+++ b/polaris-migrator/src/index.ts
@@ -5,3 +5,5 @@ export type {CLIConfig} from './constants';
 
 export {migrate} from './migrate';
 export type {MigrateOptions} from './migrate';
+
+export {isKeyOf} from './utilities/type-guards';

--- a/polaris-migrator/src/index.ts
+++ b/polaris-migrator/src/index.ts
@@ -5,5 +5,3 @@ export type {CLIConfig} from './constants';
 
 export {migrate} from './migrate';
 export type {MigrateOptions} from './migrate';
-
-export {isKeyOf} from './utilities/type-guards';

--- a/polaris-tokens/src/token-groups/breakpoints.ts
+++ b/polaris-tokens/src/token-groups/breakpoints.ts
@@ -31,10 +31,5 @@ export const breakpoints = {
 export type BreakpointsTokenGroup = TokenGroup<typeof breakpoints>;
 export type BreakpointsTokenName = keyof BreakpointsTokenGroup;
 
-// e.g. "xs" | "sm" | "md" | "lg" | "xl"
-export type BreakpointsAlias = Extract<
-  BreakpointsTokenName,
-  `breakpoints-${string}`
-> extends `breakpoints-${infer Alias}`
-  ? Alias
-  : never;
+export const breakpointsAlias = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+export type BreakpointsAlias = typeof breakpointsAlias[number];

--- a/polaris-tokens/src/token-groups/depth.ts
+++ b/polaris-tokens/src/token-groups/depth.ts
@@ -45,10 +45,16 @@ export const depth = {
 export type DepthTokenGroup = TokenGroup<typeof depth>;
 export type DepthTokenName = keyof DepthTokenGroup;
 
-// temporary until shadows prefix is removed
-type ShadowsTokenName = Exclude<DepthTokenName, `shadows-${string}`>;
-
-// e.g. "transparent" | "faint" | "base" | "deep" | ...
-export type DepthShadowAlias = ShadowsTokenName extends `shadow-${infer Scale}`
-  ? Scale
-  : never;
+export const depthShadowAlias = [
+  'base',
+  'transparent',
+  'faint',
+  'deep',
+  'button',
+  'top-bar',
+  'card',
+  'popover',
+  'layer',
+  'modal',
+] as const;
+export type DepthShadowAlias = typeof depthShadowAlias[number];

--- a/polaris-tokens/src/token-groups/font.ts
+++ b/polaris-tokens/src/token-groups/font.ts
@@ -71,26 +71,25 @@ export const font = {
 export type FontTokenGroup = TokenGroup<typeof font>;
 export type FontTokenName = keyof FontTokenGroup;
 
-// e.g. "400" | "500" | "600" | "700" | "100" | ...
-export type FontSizeScale = Extract<
-  FontTokenName,
-  `font-size-${number}`
-> extends `font-size-${infer Scale}`
-  ? Scale
-  : never;
+export const fontSizeScale = [
+  '75',
+  '100',
+  '200',
+  '300',
+  '400',
+  '500',
+  '600',
+  '700',
+] as const;
+export type FontSizeScale = typeof fontSizeScale[number];
 
-// e.g. "1" | "2" | "3" | "4" | "5" | "6" | "7"
-export type FontLineHeightScale = Extract<
-  FontTokenName,
-  `font-line-height-${number}`
-> extends `font-line-height-${infer Scale}`
-  ? Scale
-  : never;
+export const fontLineHeightScale = ['1', '2', '3', '4', '5', '6', '7'] as const;
+export type FontLineHeightScale = typeof fontLineHeightScale[number];
 
-// e.g. "bold" | "regular" | "medium" | "semibold"
-export type FontWeightAlias = Extract<
-  FontTokenName,
-  `font-weight-${string}`
-> extends `font-weight-${infer Alias}`
-  ? Alias
-  : never;
+export const fontWeightAlias = [
+  'regular',
+  'medium',
+  'semibold',
+  'bold',
+] as const;
+export type FontWeightAlias = typeof fontWeightAlias[number];

--- a/polaris-tokens/src/token-groups/motion.ts
+++ b/polaris-tokens/src/token-groups/motion.ts
@@ -71,18 +71,26 @@ export const motion = {
 export type MotionTokenGroup = TokenGroup<typeof motion>;
 export type MotionTokenName = keyof MotionTokenGroup;
 
-// e.g. "0" | "50" | "100" | "150" | ...
-export type MotionDurationScale = Extract<
-  MotionTokenName,
-  `duration-${number}`
-> extends `duration-${infer Scale}`
-  ? Scale
-  : never;
+export const motionDurationScale = [
+  '0',
+  '50',
+  '100',
+  '150',
+  '200',
+  '250',
+  '300',
+  '350',
+  '400',
+  '450',
+  '500',
+  '5000',
+] as const;
+export type MotionDurationScale = typeof motionDurationScale[number];
 
-// e.g. "bounce" | "fade-in" | "pulse" | "spin"
-export type MotionKeyframesAlias = Extract<
-  MotionTokenName,
-  `keyframes-${string}`
-> extends `keyframes-${infer Alias}`
-  ? Alias
-  : never;
+export const motionKeyframesAlias = [
+  'bounce',
+  'fade-in',
+  'pulse',
+  'spin',
+] as const;
+export type MotionKeyframesAlias = typeof motionKeyframesAlias[number];

--- a/polaris-tokens/src/token-groups/shape.ts
+++ b/polaris-tokens/src/token-groups/shape.ts
@@ -66,8 +66,16 @@ export const shape = {
 export type ShapeTokenGroup = TokenGroup<typeof shape>;
 export type ShapeTokenName = keyof ShapeTokenGroup;
 
-export const borderRadiusScale = ['05', '1', '2', '3', '4', '5', '6'] as const;
-export type ShapeBorderRadiusScale = typeof borderRadiusScale[number];
+export const shapeBorderRadiusScale = [
+  '05',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+] as const;
+export type ShapeBorderRadiusScale = typeof shapeBorderRadiusScale[number];
 
-export const borderRadiusAlias = ['base', 'large', 'half'] as const;
-export type ShapeBorderRadiusAlias = typeof borderRadiusAlias[number];
+export const shapeBorderRadiusAlias = ['base', 'large', 'half'] as const;
+export type ShapeBorderRadiusAlias = typeof shapeBorderRadiusAlias[number];

--- a/polaris-tokens/src/token-groups/shape.ts
+++ b/polaris-tokens/src/token-groups/shape.ts
@@ -66,23 +66,8 @@ export const shape = {
 export type ShapeTokenGroup = TokenGroup<typeof shape>;
 export type ShapeTokenName = keyof ShapeTokenGroup;
 
-type ShapeBorderRadiusTokenName = Extract<
-  ShapeTokenName,
-  `border-radius-${string}`
->;
+export const borderRadiusScale = ['05', '1', '2', '3', '4', '5', '6'] as const;
+export type ShapeBorderRadiusScale = typeof borderRadiusScale[number];
 
-// e.g. "05" | "1" | "2" | "3" | "4" | "5" | "6"
-export type ShapeBorderRadiusScale = Extract<
-  ShapeBorderRadiusTokenName,
-  `border-radius-${number}`
-> extends `border-radius-${infer Scale}`
-  ? Scale
-  : never;
-
-// e.g. "base" | "large" | "half"
-export type ShapeBorderRadiusAlias = Exclude<
-  ShapeBorderRadiusTokenName,
-  `border-radius-${number}`
-> extends `border-radius-${infer Alias}`
-  ? Alias
-  : never;
+export const borderRadiusAlias = ['base', 'large', 'half'] as const;
+export type ShapeBorderRadiusAlias = typeof borderRadiusAlias[number];

--- a/polaris-tokens/src/token-groups/spacing.ts
+++ b/polaris-tokens/src/token-groups/spacing.ts
@@ -57,10 +57,23 @@ export const spacing = {
 export type SpacingTokenGroup = TokenGroup<typeof spacing>;
 export type SpacingTokenName = keyof SpacingTokenGroup;
 
-// e.g. "0" | "025" | "05" | "1" | "2" | "3" | ...
-export type SpacingSpaceScale = Extract<
-  SpacingTokenName,
-  `space-${number}`
-> extends `space-${infer Scale}`
-  ? Scale
-  : never;
+export const spaceScale = [
+  '0',
+  '025',
+  '05',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '8',
+  '10',
+  '12',
+  '16',
+  '20',
+  '24',
+  '28',
+  '32',
+] as const;
+export type SpacingSpaceScale = typeof spaceScale[number];

--- a/polaris-tokens/src/token-groups/spacing.ts
+++ b/polaris-tokens/src/token-groups/spacing.ts
@@ -57,7 +57,7 @@ export const spacing = {
 export type SpacingTokenGroup = TokenGroup<typeof spacing>;
 export type SpacingTokenName = keyof SpacingTokenGroup;
 
-export const spaceScale = [
+export const spacingSpaceScale = [
   '0',
   '025',
   '05',
@@ -76,4 +76,4 @@ export const spaceScale = [
   '28',
   '32',
 ] as const;
-export type SpacingSpaceScale = typeof spaceScale[number];
+export type SpacingSpaceScale = typeof spacingSpaceScale[number];

--- a/polaris-tokens/src/token-groups/zIndex.ts
+++ b/polaris-tokens/src/token-groups/zIndex.ts
@@ -51,9 +51,9 @@ export const zIndexZScale = [
   '6',
   '7',
   '8',
-  '10',
-  '12',
   '9',
+  '10',
   '11',
+  '12',
 ] as const;
 export type ZIndexZScale = typeof zIndexZScale[number];

--- a/polaris-tokens/src/token-groups/zIndex.ts
+++ b/polaris-tokens/src/token-groups/zIndex.ts
@@ -42,10 +42,18 @@ export const zIndex = {
 export type ZIndexTokenGroup = TokenGroup<typeof zIndex>;
 export type ZIndexTokenName = keyof ZIndexTokenGroup;
 
-// e.g. "1" | "2" | "3" | "4" | "5" | "6" | ...
-export type ZIndexZScale = Extract<
-  ZIndexTokenName,
-  `z-${number}`
-> extends `z-${infer Scale}`
-  ? Scale
-  : never;
+export const zIndexZScale = [
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '10',
+  '12',
+  '9',
+  '11',
+] as const;
+export type ZIndexZScale = typeof zIndexZScale[number];

--- a/polaris-tokens/src/utilities.ts
+++ b/polaris-tokens/src/utilities.ts
@@ -205,3 +205,10 @@ function getDownMediaCondition(breakpoint: string) {
   const offsetBreakpoint = parseFloat(toPx(breakpoint) ?? '') - 0.04;
   return `(max-width: ${toEm(`${offsetBreakpoint}px`)})`;
 }
+
+export function isKeyOf<T extends {[key: string]: any}>(
+  obj: T,
+  key: PropertyKey | undefined,
+): key is keyof T {
+  return Object.keys(obj).includes(key as string);
+}

--- a/polaris-tokens/tests/token-groups/breakpoints.test.ts
+++ b/polaris-tokens/tests/token-groups/breakpoints.test.ts
@@ -1,5 +1,4 @@
-import {isKeyOf} from '@shopify/polaris-migrator';
-
+import {isKeyOf} from '../../src/utilities';
 import {
   breakpoints,
   breakpointsAlias,

--- a/polaris-tokens/tests/token-groups/breakpoints.test.ts
+++ b/polaris-tokens/tests/token-groups/breakpoints.test.ts
@@ -5,7 +5,7 @@ import {
 } from '../../src/token-groups/breakpoints';
 
 describe('BreakpointsAlias', () => {
-  it('extracts the breakpoint alias from the breakpoints token', () => {
+  it('has a breakpoints token for each breakpoint alias', () => {
     for (const alias of breakpointsAlias) {
       expect(isKeyOf(breakpoints, `breakpoints-${alias}`)).toBe(true);
     }

--- a/polaris-tokens/tests/token-groups/breakpoints.test.ts
+++ b/polaris-tokens/tests/token-groups/breakpoints.test.ts
@@ -1,0 +1,14 @@
+import {isKeyOf} from '@shopify/polaris-migrator';
+
+import {
+  breakpoints,
+  breakpointsAlias,
+} from '../../src/token-groups/breakpoints';
+
+describe('BreakpointsAlias', () => {
+  it('extracts the breakpoint alias from the breakpoints token', () => {
+    for (const alias of breakpointsAlias) {
+      expect(isKeyOf(breakpoints, `breakpoints-${alias}`)).toBe(true);
+    }
+  });
+});

--- a/polaris-tokens/tests/token-groups/depth.test.ts
+++ b/polaris-tokens/tests/token-groups/depth.test.ts
@@ -2,7 +2,7 @@ import {isKeyOf} from '../../src/utilities';
 import {depth, depthShadowAlias} from '../../src/token-groups/depth';
 
 describe('DepthShadowAlias', () => {
-  it('extracts the depth alias from the depth token', () => {
+  it('has a depth token for each shadow alias', () => {
     for (const alias of depthShadowAlias) {
       expect(isKeyOf(depth, `shadow-${alias}`)).toBe(true);
     }

--- a/polaris-tokens/tests/token-groups/depth.test.ts
+++ b/polaris-tokens/tests/token-groups/depth.test.ts
@@ -1,5 +1,4 @@
-import {isKeyOf} from '@shopify/polaris-migrator';
-
+import {isKeyOf} from '../../src/utilities';
 import {depth, depthShadowAlias} from '../../src/token-groups/depth';
 
 describe('DepthShadowAlias', () => {

--- a/polaris-tokens/tests/token-groups/depth.test.ts
+++ b/polaris-tokens/tests/token-groups/depth.test.ts
@@ -1,0 +1,11 @@
+import {isKeyOf} from '@shopify/polaris-migrator';
+
+import {depth, depthShadowAlias} from '../../src/token-groups/depth';
+
+describe('DepthShadowAlias', () => {
+  it('extracts the depth alias from the depth token', () => {
+    for (const alias of depthShadowAlias) {
+      expect(isKeyOf(depth, `shadow-${alias}`)).toBe(true);
+    }
+  });
+});

--- a/polaris-tokens/tests/token-groups/font.test.ts
+++ b/polaris-tokens/tests/token-groups/font.test.ts
@@ -1,5 +1,4 @@
-import {isKeyOf} from '@shopify/polaris-migrator';
-
+import {isKeyOf} from '../../src/utilities';
 import {
   font,
   fontSizeScale,

--- a/polaris-tokens/tests/token-groups/font.test.ts
+++ b/polaris-tokens/tests/token-groups/font.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../src/token-groups/font';
 
 describe('FontSizeScale', () => {
-  it('extracts the font size scale from the font token', () => {
+  it('has a font token for each font size scale', () => {
     for (const sizeScale of fontSizeScale) {
       expect(isKeyOf(font, `font-size-${sizeScale}`)).toBe(true);
     }
@@ -15,7 +15,7 @@ describe('FontSizeScale', () => {
 });
 
 describe('FontLineHeightScale', () => {
-  it('extracts the font line height scale from the font token', () => {
+  it('has a font token for each font line height scale', () => {
     for (const lineHeightScale of fontLineHeightScale) {
       expect(isKeyOf(font, `font-line-height-${lineHeightScale}`)).toBe(true);
     }
@@ -23,7 +23,7 @@ describe('FontLineHeightScale', () => {
 });
 
 describe('FontWeightAlias', () => {
-  it('extracts the font weight alias from the font token', () => {
+  it('has a font token for each font weight alias', () => {
     for (const alias of fontWeightAlias) {
       expect(isKeyOf(font, `font-weight-${alias}`)).toBe(true);
     }

--- a/polaris-tokens/tests/token-groups/font.test.ts
+++ b/polaris-tokens/tests/token-groups/font.test.ts
@@ -1,0 +1,32 @@
+import {isKeyOf} from '@shopify/polaris-migrator';
+
+import {
+  font,
+  fontSizeScale,
+  fontLineHeightScale,
+  fontWeightAlias,
+} from '../../src/token-groups/font';
+
+describe('FontSizeScale', () => {
+  it('extracts the font size scale from the font token', () => {
+    for (const sizeScale of fontSizeScale) {
+      expect(isKeyOf(font, `font-size-${sizeScale}`)).toBe(true);
+    }
+  });
+});
+
+describe('FontLineHeightScale', () => {
+  it('extracts the font line height scale from the font token', () => {
+    for (const lineHeightScale of fontLineHeightScale) {
+      expect(isKeyOf(font, `font-line-height-${lineHeightScale}`)).toBe(true);
+    }
+  });
+});
+
+describe('FontWeightAlias', () => {
+  it('extracts the font weight alias from the font token', () => {
+    for (const alias of fontWeightAlias) {
+      expect(isKeyOf(font, `font-weight-${alias}`)).toBe(true);
+    }
+  });
+});

--- a/polaris-tokens/tests/token-groups/motion.test.ts
+++ b/polaris-tokens/tests/token-groups/motion.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../../src/token-groups/motion';
 
 describe('MotionDurationScale', () => {
-  it('extracts the motion duration scale from the motion token', () => {
+  it('has a motion token for each duration scale', () => {
     for (const scale of motionDurationScale) {
       expect(isKeyOf(motion, `duration-${scale}`)).toBe(true);
     }
@@ -14,7 +14,7 @@ describe('MotionDurationScale', () => {
 });
 
 describe('MotionKeyframesAlias', () => {
-  it('extracts the motion keyframe alias from the motion token', () => {
+  it('has a motion token for each keyframes alias', () => {
     for (const alias of motionKeyframesAlias) {
       expect(isKeyOf(motion, `keyframes-${alias}`)).toBe(true);
     }

--- a/polaris-tokens/tests/token-groups/motion.test.ts
+++ b/polaris-tokens/tests/token-groups/motion.test.ts
@@ -1,0 +1,23 @@
+import {isKeyOf} from '@shopify/polaris-migrator';
+
+import {
+  motion,
+  motionDurationScale,
+  motionKeyframesAlias,
+} from '../../src/token-groups/motion';
+
+describe('MotionDurationScale', () => {
+  it('extracts the motion duration scale from the motion token', () => {
+    for (const scale of motionDurationScale) {
+      expect(isKeyOf(motion, `duration-${scale}`)).toBe(true);
+    }
+  });
+});
+
+describe('MotionKeyframesAlias', () => {
+  it('extracts the motion keyframe alias from the motion token', () => {
+    for (const alias of motionKeyframesAlias) {
+      expect(isKeyOf(motion, `keyframes-${alias}`)).toBe(true);
+    }
+  });
+});

--- a/polaris-tokens/tests/token-groups/motion.test.ts
+++ b/polaris-tokens/tests/token-groups/motion.test.ts
@@ -1,5 +1,4 @@
-import {isKeyOf} from '@shopify/polaris-migrator';
-
+import {isKeyOf} from '../../src/utilities';
 import {
   motion,
   motionDurationScale,

--- a/polaris-tokens/tests/token-groups/shape.test.ts
+++ b/polaris-tokens/tests/token-groups/shape.test.ts
@@ -1,5 +1,4 @@
-import {isKeyOf} from '@shopify/polaris-migrator';
-
+import {isKeyOf} from '../../src/utilities';
 import {
   shape,
   borderRadiusScale,

--- a/polaris-tokens/tests/token-groups/shape.test.ts
+++ b/polaris-tokens/tests/token-groups/shape.test.ts
@@ -1,0 +1,23 @@
+import {isKeyOf} from '@shopify/polaris-migrator';
+
+import {
+  shape,
+  borderRadiusScale,
+  borderRadiusAlias,
+} from '../../src/token-groups/shape';
+
+describe('ShapeBorderRadiusScale', () => {
+  it('extracts the border radius scale from the shape token', () => {
+    for (const scale of borderRadiusScale) {
+      expect(isKeyOf(shape, `border-radius-${scale}`)).toBe(true);
+    }
+  });
+});
+
+describe('ShapeBorderRadiusAlias', () => {
+  it('extracts the border radius alias from the shape token', () => {
+    for (const alias of borderRadiusAlias) {
+      expect(isKeyOf(shape, `border-radius-${alias}`)).toBe(true);
+    }
+  });
+});

--- a/polaris-tokens/tests/token-groups/shape.test.ts
+++ b/polaris-tokens/tests/token-groups/shape.test.ts
@@ -1,13 +1,13 @@
 import {isKeyOf} from '../../src/utilities';
 import {
   shape,
-  borderRadiusScale,
-  borderRadiusAlias,
+  shapeBorderRadiusScale,
+  shapeBorderRadiusAlias,
 } from '../../src/token-groups/shape';
 
 describe('ShapeBorderRadiusScale', () => {
   it('extracts the border radius scale from the shape token', () => {
-    for (const scale of borderRadiusScale) {
+    for (const scale of shapeBorderRadiusScale) {
       expect(isKeyOf(shape, `border-radius-${scale}`)).toBe(true);
     }
   });
@@ -15,7 +15,7 @@ describe('ShapeBorderRadiusScale', () => {
 
 describe('ShapeBorderRadiusAlias', () => {
   it('extracts the border radius alias from the shape token', () => {
-    for (const alias of borderRadiusAlias) {
+    for (const alias of shapeBorderRadiusAlias) {
       expect(isKeyOf(shape, `border-radius-${alias}`)).toBe(true);
     }
   });

--- a/polaris-tokens/tests/token-groups/shape.test.ts
+++ b/polaris-tokens/tests/token-groups/shape.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../../src/token-groups/shape';
 
 describe('ShapeBorderRadiusScale', () => {
-  it('extracts the border radius scale from the shape token', () => {
+  it('has a shape token for each border radius scale', () => {
     for (const scale of shapeBorderRadiusScale) {
       expect(isKeyOf(shape, `border-radius-${scale}`)).toBe(true);
     }
@@ -14,7 +14,7 @@ describe('ShapeBorderRadiusScale', () => {
 });
 
 describe('ShapeBorderRadiusAlias', () => {
-  it('extracts the border radius alias from the shape token', () => {
+  it('has a shape token for each border radius alias', () => {
     for (const alias of shapeBorderRadiusAlias) {
       expect(isKeyOf(shape, `border-radius-${alias}`)).toBe(true);
     }

--- a/polaris-tokens/tests/token-groups/spacing.test.ts
+++ b/polaris-tokens/tests/token-groups/spacing.test.ts
@@ -2,7 +2,7 @@ import {isKeyOf} from '../../src/utilities';
 import {spacing, spacingSpaceScale} from '../../src/token-groups/spacing';
 
 describe('SpacingSpaceScale', () => {
-  it('extracts the spacing scale from the spacing token', () => {
+  it('has a space token for each spacing scale', () => {
     for (const scale of spacingSpaceScale) {
       expect(isKeyOf(spacing, `space-${scale}`)).toBe(true);
     }

--- a/polaris-tokens/tests/token-groups/spacing.test.ts
+++ b/polaris-tokens/tests/token-groups/spacing.test.ts
@@ -1,0 +1,11 @@
+import {isKeyOf} from '@shopify/polaris-migrator';
+
+import {spacing, spaceScale} from '../../src/token-groups/spacing';
+
+describe('SpacingSpaceScale', () => {
+  it('extracts the spacing scale from the spacing token', () => {
+    for (const scale of spaceScale) {
+      expect(isKeyOf(spacing, `space-${scale}`)).toBe(true);
+    }
+  });
+});

--- a/polaris-tokens/tests/token-groups/spacing.test.ts
+++ b/polaris-tokens/tests/token-groups/spacing.test.ts
@@ -1,9 +1,9 @@
 import {isKeyOf} from '../../src/utilities';
-import {spacing, spaceScale} from '../../src/token-groups/spacing';
+import {spacing, spacingSpaceScale} from '../../src/token-groups/spacing';
 
 describe('SpacingSpaceScale', () => {
   it('extracts the spacing scale from the spacing token', () => {
-    for (const scale of spaceScale) {
+    for (const scale of spacingSpaceScale) {
       expect(isKeyOf(spacing, `space-${scale}`)).toBe(true);
     }
   });

--- a/polaris-tokens/tests/token-groups/spacing.test.ts
+++ b/polaris-tokens/tests/token-groups/spacing.test.ts
@@ -1,5 +1,4 @@
-import {isKeyOf} from '@shopify/polaris-migrator';
-
+import {isKeyOf} from '../../src/utilities';
 import {spacing, spaceScale} from '../../src/token-groups/spacing';
 
 describe('SpacingSpaceScale', () => {

--- a/polaris-tokens/tests/token-groups/zIndex.test.ts
+++ b/polaris-tokens/tests/token-groups/zIndex.test.ts
@@ -2,7 +2,7 @@ import {isKeyOf} from '../../src/utilities';
 import {zIndex, zIndexZScale} from '../../src/token-groups/zIndex';
 
 describe('ZIndexZScale', () => {
-  it('extracts the z-index scale from the zIndex token', () => {
+  it('has a zIndex token for each z-index scale', () => {
     for (const scale of zIndexZScale) {
       expect(isKeyOf(zIndex, `z-${scale}`)).toBe(true);
     }

--- a/polaris-tokens/tests/token-groups/zIndex.test.ts
+++ b/polaris-tokens/tests/token-groups/zIndex.test.ts
@@ -1,0 +1,11 @@
+import {isKeyOf} from '@shopify/polaris-migrator';
+
+import {zIndex, zIndexZScale} from '../../src/token-groups/zIndex';
+
+describe('ZIndexZScale', () => {
+  it('extracts the z-index scale from the zIndex token', () => {
+    for (const scale of zIndexZScale) {
+      expect(isKeyOf(zIndex, `z-${scale}`)).toBe(true);
+    }
+  });
+});

--- a/polaris-tokens/tests/token-groups/zIndex.test.ts
+++ b/polaris-tokens/tests/token-groups/zIndex.test.ts
@@ -1,5 +1,4 @@
-import {isKeyOf} from '@shopify/polaris-migrator';
-
+import {isKeyOf} from '../../src/utilities';
 import {zIndex, zIndexZScale} from '../../src/token-groups/zIndex';
 
 describe('ZIndexZScale', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #7381.

### WHAT is this pull request doing?

Removes instances where we use `Extract` and/or `Exclude` when defining types. Explicitly defines the token values/aliases instead, in addition with tests.

I ran `yarn && yarn build` and our storybook and style guide locally to check that no regressions were introduced.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
