### PR TITLE
Inline remove wrap children in div

### DIFF
--- a/.changeset/quick-spies-grin.md
+++ b/.changeset/quick-spies-grin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Removed wrap children with div from Inline component

--- a/polaris-react/src/components/Inline/Inline.stories.tsx
+++ b/polaris-react/src/components/Inline/Inline.stories.tsx
@@ -33,7 +33,7 @@ export function AlignYCenter() {
 
 export function AlignYTop() {
   return (
-    <Inline alignY="top" spacing="1'>
+    <Inline alignY="top">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
@@ -44,7 +44,7 @@ export function AlignYTop() {
 
 export function AlignYBottom() {
   return (
-    <Inline alignY="bottom" spacing="1'>
+    <Inline alignY="bottom" spacing="1">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
@@ -55,7 +55,7 @@ export function AlignYBottom() {
 
 export function AlignYBaseline() {
   return (
-    <Inline alignY="baseline" spacing="1'>
+    <Inline alignY="baseline" spacing="1">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
@@ -77,7 +77,7 @@ export function AlignStart() {
 
 export function AlignCenter() {
   return (
-    <Inline align="center">
+    <Inline align="center" alignY="center">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
@@ -88,7 +88,7 @@ export function AlignCenter() {
 
 export function AlignEnd() {
   return (
-    <Inline align="end">
+    <Inline align="end" alignY="center">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>

--- a/polaris-react/src/components/Inline/Inline.stories.tsx
+++ b/polaris-react/src/components/Inline/Inline.stories.tsx
@@ -33,7 +33,7 @@ export function AlignYCenter() {
 
 export function AlignYTop() {
   return (
-    <Inline alignY="top">
+    <Inline alignY="top" spacing="1">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
@@ -66,7 +66,7 @@ export function AlignYBaseline() {
 
 export function AlignStart() {
   return (
-    <Inline align="start" alignY="center">
+    <Inline align="start" alignY="center" spacing="1">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
@@ -77,7 +77,7 @@ export function AlignStart() {
 
 export function AlignCenter() {
   return (
-    <Inline align="center" alignY="center">
+    <Inline align="center" alignY="center" spacing="1">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
@@ -88,7 +88,7 @@ export function AlignCenter() {
 
 export function AlignEnd() {
   return (
-    <Inline align="end" alignY="center">
+    <Inline align="end" alignY="center" spacing="1">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
@@ -99,7 +99,7 @@ export function AlignEnd() {
 
 export function AlignCenterAlignYCenter() {
   return (
-    <Inline align="center" alignY="center">
+    <Inline align="center" alignY="center" spacing="1">
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
@@ -110,7 +110,7 @@ export function AlignCenterAlignYCenter() {
 
 export function NonWrapping() {
   return (
-    <Inline wrap={false}>
+    <Inline wrap={false} spacing="1">
       <Badge>Paid</Badge>
       <Badge>Processing</Badge>
       <Badge>Fulfilled</Badge>
@@ -123,7 +123,9 @@ export function Spacing() {
   return (
     <Inline spacing="8">
       <Badge>Paid</Badge>
+      <Badge>Processing</Badge>
       <Badge>Fulfilled</Badge>
+      <Badge>Completed</Badge>
     </Inline>
   );
 }

--- a/polaris-react/src/components/Inline/Inline.stories.tsx
+++ b/polaris-react/src/components/Inline/Inline.stories.tsx
@@ -55,7 +55,7 @@ export function AlignYBottom() {
 
 export function AlignYBaseline() {
   return (
-    <Inline alignY="baseline">
+    <Inline alignY="baseline" spacing="1'>
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>

--- a/polaris-react/src/components/Inline/Inline.stories.tsx
+++ b/polaris-react/src/components/Inline/Inline.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Badge, Heading, Icon, Inline} from '@shopify/polaris';
-import {CapitalMajor} from '@shopify/polaris-icons';
+import {Box, Badge, Heading, Icon, Inline, Thumbnail} from '@shopify/polaris';
+import {CapitalMajor, ImageMajor} from '@shopify/polaris-icons';
 
 export default {
   component: Inline,
@@ -13,7 +13,9 @@ export function Default() {
       <Badge>One</Badge>
       <Badge>Two</Badge>
       <Badge>Three</Badge>
-      <Icon source={CapitalMajor} color="primary" />
+      <Box>
+        <Icon source={CapitalMajor} color="primary" />
+      </Box>
     </Inline>
   );
 }
@@ -21,10 +23,10 @@ export function Default() {
 export function AlignYCenter() {
   return (
     <Inline alignY="center" spacing="1">
+      <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
       <Badge>Three</Badge>
-      <Icon source={CapitalMajor} color="primary" />
     </Inline>
   );
 }
@@ -32,10 +34,10 @@ export function AlignYCenter() {
 export function AlignYTop() {
   return (
     <Inline alignY="top">
+      <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
       <Badge>Three</Badge>
-      <Icon source={CapitalMajor} color="primary" />
     </Inline>
   );
 }
@@ -43,10 +45,10 @@ export function AlignYTop() {
 export function AlignYBottom() {
   return (
     <Inline alignY="bottom">
+      <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
       <Badge>Three</Badge>
-      <Icon source={CapitalMajor} color="primary" />
     </Inline>
   );
 }
@@ -54,21 +56,21 @@ export function AlignYBottom() {
 export function AlignYBaseline() {
   return (
     <Inline alignY="baseline">
+      <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
       <Badge>Three</Badge>
-      <Icon source={CapitalMajor} color="primary" />
     </Inline>
   );
 }
 
 export function AlignStart() {
   return (
-    <Inline align="start">
+    <Inline align="start" alignY="center">
+      <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
       <Badge>Three</Badge>
-      <Icon source={CapitalMajor} color="primary" />
     </Inline>
   );
 }
@@ -76,10 +78,10 @@ export function AlignStart() {
 export function AlignCenter() {
   return (
     <Inline align="center">
+      <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
       <Badge>Three</Badge>
-      <Icon source={CapitalMajor} color="primary" />
     </Inline>
   );
 }
@@ -87,10 +89,10 @@ export function AlignCenter() {
 export function AlignEnd() {
   return (
     <Inline align="end">
+      <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
       <Badge>Three</Badge>
-      <Icon source={CapitalMajor} color="primary" />
     </Inline>
   );
 }
@@ -98,10 +100,10 @@ export function AlignEnd() {
 export function AlignCenterAlignYCenter() {
   return (
     <Inline align="center" alignY="center">
+      <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>
       <Badge>Three</Badge>
-      <Icon source={CapitalMajor} color="primary" />
     </Inline>
   );
 }
@@ -120,22 +122,6 @@ export function NonWrapping() {
 export function Spacing() {
   return (
     <Inline spacing="8">
-      <Badge>Paid</Badge>
-      <Badge>Fulfilled</Badge>
-    </Inline>
-  );
-}
-
-export function VerticalCentering() {
-  return (
-    <Inline alignY="center">
-      <Heading>
-        Order
-        <br />
-        #1136
-        <br />
-        was paid
-      </Heading>
       <Badge>Paid</Badge>
       <Badge>Fulfilled</Badge>
     </Inline>

--- a/polaris-react/src/components/Inline/Inline.stories.tsx
+++ b/polaris-react/src/components/Inline/Inline.stories.tsx
@@ -33,7 +33,7 @@ export function AlignYCenter() {
 
 export function AlignYTop() {
   return (
-    <Inline alignY="top">
+    <Inline alignY="top" spacing="1'>
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>

--- a/polaris-react/src/components/Inline/Inline.stories.tsx
+++ b/polaris-react/src/components/Inline/Inline.stories.tsx
@@ -44,7 +44,7 @@ export function AlignYTop() {
 
 export function AlignYBottom() {
   return (
-    <Inline alignY="bottom">
+    <Inline alignY="bottom" spacing="1'>
       <Thumbnail source={ImageMajor} alt="example" />
       <Badge>One</Badge>
       <Badge>Two</Badge>

--- a/polaris-react/src/components/Inline/Inline.tsx
+++ b/polaris-react/src/components/Inline/Inline.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import type {SpacingSpaceScale} from '@shopify/polaris-tokens';
 
-import {elementChildren} from '../../utilities/components';
-
 import styles from './Inline.scss';
 
 const AlignY = {
@@ -43,13 +41,9 @@ export const Inline = function Inline({
     '--pc-inline-spacing': `var(--p-space-${spacing})`,
   } as React.CSSProperties;
 
-  const itemMarkup = elementChildren(children).map((child, index) => {
-    return <div key={index}>{child}</div>;
-  });
-
   return (
     <div className={styles.Inline} style={style}>
-      {itemMarkup}
+      {children}
     </div>
   );
 };


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris/issues/7592

Reasons why we don't want to wrap children in div
- Unexpected layouts. Passing in an inline element gets renders in a block
- Performance. Looping over ever child element to wrap in an extra div can add up. This is also less performant on the client as it adds to the DOM
- Argo and other consumers have to do funky things to match this functionality cc @olavoasantos 

Expected vs unexpected layout:
![image](https://user-images.githubusercontent.com/6844391/199729692-098b5bc0-7617-4561-95e5-556a711883a8.png)
