### PR TITLE
Fix home promo images

### DIFF
--- a/.changeset/six-ligers-suffer.md
+++ b/.changeset/six-ligers-suffer.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed home promo image layout

--- a/polaris.shopify.com/src/components/HomePage/HomePage.module.scss
+++ b/polaris.shopify.com/src/components/HomePage/HomePage.module.scss
@@ -97,8 +97,8 @@
   gap: 1rem;
 
   @media screen and (max-width: $breakpointTablet) {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
     gap: 1rem;
     margin-top: 2rem;
   }

--- a/polaris.shopify.com/src/components/HomePage/HomePage.module.scss
+++ b/polaris.shopify.com/src/components/HomePage/HomePage.module.scss
@@ -92,7 +92,7 @@
 .Promos {
   margin-top: 4rem;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   overflow: hidden;
   gap: 1rem;
 

--- a/polaris.shopify.com/src/components/HomePage/HomePage.tsx
+++ b/polaris.shopify.com/src/components/HomePage/HomePage.tsx
@@ -74,6 +74,7 @@ function HomePage({}: Props) {
               <Image
                 width={1600}
                 height={800}
+                style={{width: '100%', height: 'auto'}}
                 src="/images/home-news.png"
                 alt="A list showcasing the new font sizes in Polaris"
               />


### PR DESCRIPTION
Somethings broke after the NextJS 13 bump. I went through all the pages except home 😞.

Before | After
---|---
![localhost_3000_](https://user-images.githubusercontent.com/6844391/199270155-7f3bee26-ef72-44c4-9a37-7323fb5340f0.png) | ![localhost_3000_ (2)](https://user-images.githubusercontent.com/6844391/199278285-dc46da48-ea20-42d8-9473-ffaf30ef9a1a.png)
