### PR TITLE
[Breadcrumbs] Allow breadcrumbs to be singular

### DIFF
--- a/.changeset/twelve-grapes-reply.md
+++ b/.changeset/twelve-grapes-reply.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-Adds the ability for breadcrumbs to be passed as a singular object instead of an array to allow support for upcoming v11 changes
+Added the ability for breadcrumbs to be passed as a singular object instead of an array to allow support for upcoming v11 changes

--- a/.changeset/twelve-grapes-reply.md
+++ b/.changeset/twelve-grapes-reply.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Adds the ability for breadcrumbs to be passed as a singular object instead of an array to allow support for upcoming v11 changes

--- a/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -11,11 +11,14 @@ import styles from './Breadcrumbs.scss';
 
 export interface BreadcrumbsProps {
   /** Collection of breadcrumbs */
-  breadcrumbs: (CallbackAction | LinkAction)[];
+  breadcrumbs: (CallbackAction | LinkAction) | (CallbackAction | LinkAction)[];
 }
 
 export function Breadcrumbs({breadcrumbs}: BreadcrumbsProps) {
-  const breadcrumb = breadcrumbs[breadcrumbs.length - 1];
+  const breadcrumb =
+    breadcrumbs instanceof Array
+      ? breadcrumbs[breadcrumbs.length - 1]
+      : breadcrumbs;
   if (breadcrumb == null) {
     return null;
   }

--- a/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -15,10 +15,9 @@ export interface BreadcrumbsProps {
 }
 
 export function Breadcrumbs({breadcrumbs}: BreadcrumbsProps) {
-  const breadcrumb =
-    breadcrumbs instanceof Array
-      ? breadcrumbs[breadcrumbs.length - 1]
-      : breadcrumbs;
+  const breadcrumb = Array.isArray(breadcrumbs)
+    ? breadcrumbs[breadcrumbs.length - 1]
+    : breadcrumbs;
   if (breadcrumb == null) {
     return null;
   }

--- a/polaris-react/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
+++ b/polaris-react/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
@@ -116,7 +116,7 @@ describe('<Breadcrumbs />', () => {
     };
     const wrapper = mountWithApp(<Breadcrumbs breadcrumbs={breadcrumb} />);
 
-    expect(wrapper.html()).toBe('');
+    expect(wrapper.html()).not.toBe('');
   });
 
   it('renders nothing when empty', () => {

--- a/polaris-react/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
+++ b/polaris-react/src/components/Breadcrumbs/tests/Breadcrumbs.test.tsx
@@ -109,6 +109,16 @@ describe('<Breadcrumbs />', () => {
     });
   });
 
+  it('renders when not passed an array', () => {
+    const breadcrumb: LinkAction = {
+      content: 'Products',
+      url: 'https://www.shopify.com',
+    };
+    const wrapper = mountWithApp(<Breadcrumbs breadcrumbs={breadcrumb} />);
+
+    expect(wrapper.html()).toBe('');
+  });
+
   it('renders nothing when empty', () => {
     const wrapper = mountWithApp(<Breadcrumbs breadcrumbs={[]} />);
 

--- a/polaris-react/src/components/Page/Page.tsx
+++ b/polaris-react/src/components/Page/Page.tsx
@@ -40,7 +40,10 @@ export function Page({
         rest.secondaryActions.length > 0) ||
         isReactElement(rest.secondaryActions))) ||
     (rest.actionGroups != null && rest.actionGroups.length > 0) ||
-    (rest.breadcrumbs != null && rest.breadcrumbs.length > 0);
+    (rest.breadcrumbs != null &&
+      rest.breadcrumbs instanceof Array &&
+      rest.breadcrumbs.length > 0) ||
+    rest.breadcrumbs != null;
 
   const contentClassName = classNames(
     !hasHeaderContent && styles.Content,

--- a/polaris-react/src/components/Page/Page.tsx
+++ b/polaris-react/src/components/Page/Page.tsx
@@ -41,7 +41,7 @@ export function Page({
         isReactElement(rest.secondaryActions))) ||
     (rest.actionGroups != null && rest.actionGroups.length > 0) ||
     (rest.breadcrumbs != null &&
-      rest.breadcrumbs instanceof Array &&
+      Array.isArray(rest.breadcrumbs) &&
       rest.breadcrumbs.length > 0) ||
     rest.breadcrumbs != null;
 

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -98,7 +98,8 @@ export function Header({
     !actionGroups.length;
 
   const breadcrumbMarkup =
-    (Array.isArray(breadcrumbs) && breadcrumbs.length > 0) || breadcrumbs ? (
+    (Array.isArray(breadcrumbs) && breadcrumbs.length > 0) ||
+    (!Array.isArray(breadcrumbs) && breadcrumbs) ? (
       <div className={styles.BreadcrumbWrapper}>
         <Breadcrumbs breadcrumbs={breadcrumbs} />
       </div>

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -98,7 +98,7 @@ export function Header({
     !actionGroups.length;
 
   const breadcrumbMarkup =
-    breadcrumbs.length > 0 ? (
+    (breadcrumbs instanceof Array && breadcrumbs.length > 0) || breadcrumbs ? (
       <div className={styles.BreadcrumbWrapper}>
         <Breadcrumbs breadcrumbs={breadcrumbs} />
       </div>
@@ -178,7 +178,7 @@ export function Header({
     navigationMarkup && styles.hasNavigation,
     actionMenuMarkup && styles.hasActionMenu,
     isNavigationCollapsed && styles.mobileView,
-    !breadcrumbs.length && styles.noBreadcrumbs,
+    !breadcrumbMarkup && styles.noBreadcrumbs,
     title && title.length < LONG_TITLE && styles.mediumTitle,
     title && title.length > LONG_TITLE && styles.longTitle,
   );

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -74,7 +74,7 @@ export function Header({
   primaryAction,
   pagination,
   additionalNavigation,
-  breadcrumbs = [],
+  breadcrumbs,
   secondaryActions = [],
   actionGroups = [],
   compactTitle = false,

--- a/polaris-react/src/components/Page/components/Header/Header.tsx
+++ b/polaris-react/src/components/Page/components/Header/Header.tsx
@@ -98,7 +98,7 @@ export function Header({
     !actionGroups.length;
 
   const breadcrumbMarkup =
-    (breadcrumbs instanceof Array && breadcrumbs.length > 0) || breadcrumbs ? (
+    (Array.isArray(breadcrumbs) && breadcrumbs.length > 0) || breadcrumbs ? (
       <div className={styles.BreadcrumbWrapper}>
         <Breadcrumbs breadcrumbs={breadcrumbs} />
       </div>

--- a/polaris-react/src/components/Page/components/Header/tests/Header.test.tsx
+++ b/polaris-react/src/components/Page/components/Header/tests/Header.test.tsx
@@ -62,6 +62,24 @@ describe('<Header />', () => {
         breadcrumbs,
       });
     });
+
+    it('renders breadcrumb markup if not an array', () => {
+      const breadcrumb: LinkAction = {
+        content: 'Products',
+        url: 'https://www.google.com',
+      };
+      const header = mountWithApp(
+        <Header {...mockProps} breadcrumbs={breadcrumb} />,
+      );
+      expect(header).toContainReactComponent(Breadcrumbs, {
+        breadcrumbs: breadcrumb,
+      });
+    });
+
+    it('does not render breadcrumb markup if no breadcrumbs', () => {
+      const header = mountWithApp(<Header {...mockProps} />);
+      expect(header).not.toContainReactComponent(Breadcrumbs);
+    });
   });
 
   describe('primaryAction', () => {

--- a/polaris-react/src/components/Page/tests/Page.test.tsx
+++ b/polaris-react/src/components/Page/tests/Page.test.tsx
@@ -248,6 +248,17 @@ describe('<Page />', () => {
       expect(page).toContainReactComponent(Header);
     });
 
+    it('renders a <Header /> when defined not as an array', () => {
+      const breadcrumbs = {
+        content: 'Products',
+        onAction: noop,
+      };
+      const page = mountWithApp(
+        <Page {...mockProps} breadcrumbs={breadcrumbs} />,
+      );
+      expect(page).toContainReactComponent(Header);
+    });
+
     it('gets passed into the <Header />', () => {
       const page = mountWithApp(
         <Page {...mockProps} breadcrumbs={breadcrumbs} />,


### PR DESCRIPTION
### WHY are these changes introduced?

For an upcoming change to breadcrumbs where arrays will no longer be allowed, this change allows current consumers to begin making that transition.

For a while now only the last item in the array has been shown in the breadcrumb component. Changing the interface away from accepting arrays will make the props more indicative of the final component output and easier to understand at a glance.

### WHAT is this pull request doing?

It just changes the interface to allow arrays and non-arrays. Tests have been added for this as well.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
