### PR TITLE
[polaris.shopify.com] Fix references to Box `margin` in alpha examples

### DIFF
--- a/.changeset/many-carrots-heal.md
+++ b/.changeset/many-carrots-heal.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fix references to `Box` margin props in alpha layout examples

--- a/polaris.shopify.com/pages/examples/alpha-stack-with-align.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-stack-with-align.tsx
@@ -6,7 +6,7 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 function AlphaStackWithAlignExample() {
   return (
     <div style={{width: '500px'}}>
-      <Box marginBottom="2">
+      <Box paddingBottom="2">
         <Text variant="bodySm" as="h3">
           with align start
         </Text>
@@ -24,7 +24,7 @@ function AlphaStackWithAlignExample() {
         </AlphaStack>
       </Box>
       <hr />
-      <Box marginBottom="2">
+      <Box paddingBottom="2">
         <Text variant="bodySm" as="h3">
           with align center
         </Text>
@@ -42,7 +42,7 @@ function AlphaStackWithAlignExample() {
         </AlphaStack>
       </Box>
       <hr />
-      <Box marginBottom="2">
+      <Box paddingBottom="2">
         <Text variant="bodySm" as="h3">
           with align end
         </Text>

--- a/polaris.shopify.com/pages/examples/alpha-stack-with-spacing.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-stack-with-spacing.tsx
@@ -6,7 +6,7 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 function AlphaStackWithSpacingExample() {
   return (
     <div style={{width: '500px'}}>
-      <Box marginBottom="2">
+      <Box paddingBottom="2">
         <Text variant="bodySm" as="h3">
           with spacing 0
         </Text>
@@ -24,7 +24,7 @@ function AlphaStackWithSpacingExample() {
         </AlphaStack>
       </Box>
       <hr />
-      <Box marginBottom="2">
+      <Box paddingBottom="2">
         <Text variant="bodySm" as="h3">
           with spacing 4
         </Text>
@@ -42,7 +42,7 @@ function AlphaStackWithSpacingExample() {
         </AlphaStack>
       </Box>
       <hr />
-      <Box marginBottom="2">
+      <Box paddingBottom="2">
         <Text variant="bodySm" as="h3">
           with spacing 10
         </Text>

--- a/polaris.shopify.com/pages/examples/inline-with-align-y.tsx
+++ b/polaris.shopify.com/pages/examples/inline-with-align-y.tsx
@@ -6,7 +6,7 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 function InlineWithAlignYExample() {
   return (
     <div style={{width: '500px'}}>
-      <Box marginBottom="2">
+      <Box paddingBottom="2">
         <Text variant="bodySm" as="h3">
           with alignY top
         </Text>
@@ -22,7 +22,7 @@ function InlineWithAlignYExample() {
         </Inline>
       </Box>
       <hr />
-      <Box marginBottom="2">
+      <Box paddingBottom="2">
         <Text variant="bodySm" as="h3">
           with alignY center
         </Text>
@@ -38,7 +38,7 @@ function InlineWithAlignYExample() {
         </Inline>
       </Box>
       <hr />
-      <Box marginBottom="2">
+      <Box paddingBottom="2">
         <Text variant="bodySm" as="h3">
           with alignY bottom
         </Text>
@@ -54,7 +54,7 @@ function InlineWithAlignYExample() {
         </Inline>
       </Box>
       <hr />
-      <Box marginBottom="2">
+      <Box paddingBottom="2">
         <Text variant="bodySm" as="h3">
           with alignY baseline
         </Text>

--- a/polaris.shopify.com/pages/examples/inline-with-align.tsx
+++ b/polaris.shopify.com/pages/examples/inline-with-align.tsx
@@ -6,7 +6,7 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 function InlineWithAlignExample() {
   return (
     <div style={{width: '500px'}}>
-      <Box marginBottom="2">
+      <Box paddingBottom="2">
         <Text variant="bodySm" as="h3">
           with align start
         </Text>
@@ -22,7 +22,7 @@ function InlineWithAlignExample() {
         </Inline>
       </Box>
       <hr />
-      <Box marginBottom="2">
+      <Box paddingBottom="2">
         <Text variant="bodySm" as="h3">
           with align center
         </Text>
@@ -38,7 +38,7 @@ function InlineWithAlignExample() {
         </Inline>
       </Box>
       <hr />
-      <Box marginBottom="2">
+      <Box paddingBottom="2">
         <Text variant="bodySm" as="h3">
           with align end
         </Text>


### PR DESCRIPTION
### WHY are these changes introduced?

We recently shipped a pr to remove any margin related props from `Box`.
Some of the alpha layout examples on the styleguide still referenced the removed prop.

### WHAT is this pull request doing?

Updates reference to `marginXX` in the alpha layout examples.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
