### PR TITLE
[IndexTable] Show IndexTable border when inside Tabs and Card

### DIFF
--- a/.changeset/violet-clouds-do.md
+++ b/.changeset/violet-clouds-do.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix border radius of IndexTable when nested in Tabs and Card

--- a/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.stories.tsx
@@ -11,6 +11,7 @@ import {
   TextField,
   Text,
   useIndexResourceState,
+  Tabs,
 } from '@shopify/polaris';
 
 export default {
@@ -1727,4 +1728,104 @@ export function SmallScreenWithAllOfItsElements() {
       return value === '' || value == null;
     }
   }
+}
+
+export function WithTabs() {
+  const customers = [
+    {
+      id: '3411',
+      url: 'customers/341',
+      name: 'Mae Jemison',
+      location: 'Decatur, USA',
+      orders: 20,
+      amountSpent: '$2,400',
+    },
+    {
+      id: '2561',
+      url: 'customers/256',
+      name: 'Ellen Ochoa',
+      location: 'Los Angeles, USA',
+      orders: 30,
+      amountSpent: '$140',
+    },
+  ];
+  const resourceName = {
+    singular: 'customer',
+    plural: 'customers',
+  };
+
+  const {selectedResources, allResourcesSelected, handleSelectionChange} =
+    useIndexResourceState(customers);
+
+  const rowMarkup = customers.map(
+    ({id, name, location, orders, amountSpent}, index) => (
+      <IndexTable.Row
+        id={id}
+        key={id}
+        selected={selectedResources.includes(id)}
+        position={index}
+      >
+        <IndexTable.Cell>
+          <Text variant="bodyMd" fontWeight="bold" as="span">
+            {name}
+          </Text>
+        </IndexTable.Cell>
+        <IndexTable.Cell>{location}</IndexTable.Cell>
+        <IndexTable.Cell>{orders}</IndexTable.Cell>
+        <IndexTable.Cell>{amountSpent}</IndexTable.Cell>
+      </IndexTable.Row>
+    ),
+  );
+
+  const [selected, setSelected] = useState(0);
+  const handleTabChange = useCallback(
+    (selectedTabIndex) => setSelected(selectedTabIndex),
+    [],
+  );
+  const tabs = [
+    {
+      id: 'all-customers-1',
+      content: 'All',
+      accessibilityLabel: 'All customers',
+      panelID: 'all-customers-content-1',
+    },
+    {
+      id: 'accepts-marketing-1',
+      content: 'Accepts marketing',
+      panelID: 'accepts-marketing-content-1',
+    },
+    {
+      id: 'repeat-customers-1',
+      content: 'Repeat customers',
+      panelID: 'repeat-customers-content-1',
+    },
+    {
+      id: 'prospects-1',
+      content: 'Prospects',
+      panelID: 'prospects-content-1',
+    },
+  ];
+
+  return (
+    <Card>
+      <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
+        <IndexTable
+          resourceName={resourceName}
+          itemCount={customers.length}
+          selectedItemsCount={
+            allResourcesSelected ? 'All' : selectedResources.length
+          }
+          onSelectionChange={handleSelectionChange}
+          headings={[
+            {title: 'Name'},
+            {title: 'Location'},
+            {title: 'Order count'},
+            {title: 'Amount spent'},
+          ]}
+        >
+          {rowMarkup}
+        </IndexTable>
+      </Tabs>
+    </Card>
+  );
 }

--- a/polaris-react/src/components/Tabs/Tabs.scss
+++ b/polaris-react/src/components/Tabs/Tabs.scss
@@ -145,8 +145,13 @@ $item-vertical-padding: $item-min-height * 0.5;
   display: flex;
 }
 
+.PanelWrapper {
+  border-radius: inherit;
+}
+
 .Panel {
   display: block;
+  border-radius: inherit;
 
   &:focus {
     outline: none;

--- a/polaris-react/src/components/Tabs/Tabs.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.tsx
@@ -152,7 +152,7 @@ class TabsInner extends PureComponent<CombinedProps, State> {
     );
 
     return (
-      <div>
+      <div className={styles.PanelWrapper}>
         <div className={styles.Wrapper}>
           <TabMeasurer
             tabToFocus={tabToFocus}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/7368 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

As described in the issue and reproduced in the [sample](https://codesandbox.io/s/nifty-dawn-5t4tec?file=/App.js), when `IndexTable` is wrapped in `Tabs` and `Card`:
```tsx
<Card>
  <Tabs ...>
    <IndexTable ... />
  </Tabs>
</Card>
```

The `IndexTable` has no bottom border radius. However, when not wrapped in the `Tabs` component it does. The underlying reason is that `IndexTable` only inherits its [border-radius from its parent](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/IndexTable/IndexTable.scss#L13).

So, even the following example, which is essentially what the `Tabs` component does, would lead to `IndexTable` not inheriting the `border-radius` property from `Card`:
```tsx
<Card>
  <div>
    <IndexTable ... />
  </div>
</Card>
```

### WHAT is this pull request doing?

To solve this, I have updated the `Tabs` component with `border-radius: inherit` properties for the components that wrap the `panel` component. That is transforming the last example to:
```tsx
<Card>
  <div style={{borderRadius: 'inherit'}}>
    <IndexTable ... />
  </div>
</Card>
```

I believe it's reasonable for the panel child of the `Tabs` component to inherit `border-radius` from the `Tabs` parent. Let me know if you think this is not the right way to approach this.

Before & after:
<div>
<img src="https://user-images.githubusercontent.com/9371695/202690290-5c4064ca-3d59-4afc-99a4-470a6df135ff.png" alt="Before image that has no border of IndexTable" />
<img src="https://user-images.githubusercontent.com/9371695/202690314-a90b8ce3-8caa-4498-bd5f-b4ae44328937.png" alt="After image that has a border of IndexTable" />
</div>

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

I've added another story in the storybook for `IndexTable` called `With Tabs`. I am not 100 % certain we want this as a story, so I can potentially remove it.

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<!--
<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>
-->

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
