### PR TITLE
[SkeletonPage] Rebuild with layout primitives

### DIFF
--- a/.changeset/strong-bottles-swim.md
+++ b/.changeset/strong-bottles-swim.md
@@ -3,3 +3,5 @@
 ---
 
 Refactored `SkeletonPage` to use primitive Layout components
+Removed `max-width: 100%` from AlphaStack
+Added `narrowWidth` and `fullWidth` examples to AlphaStack stories

--- a/.changeset/strong-bottles-swim.md
+++ b/.changeset/strong-bottles-swim.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Refactored `SkeletonPage` to use primitive Layout components

--- a/.changeset/strong-bottles-swim.md
+++ b/.changeset/strong-bottles-swim.md
@@ -1,7 +1,7 @@
 ---
-'@shopify/polaris': patch
+'@shopify/polaris': minor
 ---
 
 Refactored `SkeletonPage` to use primitive Layout components
-Removed `max-width: 100%` from AlphaStack
-Added `narrowWidth` and `fullWidth` examples to AlphaStack stories
+Removed `max-width` on children in `AlphaStack`
+Added `narrowWidth` and `fullWidth` examples to `AlphaStack` stories

--- a/polaris-react/playground/Playground.tsx
+++ b/polaris-react/playground/Playground.tsx
@@ -1,63 +1,11 @@
 import React from 'react';
 
-import {
-  Card,
-  Layout,
-  Page,
-  SkeletonBodyText,
-  SkeletonDisplayText,
-  SkeletonPage,
-  TextContainer,
-} from '../src';
+import {Page} from '../src';
 
 export function Playground() {
   return (
     <Page title="Playground">
-      <SkeletonPage primaryAction narrowWidth>
-        <Layout>
-          <Layout.Section>
-            <Card sectioned>
-              <SkeletonBodyText />
-            </Card>
-            <Card sectioned>
-              <TextContainer>
-                <SkeletonDisplayText size="small" />
-                <SkeletonBodyText />
-              </TextContainer>
-            </Card>
-            <Card sectioned>
-              <TextContainer>
-                <SkeletonDisplayText size="small" />
-                <SkeletonBodyText />
-              </TextContainer>
-            </Card>
-          </Layout.Section>
-          <Layout.Section secondary>
-            <Card>
-              <Card.Section>
-                <TextContainer>
-                  <SkeletonDisplayText size="small" />
-                  <SkeletonBodyText lines={2} />
-                </TextContainer>
-              </Card.Section>
-              <Card.Section>
-                <SkeletonBodyText lines={1} />
-              </Card.Section>
-            </Card>
-            <Card subdued>
-              <Card.Section>
-                <TextContainer>
-                  <SkeletonDisplayText size="small" />
-                  <SkeletonBodyText lines={2} />
-                </TextContainer>
-              </Card.Section>
-              <Card.Section>
-                <SkeletonBodyText lines={2} />
-              </Card.Section>
-            </Card>
-          </Layout.Section>
-        </Layout>
-      </SkeletonPage>
+      {/* Add the code you want to test in here */}
     </Page>
   );
 }

--- a/polaris-react/playground/Playground.tsx
+++ b/polaris-react/playground/Playground.tsx
@@ -1,11 +1,63 @@
 import React from 'react';
 
