### PR TITLE
[IndexTable] Adjust sortable header tooltip positioning and right-aligned sortable header animation

### DIFF
--- a/.changeset/pink-knives-punch.md
+++ b/.changeset/pink-knives-punch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[IndexTable] Sets header sort tooltip preferred position to "above" and adjusts right-aligned, sortable header animation

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -328,8 +328,7 @@ $loading-panel-height: 53px;
 
   &:not(.TableHeadingSortIcon-heading-align-end),
   &:not(.TableHeadingSortButton-heading-align-end-previously-sorted) {
-    transition: opacity var(--p-duration-200) var(--p-ease-in)
-      var(--p-duration-100);
+    transition: opacity var(--p-duration-50) var(--p-ease);
   }
 }
 

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -292,17 +292,17 @@ $loading-panel-height: 53px;
   }
 
   .TableHeadingSortIcon-heading-align-end {
-    animation: hide-right-aligned-sort-button-icon var(--p-duration-100)
-      var(--p-ease-in);
+    animation: hide-right-aligned-sort-button-icon var(--p-duration-50);
   }
 }
 
 .TableHeadingSortButton-heading-align-end {
   transform: translateX(var(--p-space-5));
-  transition: all var(--p-duration-100) var(--p-ease-in);
+  transition-delay: var(--p-duration-50);
 
   &:hover,
   &:focus {
+    transition-delay: none;
     transform: translateX(var(--p-space-1));
   }
 }
