### PR TITLE
Revert "Revert "Properly handle buttons with `aria-disabled` in focus helpers""

### DIFF
--- a/.changeset/gentle-cobras-punch.md
+++ b/.changeset/gentle-cobras-punch.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Updated the focus helper functions to no longer treat buttons with `aria-disabled="disabled"` and `tabindex="-1" (but no`disabled` attribute) as focusable.
+Updated the focus helper functions to no longer treat buttons with `aria-disabled="true"` and `tabindex="-1" (but no`disabled` attribute) as focusable.

--- a/.changeset/gentle-cobras-punch.md
+++ b/.changeset/gentle-cobras-punch.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Updates the focus helper functions to no longer treat buttons with `aria-disabled="disabled"` and `tabindex="-1" (but no`disabled` attribute) as focusable.
+Updated the focus helper functions to no longer treat buttons with `aria-disabled="disabled"` and `tabindex="-1" (but no`disabled` attribute) as focusable.

--- a/.changeset/gentle-cobras-punch.md
+++ b/.changeset/gentle-cobras-punch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updates the focus helper functions to no longer treat buttons with `aria-disabled="disabled"` and `tabindex="-1" (but no`disabled` attribute) as focusable.

--- a/polaris-react/src/utilities/focus.ts
+++ b/polaris-react/src/utilities/focus.ts
@@ -6,9 +6,9 @@ export type MouseUpBlurHandler = (
 ) => void;
 
 const FOCUSABLE_SELECTOR =
-  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([tabindex="-1"]),*[tabindex]';
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([aria-disabled]):not([tabindex="-1"]),*[tabindex]';
 const KEYBOARD_FOCUSABLE_SELECTORS =
-  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([tabindex="-1"]),*[tabindex]:not([tabindex="-1"])';
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([aria-disabled]):not([tabindex="-1"]),*[tabindex]:not([tabindex="-1"])';
 const MENUITEM_FOCUSABLE_SELECTORS =
   'a[role="menuitem"],frame[role="menuitem"],iframe[role="menuitem"],input[role="menuitem"]:not([type=hidden]):not(:disabled),select[role="menuitem"]:not(:disabled),textarea[role="menuitem"]:not(:disabled),button[role="menuitem"]:not(:disabled),*[tabindex]:not([tabindex="-1"])';
 export const handleMouseUpByBlurring: MouseUpBlurHandler = ({currentTarget}) =>

--- a/polaris-react/src/utilities/focus.ts
+++ b/polaris-react/src/utilities/focus.ts
@@ -6,9 +6,9 @@ export type MouseUpBlurHandler = (
 ) => void;
 
 const FOCUSABLE_SELECTOR =
-  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]';
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([tabindex="-1"]),*[tabindex]';
 const KEYBOARD_FOCUSABLE_SELECTORS =
-  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled),*[tabindex]:not([tabindex="-1"])';
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([tabindex="-1"]),*[tabindex]:not([tabindex="-1"])';
 const MENUITEM_FOCUSABLE_SELECTORS =
   'a[role="menuitem"],frame[role="menuitem"],iframe[role="menuitem"],input[role="menuitem"]:not([type=hidden]):not(:disabled),select[role="menuitem"]:not(:disabled),textarea[role="menuitem"]:not(:disabled),button[role="menuitem"]:not(:disabled),*[tabindex]:not([tabindex="-1"])';
 export const handleMouseUpByBlurring: MouseUpBlurHandler = ({currentTarget}) =>

--- a/polaris-react/src/utilities/focus.ts
+++ b/polaris-react/src/utilities/focus.ts
@@ -6,9 +6,9 @@ export type MouseUpBlurHandler = (
 ) => void;
 
 const FOCUSABLE_SELECTOR =
-  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([aria-disabled]):not([tabindex="-1"]),*[tabindex]';
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([aria-disabled="true"]):not([tabindex="-1"]),*[tabindex]';
 const KEYBOARD_FOCUSABLE_SELECTORS =
-  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([aria-disabled]):not([tabindex="-1"]),*[tabindex]:not([tabindex="-1"])';
+  'a,frame,iframe,input:not([type=hidden]):not(:disabled),select:not(:disabled),textarea:not(:disabled),button:not(:disabled):not([aria-disabled="true"]):not([tabindex="-1"]),*[tabindex]:not([tabindex="-1"])';
 const MENUITEM_FOCUSABLE_SELECTORS =
   'a[role="menuitem"],frame[role="menuitem"],iframe[role="menuitem"],input[role="menuitem"]:not([type=hidden]):not(:disabled),select[role="menuitem"]:not(:disabled),textarea[role="menuitem"]:not(:disabled),button[role="menuitem"]:not(:disabled),*[tabindex]:not([tabindex="-1"])';
 export const handleMouseUpByBlurring: MouseUpBlurHandler = ({currentTarget}) =>


### PR DESCRIPTION
Reverts #7819, restoring the original change made in #7760 to fix #7728 - with a small tweak* to avoid a downstream accessibility issue caused by the original fix.

Please see the original PR (#7819) for more details on the issue being fixed.

<details><summary>*Investigation notes:</summary>
The first version of this change simply added `:not([tabindex="-1"])` to the affected CSS selector string in JS. It was updated to include `:not([aria-disabled])` based on [this review comment](https://github.com/Shopify/polaris/pull/7760#discussion_r1026916700), but this ultimately caused some Storybook accessibility failures in CI in web and prompted the original change to be reverted.

After creating a few snapshots with variations on this change, I narrowed down the issue to being caused by the addition of `:not([aria-disabled])` to the `FOCUSABLE_SELECTOR` constant in `focus.ts`:

https://github.com/Shopify/polaris/blob/35ab232b5619b691fcfe4686d504b9b470836b2f/polaris-react/src/utilities/focus.ts#L8-L9

This caused failures like this to occur in web upon upgrading to the newest version of Polaris:

```
Error: Elements must only use allowed ARIA attributes (aria-allowed-attr)
Affected node(s):
    <div tabindex="0" aria-describedby="PolarisTooltipContent1" data-polaris-tooltip-activator="true" aria-controls="Polarispopover1" aria-owns="Polarispopover1" aria-expanded="false">
    <div tabindex="0" aria-describedby="PolarisTooltipContent5" data-polaris-tooltip-activator="true" aria-controls="Polarispopover2" aria-owns="Polarispopover2" aria-expanded="false">
    <div tabindex="0" aria-describedby="PolarisTooltipContent6" data-polaris-tooltip-activator="true" aria-controls="Polarispopover3" aria-owns="Polarispopover3" aria-expanded="false">
    <div tabindex="0" aria-describedby="PolarisTooltipContent9" data-polaris-tooltip-activator="true" aria-controls="Polarispopover4" aria-owns="Polarispopover4" aria-expanded="false">
  For help resolving this see: https://dequeuniversity.com/rules/axe/4.4/aria-allowed-attr?application=axe-puppeteer