-import {Page} from '../src';
+import {
+  Card,
+  Layout,
+  Page,
+  SkeletonBodyText,
+  SkeletonDisplayText,
+  SkeletonPage,
+  TextContainer,
+} from '../src';
 
 export function Playground() {
   return (
     <Page title="Playground">
-      {/* Add the code you want to test in here */}
+      <SkeletonPage primaryAction narrowWidth>
+        <Layout>
+          <Layout.Section>
+            <Card sectioned>
+              <SkeletonBodyText />
+            </Card>
+            <Card sectioned>
+              <TextContainer>
+                <SkeletonDisplayText size="small" />
+                <SkeletonBodyText />
+              </TextContainer>
+            </Card>
+            <Card sectioned>
+              <TextContainer>
+                <SkeletonDisplayText size="small" />
+                <SkeletonBodyText />
+              </TextContainer>
+            </Card>
+          </Layout.Section>
+          <Layout.Section secondary>
+            <Card>
+              <Card.Section>
+                <TextContainer>
+                  <SkeletonDisplayText size="small" />
+                  <SkeletonBodyText lines={2} />
+                </TextContainer>
+              </Card.Section>
+              <Card.Section>
+                <SkeletonBodyText lines={1} />
+              </Card.Section>
+            </Card>
+            <Card subdued>
+              <Card.Section>
+                <TextContainer>
+                  <SkeletonDisplayText size="small" />
+                  <SkeletonBodyText lines={2} />
+                </TextContainer>
+              </Card.Section>
+              <Card.Section>
+                <SkeletonBodyText lines={2} />
+              </Card.Section>
+            </Card>
+          </Layout.Section>
+        </Layout>
+      </SkeletonPage>
     </Page>
   );
 }

--- a/polaris-react/src/components/AlphaStack/AlphaStack.scss
+++ b/polaris-react/src/components/AlphaStack/AlphaStack.scss
@@ -26,10 +26,6 @@
   @media #{$p-breakpoints-xl-up} {
     gap: var(--pc-stack-gap-xl);
   }
-
-  > * {
-    max-width: 100%;
-  }
 }
 
 .listReset {

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
@@ -2,62 +2,8 @@
 
 $primary-action-button-height: 36px;
 $primary-action-button-width: 100px;
-$skeleton-display-text-max-width: 120px;
-
-.Page {
-  @include page-layout;
-}
-
-.fullWidth {
-  max-width: none;
-}
-
-.narrowWidth {
-  max-width: $layout-width-primary-max;
-}
-
-.Content {
-  @include page-content-layout;
-}
-
-.Header {
-  @include page-header-layout;
-  padding-bottom: var(--p-space-2);
-}
-
-.BreadcrumbAction {
-  padding-top: var(--p-space-4);
-  padding-bottom: var(--p-space-4);
-  margin-top: calc(-1 * var(--p-space-1));
-  margin-bottom: calc(-1 * var(--p-space-1));
-}
-
-.TitleAndPrimaryAction {
-  display: flex;
-  align-items: flex-start;
-}
-
-.TitleWrapper {
-  flex: 1 1 0%;
-}
-
-.Title {
-  font-weight: var(--p-font-weight-semibold);
-  font-size: 24px;
-  line-height: 28px;
-
-  @media #{$p-breakpoints-md-up} {
-    font-size: 20px;
-  }
-}
 
 .SkeletonTitle {
-  display: flex;
-  background-color: var(--p-surface-neutral);
-  border-radius: var(--p-border-radius-base);
-  max-width: $skeleton-display-text-max-width;
-  height: 28px;
-
   @media screen and (-ms-high-contrast: active) {
     background-color: grayText;
   }
@@ -69,34 +15,5 @@ $skeleton-display-text-max-width: 120px;
   > * {
     height: $primary-action-button-height;
     min-width: $primary-action-button-width;
-  }
-}
-
-.Actions {
-  margin-top: var(--p-space-2);
-  display: flex;
-  flex-direction: row-reverse;
-  justify-content: flex-end;
-  align-items: center;
-}
-
-.Action {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  min-height: control-slim-height();
-  padding-right: var(--p-space-6);
-  margin-top: calc(-1 * var(--p-space-1));
-  margin-bottom: calc(-1 * var(--p-space-1));
-  padding-top: var(--p-space-4);
-
-  &:first-child {
-    padding-right: 0;
-  }
-
-  @media #{$p-breakpoints-lg-down} {
-    &:not(:last-child) {
-      display: none;
-    }
   }
 }

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
@@ -3,6 +3,12 @@
 $primary-action-button-height: 36px;
 $primary-action-button-width: 100px;
 
