### PR TITLE
Properly handle buttons with `aria-disabled` in focus helpers

### DIFF
--- a/.changeset/gentle-cobras-punch.md
+++ b/.changeset/gentle-cobras-punch.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Updates the focus helper functions to no longer treat buttons with `aria-disabled="disabled"` and `tabindex="-1" (but no`disabled` attribute) as focusable.
+Updated the focus helper functions to no longer treat buttons with `aria-disabled="disabled"` and `tabindex="-1" (but no`disabled` attribute) as focusable.

--- a/.changeset/gentle-cobras-punch.md
+++ b/.changeset/gentle-cobras-punch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updates the focus helper functions to no longer treat buttons with `aria-disabled="disabled"` and `tabindex="-1" (but no`disabled` attribute) as focusable.

--- a/polaris-react/src/utilities/focus.ts
+++ b/polaris-react/src/utilities/focus.ts
@@ -6,9 +6,9 @@ export type MouseUpBlurHandler = (
 ) => void;
 
 const FOCUSABLE_SELECTOR =
-  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([tabindex="-1"]),*[tabindex]';
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([aria-disabled]):not([tabindex="-1"]),*[tabindex]';
 const KEYBOARD_FOCUSABLE_SELECTORS =
-  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([tabindex="-1"]),*[tabindex]:not([tabindex="-1"])';
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([aria-disabled]):not([tabindex="-1"]),*[tabindex]:not([tabindex="-1"])';
 const MENUITEM_FOCUSABLE_SELECTORS =
   'a[role="menuitem"],frame[role="menuitem"],iframe[role="menuitem"],input[role="menuitem"]:not([type=hidden]):not(:disabled),select[role="menuitem"]:not(:disabled),textarea[role="menuitem"]:not(:disabled),button[role="menuitem"]:not(:disabled),*[tabindex]:not([tabindex="-1"])';
 export const handleMouseUpByBlurring: MouseUpBlurHandler = ({currentTarget}) =>

--- a/polaris-react/src/utilities/focus.ts
+++ b/polaris-react/src/utilities/focus.ts
@@ -6,9 +6,9 @@ export type MouseUpBlurHandler = (
 ) => void;
 
 const FOCUSABLE_SELECTOR =
-  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]';
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([tabindex="-1"]),*[tabindex]';
 const KEYBOARD_FOCUSABLE_SELECTORS =
-  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]:not([tabindex="-1"])';
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([tabindex="-1"]),*[tabindex]:not([tabindex="-1"])';
 const MENUITEM_FOCUSABLE_SELECTORS =
   'a[role="menuitem"],frame[role="menuitem"],iframe[role="menuitem"],input[role="menuitem"]:not([type=hidden]):not(:disabled),select[role="menuitem"]:not(:disabled),textarea[role="menuitem"]:not(:disabled),button[role="menuitem"]:not(:disabled),*[tabindex]:not([tabindex="-1"])';
 export const handleMouseUpByBlurring: MouseUpBlurHandler = ({currentTarget}) =>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #7728 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

Earlier this year, #6461 changed disabled buttons to use a combination of `aria-disabled="disabled"` and `tabindex="-1"` instead of the `disabled` attribute to make them more accessible for keyboard and screen reader users. This caused the focus-related helper functions in `focus.ts` to incorrectly identify disabled Polaris `<Button>` components as focusable, which in turn broke focus trapping (see #7728).

This PR updates a CSS query defined in `focus.ts` to exclude buttons with `tabindex="-1"` when querying focusable elements so that disabled Polaris buttons are no longer selected.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';

import {Button, Modal, Page, Stack, TextField} from '../src';

export function Playground() {
  const [isModalOpen, setIsModalOpen] = useState(false);

  function handleClose() {
    setIsModalOpen(false);
  }

  function noop() {}

  return (
    <Page title="Playground">
      <Button onClick={() => setIsModalOpen(true)}>Open modal</Button>
      <Button disabled>Disabled button</Button>

      <Modal
        open={isModalOpen}
        onClose={handleClose}
        title="Example modal"
        primaryAction={{
          content: 'Primary action',
          onAction: handleClose,
          disabled: true,
        }}
      >
        <Modal.Section>
          <Stack vertical>
            <p>Some content</p>
            <TextField
              onChange={noop}
              autoComplete=""
              label="Text field 1"
              value=""
            />
            <TextField
              onChange={noop}
              autoComplete=""
              label="Text field 2"
              value=""
            />
          </Stack>
        </Modal.Section>
      </Modal>
    </Page>
  );
}
```

</details>

1. Copy the above code into `Playground.tsx` and run `yarn dev`
2. Confirm that the changes in this PR fix #7728:
    1. Click "Open modal"
    2. Use the Tab key to cycle through focusable elements within the modal
    3. Confirm that focus wraps around to the beginning of the modal despite the primary action button being disabled

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
