### PR TITLE
[Modal] Fix content overflow / scroll bug

### DIFF
--- a/.changeset/pretty-drinks-tie.md
+++ b/.changeset/pretty-drinks-tie.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed modal scroll bug

--- a/polaris-react/src/components/Modal/Modal.stories.tsx
+++ b/polaris-react/src/components/Modal/Modal.stories.tsx
@@ -6,7 +6,6 @@ import {
   Checkbox,
   ChoiceList,
   DropZone,
-  Form,
   FormLayout,
   Modal,
   Stack,
@@ -490,29 +489,44 @@ export function WithLongContent() {
       title="Long form modal"
       open
       onClose={() => {}}
-      sectioned
       primaryAction={{content: 'Save'}}
     >
-      <Banner title="Heyo" />
-      <Form onSubmit={() => {}}>
+      <Modal.Section>
+        <Banner title="Payment details" />
+      </Modal.Section>
+      <Modal.Section>
         <FormLayout>
           <FormLayout.Group>
-            <TextField label="URL" type="url" autoComplete="url" />
-            <TextField label="URL" type="url" autoComplete="url" />
-            <TextField label="URL" type="url" autoComplete="url" />
+            <TextField label="Payment method type" autoComplete="off" />
+            <TextField label="Card number" autoComplete="off" />
+          </FormLayout.Group>
+
+          <FormLayout.Group>
+            <TextField label="Expires" autoComplete="off" />
+            <TextField label="CVV" autoComplete="off" />
+          </FormLayout.Group>
+
+          <FormLayout.Group>
+            <TextField label="Country/region" autoComplete="off" />
+          </FormLayout.Group>
+
+          <FormLayout.Group>
+            <TextField label="First name" autoComplete="off" />
+            <TextField label="Last name" autoComplete="off" />
+          </FormLayout.Group>
+
+          <FormLayout.Group>
+            <TextField label="Address" autoComplete="off" />
+            <TextField label="Apartment, suite, etc." autoComplete="off" />
+          </FormLayout.Group>
+
+          <FormLayout.Group>
+            <TextField label="City" autoComplete="off" />
+            <TextField label="Province" autoComplete="off" />
+            <TextField label="Postal code" autoComplete="off" />
           </FormLayout.Group>
         </FormLayout>
-        <FormLayout>
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-        </FormLayout>
-      </Form>
+      </Modal.Section>
     </Modal>
   );
 }
@@ -527,26 +541,42 @@ export function WithLongContentNoScroll() {
       noScroll
       primaryAction={{content: 'Save'}}
     >
-      <Banner title="Heyo" />
-      <Form onSubmit={() => {}}>
+      <Modal.Section>
+        <Banner title="Payment details" />
+      </Modal.Section>
+      <Modal.Section>
         <FormLayout>
           <FormLayout.Group>
-            <TextField label="URL" type="url" autoComplete="url" />
-            <TextField label="URL" type="url" autoComplete="url" />
-            <TextField label="URL" type="url" autoComplete="url" />
+            <TextField label="Payment method type" autoComplete="off" />
+            <TextField label="Card number" autoComplete="off" />
+          </FormLayout.Group>
+
+          <FormLayout.Group>
+            <TextField label="Expires" autoComplete="off" />
+            <TextField label="CVV" autoComplete="off" />
+          </FormLayout.Group>
+
+          <FormLayout.Group>
+            <TextField label="Country/region" autoComplete="off" />
+          </FormLayout.Group>
+
+          <FormLayout.Group>
+            <TextField label="First name" autoComplete="off" />
+            <TextField label="Last name" autoComplete="off" />
+          </FormLayout.Group>
+
+          <FormLayout.Group>
+            <TextField label="Address" autoComplete="off" />
+            <TextField label="Apartment, suite, etc." autoComplete="off" />
+          </FormLayout.Group>
+
+          <FormLayout.Group>
+            <TextField label="City" autoComplete="off" />
+            <TextField label="Province" autoComplete="off" />
+            <TextField label="Postal code" autoComplete="off" />
           </FormLayout.Group>
         </FormLayout>
-        <FormLayout>
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-          <TextField label="URL" type="url" autoComplete="url" />
-        </FormLayout>
-      </Form>
+      </Modal.Section>
     </Modal>
   );
 }

--- a/polaris-react/src/components/Modal/Modal.tsx
+++ b/polaris-react/src/components/Modal/Modal.tsx
@@ -165,7 +165,9 @@ export const Modal: React.FunctionComponent<ModalProps> & {
     );
 
     const scrollContainerMarkup = noScroll ? (
-      <Box width="100%">{body}</Box>
+      <Box width="100%" overflowX="hidden">
+        {body}
+      </Box>
     ) : (
       <Scrollable
         shadow


### PR DESCRIPTION
Fixes: https://github.com/Shopify/polaris/issues/8013

[Spin link](https://admin.web.billing-kmux.kyle-durand.us.spin.dev/store/shop1)

The cause of this bug was not porting over `overflow-x: hidden` from the body markup container

Before | After
---|---
![](https://screenshot.click/10-32-qzmr9-qfziv.png) | ![](https://screenshot.click/10-32-lbwb7-4b4z2.png)
