### PR TITLE
[Tabs] allow disabling tab(s)

### DIFF
--- a/polaris-react/src/components/Tabs/Tabs.scss
+++ b/polaris-react/src/components/Tabs/Tabs.scss
@@ -110,6 +110,15 @@ $item-vertical-padding: $item-min-height * 0.5;
   &:visited {
     color: inherit;
   }
+
+  &:disabled {
+    cursor: default;
+
+    .Title {
+      cursor: default;
+      color: var(--p-text-disabled);
+    }
+  }
 }
 
 .Tab-selected {

--- a/polaris-react/src/components/Tabs/Tabs.scss
+++ b/polaris-react/src/components/Tabs/Tabs.scss
@@ -110,15 +110,6 @@ $item-vertical-padding: $item-min-height * 0.5;
   &:visited {
     color: inherit;
   }
-
-  &:disabled {
-    cursor: default;
-
-    .Title {
-      cursor: default;
-      color: var(--p-text-disabled);
-    }
-  }
 }
 
 .Tab-selected {
@@ -140,6 +131,16 @@ $item-vertical-padding: $item-min-height * 0.5;
     &::before {
       background: var(--p-action-primary);
     }
+  }
+}
+
+.Tab-disabled {
+  cursor: default;
+  pointer-events: none;
+
+  .Title {
+    cursor: default;
+    color: var(--p-text-disabled);
   }
 }
 

--- a/polaris-react/src/components/Tabs/Tabs.stories.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.stories.tsx
@@ -170,3 +170,52 @@ export function WithCustomDisclosure() {
     </Card>
   );
 }
+
+export function WithDisabledTab() {
+  const [selected, setSelected] = useState(0);
+
+  const handleTabChange = useCallback(
+    (selectedTabIndex) => setSelected(selectedTabIndex),
+    [],
+  );
+
+  const tabs = [
+    {
+      id: 'all-customers-4',
+      content: 'All',
+      accessibilityLabel: 'All customers',
+      panelID: 'all-customers-content-4',
+    },
+    {
+      id: 'accepts-marketing-4',
+      content: 'Accepts marketing',
+      panelID: 'accepts-marketing-content-4',
+    },
+    {
+      id: 'repeat-customers-4',
+      content: 'Repeat customers',
+      panelID: 'repeat-customers-content-4',
+      disabled: true,
+    },
+    {
+      id: 'prospects-4',
+      content: 'Prospects',
+      panelID: 'prospects-content-4',
+    },
+  ];
+
+  return (
+    <Card>
+      <Tabs
+        tabs={tabs}
+        selected={selected}
+        onSelect={handleTabChange}
+        disclosureText="More views"
+      >
+        <Card.Section title={tabs[selected].content}>
+          <p>Tab {selected} selected</p>
+        </Card.Section>
+      </Tabs>
+    </Card>
+  );
+}

