### PR TITLE
adding pages from alt-text branch

### DIFF
--- a/polaris.shopify.com/content/patterns/app-settings-layout.ts
+++ b/polaris.shopify.com/content/patterns/app-settings-layout.ts
@@ -4,7 +4,7 @@ const pattern: SingleVariantPattern = {
   title: 'App settings layout',
   description:
     'Lets merchants easily scan many groups of settings and find the ones they want to change.',
-  howItHelps: `![App settings page with two columns.](/images/patterns/app-settings-cover-image.png)
+  howItHelps: `![App settings page with two columns](/images/patterns/app-settings-cover-image.png)
 
   1. In the left column, glanceable labels and descriptions are listed to make it easier for merchants to scan the page and quickly find what they are looking for.
   2. In the right column, settings are grouped in cards to make it easier for merchants to configure a setting after it's been found, or to configure multiple settings that might belong together.
@@ -21,9 +21,9 @@ const pattern: SingleVariantPattern = {
   usefulToKnow: `
   | | |
   |-|-|
-  |Don't include a description unless it's helpful.|![Section header with no description on an app settings page.](/images/patterns/app-settings-usage-1.png)|
-  |Place grouped settings within cards.|![App settings page with section headings and grouped settings.](/images/patterns/app-settings-usage-2.png)|
-  |Stack all setting groups vertically on the page.|![App settings page with two vertically stacked sections.](/images/patterns/app-settings-usage-3.png)|`,
+  |Don't include a description unless it's helpful.|![Section header with no description on an app settings page](/images/patterns/app-settings-usage-1.png)|
+  |Place grouped settings within cards.|![App settings page with section headings and grouped settings](/images/patterns/app-settings-usage-2.png)|
+  |Stack all setting groups vertically on the page.|![App settings page with two vertically stacked sections](/images/patterns/app-settings-usage-3.png)|`,
   relatedResources: `* See another two-column layout in use in the [Resource detail layout](/patterns/resource-details-layout) pattern.
 * See a single-column layout in use in the [Resource index layout](/patterns/resource-index-layout) pattern.
 * Learn more about [Layout](https://shopify.dev/apps/design-guidelines/layout) in the app design guidelines.

--- a/polaris.shopify.com/content/patterns/app-settings-layout.ts
+++ b/polaris.shopify.com/content/patterns/app-settings-layout.ts
@@ -4,7 +4,7 @@ const pattern: SingleVariantPattern = {
   title: 'App settings layout',
   description:
     'Lets merchants easily scan many groups of settings and find the ones they want to change.',
-  howItHelps: `![A labeled diagram of an app settings page layout. The left column is labeled "1" it contains glanceable labels and descriptions. The right column is labeled "2" and contains a list of cards.](/images/patterns/app-settings-cover-image.png)
+  howItHelps: `![App settings page with two columns.](/images/patterns/app-settings-cover-image.png)
 
   1. In the left column, glanceable labels and descriptions are listed to make it easier for merchants to scan the page and quickly find what they are looking for.
   2. In the right column, settings are grouped in cards to make it easier for merchants to configure a setting after it's been found, or to configure multiple settings that might belong together.
@@ -21,9 +21,9 @@ const pattern: SingleVariantPattern = {
   usefulToKnow: `
   | | |
   |-|-|
-  |Don't include a description unless it's helpful.|![](/images/patterns/app-settings-usage-1.png)|
-  |Place grouped settings within cards.|![](/images/patterns/app-settings-usage-2.png)|
-  |Stack all setting groups vertically on the page.|![](/images/patterns/app-settings-usage-3.png)|`,
+  |Don't include a description unless it's helpful.|![Section header with no description on an app settings page.](/images/patterns/app-settings-usage-1.png)|
+  |Place grouped settings within cards.|![App settings page with section headings and grouped settings.](/images/patterns/app-settings-usage-2.png)|
+  |Stack all setting groups vertically on the page.|![App settings page with two vertically stacked sections.](/images/patterns/app-settings-usage-3.png)|`,
   relatedResources: `* See another two-column layout in use in the [Resource detail layout](/patterns/resource-details-layout) pattern.
 * See a single-column layout in use in the [Resource index layout](/patterns/resource-index-layout) pattern.
 * Learn more about [Layout](https://shopify.dev/apps/design-guidelines/layout) in the app design guidelines.

--- a/polaris.shopify.com/content/patterns/date-picking.ts
+++ b/polaris.shopify.com/content/patterns/date-picking.ts
@@ -12,7 +12,7 @@ const pattern: MultiVariantPattern = {
       slug: 'single-date',
       description:
         'This enables merchants to type a specific date or pick it from a calendar.',
-      howItHelps: `![A labeled diagram of an active input field displaying a calendar beneath it. The input field is labeled "1". The calendar is labeled "2".](/images/patterns/single-list-cover-image.png)
+      howItHelps: `![Date text input and a single-month calendar](/images/patterns/single-list-cover-image.png)
 
 1. The text input gives merchants the option to use the keyboard to enter a date.
 2. A single month calendar allows merchants to select a date while seeing its relationship to other days.
@@ -31,8 +31,8 @@ const pattern: MultiVariantPattern = {
       usefulToKnow: `
 | | |
 |-|-|
-|Labels need to simply depict the task at hand. Whether that be a start date, end date, start time etc.|![](/images/patterns/single-list-usage-1.png)|
-|This pattern can be duplicated to allow users to add an end date or time.|![](/images/patterns/single-list-usage-2.png)|
+|Labels need to simply depict the task at hand. Whether that be a start date, end date, start time etc.|![Date input labeled “Expiry date”](/images/patterns/single-list-usage-1.png)|
+|This pattern can be duplicated to allow users to add an end date or time.|![“Active dates” section with “start date” and “end date” inputs, toggled on with a “Set end date” checkbox.](/images/patterns/single-list-usage-2.png)|
 `,
       example: {
         relatedComponents: [
@@ -226,7 +226,7 @@ const pattern: MultiVariantPattern = {
       title: 'Date range',
       slug: 'date-range',
       description: 'This enables merchants to select a date range.',
-      howItHelps: `![](/images/patterns/date-range-cover-image.png)
+      howItHelps: `![Date range picker with three numbered zones.](/images/patterns/date-range-cover-image.png)
 
 1. Providing multiple ways to select a date range gives merchants full flexibility. The list provides quick access to common options, the text input makes it easier to set large custom ranges, and the calendar is an intuitive way to set a more narrow scope.
 2. Displaying two months makes it easier for merchants to select date ranges that span across both.
@@ -246,9 +246,9 @@ const pattern: MultiVariantPattern = {
       usefulToKnow: `
 | | |
 |-|-|
-|Pin any relevant, merchant-specific dates to the top of the option list.|![](/images/patterns/date-range-usage-1.png)|
-|If a date cannot be selected, indicate it with the [disabled text color token](/tokens/colors)|![](/images/patterns/date-range-usage-2.png)|
-|If a merchant enters a nonexistent date, revert to the previously selected date.|![](/images/patterns/date-range-usage-3.png)|
+|Pin any relevant, merchant-specific dates to the top of the option list.|![List of date options such as “BFCM (2023)”](/images/patterns/date-range-usage-1.png)|
+|If a date cannot be selected, indicate it with the [disabled text color token](/tokens/colors)|![Single-month calendar with a range of unselectable dates](/images/patterns/date-range-usage-2.png)|
+|If a merchant enters a nonexistent date, revert to the previously selected date.|![Calendar with date inputs reading an incorrect date](/images/patterns/date-range-usage-3.png)|
 `,
       example: {
         relatedComponents: [
@@ -823,7 +823,7 @@ const pattern: MultiVariantPattern = {
       slug: 'date-list',
       description:
         'This enables merchants to select a date or a date range from a list of preset dates.',
-      howItHelps: `![](/images/patterns/date-list-cover-image.png)
+      howItHelps: `![Option list with common suggested dates, such as “Today” and “Last 30 days.”](/images/patterns/date-list-cover-image.png)
 
 1. The date list provides merchants with suggested dates. This makes date picking simpler when useful dates are predictable and custom dates aren’t necessary.
 
@@ -838,9 +838,9 @@ const pattern: MultiVariantPattern = {
       usefulToKnow: `
 | | |
 |-|-|
-|In the button preview, set a default date range that a merchant will most likely use.|![](/images/patterns/date-list-usage-1.png)|
-|Single dates should be at the top of the list, followed by date ranges from smallest to largest ranges.|![](/images/patterns/date-list-usage-2.png)|
-|A date list can be modified to serve unique situations, like providing suggested search queries in the customer segment editor.|![](/images/patterns/date-list-usage-3.png)|
+|In the button preview, set a default date range that a merchant will most likely use.|![Button showing a calendar icon labeled “Today”](/images/patterns/date-list-usage-1.png)|
+|Single dates should be at the top of the list, followed by date ranges from smallest to largest ranges.|![Option list with common suggested dates followed by ranges](/images/patterns/date-list-usage-2.png)|
+|A date list can be modified to serve unique situations, like providing suggested search queries in the customer segment editor.|![Customer segment editor with a date list showing common ranges and related code snippets](/images/patterns/date-list-usage-3.png)|
 `,
       example: {
         relatedComponents: [

--- a/polaris.shopify.com/content/patterns/date-picking.ts
+++ b/polaris.shopify.com/content/patterns/date-picking.ts
@@ -32,7 +32,7 @@ const pattern: MultiVariantPattern = {
 | | |
 |-|-|
 |Labels need to simply depict the task at hand. Whether that be a start date, end date, start time etc.|![Date input labeled “Expiry date”](/images/patterns/single-list-usage-1.png)|
-|This pattern can be duplicated to allow users to add an end date or time.|![“Active dates” section with “start date” and “end date” inputs, toggled on with a “Set end date” checkbox.](/images/patterns/single-list-usage-2.png)|
+|This pattern can be duplicated to allow users to add an end date or time.|![“Active dates” section with “start date” and “end date” inputs, toggled on with a “Set end date” checkbox](/images/patterns/single-list-usage-2.png)|
 `,
       example: {
         relatedComponents: [
@@ -226,7 +226,7 @@ const pattern: MultiVariantPattern = {
       title: 'Date range',
       slug: 'date-range',
       description: 'This enables merchants to select a date range.',
-      howItHelps: `![Date range picker with three numbered zones.](/images/patterns/date-range-cover-image.png)
+      howItHelps: `![Date range picker with three numbered zones](/images/patterns/date-range-cover-image.png)
 
 1. Providing multiple ways to select a date range gives merchants full flexibility. The list provides quick access to common options, the text input makes it easier to set large custom ranges, and the calendar is an intuitive way to set a more narrow scope.
 2. Displaying two months makes it easier for merchants to select date ranges that span across both.
@@ -823,7 +823,7 @@ const pattern: MultiVariantPattern = {
       slug: 'date-list',
       description:
         'This enables merchants to select a date or a date range from a list of preset dates.',
-      howItHelps: `![Option list with common suggested dates, such as “Today” and “Last 30 days.”](/images/patterns/date-list-cover-image.png)
+      howItHelps: `![Option list with common suggested dates, such as “Today” and “Last 30 days”](/images/patterns/date-list-cover-image.png)
 
 1. The date list provides merchants with suggested dates. This makes date picking simpler when useful dates are predictable and custom dates aren’t necessary.
 

--- a/polaris.shopify.com/content/patterns/resource-details-layout.ts
+++ b/polaris.shopify.com/content/patterns/resource-details-layout.ts
@@ -25,11 +25,11 @@ const pattern: SingleVariantPattern = {
   usefulToKnow: `
   | | |
   |-|-|
-  |Always use the default width. Full width tends to waste space and make the page harder to parse.|![Details page with margins on either side of the main content.](/images/patterns/resource-detail-usage-1.png)|
-  |Group similar content in the same card.|![Diagram showing multiple cards compared to a single card that groups the same content.](/images/patterns/resource-detail-usage-2.png)|
+  |Always use the default width. Full width tends to waste space and make the page harder to parse.|![Details page with margins on either side of the main content](/images/patterns/resource-detail-usage-1.png)|
+  |Group similar content in the same card.|![Diagram showing multiple cards compared to a single card that groups the same content](/images/patterns/resource-detail-usage-2.png)|
   |Put information that defines the resource object in the primary column.|![Product detail example](/images/patterns/resource-detail-usage-3.png)|,
-  |Put supporting information such as status, metadata, and summaries in the secondary column.|![Product details page with the secondary column outlined.](/images/patterns/resource-detail-usage-4.png)|
-  |Arrange content in order of importance.|![Product details page with “Very important section” card placed above “Somewhat important section” card.](/images/patterns/resource-detail-usage-5.png)|`,
+  |Put supporting information such as status, metadata, and summaries in the secondary column.|![Product details page with the secondary column outlined](/images/patterns/resource-detail-usage-4.png)|
+  |Arrange content in order of importance.|![Product details page with “Very important section” card placed above “Somewhat important section” card](/images/patterns/resource-detail-usage-5.png)|`,
   relatedResources: `* The [Resource index layout](/patterns/resource-index-layout) pattern is a complement to the resource detail layout pattern.
 * Learn about the meaning of “resources” on the [Resource list](/components/resource-list) component page
 * Learn more about [Layout](https://shopify.dev/apps/design-guidelines/layout) in the app design guidelines.

--- a/polaris.shopify.com/content/patterns/resource-details-layout.ts
+++ b/polaris.shopify.com/content/patterns/resource-details-layout.ts
@@ -4,7 +4,7 @@ const pattern: SingleVariantPattern = {
   title: 'Resource details layout',
   description:
     'Lets merchants effectively create, view, and edit any resource object.',
-  howItHelps: `![A labeled diagram of a resource detail layout.](/images/patterns/resource-detail-cover-image.png)
+  howItHelps: `![Product details page](/images/patterns/resource-detail-cover-image.png)
 
 1. The page header provides easy access to actions and navigation. It spans the full width of the page to show merchants that these actions represent the page as a whole.
 2. The main content is split in two columns, primary content to the left and secondary content to the right. The primary content occupies two thirds of the page to give more space to what’s most important most of the time.
@@ -25,11 +25,11 @@ const pattern: SingleVariantPattern = {
   usefulToKnow: `
   | | |
   |-|-|
-  |Always use the default width. Full width tends to waste space and make the page harder to parse.|![](/images/patterns/resource-detail-usage-1.png)|
-  |Group similar content in the same card.|![](/images/patterns/resource-detail-usage-2.png)|
-  |Put information that defines the resource object in the primary column.|![](/images/patterns/resource-detail-usage-3.png)|,
-  |Put supporting information such as status, metadata, and summaries in the secondary column.|![](/images/patterns/resource-detail-usage-4.png)|
-  |Arrange content in order of importance.|![](/images/patterns/resource-detail-usage-5.png)|`,
+  |Always use the default width. Full width tends to waste space and make the page harder to parse.|![Details page with margins on either side of the main content.](/images/patterns/resource-detail-usage-1.png)|
+  |Group similar content in the same card.|![Diagram showing multiple cards compared to a single card that groups the same content.](/images/patterns/resource-detail-usage-2.png)|
+  |Put information that defines the resource object in the primary column.|![Product detail example](/images/patterns/resource-detail-usage-3.png)|,
+  |Put supporting information such as status, metadata, and summaries in the secondary column.|![Product details page with the secondary column outlined.](/images/patterns/resource-detail-usage-4.png)|
+  |Arrange content in order of importance.|![Product details page with “Very important section” card placed above “Somewhat important section” card.](/images/patterns/resource-detail-usage-5.png)|`,
   relatedResources: `* The [Resource index layout](/patterns/resource-index-layout) pattern is a complement to the resource detail layout pattern.
 * Learn about the meaning of “resources” on the [Resource list](/components/resource-list) component page
 * Learn more about [Layout](https://shopify.dev/apps/design-guidelines/layout) in the app design guidelines.

--- a/polaris.shopify.com/content/patterns/resource-index-layout.ts
+++ b/polaris.shopify.com/content/patterns/resource-index-layout.ts
@@ -4,7 +4,7 @@ const pattern: SingleVariantPattern = {
   title: 'Resource index layout',
   description:
     'Lets merchants effectively view, manage, and take action on resource objects.',
-  howItHelps: `![A labeled diagram of an app settings page layout. The left column is labeled "1" it contains glanceable labels and descriptions. The right column is labeled "2" and contains a list of cards.](/images/patterns/resource-index-cover-image.png)
+  howItHelps: `![Products index page.](/images/patterns/resource-index-cover-image.png)
 
 1. The resource index layout is based on a single column to create a clear top-to-bottom hierarchy of tasks and to provide horizontal space for resource data.
 2. At the top of the page, merchants find the page title and actions that affect the index as a whole.
@@ -22,9 +22,9 @@ const pattern: SingleVariantPattern = {
   usefulToKnow: `
   | | |
   |-|-|
-  |Use the resource type as page title.|![](/images/patterns/resource-index-usage-1.png)|
-  |Always use the primary action in the top right corner for resource creation. Remove the button if there is no such functionality.|![](/images/patterns/resource-index-usage-2.png)|
-  |Set the page width to normal if the index doesn’t need full width.|![](/images/patterns/resource-index-usage-3.png)|`,
+  |Use the resource type as page title.|![“Orders” and “Gift cards” pages](/images/patterns/resource-index-usage-1.png)|
+  |Always use the primary action in the top right corner for resource creation. Remove the button if there is no such functionality.|![“Add product” primary action button on a resource index page](/images/patterns/resource-index-usage-2.png)|
+  |Set the page width to normal if the index doesn’t need full width.|![Index page with margins on either side of the main content.](/images/patterns/resource-index-usage-3.png)|`,
   relatedResources: `* The [Resource detail layout](/patterns/resource-details-layout) pattern is a complement to the resource index layout pattern.
 * Use the [Empty state component](/components/empty-state) when the resource index is empty.
 * Learn about the meaning of “resources” on the [Resource list](/components/resource-list) component page

--- a/polaris.shopify.com/content/patterns/resource-index-layout.ts
+++ b/polaris.shopify.com/content/patterns/resource-index-layout.ts
@@ -4,7 +4,7 @@ const pattern: SingleVariantPattern = {
   title: 'Resource index layout',
   description:
     'Lets merchants effectively view, manage, and take action on resource objects.',
-  howItHelps: `![Products index page.](/images/patterns/resource-index-cover-image.png)
+  howItHelps: `![Products index page](/images/patterns/resource-index-cover-image.png)
 
 1. The resource index layout is based on a single column to create a clear top-to-bottom hierarchy of tasks and to provide horizontal space for resource data.
 2. At the top of the page, merchants find the page title and actions that affect the index as a whole.
@@ -24,7 +24,7 @@ const pattern: SingleVariantPattern = {
   |-|-|
   |Use the resource type as page title.|![“Orders” and “Gift cards” pages](/images/patterns/resource-index-usage-1.png)|
   |Always use the primary action in the top right corner for resource creation. Remove the button if there is no such functionality.|![“Add product” primary action button on a resource index page](/images/patterns/resource-index-usage-2.png)|
-  |Set the page width to normal if the index doesn’t need full width.|![Index page with margins on either side of the main content.](/images/patterns/resource-index-usage-3.png)|`,
+  |Set the page width to normal if the index doesn’t need full width.|![Index page with margins on either side of the main content](/images/patterns/resource-index-usage-3.png)|`,
   relatedResources: `* The [Resource detail layout](/patterns/resource-details-layout) pattern is a complement to the resource index layout pattern.
 * Use the [Empty state component](/components/empty-state) when the resource index is empty.
 * Learn about the meaning of “resources” on the [Resource list](/components/resource-list) component page

--- a/yarn.lock
+++ b/yarn.lock
@@ -3369,6 +3369,24 @@
     "@shopify/cli-kit" "3.10.1"
     "@shopify/ngrok" "^4.3.2"
 
+"@shopify/polaris-icons@^6.7.0":
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-6.7.0.tgz#1feb60ecab1a94211f4290eebc6d607d778eeaf9"
+  integrity sha512-4tlMQvZlaTvp4uYWo5zZq7NSvD1IIxS13/anRWXwcCD/HPLj7wnyYfwveHQOwo1iyrVV4Z2+hTJYTFVe3CBR0g==
+
+"@shopify/polaris@^10.16.0":
+  version "10.16.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-10.16.0.tgz#274e9ebbe66eed131109c13217566fe87377d55e"
+  integrity sha512-py36+7kEHe87DNRLj2KjjJeKmwfXqFZyTazqDImMKS/bmgfEa/lknUJYi0b971yP9Y917+GfVybhmqhcopbjnQ==
+  dependencies:
+    "@shopify/polaris-icons" "^6.7.0"
+    "@shopify/polaris-tokens" "^6.3.0"
+    "@types/react" "^18.0.15"
+    "@types/react-dom" "^18.0.6"
+    "@types/react-transition-group" "^4.4.2"
+    react-fast-compare "^3.2.0"
+    react-transition-group "^4.4.2"
+
 "@shopify/postcss-plugin@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@shopify/postcss-plugin/-/postcss-plugin-5.0.1.tgz#2926cc11ef5ca456b8ac6586810c0f284136fc17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3369,24 +3369,6 @@
     "@shopify/cli-kit" "3.10.1"
     "@shopify/ngrok" "^4.3.2"
 
-"@shopify/polaris-icons@^6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris-icons/-/polaris-icons-6.7.0.tgz#1feb60ecab1a94211f4290eebc6d607d778eeaf9"
-  integrity sha512-4tlMQvZlaTvp4uYWo5zZq7NSvD1IIxS13/anRWXwcCD/HPLj7wnyYfwveHQOwo1iyrVV4Z2+hTJYTFVe3CBR0g==
-
-"@shopify/polaris@^10.16.0":
-  version "10.16.0"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-10.16.0.tgz#274e9ebbe66eed131109c13217566fe87377d55e"
-  integrity sha512-py36+7kEHe87DNRLj2KjjJeKmwfXqFZyTazqDImMKS/bmgfEa/lknUJYi0b971yP9Y917+GfVybhmqhcopbjnQ==
-  dependencies:
-    "@shopify/polaris-icons" "^6.7.0"
-    "@shopify/polaris-tokens" "^6.3.0"
-    "@types/react" "^18.0.15"
-    "@types/react-dom" "^18.0.6"
-    "@types/react-transition-group" "^4.4.2"
-    react-fast-compare "^3.2.0"
-    react-transition-group "^4.4.2"
-
 "@shopify/postcss-plugin@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@shopify/postcss-plugin/-/postcss-plugin-5.0.1.tgz#2926cc11ef5ca456b8ac6586810c0f284136fc17"


### PR DESCRIPTION
### WHY are these changes introduced?

Attempting to fix broken alt-text branch to fix https://github.com/Shopify/polaris/issues/8170

Adds short alt text from the [patterns alt text document](https://docs.google.com/document/d/1Yi4HX03-zAHTa_ehxlub7DYKeq3_ErT9WvQDH7GTfz0/edit?usp=sharing). Long (descriptive) alt text to be added later with https://github.com/Shopify/polaris/issues/8334