### PR TITLE
Simplify design patterns page

### DIFF
--- a/.changeset/pretty-bats-know.md
+++ b/.changeset/pretty-bats-know.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': minor
+---
+
+Remove section on compositions vs patterns.

--- a/polaris.shopify.com/content/patterns/design-patterns.md
+++ b/polaris.shopify.com/content/patterns/design-patterns.md
@@ -37,6 +37,6 @@ Patterns are always used in the same way for the same reasons. Merchants need to
 
 Patterns are always informed by and designed together with similar patterns. For example, patterns with similar purpose should complement each other, and patterns with similar functionality should share appearance and behavior.
 
-![A solution box within a problem box within a situation box.](/images/foundations/patterns/design-patterns/situation-problem-solution.png)
-
 Patterns come with a solution, problem, and situation that belong together. Solutions taken out of this context are no longer a pattern.
+
+![A solution box within a problem box within a situation box.](/images/foundations/patterns/design-patterns/situation-problem-solution.png)

--- a/polaris.shopify.com/content/patterns/design-patterns.md
+++ b/polaris.shopify.com/content/patterns/design-patterns.md
@@ -40,28 +40,3 @@ Patterns are always informed by and designed together with similar patterns. For
 ![A solution box within a problem box within a situation box.](/images/foundations/patterns/design-patterns/situation-problem-solution.png)
 
 Patterns come with a solution, problem, and situation that belong together. Solutions taken out of this context are no longer a pattern.
-
-## Patterns vs. compositions
-
-Patterns are for merchants and compositions are for builders.
-
-### Pattern purpose
-
-- Design the best possible merchant experience
-- Simplify learning the UI
-- Improve recognizability and ease of use
-- Improve merchants’ admin proficiency
-
-### Composition purpose
-
-- Share as much code as possible
-- Speed up the build process
-- Improve maintainability and reusability
-- Ensure build consistency
-
-### How to distinguish
-
-- Patterns solve usability problems that relate to the usage of admin, while compositions solve build problems that relate to the build process
-- Patterns ensure consistent product experience, while compositions ensure consistent implementation
-- A pattern can be hard coded and still be a pattern, and a composition can be using Polaris primitives and tokens and still not be a pattern
-- Patterns are the language we speak with merchants, compositions are the code we share among us

--- a/polaris.shopify.com/content/patterns/design-patterns.md
+++ b/polaris.shopify.com/content/patterns/design-patterns.md
@@ -23,11 +23,7 @@ Do you have ideas or feedback on how we can make these guidelines more empowerin
 
 ## Principles
 
-For patterns to be successful, they need to be contextual, consistent, and unified.
-
-### Contextual
-
-A pattern is always paired with the problem it solves and the situation it appears in. A solution applied in a context it wasn’t designed for is not a pattern.
+For patterns to be successful, they need to be consistent, unified, and contextual.
 
 ### Consistent
 
@@ -37,6 +33,8 @@ Patterns are always used in the same way for the same reasons. Merchants need to
 
 Patterns are always informed by and designed together with similar patterns. For example, patterns with similar purpose should complement each other, and patterns with similar functionality should share appearance and behavior.
 
-Patterns come with a solution, problem, and situation that belong together. Solutions taken out of this context are no longer a pattern.
+### Contextual
+
+A pattern is always paired with the problem it solves and the situation it appears in. A solution applied in a context it wasn’t designed for is not a pattern.
 
 ![A solution box within a problem box within a situation box.](/images/foundations/patterns/design-patterns/situation-problem-solution.png)

--- a/polaris.shopify.com/content/patterns/design-patterns.md
+++ b/polaris.shopify.com/content/patterns/design-patterns.md
@@ -15,7 +15,7 @@ A design pattern is a repeatable solution to a common UX problem in a specific m
 
 ---
 
-### Join the conversation!
+### Join the conversation
 
 Do you have ideas or feedback on how we can make these guidelines more empowering and useful? Please share your thoughts in the [GitHub discussion](https://github.com/Shopify/polaris/discussions/6046).
 


### PR DESCRIPTION
### WHY are these changes introduced?

The design pattern page currently includes a section describing the differences between compositions and patterns. While this information is valuable to us a team, we are still defining and testing these concepts. Publishing them on the site at this stage seems to have introduced some confusion for readers. 

### WHAT is this pull request doing?

Removes section on compositions vs patterns until we develop stronger opinions and feel comfortable publishing them publicly. 

Also reorganizes the order of the principles, placing "Contextual" last, and closest to the related image. 