### PR TITLE
[TextField]: Enable proper focus when clicking the stepper

### DIFF
--- a/.changeset/warm-cars-fry.md
+++ b/.changeset/warm-cars-fry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Changed onClick focus for stepper from `setFocus(true)` to `input.focus()` to allow `onBlur` to be called.

--- a/.changeset/warm-cars-fry.md
+++ b/.changeset/warm-cars-fry.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Changed onClick focus for stepper from `setFocus(true)` to `input.focus()` to allow `onBlur` to be called.
+Added `onBlur` prop to numerical steppers (`Spinner` component of `TextField`) to remove multi focus issue in `TextField`.

--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -34,17 +34,28 @@ export function Default() {
 
 export function Number() {
   const [value, setValue] = useState('1');
+  const [value1, setValue1] = useState('1');
 
   const handleChange = useCallback((newValue) => setValue(newValue), []);
+  const handleChange1 = useCallback((newValue) => setValue1(newValue), []);
 
   return (
-    <TextField
-      label="Quantity"
-      type="number"
-      value={value}
-      onChange={handleChange}
-      autoComplete="off"
-    />
+    <Stack vertical>
+      <TextField
+        label="First Quantity"
+        type="number"
+        value={value}
+        onChange={handleChange}
+        autoComplete="off"
+      />
+      <TextField
+        label="Second Quantity"
+        type="number"
+        value={value1}
+        onChange={handleChange1}
+        autoComplete="off"
+      />
+    </Stack>
   );
 }
 

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -407,6 +407,7 @@ export function TextField({
         onMouseDown={handleButtonPress}
         onMouseUp={handleButtonRelease}
         ref={spinnerRef}
+        onBlur={handleOnBlur}
       />
     ) : null;
 
@@ -474,14 +475,6 @@ export function TextField({
 
     if (onFocus) {
       onFocus(event as React.FocusEvent<HTMLInputElement>);
-    }
-  };
-
-  const handleOnBlur = (event: React.FocusEvent) => {
-    setFocus(false);
-
-    if (onBlur) {
-      onBlur(event);
     }
   };
 
@@ -634,6 +627,14 @@ export function TextField({
     }
 
     event.preventDefault();
+  }
+
+  function handleOnBlur(event: React.FocusEvent) {
+    setFocus(false);
+
+    if (onBlur) {
+      onBlur(event);
+    }
   }
 
   function isInput(target: HTMLElement | EventTarget) {

--- a/polaris-react/src/components/TextField/components/Spinner/Spinner.tsx
+++ b/polaris-react/src/components/TextField/components/Spinner/Spinner.tsx
@@ -11,10 +11,11 @@ export interface SpinnerProps {
   onClick?(event: React.MouseEvent): void;
   onMouseDown(onChange: HandleStepFn): void;
   onMouseUp(): void;
+  onBlur(event: React.FocusEvent): void;
 }
 
 export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
-  function Spinner({onChange, onClick, onMouseDown, onMouseUp}, ref) {
+  function Spinner({onChange, onClick, onMouseDown, onMouseUp, onBlur}, ref) {
     function handleStep(step: number) {
       return () => onChange(step);
     }
@@ -35,6 +36,7 @@ export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
           onClick={handleStep(1)}
           onMouseDown={handleMouseDown(handleStep(1))}
           onMouseUp={onMouseUp}
+          onBlur={onBlur}
         >
           <div className={styles.SpinnerIcon}>
             <Icon source={CaretUpMinor} />
@@ -47,6 +49,7 @@ export const Spinner = React.forwardRef<HTMLDivElement, SpinnerProps>(
           onClick={handleStep(-1)}
           onMouseDown={handleMouseDown(handleStep(-1))}
           onMouseUp={onMouseUp}
+          onBlur={onBlur}
         >
           <div className={styles.SpinnerIcon}>
             <Icon source={CaretDownMinor} />

--- a/polaris-react/src/components/TextField/components/Spinner/tests/Spinner.test.tsx
+++ b/polaris-react/src/components/TextField/components/Spinner/tests/Spinner.test.tsx
@@ -4,11 +4,18 @@ import {mountWithApp} from 'tests/utilities';
 import {Spinner} from '../Spinner';
 
 describe('<Spinner />', () => {
+  const defaultProps = {
+    onChange: noop,
+    onMouseDown: noop,
+    onMouseUp: noop,
+    onBlur: noop,
+  };
+
   describe('onChange', () => {
     it('adds a change callback', () => {
       const spy = jest.fn();
       const spinner = mountWithApp(
-        <Spinner onChange={spy} onMouseDown={noop} onMouseUp={noop} />,
+        <Spinner {...defaultProps} onChange={spy} />,
       );
 
       spinner.find('div', {role: 'button'})!.trigger('onClick');
@@ -19,14 +26,7 @@ describe('<Spinner />', () => {
   describe('onClick', () => {
     it('adds a click callback', () => {
       const spy = jest.fn();
-      const spinner = mountWithApp(
-        <Spinner
-          onClick={spy}
-          onChange={noop}
-          onMouseDown={noop}
-          onMouseUp={noop}
-        />,
-      );
+      const spinner = mountWithApp(<Spinner {...defaultProps} onClick={spy} />);
       spinner.find('div', {className: 'Spinner'})!.trigger('onClick');
       expect(spy).toHaveBeenCalledTimes(1);
     });
@@ -40,9 +40,9 @@ describe('<Spinner />', () => {
       const changeSpy = jest.fn();
       const spinner = mountWithApp(
         <Spinner
+          {...defaultProps}
           onChange={changeSpy}
           onMouseDown={mouseDownSpy}
-          onMouseUp={noop}
         />,
       );
 
@@ -61,9 +61,9 @@ describe('<Spinner />', () => {
       const changeSpy = jest.fn();
       const spinner = mountWithApp(
         <Spinner
+          {...defaultProps}
           onChange={changeSpy}
           onMouseDown={mouseDownSpy}
-          onMouseUp={noop}
         />,
       );
 
@@ -80,12 +80,23 @@ describe('<Spinner />', () => {
     it('adds a mouse up callback', () => {
       const spy = jest.fn();
       const spinner = mountWithApp(
-        <Spinner onChange={noop} onMouseDown={noop} onMouseUp={spy} />,
+        <Spinner {...defaultProps} onMouseUp={spy} />,
       );
 
       spinner.find('div', {role: 'button'})!.trigger('onMouseUp');
 
       expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onBlur()', () => {
+    it('is called when the stepper is blurred', () => {
+      const onBlurSpy = jest.fn();
+      const spinner = mountWithApp(
+        <Spinner {...defaultProps} onBlur={onBlurSpy} />,
+      );
+      spinner.find('div', {role: 'button'})!.trigger('onBlur');
+      expect(onBlurSpy).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

(All the same issue just were multiple 😄 ) 
Fixes https://github.com/Shopify/polaris/issues/7035
Fixes https://github.com/Shopify/polaris/issues/7250
Fixes https://github.com/Shopify/polaris/issues/7718
Resolves https://github.com/Shopify/inventory-states-ux/issues/654

### 📣 Hey reviewers, there are TWO commits I'd love your eyes on! 😄 

####  COMMIT 1 approach
Changed the focus from the stepper to become the `input` in order to call the `onBlur`

For some reason, setting the Focus via the state (`setFocus`) in the child doesn't call the `onBlur` which caused all the issues seen above. Setting the focus directly on the `input` when using the stepper calls the `onBlur`, which fixes this. 

####  COMMIT 2 approach
Doing the commit 1 approach meant that the focus was lost on the stepper, it actually didn't have any repercussions BUT this new approach just adds an `onBlur` down to the stepper (called Spinner 😕), which also solves this problem! 

### WHAT is this pull request doing?

| BEFORE | AFTER|
| ----- | ----- |
|<img width="150" alt="Screenshot 2023-01-18 at 5 34 21 PM" src="https://user-images.githubusercontent.com/43223543/213334839-8afc6514-232b-40e5-a584-a34fee5ae9ae.png"> | <img width="300" alt="Screenshot 2023-01-18 at 5 34 06 PM" src="https://user-images.githubusercontent.com/43223543/213334815-d6c4a293-5eda-4c1a-bd14-c2625d720e7f.png"> |

 <details>
      <summary>EXPAND TO SEE VIDEO BEFORE / AFTER BEHAVIOUR 📹 </summary>
     
## BEFORE

https://user-images.githubusercontent.com/43223543/213334719-fdd10c12-6062-4e79-a48d-121d250afe82.mp4



## AFTER

https://user-images.githubusercontent.com/43223543/213334730-50e8fafa-9205-45ba-abfe-3daf909b028b.mp4



</details>

### How to 🎩

[Most recent storybook link](https://5d559397bae39100201eedc1-rnwtxycams.chromatic.com/?path=/story/all-components-textfield--number)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React, {useCallback, useState} from 'react';

import {Page, TextField} from '../src';

export function Playground() {
  const [value, setValue] = useState('1');
  const [value1, setValue1] = useState('1');
  const [value2, setValue2] = useState('1');

  const handleChange = useCallback(
    (newValue: React.SetStateAction<string>) => setValue(newValue),
    [],
  );

  const handleChange1 = useCallback(
    (newValue: React.SetStateAction<string>) => setValue1(newValue),
    [],
  );

  const handleChange2 = useCallback(
    (newValue: React.SetStateAction<string>) => setValue2(newValue),
    [],
  );

  return (
    <Page title="Playground">
      <TextField
        label="Quantity"
        type="number"
        value={value}
        onChange={handleChange}
        autoComplete="off"
        align="left"
        labelHidden
      />
      <TextField
        label="Quantity"
        type="number"
        value={value1}
        onChange={handleChange1}
        autoComplete="off"
        align="left"
        labelHidden
        selectTextOnFocus
      />
      <TextField
        label="Quantity"
        type="number"
        value={value2}
        onChange={handleChange2}
        autoComplete="off"
        align="left"
        labelHidden
      />
    </Page>
  );
}

```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
