### PR TITLE
[Text] Fix optional `id` prop

### DIFF
--- a/.changeset/calm-buses-sniff.md
+++ b/.changeset/calm-buses-sniff.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed how optional `id` prop rendered in `Text`

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -85,7 +85,7 @@ export const Text = ({
   );
 
   return (
-    <Component className={className} {...(id ? id : null)}>
+    <Component className={className} {...(id && {id})}>
       {children}
     </Component>
   );


### PR DESCRIPTION
### WHY are these changes introduced?

A recent [PR](https://github.com/Shopify/polaris/pull/7363) that adds an `id` prop to the Text component was causing a TS error.

### WHAT is this pull request doing?
Small fix to update the way the `id` prop is optionally rendered.
    <details>
      <summary>TS error</summary>
      <img src="https://user-images.githubusercontent.com/26749317/195863679-cfa8e8f7-6d1c-49f3-8b2a-5401931a49d9.png" alt="TS error">
    </details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';

import {Page, Text} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
      <Text as="h1" variant="heading2xl">
        Text — no id
      </Text>
      <Text as="h1" variant="heading2xl" id="text-heading-test">
        Text — with id
      </Text>
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
