### PR TITLE
[Button] Add examples for button with icon and disclosure

### DIFF
--- a/.changeset/dirty-flies-matter.md
+++ b/.changeset/dirty-flies-matter.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Added storybook examples for `Button` with icon and disclosure

--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
 import {Button, ButtonGroup} from '@shopify/polaris';
+import {CalendarMinor} from '@shopify/polaris-icons';
 
 export default {
   component: Button,
@@ -102,7 +103,7 @@ export function Pressed() {
   );
 }
 
-export function PlainDisclosure() {
+export function WithPlainDisclosure() {
   const [expanded, setExpanded] = useState(false);
 
   return (
@@ -118,7 +119,7 @@ export function PlainDisclosure() {
   );
 }
 
-export function RightAlignedDisclosure() {
+export function WithRightAlignedDisclosure() {
   const [expanded, setExpanded] = useState(false);
 
   return (
@@ -135,13 +136,25 @@ export function RightAlignedDisclosure() {
   );
 }
 
-export function SelectDisclosure() {
+export function WithSelectDisclosure() {
   return (
     <div style={{height: '100px'}}>
       <Button disclosure="select" onClick={() => console.log('Open Popover')}>
         Select options
       </Button>
     </div>
+  );
+}
+
+export function WithIcon() {
+  return <Button icon={CalendarMinor}>Choose date range</Button>;
+}
+
+export function WithIconAndDisclosure() {
+  return (
+    <Button icon={CalendarMinor} disclosure>
+      Choose date range
+    </Button>
   );
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

To help with tophatting rebuilding the Button component with layout primitives.

### WHAT is this pull request doing?

Adds storybook examples of a button with icon and button with icon and disclosure.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

[Storybook](https://5d559397bae39100201eedc1-sxswwhdpxv.chromatic.com/?path=/story/all-components-button--with-icon)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
