### PR TITLE
[ResourceItem] Realign shortcut actions to match header

### DIFF
--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -270,7 +270,7 @@ class BaseResourceItem extends Component<CombinedProps, State> {
       } else if (breakpoints?.lgUp) {
         actionsMarkup = (
           <div className={styles.Actions} onClick={stopPropagation}>
-            <Box position="absolute" insetBlockStart="4" insetInlineEnd="4">
+            <Box position="absolute" insetBlockStart="4" insetInlineEnd="5">
               <ButtonGroup segmented>
                 {buttonsFrom(shortcutActions, {size: 'slim'})}
               </ButtonGroup>


### PR DESCRIPTION
Header alignment changed in https://github.com/Shopify/polaris/pull/7965. Adjusting shortcut action spacing to match