### PR TITLE
Add missing values to borderRadius length map

### DIFF
--- a/.changeset/two-hotels-scream.md
+++ b/.changeset/two-hotels-scream.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Add missing values to borderRadius length map

--- a/polaris-migrator/src/migrations/replace-border-declarations/replace-border-declarations.ts
+++ b/polaris-migrator/src/migrations/replace-border-declarations/replace-border-declarations.ts
@@ -303,7 +303,9 @@ const borderWidthLengthMap = {
 
 const borderRadiusLengthMap = {
   '2px': '--p-border-radius-05',
+  '3px': '--p-border-radius-base',
   '4px': '--p-border-radius-1',
+  '6px': '--p-border-radius-large',
   '8px': '--p-border-radius-2',
   '12px': '--p-border-radius-3',
   '16px': '--p-border-radius-4',


### PR DESCRIPTION
### WHY are these changes introduced?

Add `--p-border-radius-base` and `--p-border-radius-large` to the border-radius length map until we finalize our scale. 