### PR TITLE
Bump size limit threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     {
       "name": "polaris-react-cjs",
       "path": "polaris-react/build/cjs/index.js",
-      "limit": "215 kB"
+      "limit": "216 kB"
     },
     {
       "name": "polaris-react-esm",


### PR DESCRIPTION
### WHY are these changes introduced?

We have a PR in progress to fix a recent update to `Scrollable` that's exceeding our size limit. Small bump to let the check pass.