### PR TITLE
[IndexTable.Row] Add new useRowFocused hook

### DIFF
--- a/.changeset/gorgeous-wasps-jog.md
+++ b/.changeset/gorgeous-wasps-jog.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add new useIndexTableRowFocused hook

--- a/polaris-react/src/components/IndexTable/components/Row/Row.tsx
+++ b/polaris-react/src/components/IndexTable/components/Row/Row.tsx
@@ -8,7 +8,11 @@ import {
 } from '../../../../utilities/index-provider';
 import {Checkbox} from '../Checkbox';
 import {classNames, variationName} from '../../../../utilities/css';
-import {RowContext, RowHoveredContext} from '../../../../utilities/index-table';
+import {
+  RowContext,
+  RowHoveredContext,
+  RowFocusedContext,
+} from '../../../../utilities/index-table';
 import styles from '../../IndexTable.scss';
 
 type RowStatus = 'success' | 'subdued';
@@ -43,6 +47,11 @@ export const Row = memo(function Row({
     value: hovered,
     setTrue: setHoverIn,
     setFalse: setHoverOut,
+  } = useToggle(false);
+  const {
+    value: focused,
+    setTrue: setFocused,
+    setFalse: setBlurred,
   } = useToggle(false);
 
   const handleInteraction = useCallback(
@@ -146,17 +155,21 @@ export const Row = memo(function Row({
   return (
     <RowContext.Provider value={contextValue}>
       <RowHoveredContext.Provider value={hovered}>
-        <RowWrapper
-          key={id}
-          className={rowClassName}
-          onMouseEnter={setHoverIn}
-          onMouseLeave={setHoverOut}
-          onClick={handleRowClick}
-          ref={tableRowCallbackRef}
-        >
-          {checkboxMarkup}
-          {children}
-        </RowWrapper>
+        <RowFocusedContext.Provider value={focused}>
+          <RowWrapper
+            key={id}
+            className={rowClassName}
+            onMouseEnter={setHoverIn}
+            onMouseLeave={setHoverOut}
+            onClick={handleRowClick}
+            onFocus={setFocused}
+            onBlur={setBlurred}
+            ref={tableRowCallbackRef}
+          >
+            {checkboxMarkup}
+            {children}
+          </RowWrapper>
+        </RowFocusedContext.Provider>
       </RowHoveredContext.Provider>
     </RowContext.Provider>
   );

--- a/polaris-react/src/index.ts
+++ b/polaris-react/src/index.ts
@@ -425,6 +425,7 @@ export {useEventListener} from './utilities/use-event-listener';
 export {useIndexResourceState} from './utilities/use-index-resource-state';
 export {
   useRowHovered as useIndexTableRowHovered,
+  useRowFocused as useIndexTableRowFocused,
   useRowSelected as useIndexTableRowSelected,
   useContainerScroll as useIndexTableContainerScroll,
 } from './utilities/index-table';

--- a/polaris-react/src/utilities/index-table/context.ts
+++ b/polaris-react/src/utilities/index-table/context.ts
@@ -12,6 +12,8 @@ export const RowContext = createContext<RowContextType>({});
 
 export const RowHoveredContext = createContext<boolean | undefined>(undefined);
 
+export const RowFocusedContext = createContext<boolean | undefined>(undefined);
+
 export interface ScrollContextType {
   scrollableContainer: HTMLDivElement | null;
   canScrollLeft: boolean;

--- a/polaris-react/src/utilities/index-table/hooks.ts
+++ b/polaris-react/src/utilities/index-table/hooks.ts
@@ -1,10 +1,20 @@
 import {useContext} from 'react';
 
-import {RowContext, RowHoveredContext, ScrollContext} from './context';
+import {
+  RowContext,
+  RowHoveredContext,
+  RowFocusedContext,
+  ScrollContext,
+} from './context';
 
 export function useRowHovered() {
   const hovered = useContext(RowHoveredContext);
   return hovered;
+}
+
+export function useRowFocused() {
+  const focused = useContext(RowFocusedContext);
+  return focused;
 }
 
 export function useRowSelected() {

--- a/polaris-react/src/utilities/index-table/tests/hooks-useRowFocused.test.tsx
+++ b/polaris-react/src/utilities/index-table/tests/hooks-useRowFocused.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {mountWithApp} from 'tests/utilities';
+
+// eslint-disable-next-line @shopify/strict-component-boundaries
+import {IndexTable, IndexTableProps} from '../../../components/IndexTable';
+import {useRowFocused} from '../hooks';
+
+function Component() {
+  const focused = useRowFocused();
+  const content = focused ? 'In' : 'Out';
+
+  return <td>{content}</td>;
+}
+
+const defaultIndexTableProps: IndexTableProps = {
+  itemCount: 1,
+  selectedItemsCount: 0,
+  onSelectionChange: () => {},
+  headings: [{title: 'Heading one'}, {title: 'Heading two'}],
+};
+
+describe('useRowFocused', () => {
+  describe('when selected', () => {
+    it('returns true when the Row is focused', () => {
+      const component = mountWithApp(
+        <IndexTable {...defaultIndexTableProps}>
+          <IndexTable.Row id="id" selected position={1}>
+            <Component />
+          </IndexTable.Row>
+        </IndexTable>,
+      );
+
+      component.findAll('tr')[1]!.trigger('onFocus');
+
+      expect(component).toContainReactText('In');
+    });
+
+    it('returns false when the Row is not focused', () => {
+      const component = mountWithApp(
+        <IndexTable {...defaultIndexTableProps}>
+          <IndexTable.Row id="id" selected position={1}>
+            <Component />
+          </IndexTable.Row>
+        </IndexTable>,
+      );
+
+      component.findAll('tr')[1]!.trigger('onBlur');
+
+      expect(component).toContainReactText('Out');
+    });
+  });
+
+  describe('when unselected', () => {
+    it('returns true when the Row is focused', () => {
+      const component = mountWithApp(
+        <IndexTable {...defaultIndexTableProps}>
+          <IndexTable.Row id="id" position={1}>
+            <Component />
+          </IndexTable.Row>
+        </IndexTable>,
+      );
+
+      component.findAll('tr')[1]!.trigger('onFocus');
+
+      expect(component).toContainReactText('In');
+    });
+
+    it('returns false when the Row is not focused', () => {
+      const component = mountWithApp(
+        <IndexTable {...defaultIndexTableProps}>
+          <IndexTable.Row id="id" position={1}>
+            <Component />
+          </IndexTable.Row>
+        </IndexTable>,
+      );
+
+      component.findAll('tr')[1]!.trigger('onBlur');
+
+      expect(component).toContainReactText('Out');
+    });
+  });
+});


### PR DESCRIPTION
### WHY are these changes introduced?

This update to add an additional hook regarding the Row component have been introduced to better support accessibility initiatives for content within IndexTables. We have the `useRowHovered` hook which allows cells to react to merchants hovering rows, but we should also support merchants focusing in to Rows for those that navigate primarily through the keyboard.


### WHAT is this pull request doing?

Introduces a new `useRowFocused` hook, exported as `useIndexTableRowFocused`, which changes using `onBlur` and `onFocus` handlers.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
