### PR TITLE
Check for target component in Text migrations before modifying file

### DIFF
--- a/.changeset/rare-pandas-behave.md
+++ b/.changeset/rare-pandas-behave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-migrator': patch
+---
+
+Check for targeted component import before modifying in Text component migration

--- a/polaris-migrator/src/migrations/replace-text-component/steps/replace-display-text.ts
+++ b/polaris-migrator/src/migrations/replace-text-component/steps/replace-display-text.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../utilities/jsx';
 import {
   getImportSpecifierName,
+  hasImportSpecifier,
   normalizeImportSourcePaths,
   updateImports,
 } from '../../../utilities/imports';
@@ -35,6 +36,7 @@ export function replaceDisplayText<NodeType = ASTNode>(
   });
 
   if (!sourcePaths) return;
+  if (!hasImportSpecifier(j, source, 'DisplayText', sourcePaths.from)) return;
 
   const localElementName =
     getImportSpecifierName(j, source, 'DisplayText', sourcePaths.from) ||

--- a/polaris-migrator/src/migrations/replace-text-component/steps/replace-other.ts
+++ b/polaris-migrator/src/migrations/replace-text-component/steps/replace-other.ts
@@ -7,6 +7,7 @@ import {
   insertJSXAttribute,
 } from '../../../utilities/jsx';
 import {
+  hasImportSpecifier,
   getImportSpecifierName,
   normalizeImportSourcePaths,
   updateImports,
@@ -50,6 +51,7 @@ export function replaceOther<NodeType = ASTNode>(
     });
 
     if (!sourcePaths) return;
+    if (!hasImportSpecifier(j, source, componentName, sourcePaths.from)) return;
 
     const localElementName =
       getImportSpecifierName(j, source, componentName, sourcePaths.from) ||

--- a/polaris-migrator/src/migrations/replace-text-component/steps/replace-text-style.ts
+++ b/polaris-migrator/src/migrations/replace-text-component/steps/replace-text-style.ts
@@ -42,6 +42,7 @@ export function replaceTextStyle<NodeType = ASTNode>(
   });
 
   if (!sourcePaths) return;
+  if (!hasImportSpecifier(j, source, 'TextStyle', sourcePaths.from)) return;
 
   const localElementName =
     getImportSpecifierName(j, source, 'TextStyle', sourcePaths.from) ||


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The `Text` component import was being added to every file regardless if it was needed.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Only modify a file in the `replace-text-components` migration if the targeted deprecated components exist.