```

It appears that the test wasn't happy with some of the ARIA attributes being added to the affected `<div>` elements. The `aria-controls`, `aria-owns`, and `aria-expanded` attributes are applied in [set-activator-attributes.ts](https://github.com/Shopify/polaris/blob/revert-7819-revert-7760-acmertz/fix-focus-helpers-disabled-buttons/polaris-react/src/components/Popover/set-activator-attributes.ts) by the Popover component, [which calls the focusNextFocusableNode() helper](https://github.com/Shopify/polaris/blob/revert-7819-revert-7760-acmertz/fix-focus-helpers-disabled-buttons/polaris-react/src/components/Popover/Popover.tsx#L171) in focus.ts.

~~I wasn't able to find the exact reason why this caused the CI failures above, but my hypothesis right now is that the original change in #7819 caused a scenario where `setActivatorAttributes()` could be called for an element which lacks a `role` that allows it to use `aria-controls`, `aria-owns`, and `aria-expanded` - but the way in which the `<Popover>` manages its activator and wrapper elements with multiple refs, `useEffect()` calls, and state variables makes this tricky to confirm (coupled with the fact that the CI failure occurred in another repository, of course).~~</details>

**Update:** The issue occurred because the selector in the original PR, `:not([aria-disabled])`, incorrectly excluded elements that had `aria-disabled="false"`. Changing the selector to `:not([aria-disabled="true"])` fixes the Storybook accessibility failure that prompted the initial revert.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useState} from 'react';

import {Button, Modal, Page, Stack, TextField} from '../src';

export function Playground() {
  const [isModalOpen, setIsModalOpen] = useState(false);

  function handleClose() {
    setIsModalOpen(false);
  }

  function noop() {}

  return (
    <Page title="Playground">
      <Button onClick={() => setIsModalOpen(true)}>Open modal</Button>
      <Button disabled>Disabled button</Button>

      <Modal
        open={isModalOpen}
        onClose={handleClose}
        title="Example modal"
        primaryAction={{
          content: 'Primary action',
          onAction: handleClose,
          disabled: true,
        }}
      >
        <Modal.Section>
          <Stack vertical>
            <p>Some content</p>
            <TextField
              onChange={noop}
              autoComplete=""
              label="Text field 1"
              value=""
            />
            <TextField
              onChange={noop}
              autoComplete=""
              label="Text field 2"
              value=""
            />
          </Stack>
        </Modal.Section>
      </Modal>
    </Page>
  );
}
```

</details>

1. Copy the above code into `Playground.tsx` and run `yarn dev`
2. Confirm that the changes in this PR fix #7728:
    1. Click "Open modal"
    2. Use the Tab key to cycle through focusable elements within the modal
    3. Confirm that focus wraps around to the beginning of the modal despite the primary action button being disabled

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide