### PR TITLE
[polaris.shopify.com] Organize component page

### DIFF
--- a/.changeset/selfish-ducks-hug.md
+++ b/.changeset/selfish-ducks-hug.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Organized categories on components page

--- a/polaris.shopify.com/src/components/ComponentsPage/ComponentsPage.tsx
+++ b/polaris.shopify.com/src/components/ComponentsPage/ComponentsPage.tsx
@@ -28,41 +28,52 @@ export default function ComponentsPage() {
       />
 
       <Page title="Components" showTOC={false}>
-        {componentCategories.map((category) => {
-          return (
-            <div key={category} className={styles.Category}>
-              <h2 className={styles.CategoryName}>{category}</h2>
-              <Grid>
-                {components
-                  .filter(
-                    (slug) => pages[slug].frontMatter.category === category,
-                  )
-                  .map((slug) => {
-                    const {
-                      title,
-                      status,
-                      description = '',
-                    } = pages[slug].frontMatter;
-                    return (
-                      <Grid.Item
-                        key={title}
-                        title={title}
-                        description={stripMarkdownLinks(description)}
-                        url={`/${slug}`}
-                        status={status as Status}
-                        renderPreview={() => (
-                          <ComponentThumbnail
-                            title={title}
-                            group={slugify(category)}
-                          />
-                        )}
-                      />
-                    );
-                  })}
-              </Grid>
-            </div>
-          );
-        })}
+        {componentCategories
+          .sort((currentCategory, previousCategory) => {
+            const currentOrder =
+              pages[`components/${slugify(currentCategory)}`]?.frontMatter
+                .order || 0;
+            const previousOrder =
+              pages[`components/${slugify(previousCategory)}`]?.frontMatter
+                .order || 0;
+
+            return currentOrder - previousOrder;
+          })
+          .map((category) => {
+            return (
+              <div key={category} className={styles.Category}>
+                <h2 className={styles.CategoryName}>{category}</h2>
+                <Grid>
+                  {components
+                    .filter(
+                      (slug) => pages[slug].frontMatter.category === category,
+                    )
+                    .map((slug) => {
+                      const {
+                        title,
+                        status,
+                        description = '',
+                      } = pages[slug].frontMatter;
+                      return (
+                        <Grid.Item
+                          key={title}
+                          title={title}
+                          description={stripMarkdownLinks(description)}
+                          url={`/${slug}`}
+                          status={status as Status}
+                          renderPreview={() => (
+                            <ComponentThumbnail
+                              title={title}
+                              group={slugify(category)}
+                            />
+                          )}
+                        />
+                      );
+                    })}
+                </Grid>
+              </div>
+            );
+          })}
       </Page>
     </div>
   );

--- a/polaris.shopify.com/src/types.ts
+++ b/polaris.shopify.com/src/types.ts
@@ -17,6 +17,7 @@ export interface FrontMatter {
   description?: string;
   examples?: Example[];
   icon?: string;
+  order?: number;
   keywords?: (string | number)[];
   status?: {
     value: string;


### PR DESCRIPTION
To match the side nav order

Before | After
---|---
![image](https://screenshot.click/17-30-2ajmz-k1bhc.png) | ![image](https://screenshot.click/17-30-34mdt-jsv4b.png)

Closes: https://github.com/Shopify/polaris/issues/8421