--- a/polaris-react/src/components/Tabs/Tabs.tsx
+++ b/polaris-react/src/components/Tabs/Tabs.tsx
@@ -241,6 +241,7 @@ class TabsInner extends PureComponent<CombinedProps, State> {
         panelID={children ? tabPanelID : undefined}
         accessibilityLabel={tab.accessibilityLabel}
         url={tab.url}
+        disabled={tab.disabled}
       >
         <Text as="span" variant="bodyMd">
           {tab.content}

--- a/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
+++ b/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
@@ -71,7 +71,11 @@ export function Tab({
 
   const handleClick = onClick && onClick.bind(null, id);
 
-  const className = classNames(styles.Tab, selected && styles['Tab-selected']);
+  const className = classNames(
+    styles.Tab,
+    selected && styles['Tab-selected'],
+    disabled && styles['Tab-disabled'],
+  );
 
   let tabIndex: 0 | -1;
 
@@ -115,7 +119,6 @@ export function Tab({
       aria-controls={panelID}
       aria-label={accessibilityLabel}
       onMouseUp={handleMouseUpByBlurring}
-      disabled={disabled}
     >
       <span className={styles.Title}>{children}</span>
     </button>

--- a/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
+++ b/polaris-react/src/components/Tabs/components/Tab/Tab.tsx
@@ -18,6 +18,7 @@ export interface TabProps {
   url?: string;
   measuring?: boolean;
   accessibilityLabel?: string;
+  disabled?: boolean;
   onClick?(id: string): void;
 }
 
@@ -32,6 +33,7 @@ export function Tab({
   panelID,
   measuring,
   accessibilityLabel,
+  disabled,
 }: TabProps) {
   const wasSelected = useRef(selected);
   const panelFocused = useRef(false);
@@ -113,6 +115,7 @@ export function Tab({
       aria-controls={panelID}
       aria-label={accessibilityLabel}
       onMouseUp={handleMouseUpByBlurring}
+      disabled={disabled}
     >
       <span className={styles.Title}>{children}</span>
     </button>

--- a/polaris-react/src/components/Tabs/components/Tab/tests/Tab.test.tsx
+++ b/polaris-react/src/components/Tabs/components/Tab/tests/Tab.test.tsx
@@ -91,6 +91,20 @@ describe('<Tab />', () => {
     });
   });
 
+  describe('disabled', () => {
+    it('contains a disabled button when disabled prop present', () => {
+      const tab = mountWithApp(
+        <Tab id="my-tab" disabled>
+          Tab
+        </Tab>,
+      );
+
+      expect(tab).toContainReactComponent('button', {
+        disabled: true,
+      });
+    });
+  });
+
   describe('accessibilityLabel()', () => {
     it('uses the label for aria-label', () => {
       const label = 'Tab contents';

--- a/polaris-react/src/components/Tabs/components/Tab/tests/Tab.test.tsx
+++ b/polaris-react/src/components/Tabs/components/Tab/tests/Tab.test.tsx
@@ -92,7 +92,7 @@ describe('<Tab />', () => {
   });
 
   describe('disabled', () => {
-    it('contains a disabled button when disabled prop present', () => {
+    it('contains button with a Tab-disabled style when disabled prop present', () => {
       const tab = mountWithApp(
         <Tab id="my-tab" disabled>
           Tab
@@ -100,7 +100,7 @@ describe('<Tab />', () => {
       );
 
       expect(tab).toContainReactComponent('button', {
-        disabled: true,
+        className: 'Tab Tab-disabled',
       });
     });
   });

--- a/polaris-react/src/components/Tabs/tests/Tabs.test.tsx
+++ b/polaris-react/src/components/Tabs/tests/Tabs.test.tsx
@@ -213,6 +213,23 @@ describe('<Tabs />', () => {
         );
       });
     });
+
+    it('allows disabling one or more tabs', () => {
+      const tabs: TabsProps['tabs'] = [
+        {content: 'Tab 1', id: 'tab-1'},
+        {content: 'Tab 2', id: 'tab-2', disabled: true},
+      ];
+
+      const wrapper = mountWithApp(<Tabs {...mockProps} tabs={tabs} />);
+      const ul = wrapper.find('ul')!;
+
+      expect(ul.find(Tab, {id: 'tab-1'})!).not.toHaveReactProps({
+        disabled: true,
+      });
+      expect(ul.find(Tab, {id: 'tab-2'})!).toHaveReactProps({
+        disabled: true,
+      });
+    });
   });
 
   describe('selected', () => {

--- a/polaris-react/src/components/Tabs/types.ts
+++ b/polaris-react/src/components/Tabs/types.ts
@@ -9,4 +9,6 @@ export interface TabDescriptor {
   panelID?: string;
   /** Visually hidden text for screen readers */
   accessibilityLabel?: string;
+  /** Whether or not the tab is disabled */
+  disabled?: boolean;
 }


### PR DESCRIPTION
In a recent UX review for our 1P app, we got feedback that it would be better if we disabled rather than removed a tab (this particular tab only makes sense if a separate checkbox is selected). 

It looks like disabling tabs has been raised in the past - https://github.com/Shopify/polaris/issues/305

This PR would need a bit more tophatting, documentation, etc.. But before I start doing that, I wanted to check if this is a change that's already been considered and rejected, or is worthwhile looking into.  Feedback on the approach is also very welcome.

Thanks!  

----

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
