### PR TITLE
Add onMouseEnter prop to the each item on the ActionList component

### DIFF
--- a/.changeset/forty-crabs-march.md
+++ b/.changeset/forty-crabs-march.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Add onMouseEnter prop to the each item on the ActionList component

--- a/polaris-react/src/components/ActionList/components/Item/Item.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/Item.tsx
@@ -22,6 +22,7 @@ export function Item({
   helpText,
   url,
   onAction,
+  onMouseEnter,
   icon,
   image,
   prefix,
@@ -120,6 +121,7 @@ export function Item({
       onClick={onAction}
       onMouseUp={handleMouseUpByBlurring}
       role={role}
+      onMouseEnter={onMouseEnter}
     >
       {contentElement}
     </button>

--- a/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/ActionList/components/Item/tests/Item.test.tsx
@@ -22,6 +22,13 @@ describe('<Item />', () => {
     expect(mockOnAction).toHaveBeenCalledTimes(1);
   });
 
+  it('calls onMouseEnter when the mouse enters button', () => {
+    const onMouseEnterSpy = jest.fn();
+    const button = mountWithApp(<Item onMouseEnter={onMouseEnterSpy} />);
+    button.find('button')!.trigger('onMouseEnter');
+    expect(onMouseEnterSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('passes the external prop down to the link', () => {
     const item = mountWithApp(<Item external url="https://www.shopify.com" />);
     expect(item).toContainReactComponent(UnstyledLink, {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #[8511](https://github.com/Shopify/polaris/issues/8511) <!-- link to issue if one exists -->

The [`IndexTable`](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/IndexTable/IndexTable.tsx) component's bulkActions prop has an optional `onMouseEnter` prop in its type (`ActionListSection`) that is passed down to the [`ActionList/Components/Item/Item.tsx`](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/ActionList/components/Item/Item.tsx) component, but it's not used in the `Item.tsx`. I need to use the `onMouseEnter` prop for a prefetch task that I am working on, and I don't have access to this prop until it's properly used in the `Item.tsx` component.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
 Using the `onMouseEnter` Prop in the [Item.tsx](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/ActionList/components/Item/Item.tsx) component.
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩
1- Use this [spin link](https://admin.web.polaris-onmouseenter-fix.fatima-sajadi.us.spin.dev/store/shop1/products?selectedView=all), and select any number of products in product index page.
2- Open the console on your browser.
3- Open up the bulk edit modal and observe when you hover over the `Add available channel(s)`, and `Hello World` will be logged to your console.

https://user-images.githubusercontent.com/6689267/222245173-1fe2b1f0-7034-4955-a078-08a184d69409.mov



🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