@@ -316,7 +316,8 @@ $loading-panel-height: 53px;
 }
 
 .TableHeadingSortButton-heading-align-end-previously-sorted {
-  animation: hide-sort-button var(--p-duration-100) var(--p-ease-in);
+  animation: right-aligned-sort-button-slide-out var(--p-duration-50)
+    var(--p-ease);
 }
 
 .TableHeadingSortIcon {
@@ -325,7 +326,8 @@ $loading-panel-height: 53px;
   height: var(--p-space-5);
   width: var(--p-space-5);
 
-  &:not(.TableHeadingSortIcon-heading-align-end) {
+  &:not(.TableHeadingSortIcon-heading-align-end),
+  &:not(.TableHeadingSortButton-heading-align-end-previously-sorted) {
     transition: opacity var(--p-duration-200) var(--p-ease-in)
       var(--p-duration-100);
   }
@@ -334,7 +336,7 @@ $loading-panel-height: 53px;
 .TableHeadingSortButton:hover {
   .TableHeadingSortIcon-heading-align-end {
     animation: reveal-right-aligned-sort-button-icon var(--p-duration-200)
-      var(--p-ease-in);
+      var(--p-ease);
   }
 }
 
@@ -760,8 +762,12 @@ $scroll-bar-size: var(--p-space-2);
 }
 
 /* stylelint-disable-next-line polaris/motion/at-rule-disallowed-list -- custom reset animation for right-aligned header */
-@keyframes hide-sort-button {
+@keyframes right-aligned-sort-button-slide-out {
   0% {
+    transform: translateX(var(--p-space-1));
+  }
+
+  80% {
     transform: translateX(var(--p-space-1));
   }
 
@@ -777,8 +783,11 @@ $scroll-bar-size: var(--p-space-2);
     opacity: 0;
   }
 
-  50% {
+  40% {
     opacity: 0;
+  }
+
+  50% {
     transform: translateX(0);
   }
 
@@ -794,15 +803,17 @@ $scroll-bar-size: var(--p-space-2);
     opacity: 1;
   }
 
-  50% {
+  20% {
+    opacity: 0;
     transform: translateX(0);
   }
 
-  75% {
-    opacity: 0;
+  90% {
+    transform: translateX(calc(var(--p-space-5) * -1));
   }
 
   100% {
+    opacity: 0;
     transform: translateX(calc(var(--p-space-5) * -1));
   }
 }

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -290,6 +290,11 @@ $loading-panel-height: 53px;
       opacity: 1;
     }
   }
+
+  .TableHeadingSortIcon-heading-align-end {
+    animation: hide-right-aligned-sort-button-icon var(--p-duration-100)
+      var(--p-ease-in);
+  }
 }
 
 .TableHeadingSortButton-heading-align-end {
@@ -304,6 +309,10 @@ $loading-panel-height: 53px;
 
 .TableHeadingSortButton-heading-align-end-currently-sorted {
   transform: translateX(var(--p-space-1));
+
+  .TableHeadingSortIcon-heading-align-end {
+    animation: none;
+  }
 }
 
 .TableHeadingSortButton-heading-align-end-previously-sorted {
@@ -315,8 +324,24 @@ $loading-panel-height: 53px;
   opacity: 0;
   height: var(--p-space-5);
   width: var(--p-space-5);
-  transition: opacity var(--p-duration-200) var(--p-ease-in)
-    var(--p-duration-100);
+
+  &:not(.TableHeadingSortIcon-heading-align-end) {
+    transition: opacity var(--p-duration-200) var(--p-ease-in)
+      var(--p-duration-100);
+  }
+}
+
+.TableHeadingSortButton:hover {
+  .TableHeadingSortIcon-heading-align-end {
+    animation: reveal-right-aligned-sort-button-icon var(--p-duration-200)
+      var(--p-ease-in);
+  }
+}
+
+.TableHeadingSortButton-heading-align-end-currently-sorted:hover {
+  .TableHeadingSortIcon-heading-align-end {
+    animation: none;
+  }
 }
 
 .TableHeadingUnderline {
@@ -742,5 +767,42 @@ $scroll-bar-size: var(--p-space-2);
 
   100% {
     transform: translateX(var(--p-space-5));
+  }
+}
+
+/* stylelint-disable-next-line polaris/motion/at-rule-disallowed-list -- custom animation for right-aligned header */
+@keyframes reveal-right-aligned-sort-button-icon {
+  0% {
+    transform: translateX(calc(var(--p-space-5) * -1));
+    opacity: 0;
+  }
+
+  50% {
+    opacity: 0;
+    transform: translateX(0);
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+/* stylelint-disable-next-line polaris/motion/at-rule-disallowed-list -- custom animation for right-aligned header */
+@keyframes hide-right-aligned-sort-button-icon {
+  0% {
+    transform: translateX(0);
+    opacity: 1;
+  }
+
+  50% {
+    transform: translateX(0);
+  }
+
+  75% {
+    opacity: 0;
+  }
+
+  100% {
+    transform: translateX(calc(var(--p-space-5) * -1));
   }
 }

--- a/polaris-react/src/components/IndexTable/IndexTable.tsx
+++ b/polaris-react/src/components/IndexTable/IndexTable.tsx
@@ -992,7 +992,11 @@ function IndexTableBase({
       if (!heading.tooltipContent) {
         return (
           // Regular header with sort icon and sort direction tooltip
-          <Tooltip {...defaultTooltipProps} content={sortTooltipContent}>
+          <Tooltip
+            {...defaultTooltipProps}
+            content={sortTooltipContent}
+            preferredPosition="above"
+          >
             {sortMarkup}
           </Tooltip>
         );


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->


https://user-images.githubusercontent.com/100380574/225723264-3cfc9312-3ae2-4f1d-99d4-5749eef6fc69.mov

### WHY are these changes introduced?

These changes refine the recently introduced right-aligned, sortable header styles in the IndexTable component, specifically the reveal and hiding of the sort icon.

The preferred position of the Tooltip containing the sort markup in sortable table headers has also been adjusted to "above".

Fixes [#407753](https://github.com/Shopify/shopify/issues/407753) <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

[Spin](https://admin.web.right-aligned-index-table-review.rick-caplan.us.spin.dev/store/shop1/orders?inContextTimeframe=none)

- [ ] hover on and off of the Total header and confirm the animation is as expected (sort icon fades, header text slides to left when it's revealed and to right when it is hidden)
- [ ] click on the Total header, confirm the sort icon persists and does not animate if you move the cursor off
- [ ] click on the Total header again, confirm the sort reverses and does not animate if you move the cursor off
- [ ] click on another header, confirm the sort icon fades out and the "Total" text slides to the right
- [ ] confirm the sort tooltip renders above the headers when the cursor hovers over them

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
