### PR TITLE
[PopOver] Fix popover activator focus depending on keypress

### DIFF
--- a/.changeset/brown-gifts-notice.md
+++ b/.changeset/brown-gifts-notice.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix popover activator focus on esc

--- a/.changeset/brown-gifts-notice.md
+++ b/.changeset/brown-gifts-notice.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Fix popover activator focus on esc
+Fixed focus not returning to the `Popover` `activator` on keypress of Escape

--- a/polaris-react/src/components/Popover/Popover.stories.tsx
+++ b/polaris-react/src/components/Popover/Popover.stories.tsx
@@ -25,15 +25,29 @@ export default {
 } as ComponentMeta<typeof Popover>;
 
 export function WithActionList() {
-  const [popoverActive, setPopoverActive] = useState(true);
+  // const [popoverActive, setPopoverActive] = useState(true);
+  const [activePopover, setActivePopover] = useState(null);
 
-  const togglePopoverActive = useCallback(
-    () => setPopoverActive((popoverActive) => !popoverActive),
-    [],
-  );
+  const togglePopoverActive = useCallback((popover, isClosing) => {
+    const ap = isClosing ? null : popover;
+    setActivePopover(ap);
+  }, []);
 
   const activator = (
-    <Button onClick={togglePopoverActive} disclosure>
+    <Button
+      id="button-1"
+      onClick={() => togglePopoverActive('popover1', false)}
+      disclosure
+    >
+      More actions
+    </Button>
+  );
+  const activator2 = (
+    <Button
+      id="button-2"
+      onClick={() => togglePopoverActive('popover2', false)}
+      disclosure
+    >
       More actions
     </Button>
   );
@@ -41,10 +55,21 @@ export function WithActionList() {
   return (
     <div style={{height: '250px'}}>
       <Popover
-        active={popoverActive}
+        active={activePopover === 'popover1'}
         activator={activator}
         autofocusTarget="first-node"
-        onClose={togglePopoverActive}
+        onClose={() => togglePopoverActive('popover1', true)}
+      >
+        <ActionList
+          actionRole="menuitem"
+          items={[{content: 'Import'}, {content: 'Export'}]}
+        />
+      </Popover>
+      <Popover
+        active={activePopover === 'popover2'}
+        activator={activator2}
+        autofocusTarget="first-node"
+        onClose={() => togglePopoverActive('popover2', true)}
       >
         <ActionList
           actionRole="menuitem"

--- a/polaris-react/src/components/Popover/Popover.stories.tsx
+++ b/polaris-react/src/components/Popover/Popover.stories.tsx
@@ -25,12 +25,11 @@ export default {
 } as ComponentMeta<typeof Popover>;
 
 export function WithActionList() {
-  // const [popoverActive, setPopoverActive] = useState(true);
   const [activePopover, setActivePopover] = useState(null);
 
   const togglePopoverActive = useCallback((popover, isClosing) => {
-    const ap = isClosing ? null : popover;
-    setActivePopover(ap);
+    const currentPopover = isClosing ? null : popover;
+    setActivePopover(currentPopover);
   }, []);
 
   const activator = (

--- a/polaris-react/src/components/Popover/Popover.tsx
+++ b/polaris-react/src/components/Popover/Popover.tsx
@@ -159,17 +159,27 @@ const PopoverComponent = forwardRef<PopoverPublicAPI, PopoverProps>(
         return;
       }
 
-      if (
-        (source === PopoverCloseSource.FocusOut ||
-          source === PopoverCloseSource.EscapeKeypress) &&
-        activatorNode
-      ) {
+      if (source === PopoverCloseSource.FocusOut && activatorNode) {
         const focusableActivator =
           findFirstFocusableNodeIncludingDisabled(activatorNode) ||
           findFirstFocusableNodeIncludingDisabled(activatorContainer.current) ||
           activatorContainer.current;
         if (!focusNextFocusableNode(focusableActivator, isInPortal)) {
           focusableActivator.focus();
+        }
+      } else if (
+        source === PopoverCloseSource.EscapeKeypress &&
+        activatorNode
+      ) {
+        const focusableActivator =
+          findFirstFocusableNodeIncludingDisabled(activatorNode) ||
+          findFirstFocusableNodeIncludingDisabled(activatorContainer.current) ||
+          activatorContainer.current;
+
+        if (focusableActivator) {
+          focusableActivator.focus();
+        } else {
+          focusNextFocusableNode(focusableActivator, isInPortal);
         }
       }
     };

--- a/polaris-react/src/components/Popover/tests/Popover.test.tsx
+++ b/polaris-react/src/components/Popover/tests/Popover.test.tsx
@@ -5,7 +5,7 @@ import {Portal} from '../../Portal';
 import {PositionedOverlay} from '../../PositionedOverlay';
 import {Popover} from '../Popover';
 import type {PopoverPublicAPI} from '../Popover';
-import {Pane, PopoverOverlay} from '../components';
+import {Pane, PopoverCloseSource, PopoverOverlay} from '../components';
 import * as setActivatorAttributes from '../set-activator-attributes';
 import {TextContainer} from '../../TextContainer';
 
@@ -273,23 +273,56 @@ describe('<Popover />', () => {
     expect(onCloseSpy).not.toHaveBeenCalled();
   });
 
-  it('focuses the next available element when the popover is closed', () => {
-    const id = 'focus-target';
+  it('focuses the next available element when the popover is closed using the tab key', () => {
+    const activatorId = 'focus-target';
+    const nextFocusedId = 'focus-target2';
     function PopoverTest() {
       return (
         <>
           <div>
-            <Popover active activator={<div />} onClose={noop} />
+            <Popover
+              active
+              activator={<button id={activatorId} />}
+              onClose={noop}
+            />
           </div>
-          <button id={id} />
+          <button id={nextFocusedId} />
         </>
       );
     }
 
     const popover = mountWithApp(<PopoverTest />);
+    popover
+      .find(PopoverOverlay)
+      ?.trigger('onClose', PopoverCloseSource.FocusOut);
+    const focusTarget = popover.find('button', {id: nextFocusedId})!.domNode;
 
-    popover.find(PopoverOverlay)!.trigger('onClose', 1);
-    const focusTarget = popover.find('button', {id})!.domNode;
+    expect(document.activeElement).toBe(focusTarget);
+  });
+
+  it('focuses the initial element that activated the popover when the popover is closed using the esc key', () => {
+    const activatorId = 'focus-target';
+    const nextFocusedId = 'focus-target2';
+    function PopoverTest() {
+      return (
+        <>
+          <div>
+            <Popover
+              active
+              activator={<button id={activatorId} />}
+              onClose={noop}
+            />
+          </div>
+          <button id={nextFocusedId} />
+        </>
+      );
+    }
+
+    const popover = mountWithApp(<PopoverTest />);
+    popover
+      .find(PopoverOverlay)
+      ?.trigger('onClose', PopoverCloseSource.EscapeKeypress);
+    const focusTarget = popover.find('button', {id: activatorId})!.domNode;
 
     expect(document.activeElement).toBe(focusTarget);
   });


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #[3856](https://github.com/Shopify/polaris/issues/3856)

Slack thread for context: [HERE](https://shopify.slack.com/archives/C4Y8N30KD/p1674677787104739)

In the [docs](https://polaris.shopify.com/components/popover), it is mentioned  "When the popover is closed, focus returns to the element that launched it" but in reality, it would always jump to the next focusable element (see [codesandbox](https://codesandbox.io/s/epic-herschel-z1luu6?file=/App.js) example) instead of returning focus to the activator that opened the popover.

A regression was introduced at some point, preventing focus to restore to the activator that originally launched the popover if the ESC key was pressed ([context here](https://github.com/Shopify/polaris-ux-archive/issues/161#issue-337643009)). This PR ensures the following:


1. Focus jumps to next element after tabbing out of the popover (this works today)
2. Focus returns to initial activator when esc out of popover (currently broken)

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<details><summary>Before/After</summary>

1. Before splitting out esc and tab functionality (focus jumped to next element in both scenarios):


https://user-images.githubusercontent.com/69861203/214920147-62684d5c-7872-4738-864d-695153e3ee0f.mov



2. After splitting (focus restores on esc, focus jumps on tab):

ESC:

https://user-images.githubusercontent.com/69861203/214919860-88658a96-3dcf-45e4-b0a4-ad9a6bb19d43.mov


TAB: 

https://user-images.githubusercontent.com/69861203/214919870-7855857b-4f18-40a9-b0cd-c338c69b6884.mov




</details>


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

Spin link: [SPIN](https://admin.web.polarispopoversnap.rana-jurjus.us.spin.dev/store/shop1/themes/1/editor?context=theme&category=gid%3A%2F%2Fshopify%2FOnlineStoreThemeSettingsCategory%2FColors%3Ftheme_id%3D1%26first_setting_id%3Dcolors_solid_button_labels)

1. Click the paintbrush in the left sidebar and select the colors dropdown
2. Select any non-gradient color swatches (The circles next to each label) to open a popover. Alternate between tabbing through and esc from the popover that opens.
3. If you tab through the popover, expect focus to shift to the next element (likely a datasource icon). If you esc from the popover, expect focus to shift back to the initial swatch you selected to launch the popover.



### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [X] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [X] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
