### PR TITLE
Free up space on GitHub workflow images

### DIFF
--- a/.github/workflows/ci-a11y-vrt.yml
+++ b/.github/workflows/ci-a11y-vrt.yml
@@ -23,6 +23,15 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v3
 
+      - name: Free up space on GitHub image
+        run: |
+          # Based on the official advice:
+          # https://github.com/actions/virtual-environments/issues/2840#issuecomment-790492173
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: Setup Node with v16.13.0
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,15 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v3
 
+      - name: Free up space on GitHub image
+        run: |
+          # Based on the official advice:
+          # https://github.com/actions/virtual-environments/issues/2840#issuecomment-790492173
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: Setup Node with v${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/publish-polaris-for-vscode.yml
+++ b/.github/workflows/publish-polaris-for-vscode.yml
@@ -13,6 +13,15 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout
 
+      - name: Free up space on GitHub image
+        run: |
+          # Based on the official advice:
+          # https://github.com/actions/virtual-environments/issues/2840#issuecomment-790492173
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - uses: actions/setup-node@v3
         name: Use Node.js 16.x
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,15 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
+      - name: Free up space on GitHub image
+        run: |
+          # Based on the official advice:
+          # https://github.com/actions/virtual-environments/issues/2840#issuecomment-790492173
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -13,6 +13,14 @@ jobs:
       CI_JOB_NUMBER: 1
     steps:
       - uses: actions/checkout@v3
+      - name: Free up space on GitHub image
+        run: |
+          # Based on the official advice:
+          # https://github.com/actions/virtual-environments/issues/2840#issuecomment-790492173
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/.github/workflows/snapit.yml
+++ b/.github/workflows/snapit.yml
@@ -77,6 +77,15 @@ jobs:
             git checkout origin/main -- .changeset
           fi
 
+      - name: Free up space on GitHub image
+        run: |
+          # Based on the official advice:
+          # https://github.com/actions/virtual-environments/issues/2840#issuecomment-790492173
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
### WHY are these changes introduced?

We're getting `ENOSPC` errors during `yarn install` in CI. For example, [in this build](https://github.com/Shopify/polaris/actions/runs/3381884402/jobs/5616237293), it happens to run out of space while trying to install puppeteer.

### WHAT is this pull request doing?

Based on what appears to be [official advice](https://github.com/actions/runner-images/issues/2840#issuecomment-790492173), we remove up to 10GB of unnecessary files on the images before attempting `yarn install` in any CI jobs:

```yaml
      - name: Free up space on GitHub image
        run: |
          # Based on the official advice:
          # https://github.com/actions/virtual-environments/issues/2840#issuecomment-790492173
          sudo rm -rf /usr/share/dotnet
          sudo rm -rf /opt/ghc
          sudo rm -rf "/usr/local/share/boost"
          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
```

See the difference:

```
$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   80G  3.3G  97% /
[...]
$ sudo rm ...
$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   71G   13G  85% /
```