### PR TITLE
Update `Text` component to support `legend` element

### DIFF
--- a/.changeset/seven-cobras-breathe.md
+++ b/.changeset/seven-cobras-breathe.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Added `legend` as supported element for `Text` component

--- a/.changeset/seven-cobras-breathe.md
+++ b/.changeset/seven-cobras-breathe.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/polaris': patch
+'@shopify/polaris': minor
 ---
 
 Added `legend` as supported element for `Text` component

--- a/polaris-react/src/components/Text/Text.tsx
+++ b/polaris-react/src/components/Text/Text.tsx
@@ -4,7 +4,16 @@ import {classNames} from '../../utilities/css';
 
 import styles from './Text.scss';
 
-type Element = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span';
+type Element =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'p'
+  | 'span'
+  | 'legend';
 
 type Variant =
   | 'headingXs'


### PR DESCRIPTION
### WHY are these changes introduced?

Added `legend` as supported element for `Text` component so that text styles can be easily applied in cases when `legend` is the semantically correct markup.