### PR TITLE
Remove support for React 16 and 17

### DIFF
--- a/documentation/guides/migrating-from-v10-to-v11.md
+++ b/documentation/guides/migrating-from-v10-to-v11.md
@@ -14,6 +14,10 @@ Polaris v11.0.0 ([full release notes](https://github.com/Shopify/polaris/release
 
 NodeJS version 14 is no longer supported. NodeJS 18 is recommended and 16 is the minimum supported version.
 
+## React support
+
+React version 16 and 17 is no longer supported. React 18 is the minimum supported version.
+
 ## TypeScript
 
 Built types in `@shopify/polaris` have moved from `build/ts/latest` to `build/ts`.

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -65,6 +65,10 @@
     "react-fast-compare": "^3.2.0",
     "react-transition-group": "^4.4.2"
   },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
   "devDependencies": {
     "@changesets/get-release-plan": "^3.0.13",
     "@shopify/browserslist-config": "^3.0.0",

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -65,10 +65,6 @@
     "react-fast-compare": "^3.2.0",
     "react-transition-group": "^4.4.2"
   },
-  "peerDependencies": {
-    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
-  },
   "devDependencies": {
     "@changesets/get-release-plan": "^3.0.13",
     "@shopify/browserslist-config": "^3.0.0",

--- a/polaris-react/rollup.config.mjs
+++ b/polaris-react/rollup.config.mjs
@@ -33,7 +33,6 @@ function generateConfig({output, targets, stylesConfig}) {
         // Options that may be present on the `babelConfig` object but
         // we want to override
         envName: 'production',
-        // @ts-expect-error targets is a valid babel option but @types/babel__core doesn't know that yet
         targets,
       }),
       replace({


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/8331

### WHAT is this pull request doing?

Removing support for v16 and v17 from Shopify Polaris.