### PR TITLE
[ResourceItem] Use layout components

### DIFF
--- a/.changeset/nine-worms-sip.md
+++ b/.changeset/nine-worms-sip.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Rebuilt `ResourceItem` with layout components

--- a/polaris-react/src/components/BulkActions/BulkActions.scss
+++ b/polaris-react/src/components/BulkActions/BulkActions.scss
@@ -90,7 +90,6 @@ $bulk-actions-button-stacking-order: (
 
 .CheckableContainer {
   flex: 1 1 0;
-  // margin-left: -6px;
   margin-left: calc(-1 * (var(--p-space-05) + var(--p-space-1)));
 }
 

--- a/polaris-react/src/components/BulkActions/BulkActions.scss
+++ b/polaris-react/src/components/BulkActions/BulkActions.scss
@@ -75,6 +75,7 @@ $bulk-actions-button-stacking-order: (
     width: auto;
     justify-content: flex-start;
     margin-right: var(--p-space-2);
+    margin-left: calc(-1 * var(--p-space-05));
   }
 
   .Group-measuring & {
@@ -89,6 +90,8 @@ $bulk-actions-button-stacking-order: (
 
 .CheckableContainer {
   flex: 1 1 0;
+  // margin-left: -6px;
+  margin-left: calc(-1 * (var(--p-space-05) + var(--p-space-1)));
 }
 
 .disabled {

--- a/polaris-react/src/components/ResourceItem/ResourceItem.scss
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.scss
@@ -17,31 +17,16 @@
   --pc-resource-item-offset: 40px;
   --pc-resource-item-clickable-stacking-order: 1;
   --pc-resource-item-content-stacking-order: 2;
-  position: relative;
   outline: none;
   cursor: pointer;
-
-  &:not(.persistActions) {
-    .Actions {
-      right: var(--p-space-4);
-    }
-  }
 
   &:hover {
     background-color: var(--p-surface-hovered);
 
-    &:not(.persistActions) {
-      // stylelint-disable-next-line selector-max-specificity
-      .Actions {
-        // stylelint-disable-next-line selector-max-specificity, selector-max-combinators, max-nesting-depth
-        > * {
-          @include action-unhide;
-        }
-
-        // stylelint-disable-next-line max-nesting-depth
-        @media #{$p-breakpoints-lg-down} {
-          display: none;
-        }
+    .Actions {
+      /* stylelint-disable-next-line selector-max-combinators */
+      > * {
+        @include action-unhide;
       }
     }
   }
@@ -108,49 +93,6 @@
       @include action-unhide;
     }
   }
-
-  @media #{$p-breakpoints-lg-down} {
-    display: none;
-  }
-}
-
-.persistActions {
-  .Actions {
-    position: relative;
-    display: flex;
-    flex: 0 0 auto;
-    flex-basis: auto;
-    align-items: center;
-    margin-top: 0;
-    margin-left: var(--p-space-4);
-    pointer-events: initial;
-    height: 100%;
-
-    @media #{$p-breakpoints-lg-down} {
-      display: none;
-    }
-  }
-}
-
-.Disclosure {
-  position: relative;
-  top: calc(-1 * var(--p-space-3));
-  right: calc(-1 * var(--p-space-4));
-  display: none;
-  width: var(--pc-resource-item-disclosure-width);
-  min-height: var(--pc-resource-item-min-height);
-  pointer-events: initial;
-
-  .selectMode & {
-    display: none;
-  }
-
-  @media #{$p-breakpoints-lg-down} {
-    display: flex;
-    flex: 0 0 var(--pc-resource-item-disclosure-width);
-    justify-content: center;
-    align-items: center;
-  }
 }
 
 .selected {
@@ -166,7 +108,6 @@
 }
 
 .ListItem {
-  position: relative;
   @include focus-ring($border-width: -1px);
 
   .ListItem + & {

--- a/polaris-react/src/components/ResourceItem/ResourceItem.scss
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.scss
@@ -98,13 +98,6 @@
 
 // Item actions
 .Actions {
-  // position: absolute;
-  // top: var(--p-space-4);
-  // right: var(--space-4);
-  // pointer-events: initial;
-  // height: 100%;
-  // max-height: 56px;
-
   > * {
     @include action-hide;
   }

--- a/polaris-react/src/components/ResourceItem/ResourceItem.scss
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.scss
@@ -13,8 +13,7 @@
 .ResourceItem {
   --pc-resource-item-min-height: 44px;
   --pc-resource-item-disclosure-width: 48px;
-  // Offset equals handle width + handle margin-left + handle margin-right
-  --pc-resource-item-offset: 40px;
+  --pc-resource-item-offset: 38px;
   --pc-resource-item-clickable-stacking-order: 1;
   --pc-resource-item-content-stacking-order: 2;
   outline: none;

--- a/polaris-react/src/components/ResourceItem/ResourceItem.scss
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.scss
@@ -1,19 +1,13 @@
 @import '../../styles/common';
 
 @mixin action-hide {
-  clip: rect(1px, 1px, 1px, 1px);
+  clip: rect(0, 0, 0, 0);
   overflow: hidden;
-  height: 1px;
 }
 
 @mixin action-unhide {
   clip: auto;
   overflow: visible;
-  height: 100%;
-}
-
-.CheckboxWrapper {
-  display: flex;
 }
 
 .ResourceItem {
@@ -39,7 +33,10 @@
     &:not(.persistActions) {
       // stylelint-disable-next-line selector-max-specificity
       .Actions {
-        @include action-unhide;
+        // stylelint-disable-next-line selector-max-specificity, selector-max-combinators, max-nesting-depth
+        > * {
+          @include action-unhide;
+        }
 
         // stylelint-disable-next-line max-nesting-depth
         @media #{$p-breakpoints-lg-down} {
@@ -82,67 +79,6 @@
   border: none;
 }
 
-// Item inner container
-.Container {
-  position: relative;
-  z-index: var(--pc-resource-item-content-stacking-order);
-  padding: var(--p-space-3) var(--p-space-4);
-  min-height: var(--pc-resource-item-min-height);
-  display: flex;
-  align-items: flex-start;
-
-  @media #{$p-breakpoints-sm-up} {
-    padding: var(--p-space-3) var(--p-space-5);
-  }
-}
-
-.alignmentLeading {
-  align-items: flex-start;
-}
-
-.alignmentTrailing {
-  align-items: flex-end;
-}
-
-.alignmentCenter {
-  align-items: center;
-}
-
-.alignmentFill {
-  align-items: stretch;
-}
-
-.alignmentBaseline {
-  align-items: baseline;
-}
-
-.Owned {
-  display: flex;
-}
-
-.OwnedNoMedia {
-  padding-top: var(--p-space-1);
-}
-
-// Item handle
-.Handle {
-  width: 48px;
-  min-height: var(--pc-resource-item-min-height);
-  justify-content: center;
-  align-items: center;
-  margin: calc(-1 * var(--p-space-3)) var(--p-space-1)
-    calc(-1 * var(--p-space-3)) calc(-1 * var(--p-space-3));
-  display: flex;
-
-  @media #{$p-breakpoints-sm-down} {
-    visibility: hidden;
-
-    .selectMode & {
-      visibility: visible;
-    }
-  }
-}
-
 .selectable {
   width: calc(100% + var(--pc-resource-item-offset));
   transform: translateX(calc(-1 * var(--pc-resource-item-offset)));
@@ -160,32 +96,24 @@
   }
 }
 
-.Media {
-  flex: 0 0 auto;
-  margin-right: var(--p-space-5);
-  color: inherit;
-  text-decoration: none;
-}
-
-// Item content
-.Content {
-  @include layout-flex-fix;
-  flex: 1 1 auto;
-}
-
 // Item actions
 .Actions {
-  position: absolute;
-  top: 0;
-  display: flex;
-  pointer-events: initial;
-  height: 100%;
-  max-height: 56px;
+  // position: absolute;
+  // top: var(--p-space-4);
+  // right: var(--space-4);
+  // pointer-events: initial;
+  // height: 100%;
+  // max-height: 56px;
 
-  @include action-hide;
+  > * {
+    @include action-hide;
+  }
 
   .focused & {
-    @include action-unhide;
+    // stylelint-disable-next-line selector-max-combinators
+    > * {
+      @include action-unhide;
+    }
   }
 
   @media #{$p-breakpoints-lg-down} {

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -295,14 +295,16 @@ class BaseResourceItem extends Component<CombinedProps, State> {
             gap="5"
           >
             {ownedMarkup}
-            <Box
-              width="100%"
-              padding="0"
-              paddingInlineStart="0"
-              paddingInlineEnd="0"
-            >
-              {children}
-            </Box>
+            <Inline blockAlign={getAlignment(verticalAlignment)}>
+              <Box
+                width="100%"
+                padding="0"
+                paddingInlineStart="0"
+                paddingInlineEnd="0"
+              >
+                {children}
+              </Box>
+            </Inline>
           </Columns>
           {actionsMarkup}
           {disclosureMarkup}

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -175,7 +175,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
         name || accessibilityLabel || i18n.translate('Polaris.Common.checkbox');
 
       handleMarkup = (
-        <div onClick={this.handleLargerSelectionArea}>
+        <div id="handle" onClick={this.handleLargerSelectionArea}>
           <Bleed marginInline="2">
             <Box
               paddingInlineStart="2"

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -4,6 +4,7 @@ import isEqual from 'react-fast-compare';
 
 import {ActionList} from '../ActionList';
 import {Box} from '../Box';
+import {Bleed} from '../Bleed';
 import {Button, buttonsFrom} from '../Button';
 import {ButtonGroup} from '../ButtonGroup';
 import {Checkbox} from '../Checkbox';
@@ -174,27 +175,29 @@ class BaseResourceItem extends Component<CombinedProps, State> {
         name || accessibilityLabel || i18n.translate('Polaris.Common.checkbox');
 
       handleMarkup = (
-        <Box
-          zIndex="var(--pc-resource-item-content-stacking-order)"
-          paddingInlineStart="0"
-          paddingInlineEnd="0"
-          paddingBlockStart="1"
-          paddingBlockEnd="0"
-        >
-          <div onClick={this.handleLargerSelectionArea}>
-            <div onClick={stopPropagation}>
-              <div onChange={this.handleLargerSelectionArea}>
-                <Checkbox
-                  id={this.checkboxId}
-                  label={checkboxAccessibilityLabel}
-                  labelHidden
-                  checked={selected}
-                  disabled={loading}
-                />
+        <div onClick={this.handleLargerSelectionArea}>
+          <Bleed marginBlock="2" marginInline="3">
+            <Box
+              zIndex="var(--pc-resource-item-content-stacking-order)"
+              paddingInlineStart="3"
+              paddingInlineEnd="3"
+              paddingBlockStart="3"
+              paddingBlockEnd="2"
+            >
+              <div onClick={stopPropagation}>
+                <div onChange={this.handleLargerSelectionArea}>
+                  <Checkbox
+                    id={this.checkboxId}
+                    label={checkboxAccessibilityLabel}
+                    labelHidden
+                    checked={selected}
+                    disabled={loading}
+                  />
+                </div>
               </div>
-            </div>
-          </div>
-        </Box>
+            </Box>
+          </Bleed>
+        </div>
       );
     }
 
@@ -287,11 +290,18 @@ class BaseResourceItem extends Component<CombinedProps, State> {
             blockAlign={
               media && selectable ? 'center' : getAlignment(verticalAlignment)
             }
-            gap="5"
+            gap="4"
             wrap={false}
           >
             {ownedMarkup}
-            <div>{children}</div>
+            <Box
+              width="100%"
+              padding="0"
+              paddingInlineStart="0"
+              paddingInlineEnd="0"
+            >
+              {children}
+            </Box>
           </Inline>
           {actionsMarkup}
           {disclosureMarkup}

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -175,7 +175,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
         name || accessibilityLabel || i18n.translate('Polaris.Common.checkbox');
 
       handleMarkup = (
-        <div id="handle" onClick={this.handleLargerSelectionArea}>
+        <div onClick={this.handleLargerSelectionArea}>
           <Bleed marginInline="2">
             <Box
               paddingInlineStart="2"

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -290,7 +290,10 @@ class BaseResourceItem extends Component<CombinedProps, State> {
         zIndex="var(--pc-resource-item-content-stacking-order)"
       >
         <Columns columns={{xs: '1fr auto'}} gap="0">
-          <Columns columns={{xs: media || selectable ? 'auto 1fr' : '1fr'}}>
+          <Columns
+            columns={{xs: media || selectable ? 'auto 1fr' : '1fr'}}
+            gap="5"
+          >
             {ownedMarkup}
             <Box
               width="100%"

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -203,10 +203,14 @@ class BaseResourceItem extends Component<CombinedProps, State> {
 
     if (media || selectable) {
       ownedMarkup = (
-        <>
+        <Inline
+          blockAlign={
+            media && selectable ? 'center' : getAlignment(verticalAlignment)
+          }
+        >
           {handleMarkup}
           {media}
-        </>
+        </Inline>
       );
     }
 
@@ -285,14 +289,8 @@ class BaseResourceItem extends Component<CombinedProps, State> {
         paddingInlineEnd={{xs: '4', sm: '5'}}
         zIndex="var(--pc-resource-item-content-stacking-order)"
       >
-        <Columns columns={{xs: '1fr auto auto auto'}} gap="0">
-          <Inline
-            blockAlign={
-              media && selectable ? 'center' : getAlignment(verticalAlignment)
-            }
-            gap="4"
-            wrap={false}
-          >
+        <Columns columns={{xs: '1fr auto'}} gap="0">
+          <Columns columns={{xs: media || selectable ? 'auto 1fr' : '1fr'}}>
             {ownedMarkup}
             <Box
               width="100%"
@@ -302,7 +300,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
             >
               {children}
             </Box>
-          </Inline>
+          </Columns>
           {actionsMarkup}
           {disclosureMarkup}
         </Columns>

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -3,7 +3,6 @@ import {HorizontalDotsMinor} from '@shopify/polaris-icons';
 import isEqual from 'react-fast-compare';
 
 import {ActionList} from '../ActionList';
-import {Bleed} from '../Bleed';
 import {Box} from '../Box';
 import {Button, buttonsFrom} from '../Button';
 import {ButtonGroup} from '../ButtonGroup';
@@ -175,44 +174,36 @@ class BaseResourceItem extends Component<CombinedProps, State> {
         name || accessibilityLabel || i18n.translate('Polaris.Common.checkbox');
 
       handleMarkup = (
-        <div onClick={this.handleLargerSelectionArea}>
-          <Bleed marginInline="2">
-            <Box
-              paddingInlineStart="2"
-              paddingInlineEnd="2"
-              minHeight="var(--pc-resource-item-min-height)"
-            >
-              <Inline align="center" blockAlign="center" gap="0">
-                <div onClick={stopPropagation}>
-                  <div onChange={this.handleLargerSelectionArea}>
-                    <Checkbox
-                      id={this.checkboxId}
-                      label={checkboxAccessibilityLabel}
-                      labelHidden
-                      checked={selected}
-                      disabled={loading}
-                    />
-                  </div>
-                </div>
-              </Inline>
-            </Box>
-          </Bleed>
-        </div>
+        <Box
+          zIndex="var(--pc-resource-item-content-stacking-order)"
+          paddingInlineStart="0"
+          paddingInlineEnd="0"
+          paddingBlockStart="1"
+          paddingBlockEnd="0"
+        >
+          <div onClick={this.handleLargerSelectionArea}>
+            <div onClick={stopPropagation}>
+              <div onChange={this.handleLargerSelectionArea}>
+                <Checkbox
+                  id={this.checkboxId}
+                  label={checkboxAccessibilityLabel}
+                  labelHidden
+                  checked={selected}
+                  disabled={loading}
+                />
+              </div>
+            </div>
+          </div>
+        </Box>
       );
     }
 
     if (media || selectable) {
       ownedMarkup = (
-        <Box
-          padding="0"
-          paddingInlineStart="0"
-          paddingInlineEnd="0"
-          paddingBlockStart={!media ? '1' : undefined}
-          zIndex="var(--pc-resource-item-content-stacking-order)"
-        >
+        <>
           {handleMarkup}
           {media}
-        </Box>
+        </>
       );
     }
 
@@ -293,7 +284,9 @@ class BaseResourceItem extends Component<CombinedProps, State> {
       >
         <Columns columns={{xs: '1fr auto auto auto'}} gap="0">
           <Inline
-            blockAlign={getAlignment(verticalAlignment)}
+            blockAlign={
+              media && selectable ? 'center' : getAlignment(verticalAlignment)
+            }
             gap="5"
             wrap={false}
           >

--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -15,10 +15,6 @@ import type {ThumbnailProps} from '../Thumbnail';
 import type {DisableableAction} from '../../types';
 import {classNames} from '../../utilities/css';
 import {globalIdGeneratorFactory} from '../../utilities/unique-id';
-import {
-  useBreakpoints,
-  BreakpointsDirectionAlias,
-} from '../../utilities/breakpoints';
 import {useI18n} from '../../utilities/i18n';
 import {
   ResourceListContext,
@@ -76,12 +72,8 @@ interface PropsWithClick extends BaseProps {
 }
 
 export type ResourceItemProps = PropsWithUrl | PropsWithClick;
-type BreakpointsMatches = {
-  [DirectionAlias in BreakpointsDirectionAlias]: boolean;
-};
 
 interface PropsFromWrapper {
-  breakpoints?: BreakpointsMatches;
   context: React.ContextType<typeof ResourceListContext>;
   i18n: ReturnType<typeof useI18n>;
 }
@@ -163,7 +155,6 @@ class BaseResourceItem extends Component<CombinedProps, State> {
       i18n,
       verticalAlignment,
       dataHref,
-      breakpoints,
     } = this.props;
 
     const {actionsMenuVisible, focused, focusedInner, selected} = this.state;
@@ -179,7 +170,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
 
       handleMarkup = (
         <div onClick={this.handleLargerSelectionArea}>
-          <Bleed horizontal="2">
+          <Bleed marginInline="2">
             <Box
               paddingInlineStart="2"
               paddingInlineEnd="2"
@@ -273,7 +264,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
       } else {
         actionsMarkup = (
           <div className={styles.Actions} onClick={stopPropagation}>
-            <Box position="absolute" top="4" right="4">
+            <Box position="absolute" insetBlockStart="4" insetInlineEnd="4">
               <ButtonGroup segmented>
                 {buttonsFrom(shortcutActions, {size: 'slim'})}
               </ButtonGroup>
@@ -483,11 +474,9 @@ function isSelected(id: string, selectedItems?: ResourceListSelectedItems) {
 }
 
 export function ResourceItem(props: ResourceItemProps) {
-  const breakpoints = useBreakpoints();
   return (
     <BaseResourceItem
       {...props}
-      breakpoints={breakpoints}
       context={useContext(ResourceListContext)}
       i18n={useI18n()}
     />

--- a/polaris-react/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/polaris-react/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -411,7 +411,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper.findAll('div')[6]!.trigger('onClick', {
+      wrapper.findAll('div')[5]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
@@ -426,7 +426,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper.findAll('div')[6]!.trigger('onClick', {
+      wrapper.findAll('div')[5]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: false},
       });

--- a/polaris-react/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/polaris-react/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -1,10 +1,13 @@
 import React, {AllHTMLAttributes} from 'react';
 import {mountWithApp} from 'tests/utilities';
+import {matchMedia} from '@shopify/jest-dom-mocks';
+import {setMediaWidth} from 'tests/utilities/breakpoints';
 
 import {Avatar} from '../../Avatar';
 import {Button} from '../../Button';
 import {ButtonGroup} from '../../ButtonGroup';
 import {Checkbox} from '../../Checkbox';
+import {Inline} from '../../Inline';
 import {Thumbnail} from '../../Thumbnail';
 import {UnstyledLink} from '../../UnstyledLink';
 import {ResourceItem} from '../ResourceItem';
@@ -17,10 +20,12 @@ describe('<ResourceItem />', () => {
   beforeEach(() => {
     spy = jest.spyOn(window, 'open');
     spy.mockImplementation(() => {});
+    matchMedia.mock();
   });
 
   afterEach(() => {
     spy.mockRestore();
+    matchMedia.restore();
   });
 
   const mockDefaultContext = {
@@ -126,6 +131,7 @@ describe('<ResourceItem />', () => {
     });
 
     it('is used on the disclosure action menu when there are persistent actions', () => {
+      setMediaWidth('breakpoints-lg');
       const item = mountWithApp(
         <ResourceListContext.Provider value={mockSelectableContext}>
           <ResourceItem
@@ -405,7 +411,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper.find('div', {className: styles.Handle})!.trigger('onClick', {
+      wrapper.find('div', {id: 'handle'})!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
@@ -420,7 +426,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper.find('div', {className: styles.Handle})!.trigger('onClick', {
+      wrapper.find('div', {id: 'handle'})!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: false},
       });
@@ -545,8 +551,7 @@ describe('<ResourceItem />', () => {
           <ResourceItem id={itemId} url={url} media={<Avatar customer />} />
         </ResourceListContext.Provider>,
       );
-      const media = wrapper.find('div', {className: styles.Media});
-      expect(media).toContainReactComponent(Avatar);
+      expect(wrapper).toContainReactComponent(Avatar);
     });
 
     it('includes a <Thumbnail /> if one is provided', () => {
@@ -559,8 +564,7 @@ describe('<ResourceItem />', () => {
           />
         </ResourceListContext.Provider>,
       );
-      const media = wrapper.find('div', {className: styles.Media});
-      expect(media).toContainReactComponent(Thumbnail);
+      expect(wrapper).toContainReactComponent(Thumbnail);
     });
   });
 
@@ -576,7 +580,8 @@ describe('<ResourceItem />', () => {
       });
     });
 
-    it('renders shortcut actions when some are provided', () => {
+    it('renders shortcut actions when some are provided and viewport is lgUp', () => {
+      setMediaWidth('breakpoints-lg');
       const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
@@ -591,7 +596,8 @@ describe('<ResourceItem />', () => {
       });
     });
 
-    it('renders persistent shortcut actions if persistActions is true', () => {
+    it('renders persistent shortcut actions if persistActions is true and viewport is lgUp', () => {
+      setMediaWidth('breakpoints-lg');
       const wrapper = mountWithApp(
         <ResourceListContext.Provider value={mockDefaultContext}>
           <ResourceItem
@@ -679,9 +685,7 @@ describe('<ResourceItem />', () => {
     it('renders with default flex-start alignment if not provided', () => {
       const resourceItem = mountWithApp(<ResourceItem id={itemId} url={url} />);
 
-      expect(resourceItem).toContainReactComponent('div', {
-        className: 'Container',
-      });
+      expect(resourceItem).toContainReactComponent(Inline);
     });
 
     it('renders with leading vertical alignment', () => {
@@ -689,8 +693,8 @@ describe('<ResourceItem />', () => {
         <ResourceItem id={itemId} url={url} verticalAlignment="leading" />,
       );
 
-      expect(resourceItem).toContainReactComponent('div', {
-        className: 'Container alignmentLeading',
+      expect(resourceItem).toContainReactComponent(Inline, {
+        blockAlign: 'start',
       });
     });
 
@@ -699,8 +703,8 @@ describe('<ResourceItem />', () => {
         <ResourceItem id={itemId} url={url} verticalAlignment="center" />,
       );
 
-      expect(resourceItem).toContainReactComponent('div', {
-        className: 'Container alignmentCenter',
+      expect(resourceItem).toContainReactComponent(Inline, {
+        blockAlign: 'center',
       });
     });
 
@@ -709,8 +713,8 @@ describe('<ResourceItem />', () => {
         <ResourceItem id={itemId} url={url} verticalAlignment="trailing" />,
       );
 
-      expect(resourceItem).toContainReactComponent('div', {
-        className: 'Container alignmentTrailing',
+      expect(resourceItem).toContainReactComponent(Inline, {
+        blockAlign: 'end',
       });
     });
 
@@ -719,8 +723,8 @@ describe('<ResourceItem />', () => {
         <ResourceItem id={itemId} url={url} verticalAlignment="fill" />,
       );
 
-      expect(resourceItem).toContainReactComponent('div', {
-        className: 'Container alignmentFill',
+      expect(resourceItem).toContainReactComponent(Inline, {
+        blockAlign: 'stretch',
       });
     });
 
@@ -729,8 +733,8 @@ describe('<ResourceItem />', () => {
         <ResourceItem id={itemId} url={url} verticalAlignment="baseline" />,
       );
 
-      expect(resourceItem).toContainReactComponent('div', {
-        className: 'Container alignmentBaseline',
+      expect(resourceItem).toContainReactComponent(Inline, {
+        blockAlign: 'baseline',
       });
     });
   });

--- a/polaris-react/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/polaris-react/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -411,7 +411,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper.findAll('div')[5]!.trigger('onClick', {
+      wrapper.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
@@ -426,7 +426,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper.findAll('div')[5]!.trigger('onClick', {
+      wrapper.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: false},
       });

--- a/polaris-react/src/components/ResourceItem/tests/ResourceItem.test.tsx
+++ b/polaris-react/src/components/ResourceItem/tests/ResourceItem.test.tsx
@@ -411,7 +411,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper.find('div', {id: 'handle'})!.trigger('onClick', {
+      wrapper.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
@@ -426,7 +426,7 @@ describe('<ResourceItem />', () => {
         </ResourceListContext.Provider>,
       );
 
-      wrapper.find('div', {id: 'handle'})!.trigger('onClick', {
+      wrapper.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: false},
       });

--- a/polaris-react/src/components/ResourceList/ResourceList.scss
+++ b/polaris-react/src/components/ResourceList/ResourceList.scss
@@ -167,7 +167,6 @@ $breakpoints-empty-search-results-height-up: '(min-height: #{breakpoint(600px)})
 
 .CheckableButtonWrapper {
   display: none;
-  // margin-left: -2px;
   margin-left: calc(-1 * var(--p-space-05));
 
   @media #{$p-breakpoints-sm-up} {

--- a/polaris-react/src/components/ResourceList/ResourceList.scss
+++ b/polaris-react/src/components/ResourceList/ResourceList.scss
@@ -167,6 +167,8 @@ $breakpoints-empty-search-results-height-up: '(min-height: #{breakpoint(600px)})
 
 .CheckableButtonWrapper {
   display: none;
+  // margin-left: -2px;
+  margin-left: calc(-1 * var(--p-space-05));
 
   @media #{$p-breakpoints-sm-up} {
     flex: 1;

--- a/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -352,7 +352,7 @@ describe('<ResourceList />', () => {
       );
       const resourceItem = resourceList.find(ResourceItem);
 
-      resourceItem!.findAll('div')[5]!.trigger('onClick', {
+      resourceItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
@@ -1071,13 +1071,13 @@ describe('<ResourceList />', () => {
         />,
       );
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.findAll('div')[5]!.trigger('onClick', {
+      firstItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.findAll('div')[5]!.trigger('onClick', {
+      lastItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
@@ -1096,13 +1096,13 @@ describe('<ResourceList />', () => {
         />,
       );
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.findAll('div')[5]!.trigger('onClick', {
+      firstItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.findAll('div')[5]!.trigger('onClick', {
+      lastItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
@@ -1140,13 +1140,13 @@ describe('<ResourceList />', () => {
         />,
       );
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.findAll('div')[5]!.trigger('onClick', {
+      firstItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.findAll('div')[5]!.trigger('onClick', {
+      lastItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
@@ -1172,13 +1172,13 @@ describe('<ResourceList />', () => {
       );
       // Sets {lastSelected: 0}
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.findAll('div')[5]!.trigger('onClick', {
+      firstItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.findAll('div')[5]!.trigger('onClick', {
+      lastItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });

--- a/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {mountWithApp} from 'tests/utilities';
+import {matchMedia} from '@shopify/jest-dom-mocks';
 
+// import {setMediaWidth} from 'tests/utilities/breakpoints';
 import {BulkActions} from '../../BulkActions';
 import {Button} from '../../Button';
 import {CheckableButton} from '../../CheckableButton';
@@ -45,6 +47,14 @@ const alternateTool = <div id="AlternateTool">Alternate Tool</div>;
 const defaultWindowWidth = window.innerWidth;
 
 describe('<ResourceList />', () => {
+  beforeEach(() => {
+    matchMedia.mock();
+  });
+
+  afterEach(() => {
+    matchMedia.restore();
+  });
+
   describe('renderItem', () => {
     it('renders list items', () => {
       const resourceList = mountWithApp(
@@ -340,7 +350,7 @@ describe('<ResourceList />', () => {
           onSelectionChange={onSelectionChange}
         />,
       );
-      resourceList.find('div', {className: styles.Handle})!.trigger('onClick', {
+      resourceList.find('div', {id: 'handle'})!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
@@ -1059,13 +1069,13 @@ describe('<ResourceList />', () => {
         />,
       );
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+      firstItem!.find('div', {id: 'handle'})!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+      lastItem!.find('div', {id: 'handle'})!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
@@ -1084,13 +1094,13 @@ describe('<ResourceList />', () => {
         />,
       );
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+      firstItem!.find('div', {id: 'handle'})!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+      lastItem!.find('div', {id: 'handle'})!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
@@ -1128,13 +1138,13 @@ describe('<ResourceList />', () => {
         />,
       );
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+      firstItem!.find('div', {id: 'handle'})!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+      lastItem!.find('div', {id: 'handle'})!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
@@ -1160,13 +1170,13 @@ describe('<ResourceList />', () => {
       );
       // Sets {lastSelected: 0}
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+      firstItem!.find('div', {id: 'handle'})!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.find('div', {className: styles.Handle})!.trigger('onClick', {
+      lastItem!.find('div', {id: 'handle'})!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });

--- a/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 
-// import {setMediaWidth} from 'tests/utilities/breakpoints';
 import {BulkActions} from '../../BulkActions';
 import {Button} from '../../Button';
 import {CheckableButton} from '../../CheckableButton';

--- a/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -352,7 +352,7 @@ describe('<ResourceList />', () => {
       );
       const resourceItem = resourceList.find(ResourceItem);
 
-      resourceItem!.findAll('div')[6]!.trigger('onClick', {
+      resourceItem!.findAll('div')[5]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
@@ -1071,13 +1071,13 @@ describe('<ResourceList />', () => {
         />,
       );
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.findAll('div')[6]!.trigger('onClick', {
+      firstItem!.findAll('div')[5]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.findAll('div')[6]!.trigger('onClick', {
+      lastItem!.findAll('div')[5]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
@@ -1096,13 +1096,13 @@ describe('<ResourceList />', () => {
         />,
       );
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.findAll('div')[6]!.trigger('onClick', {
+      firstItem!.findAll('div')[5]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.findAll('div')[6]!.trigger('onClick', {
+      lastItem!.findAll('div')[5]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
@@ -1140,13 +1140,13 @@ describe('<ResourceList />', () => {
         />,
       );
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.findAll('div')[6]!.trigger('onClick', {
+      firstItem!.findAll('div')[5]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.findAll('div')[6]!.trigger('onClick', {
+      lastItem!.findAll('div')[5]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
@@ -1172,13 +1172,13 @@ describe('<ResourceList />', () => {
       );
       // Sets {lastSelected: 0}
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.findAll('div')[6]!.trigger('onClick', {
+      firstItem!.findAll('div')[5]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.findAll('div')[6]!.trigger('onClick', {
+      lastItem!.findAll('div')[5]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });

--- a/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -350,7 +350,9 @@ describe('<ResourceList />', () => {
           onSelectionChange={onSelectionChange}
         />,
       );
-      resourceList.findAll('div')[6]!.trigger('onClick', {
+      const resourceItem = resourceList.find(ResourceItem);
+
+      resourceItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });

--- a/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
+++ b/polaris-react/src/components/ResourceList/tests/ResourceList.test.tsx
@@ -350,7 +350,7 @@ describe('<ResourceList />', () => {
           onSelectionChange={onSelectionChange}
         />,
       );
-      resourceList.find('div', {id: 'handle'})!.trigger('onClick', {
+      resourceList.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
@@ -1069,13 +1069,13 @@ describe('<ResourceList />', () => {
         />,
       );
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.find('div', {id: 'handle'})!.trigger('onClick', {
+      firstItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.find('div', {id: 'handle'})!.trigger('onClick', {
+      lastItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
@@ -1094,13 +1094,13 @@ describe('<ResourceList />', () => {
         />,
       );
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.find('div', {id: 'handle'})!.trigger('onClick', {
+      firstItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.find('div', {id: 'handle'})!.trigger('onClick', {
+      lastItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
@@ -1138,13 +1138,13 @@ describe('<ResourceList />', () => {
         />,
       );
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.find('div', {id: 'handle'})!.trigger('onClick', {
+      firstItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.find('div', {id: 'handle'})!.trigger('onClick', {
+      lastItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });
@@ -1170,13 +1170,13 @@ describe('<ResourceList />', () => {
       );
       // Sets {lastSelected: 0}
       const firstItem = resourceList.find(ResourceItem);
-      firstItem!.find('div', {id: 'handle'})!.trigger('onClick', {
+      firstItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {},
       });
       const allItems = resourceList.findAll(ResourceItem);
       const lastItem = allItems[allItems.length - 1];
-      lastItem!.find('div', {id: 'handle'})!.trigger('onClick', {
+      lastItem!.findAll('div')[6]!.trigger('onClick', {
         stopPropagation: () => {},
         nativeEvent: {shiftKey: true},
       });


### PR DESCRIPTION
Closes: https://github.com/Shopify/polaris/issues/7580

This slightly moves the checkbox handle 2px to the left. This means it now lines up with our 20px padding instead of 22px from the card edge. Also improves vertical alignment of the checkboxes and bulk select on xs screens

Before | After
---|---
![image](https://screenshot.click/24-12-z59dz-bpdqu.png) | ![image](https://screenshot.click/24-12-viiqs-efiaf.png)

The only CSS that remains is for interactive elements, interactive behavior (hover, focus), and transitions (which are being removed in https://github.com/Shopify/polaris/pull/7290/files). 