### PR TITLE
Fix `Bleed` regressions

### DIFF
--- a/polaris-react/src/components/Banner/Banner.tsx
+++ b/polaris-react/src/components/Banner/Banner.tsx
@@ -174,7 +174,7 @@ export const Banner = forwardRef<BannerHandles, BannerProps>(function Banner(
           <Icon source={iconName} color={iconColor} />
         </Box>
 
-        <Bleed top="05">
+        <Bleed horizontal="0" top="05">
           {headingMarkup}
           {contentMarkup}
         </Bleed>

--- a/polaris-react/src/components/Bleed/Bleed.stories.tsx
+++ b/polaris-react/src/components/Bleed/Bleed.stories.tsx
@@ -34,7 +34,7 @@ export function Default() {
 export function WithVerticalDirection() {
   return (
     <Box background="surface" padding="4">
-      <Bleed vertical="6">
+      <Bleed horizontal="0" vertical="6">
         <div style={styles} />
       </Bleed>
     </Box>
@@ -54,7 +54,7 @@ export function WithHorizontalDirection() {
 export function WithSpecificDirection() {
   return (
     <Box background="surface" padding="4">
-      <Bleed top="6">
+      <Bleed horizontal="0" top="6">
         <div style={styles} />
       </Bleed>
     </Box>

--- a/polaris.shopify.com/pages/examples/bleed-specific-direction.tsx
+++ b/polaris.shopify.com/pages/examples/bleed-specific-direction.tsx
@@ -7,22 +7,22 @@ function BleedSpecificDirectionExample() {
   return (
     <AlphaStack spacing="6" fullWidth>
       <Box background="surface" border="base" padding="4">
-        <Bleed top="4">
+        <Bleed horizontal="0" top="4">
           <Placeholder label="Top" />
         </Bleed>
       </Box>
       <Box background="surface" border="base" padding="4">
-        <Bleed bottom="4">
+        <Bleed horizontal="0" bottom="4">
           <Placeholder label="Bottom" />
         </Bleed>
       </Box>
       <Box background="surface" border="base" padding="4">
-        <Bleed left="4">
+        <Bleed horizontal="0" left="4">
           <Placeholder label="Left" />
         </Bleed>
       </Box>
       <Box background="surface" border="base" padding="4">
-        <Bleed right="4">
+        <Bleed horizontal="0" right="4">
           <Placeholder label="Right" />
         </Bleed>
       </Box>

--- a/polaris.shopify.com/pages/examples/bleed-vertical.tsx
+++ b/polaris.shopify.com/pages/examples/bleed-vertical.tsx
@@ -6,7 +6,7 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 function BleedVerticalExample() {
   return (
     <Box background="surface" border="base" padding="4">
-      <Bleed vertical="4">
+      <Bleed horizontal="0" vertical="4">
         <Placeholder label="Vertical" />
       </Bleed>
     </Box>


### PR DESCRIPTION
I'm still of the opinion that our layout components should have some defaults and the ones we have on bleed may not be right but we need to use it in more places to figure out what those defaults should be.

For now, this fixes regressions to Banner that were introduced in https://github.com/Shopify/polaris/pull/7644