### PR TITLE
Updated yml for content minor

### DIFF
--- a/.changeset/twelve-hornets-notice.md
+++ b/.changeset/twelve-hornets-notice.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-icons': patch
+---
+
+Updated the yml set to lowercase minor

--- a/.changeset/twelve-hornets-notice.md
+++ b/.changeset/twelve-hornets-notice.md
@@ -2,4 +2,4 @@
 '@shopify/polaris-icons': patch
 ---
 
-Updated the yml set to lowercase minor
+Fixed typo in set type for ContentMinor

--- a/polaris-icons/icons/ContentMinor.yml
+++ b/polaris-icons/icons/ContentMinor.yml
@@ -1,5 +1,5 @@
 name: Content
-set: Minor
+set: minor
 description: Used to represent content.
 keywords:
   - content


### PR DESCRIPTION
### WHY are these changes introduced?

Content minor icon is not showing up on [Polaris Icon Explorer](https://polaris.shopify.com/icons), the reason is because the set needs to be a lower case "minor".

### WHAT is this pull request doing?

Updated the set in the YML from "Minor" to "minor".