+.Title {
+  font-weight: var(--p-font-weight-semibold);
+  font-size: var(--p-font-size-300);
+  line-height: var(--p-font-line-height-4);
+}
+
 .SkeletonTitle {
   @media screen and (-ms-high-contrast: active) {
     background-color: grayText;

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
@@ -3,6 +3,11 @@
 $primary-action-button-height: 36px;
 $primary-action-button-width: 100px;
 
+:root {
+  --pc-skeleton-page-max-width: 998px;
+  --pc-skeleton-page-max-width-narrow: 662px;
+}
+
 .Title {
   font-weight: var(--p-font-weight-semibold);
   font-size: var(--p-font-size-300);

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.stories.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.stories.tsx
@@ -100,3 +100,103 @@ export function WithStaticContent() {
     </SkeletonPage>
   );
 }
+
+export function WithNarrowWidth() {
+  return (
+    <SkeletonPage primaryAction narrowWidth>
+      <Layout>
+        <Layout.Section>
+          <Card sectioned>
+            <SkeletonBodyText />
+          </Card>
+          <Card sectioned>
+            <TextContainer>
+              <SkeletonDisplayText size="small" />
+              <SkeletonBodyText />
+            </TextContainer>
+          </Card>
+          <Card sectioned>
+            <TextContainer>
+              <SkeletonDisplayText size="small" />
+              <SkeletonBodyText />
+            </TextContainer>
+          </Card>
+        </Layout.Section>
+        <Layout.Section secondary>
+          <Card>
+            <Card.Section>
+              <TextContainer>
+                <SkeletonDisplayText size="small" />
+                <SkeletonBodyText lines={2} />
+              </TextContainer>
+            </Card.Section>
+            <Card.Section>
+              <SkeletonBodyText lines={1} />
+            </Card.Section>
+          </Card>
+          <Card subdued>
+            <Card.Section>
+              <TextContainer>
+                <SkeletonDisplayText size="small" />
+                <SkeletonBodyText lines={2} />
+              </TextContainer>
+            </Card.Section>
+            <Card.Section>
+              <SkeletonBodyText lines={2} />
+            </Card.Section>
+          </Card>
+        </Layout.Section>
+      </Layout>
+    </SkeletonPage>
+  );
+}
+
+export function WithFullWidth() {
+  return (
+    <SkeletonPage primaryAction fullWidth>
+      <Layout>
+        <Layout.Section>
+          <Card sectioned>
+            <SkeletonBodyText />
+          </Card>
+          <Card sectioned>
+            <TextContainer>
+              <SkeletonDisplayText size="small" />
+              <SkeletonBodyText />
+            </TextContainer>
+          </Card>
+          <Card sectioned>
+            <TextContainer>
+              <SkeletonDisplayText size="small" />
+              <SkeletonBodyText />
+            </TextContainer>
+          </Card>
+        </Layout.Section>
+        <Layout.Section secondary>
+          <Card>
+            <Card.Section>
+              <TextContainer>
+                <SkeletonDisplayText size="small" />
+                <SkeletonBodyText lines={2} />
+              </TextContainer>
+            </Card.Section>
+            <Card.Section>
+              <SkeletonBodyText lines={1} />
+            </Card.Section>
+          </Card>
+          <Card subdued>
+            <Card.Section>
+              <TextContainer>
+                <SkeletonDisplayText size="small" />
+                <SkeletonBodyText lines={2} />
+              </TextContainer>
+            </Card.Section>
+            <Card.Section>
+              <SkeletonBodyText lines={2} />
+            </Card.Section>
+          </Card>
+        </Layout.Section>
+      </Layout>
+    </SkeletonPage>
+  );
+}

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -36,9 +36,7 @@ export function SkeletonPage({
   const i18n = useI18n();
 
   const titleContent = title ? (
-    <Text variant="headingXl" as="h1">
-      {title}
-    </Text>
+    <h1 className={styles.Title}>{title}</h1>
   ) : (
     <div className={styles.SkeletonTitle}>
       <Box

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -75,38 +75,40 @@ export function SkeletonPage({
     : {};
 
   return (
-    <Box
-      padding="0"
-      paddingInlineStart={{sm: '6'}}
-      paddingInlineEnd={{sm: '6'}}
-      maxWidth="998px"
-      aria-label={i18n.translate('Polaris.SkeletonPage.loadingLabel')}
-      role="status"
-      {...narrowWidthProps}
-      {...fullWidthProps}
-    >
-      <AlphaStack fullWidth gap="0">
-        <Box
-          padding={{xs: '4', md: '5'}}
-          paddingBlockEnd={{xs: '2', md: '5'}}
-          paddingInlineStart={{sm: '0'}}
-          paddingInlineEnd={{sm: '0'}}
-        >
-          {breadcrumbMarkup}
-          <Inline align="space-between" blockAlign="start">
-            {titleContent}
-            {primaryActionMarkup}
-          </Inline>
-        </Box>
-        <Box
-          paddingBlockStart={{xs: '2', md: '5'}}
-          paddingBlockEnd="2"
-          paddingInlineStart="0"
-          paddingInlineEnd="0"
-        >
-          {children}
-        </Box>
-      </AlphaStack>
-    </Box>
+    <AlphaStack align="center" fullWidth>
+      <Box
+        padding="0"
+        paddingInlineStart={{sm: '6'}}
+        paddingInlineEnd={{sm: '6'}}
+        maxWidth="998px"
+        aria-label={i18n.translate('Polaris.SkeletonPage.loadingLabel')}
+        role="status"
+        {...narrowWidthProps}
+        {...fullWidthProps}
+      >
+        <AlphaStack gap="0" fullWidth>
+          <Box
+            padding={{xs: '4', md: '5'}}
+            paddingBlockEnd={{xs: '2', md: '5'}}
+            paddingInlineStart={{sm: '0'}}
+            paddingInlineEnd={{sm: '0'}}
+          >
+            {breadcrumbMarkup}
+            <Inline align="space-between" blockAlign="start">
+              {titleContent}
+              {primaryActionMarkup}
+            </Inline>
+          </Box>
+          <Box
+            paddingBlockStart={{xs: '2', md: '5'}}
+            paddingBlockEnd="2"
+            paddingInlineStart="0"
+            paddingInlineEnd="0"
+          >
+            {children}
+          </Box>
+        </AlphaStack>
+      </Box>
+    </AlphaStack>
   );
 }

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -5,7 +5,6 @@ import {SkeletonDisplayText} from '../SkeletonDisplayText';
 import {SkeletonBodyText} from '../SkeletonBodyText';
 import {Box} from '../Box';
 import {Inline} from '../Inline';
-import {Text} from '../Text';
 import {AlphaStack} from '../AlphaStack';
 
 import styles from './SkeletonPage.scss';

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -81,6 +81,7 @@ export function SkeletonPage({
       paddingInlineEnd={{sm: '6'}}
       maxWidth="998px"
       aria-label={i18n.translate('Polaris.SkeletonPage.loadingLabel')}
+      role="status"
       {...narrowWidthProps}
       {...fullWidthProps}
     >

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -59,18 +59,6 @@ export function SkeletonPage({
     </Box>
   ) : null;
 
-  const narrowWidthProps = narrowWidth
-    ? {
-        maxWidth: '662px',
-      }
-    : {};
-
-  const fullWidthProps = fullWidth
-    ? {
-        maxWidth: 'none',
-      }
-    : {};
-
   return (
     <AlphaStack align="center" fullWidth>
       <Box
@@ -80,8 +68,12 @@ export function SkeletonPage({
         maxWidth="998px"
         aria-label={i18n.translate('Polaris.SkeletonPage.loadingLabel')}
         role="status"
-        {...narrowWidthProps}
-        {...fullWidthProps}
+        {...(narrowWidth && {
+          maxWidth: '662px',
+        })}
+        {...(fullWidth && {
+          maxWidth: 'none',
+        })}
       >
         <AlphaStack gap="0" fullWidth>
           <Box

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 
-import {classNames} from '../../utilities/css';
 import {useI18n} from '../../utilities/i18n';
 import {SkeletonDisplayText} from '../SkeletonDisplayText';
 import {SkeletonBodyText} from '../SkeletonBodyText';
+import {Box} from '../Box';
+import {Inline} from '../Inline';
+import {Text} from '../Text';
+import {AlphaStack} from '../AlphaStack';
 
 import styles from './SkeletonPage.scss';
 
@@ -31,19 +34,21 @@ export function SkeletonPage({
   breadcrumbs,
 }: SkeletonPageProps) {
   const i18n = useI18n();
-  const className = classNames(
-    styles.Page,
-    fullWidth && styles.fullWidth,
-    narrowWidth && styles.narrowWidth,
-  );
 
   const titleContent = title ? (
-    <h1 className={styles.Title}>{title}</h1>
+    <Text variant="headingXl" as="h1">
+      {title}
+    </Text>
   ) : (
-    <div className={styles.SkeletonTitle} />
+    <div className={styles.SkeletonTitle}>
+      <Box
+        background="surface-neutral"
+        minWidth="120px"
+        minHeight="28px"
+        borderRadius="base"
+      />
+    </div>
   );
-
-  const titleMarkup = <div className={styles.TitleWrapper}>{titleContent}</div>;
 
   const primaryActionMarkup = primaryAction ? (
     <div className={styles.PrimaryAction}>
@@ -52,25 +57,55 @@ export function SkeletonPage({
   ) : null;
 
   const breadcrumbMarkup = breadcrumbs ? (
-    <div className={styles.BreadcrumbAction} style={{width: 60}}>
+    <Box maxWidth="60px" paddingBlockStart="4" paddingBlockEnd="4">
       <SkeletonBodyText lines={1} />
-    </div>
+    </Box>
   ) : null;
 
+  const narrowWidthProps = narrowWidth
+    ? {
+        maxWidth: '662px',
+      }
+    : {};
+
+  const fullWidthProps = fullWidth
+    ? {
+        maxWidth: 'none',
+      }
+    : {};
+
   return (
-    <div
-      className={className}
-      role="status"
+    <Box
+      padding="0"
+      paddingInlineStart={{sm: '6'}}
+      paddingInlineEnd={{sm: '6'}}
+      maxWidth="998px"
       aria-label={i18n.translate('Polaris.SkeletonPage.loadingLabel')}
+      {...narrowWidthProps}
+      {...fullWidthProps}
     >
-      <div className={styles.Header}>
-        {breadcrumbMarkup}
-        <div className={styles.TitleAndPrimaryAction}>
-          {titleMarkup}
-          {primaryActionMarkup}
-        </div>
-      </div>
-      <div className={styles.Content}>{children}</div>
-    </div>
+      <AlphaStack fullWidth gap="0">
+        <Box
+          padding={{xs: '4', md: '5'}}
+          paddingBlockEnd={{xs: '2', md: '5'}}
+          paddingInlineStart={{sm: '0'}}
+          paddingInlineEnd={{sm: '0'}}
+        >
+          {breadcrumbMarkup}
+          <Inline align="space-between" blockAlign="start">
+            {titleContent}
+            {primaryActionMarkup}
+          </Inline>
+        </Box>
+        <Box
+          paddingBlockStart={{xs: '2', md: '5'}}
+          paddingBlockEnd="2"
+          paddingInlineStart="0"
+          paddingInlineEnd="0"
+        >
+          {children}
+        </Box>
+      </AlphaStack>
+    </Box>
   );
 }

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -65,7 +65,7 @@ export function SkeletonPage({
         padding="0"
         paddingInlineStart={{sm: '6'}}
         paddingInlineEnd={{sm: '6'}}
-        maxWidth="998px"
+        maxWidth="var(--pc-skeleton-page-max-width)"
         aria-label={i18n.translate('Polaris.SkeletonPage.loadingLabel')}
         role="status"
         {...(narrowWidth && {

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -69,10 +69,10 @@ export function SkeletonPage({
         aria-label={i18n.translate('Polaris.SkeletonPage.loadingLabel')}
         role="status"
         {...(narrowWidth && {
-          maxWidth: '662px',
+          maxWidth: 'var(--pc-skeleton-page-max-width-narrow)',
         })}
         {...(fullWidth && {
-          maxWidth: 'none',
+          maxWidth: 'var(--pc-skeleton-page-max-width)',
         })}
       >
         <AlphaStack gap="0" fullWidth>

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -72,7 +72,7 @@ export function SkeletonPage({
           maxWidth: 'var(--pc-skeleton-page-max-width-narrow)',
         })}
         {...(fullWidth && {
-          maxWidth: 'var(--pc-skeleton-page-max-width)',
+          maxWidth: 'none',
         })}
       >
         <AlphaStack gap="0" fullWidth>

--- a/polaris-react/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
+++ b/polaris-react/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {mountWithApp} from 'tests/utilities';
 
 import {Card} from '../../Card';
-import {Text} from '../../Text';
 import {Layout} from '../../Layout';
 import {SkeletonBodyText} from '../../SkeletonBodyText';
 import {SkeletonDisplayText} from '../../SkeletonDisplayText';
@@ -38,7 +37,7 @@ describe('<SkeletonPage />', () => {
     it('renders an h1 with the Title class when title is defined', () => {
       const skeletonPage = mountWithApp(<SkeletonPage title="Products" />);
 
-      expect(skeletonPage).toContainReactComponent(Text);
+      expect(skeletonPage).toContainReactComponent('h1', {className: 'Title'});
       expect(skeletonPage).not.toContainReactComponent(Box, {
         background: 'surface-neutral',
       });
@@ -47,7 +46,9 @@ describe('<SkeletonPage />', () => {
     it('renders SkeletonTitle when a title not defined', () => {
       const skeletonPage = mountWithApp(<SkeletonPage />);
 
-      expect(skeletonPage).not.toContainReactComponent(Text);
+      expect(skeletonPage).not.toContainReactComponent('h1', {
+        className: 'Title',
+      });
       expect(skeletonPage).toContainReactComponent(Box, {
         background: 'surface-neutral',
       });
@@ -56,7 +57,9 @@ describe('<SkeletonPage />', () => {
     it('renders SkeletonTitle when title is an empty string', () => {
       const skeletonPage = mountWithApp(<SkeletonPage title="" />);
 
-      expect(skeletonPage).not.toContainReactComponent(Text);
+      expect(skeletonPage).not.toContainReactComponent('h1', {
+        className: 'Title',
+      });
       expect(skeletonPage).toContainReactComponent(Box, {
         background: 'surface-neutral',
       });

--- a/polaris-react/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
+++ b/polaris-react/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
@@ -7,6 +7,7 @@ import {Layout} from '../../Layout';
 import {SkeletonBodyText} from '../../SkeletonBodyText';
 import {SkeletonDisplayText} from '../../SkeletonDisplayText';
 import {SkeletonPage} from '../SkeletonPage';
+import {Box} from '../../Box';
 
 describe('<SkeletonPage />', () => {
   it('renders its children', () => {
@@ -37,29 +38,27 @@ describe('<SkeletonPage />', () => {
     it('renders an h1 with the Title class when title is defined', () => {
       const skeletonPage = mountWithApp(<SkeletonPage title="Products" />);
 
-      expect(skeletonPage).toContainReactComponent('h1', {className: 'Title'});
-      expect(skeletonPage).not.toContainReactComponent(Text);
+      expect(skeletonPage).toContainReactComponent(Text);
+      expect(skeletonPage).not.toContainReactComponent(Box, {
+        background: 'surface-neutral',
+      });
     });
 
     it('renders SkeletonTitle when a title not defined', () => {
       const skeletonPage = mountWithApp(<SkeletonPage />);
 
-      expect(skeletonPage).not.toContainReactComponent('h1', {
-        className: 'Title',
-      });
-      expect(skeletonPage).toContainReactComponent('div', {
-        className: 'SkeletonTitle',
+      expect(skeletonPage).not.toContainReactComponent(Text);
+      expect(skeletonPage).toContainReactComponent(Box, {
+        background: 'surface-neutral',
       });
     });
 
     it('renders SkeletonTitle when title is an empty string', () => {
       const skeletonPage = mountWithApp(<SkeletonPage title="" />);
 
-      expect(skeletonPage).not.toContainReactComponent('h1', {
-        className: 'Title',
-      });
-      expect(skeletonPage).toContainReactComponent('div', {
-        className: 'SkeletonTitle',
+      expect(skeletonPage).not.toContainReactComponent(Text);
+      expect(skeletonPage).toContainReactComponent(Box, {
+        background: 'surface-neutral',
       });
     });
   });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes [#7714](https://github.com/Shopify/polaris/issues/7714)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Refactors `SkeletonPage` and its child components to use our layout primitives.
- Removes `max-width: 100%` property from AlphaStack
- Adds storybook examples for `SkeletonPage` with `narrowWidth` and with `fullWidth` props


#### Issues with current PR:

   <details>
      <summary>Unable to center `SkeletonPage` when `narrowWidth` prop is used - SOLVED ✅</summary>
<table>
<tr>
<td> Before </td> <td> After </td>
</tr>
<tr>
<td> <img width="400" alt="Screenshot 2022-11-24 at 9 13 21 AM" src="https://user-images.githubusercontent.com/59836805/203805854-4748a46a-8208-476e-9c16-d0071e4ff66b.png"> </td>
<td> <img width="400" alt="Screenshot 2022-11-24 at 9 10 25 AM" src="https://user-images.githubusercontent.com/59836805/203806188-bd5cde58-0787-46f1-a2b3-cbaf2a228d52.png"> </td>
</tr>
<tr>
<td> <img width="400" alt="Screenshot 2022-11-24 at 9 13 42 AM" src="https://user-images.githubusercontent.com/59836805/203806392-466df6a0-29ee-4d06-bc40-523b60b97853.png"> </td>
<td> <img width="400" alt="Screenshot 2022-11-24 at 9 11 17 AM" src="https://user-images.githubusercontent.com/59836805/203806492-6793f6a3-591a-4cb4-9f13-46da44f64dfe.png"> </td>
</tr>
</table>
    </details>

<details>
      <summary>Our current `Text` component has the opposite breakpoint behaviour compared to how `.Title` is used in `SkeletonPage` - SOLVED ✅</summary>
      <table>
<tr>
<td> Before </td> <td> After </td>
</tr>
<tr>
<td> <img width="400" alt="before text" src="https://user-images.githubusercontent.com/59836805/203808391-3f3bd9d2-421e-4e09-a843-e579b936d39f.gif"> </td>
<td> <img width="400" alt="before text" src="https://user-images.githubusercontent.com/59836805/203808879-55e311ef-708b-44c9-a28e-4582c77d0992.gif"> </td>
</tr>
<tr>
<td> 

```java
.Title {
  font-weight: var(--p-font-weight-semibold);
  font-size: 24px;
  line-height: 28px;

  @media #{$p-breakpoints-md-up} {
    font-size: 20px;
  }
}
```

 </td>
<td>
    
```java
.headingXl {
  font-size: var(--p-font-size-300);
  line-height: var(--p-font-line-height-3);

  @media #{$p-breakpoints-md-up} {
    font-size: var(--p-font-size-400);
    line-height: var(--p-font-line-height-4);
  }
}
```
    
</td>
</tr>
</table>
    </details>



~~`role` prop is missing from `Box`, creating a separate issue to solve this [here](https://github.com/Shopify/polaris/pull/7799)~~ SOLVED ✅

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
