### PR TITLE
[IndexTable] Update type of tooltipContent to a ReactNode

### DIFF
--- a/.changeset/soft-foxes-dream.md
+++ b/.changeset/soft-foxes-dream.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated IndexTable's heading.tooltipContent type to a React Node

--- a/.changeset/soft-foxes-dream.md
+++ b/.changeset/soft-foxes-dream.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Updated IndexTable's heading.tooltipContent type to a React Node
+Updated the `IndexTable` `heading.tooltipContent` type to a `ReactNode`

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -49,7 +49,7 @@ interface IndexTableHeadingBase {
   flush?: boolean;
   new?: boolean;
   hidden?: boolean;
-  tooltipContent?: string;
+  tooltipContent?: React.ReactNode;
   tooltipWidth?: Width;
   tooltipPersistsOnClick?: boolean;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This PR updates the `tooltipContent` type from a string to a React Node. We overlooked that we need to pass in an element for the On hand tooltip content as we are bolding some of the text in the tooltip's message.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
