### PR TITLE
[polaris.shopify.com] Get latest styles for local development

### DIFF
--- a/.changeset/early-countries-march.md
+++ b/.changeset/early-countries-march.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Copy polaris-react css to keep local dev in sync

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules
 /polaris.shopify.com/public/sitemap.xml
 /polaris.shopify.com/public/og-images
 /polaris.shopify.com/public/playroom
+/polaris.shopify.com/public/polaris-styles.css

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "yarn gen-assets && playroom build && next build",
     "start": "next start",
-    "dev": "run-p dev:*",
+    "dev": "yarn get-styles && run-p dev:*",
     "dev:server": "open http://localhost:3000 && next dev",
     "dev:playroom": "playroom start",
     "dev:watch-md": "node scripts/watch-md.mjs",
@@ -16,7 +16,8 @@
     "create-component": "generact --root src/components src/components/Template/Template.tsx",
     "gen-sitemap": "yarn next-sitemap",
     "get-props": "tsc ./scripts/get-props/src/get-props.ts --target esnext --module node16 --types \"react\" --outDir ./scripts/tmp && node ./scripts/tmp/scripts/get-props/src/get-props.js && rm -rf ./scripts/tmp",
-    "gen-assets": "node scripts/gen-assets.mjs"
+    "gen-assets": "node scripts/gen-assets.mjs",
+    "get-styles": "node scripts/get-styles.mjs"
   },
   "dependencies": {
     "@floating-ui/react-dom-interactions": "^0.10.1",

--- a/polaris.shopify.com/scripts/get-styles.mjs
+++ b/polaris.shopify.com/scripts/get-styles.mjs
@@ -4,7 +4,9 @@ const builtStylesPath = '../polaris-react/build/esm/styles.css';
 const fileDestination = 'public/polaris-styles.css';
 
 fs.copyFile(builtStylesPath, fileDestination, (error) => {
-  if (error) console.log(`Error copying polaris styles: ${error}`);
+  if (error) {
+    throw new Error(`Error copying styles file: ${error}`);
+  }
 
   console.log('✅ Copied polaris styles');
 });

--- a/polaris.shopify.com/scripts/get-styles.mjs
+++ b/polaris.shopify.com/scripts/get-styles.mjs
@@ -1,0 +1,10 @@
+import fs from 'fs';
+
+const builtStylesPath = '../polaris-react/build/esm/styles.css';
+const fileDestination = 'public/polaris-styles.css';
+
+fs.copyFile(builtStylesPath, fileDestination, (error) => {
+  if (error) console.log(`Error copying polaris styles: ${error}`);
+
+  console.log('✅ Copied polaris styles');
+});

--- a/polaris.shopify.com/src/components/PolarisExampleWrapper/PolarisExampleWrapper.tsx
+++ b/polaris.shopify.com/src/components/PolarisExampleWrapper/PolarisExampleWrapper.tsx
@@ -3,11 +3,12 @@ import translations from '@shopify/polaris/locales/en.json';
 import {ComponentType} from 'react';
 import styles from './PolarisExampleWrapper.module.scss';
 
-const stylesheetHref =
-  'https://unpkg.com/@shopify/polaris@latest/build/esm/styles.css';
-
 export const withPolarisExample = (Component: ComponentType) => {
   const PolarisHOC = (props: any) => {
+    const stylesheetHref =
+      process.env.NODE_ENV === 'development'
+        ? '/polaris-styles.css'
+        : 'https://unpkg.com/@shopify/polaris@latest/build/esm/styles.css';
     return (
       <>
         <link rel="stylesheet" href={stylesheetHref} />

--- a/polaris.shopify.com/src/components/PolarisExampleWrapper/PolarisExampleWrapper.tsx
+++ b/polaris.shopify.com/src/components/PolarisExampleWrapper/PolarisExampleWrapper.tsx
@@ -3,12 +3,13 @@ import translations from '@shopify/polaris/locales/en.json';
 import {ComponentType} from 'react';
 import styles from './PolarisExampleWrapper.module.scss';
 
+const stylesheetHref =
+  process.env.NODE_ENV === 'development'
+    ? '/polaris-styles.css'
+    : 'https://unpkg.com/@shopify/polaris@latest/build/esm/styles.css';
+
 export const withPolarisExample = (Component: ComponentType) => {
   const PolarisHOC = (props: any) => {
-    const stylesheetHref =
-      process.env.NODE_ENV === 'development'
-        ? '/polaris-styles.css'
-        : 'https://unpkg.com/@shopify/polaris@latest/build/esm/styles.css';
     return (
       <>
         <link rel="stylesheet" href={stylesheetHref} />


### PR DESCRIPTION
Pulling css from `https://unpkg.com/@shopify/polaris@latest/build/esm/styles.css` means that css can get out of sync when developing. 

**Why this is important**

We're currently developing documentation around alpha / beta components. These components are changing and our docs will too, let's make sure the css is synced so we're not seeing weird stuff!