### PR TITLE
[Text] Add responsive styling for `headingXl` and `headingLg` variants

### DIFF
--- a/.changeset/long-bugs-behave.md
+++ b/.changeset/long-bugs-behave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added responsive styling to the `Text` `headingXl` and `headingLg` variants

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -83,13 +83,23 @@
 }
 
 .headingLg {
-  font-size: var(--p-font-size-300);
-  line-height: var(--p-font-line-height-3);
+  font-size: var(--p-font-size-200);
+  line-height: var(--p-font-line-height-2);
+
+  @media #{$p-breakpoints-md-up} {
+    font-size: var(--p-font-size-300);
+    line-height: var(--p-font-line-height-3);
+  }
 }
 
 .headingXl {
-  font-size: var(--p-font-size-400);
-  line-height: var(--p-font-line-height-4);
+  font-size: var(--p-font-size-300);
+  line-height: var(--p-font-line-height-3);
+
+  @media #{$p-breakpoints-md-up} {
+    font-size: var(--p-font-size-400);
+    line-height: var(--p-font-line-height-4);
+  }
 }
 
 .heading2xl {


### PR DESCRIPTION
### WHY are these changes introduced?

There seems to be missing responsive styles for the `headingLg` Text variant so that it can map to `<DisplayText as="small">`. Also adds responsive styling to `headingXl`.

### WHAT is this pull request doing?

Adds responsive styling to the `headingXl` and `headingLg` variants for the `mdUp` breakpoint.
[Storybook URL](https://5d559397bae39100201eedc1-erawlsvvlo.chromatic.com/?path=/story/all-components-text--variants) — use the breakpointSm to see changes.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

[Storybook URL](https://5d559397bae39100201eedc1-erawlsvvlo.chromatic.com/?path=/story/all-components-text--variants) — use the breakpointSm to see changes.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
