### PR TITLE
Draft long form version of App Settings Layout pattern

### DIFF
--- a/.changeset/bright-geese-hang.md
+++ b/.changeset/bright-geese-hang.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Refactor Pattern MDX rendering to remove some duplication and table magic

--- a/polaris.shopify.com/content/patterns/app-settings-layout/index.md
+++ b/polaris.shopify.com/content/patterns/app-settings-layout/index.md
@@ -7,17 +7,47 @@ previewImg: /images/patterns/pattern-thumbnail-app-settings.png
 githubDiscussionsLink: https://github.com/Shopify/polaris/discussions/8217
 variants:
   - 'variants/default.md'
+  - 'variants/annotated-layout-component.md'
 ---
 
+<div as="HowItHelps">
+
+## How it helps merchants
+
+![App settings page with two columns](/images/patterns/app-settings-cover-image.png)
+
+1. In the left column, glanceable labels and descriptions are listed to make it easier for merchants to scan the page and quickly find what they are looking for.
+2. In the right column, settings are grouped in cards to make it easier for merchants to configure a setting after it's been found, or to configure multiple settings that might belong together.
+
+<div as="DefinitionTable">
+
+### Use when merchants need to:
+
+**Find and change app settings**
+: This pattern is used specifically for finding and updating individual app settings within the Shopify admin.
+
+</div>
+</div>
+
 <div as="Variants"></div>
+
+<div as="UsefulToKnow">
+
+### Useful to know
+
+- <span>Don't include a description unless it's helpful.</span> ![Section header with no description on an app settings page](/images/patterns/app-settings-usage-1.png)
+- <span>Place grouped settings within cards.</span> ![App settings page with section headings and grouped settings](/images/patterns/app-settings-usage-2.png)
+- <span>Stack all setting groups vertically on the page.</span> ![App settings page with two vertically stacked sections](/images/patterns/app-settings-usage-3.png)
+
+</div>
 
 <div as="Stack" gap="4">
 
 ## Related resources
 
-* See another two-column layout in use in the [Resource detail layout](/patterns/resource-details-layout) pattern.
-* See a single-column layout in use in the [Resource index layout](/patterns/resource-index-layout) pattern.
-* Learn more about [Layout](https://shopify.dev/apps/design-guidelines/layout) in the app design guidelines.
-* Check out the Polaris [Spacing](/design/space) guidelines to understand Polaris grid and spacing scale.
+- See another two-column layout in use in the [Resource detail layout](/patterns/resource-details-layout) pattern.
+- See a single-column layout in use in the [Resource index layout](/patterns/resource-index-layout) pattern.
+- Learn more about [Layout](https://shopify.dev/apps/design-guidelines/layout) in the app design guidelines.
+- Check out the Polaris [Spacing](/design/space) guidelines to understand Polaris grid and spacing scale.
 
 </div>

--- a/polaris.shopify.com/content/patterns/app-settings-layout/variants/annotated-layout-component.md
+++ b/polaris.shopify.com/content/patterns/app-settings-layout/variants/annotated-layout-component.md
@@ -1,0 +1,164 @@
+---
+slug: using-annotated-layout
+title: Using Annotated layout
+hideFromNav: true
+---
+
+<div as="Usage">
+
+## Using the Layout component to build the app-settings page
+
+We can use the Layout component from @shopify/polaris-react to build out the app-settings page.
+
+```bash
+npm install @shopify/polaris-react
+```
+
+```tsx
+import {Layout} from '@shopify/polaris-react';
+```
+
+### Scannable descriptions
+
+Use the `Layout.AnnotatedSection` component for each section of our app-settings layout.
+The title and description for each of our sections will be styled in a way that is
+easily scannable.
+
+```tsx
+<Layout>
+  <Layout.AnnotatedSection
+    title="Store details"
+    description="Shopify and your customers will use this information to contact you."
+  />
+</Layout>
+```
+
+### Group related settings
+
+Use `Layout.AnnotatedSection` to group related settings, doing so will also automatically add the right vertical padding to make each individual settings group easier to scan and identify.
+
+Within `Layout.AnnotatedSection`, we use the [`AlphaCard`](/components/layout-and-structure/AlphaCard) and
+[`AlphaStack`](/components/layout-and-structure/AlphaStack) components here
+to provide the right spacing and visual hierarchy to help merchants more easily
+configure a setting after it's been found.
+
+<!-- TODO: highlight relevant lines -->
+
+```tsx
+<Layout>
+  <Layout.AnnotatedSection
+    id="storeDetails"
+    title="Store details"
+    description="Shopify and your customers will use this information to contact you."
+  >
+    <AlphaCard>
+      <AlphaStack gap="4">
+        <TextField label="Interjamb style" />
+        <TextField label="Interjamb ratio" />
+      </AlphaStack>
+    </AlphaCard>
+  </Layout.AnnotatedSection>
+</Layout>
+```
+
+### Understanding the layout
+
+The AnnotatedLayout uses a 1:2 ratio of description:settings as this is optimal for readability on desktop. (TODO: why?).
+
+When a merchant is using a mobile device, the AnnotatedLayout component automatically stacks content as this is is more readable than
+a 2 column layout.
+
+![TODO: image of mobile stacking]()
+
+<!-- prettier-ignore -->
+```tsx
+<Layout>
+  <Layout.AnnotatedSection
+    id="storeDetails"
+    title="Store details"
+    description="Shopify and your customers will use this information to contact you."
+  >
+    <AlphaCard roundedAbove="sm" />
+  </Layout.AnnotatedSection>
+</Layout>
+```
+
+### Finishing touches
+
+TODO: `roundedAbove` on `<AlphaCard>` makes the card full width / look better
+
+```tsx
+<AlphaCard roundedAbove="sm">
+  <AlphaStack gap="4">
+    <TextField label="Store name" onChange={() => {}} autoComplete="off" />
+    <TextField
+      type="email"
+      label="Account email"
+      onChange={() => {}}
+      autoComplete="email"
+    />
+  </AlphaStack>
+</AlphaCard>
+```
+
+### All together
+
+NOTE: Use the `<Page>` component for actions and event listeners
+
+<!-- prettier-ignore -->
+```javascript {"type":"previewContext","for":"example"}
+<div style={{ paddingBottom: '2rem' }}>
+  ____CODE____
+</div>
+```
+
+```javascript {"type":"livePreview","id":"example"}
+<Page fullWidth>
+  <Layout>
+    <Layout.AnnotatedSection
+      id="storeDetails"
+      title="Store details"
+      description="Shopify and your customers will use this information to contact you."
+    >
+      <AlphaCard roundedAbove="sm">
+        <AlphaStack gap="4">
+          <TextField
+            label="Store name"
+            onChange={() => {}}
+            autoComplete="off"
+          />
+          <TextField
+            type="email"
+            label="Account email"
+            onChange={() => {}}
+            autoComplete="email"
+          />
+        </AlphaStack>
+      </AlphaCard>
+    </Layout.AnnotatedSection>
+    <Layout.AnnotatedSection
+      id="storeDetails"
+      title="Store details"
+      description="Shopify and your customers will use this information to contact you."
+    >
+      <AlphaCard roundedAbove="sm">
+        <FormLayout>
+          <TextField
+            label="Store name"
+            onChange={() => {}}
+            autoComplete="off"
+          />
+          <TextField
+            type="email"
+            label="Account email"
+            onChange={() => {}}
+            autoComplete="email"
+          />
+        </FormLayout>
+      </AlphaCard>
+    </Layout.AnnotatedSection>
+  </Layout>
+</Page>
+```
+
+</div>

--- a/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.md
+++ b/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.md
@@ -105,10 +105,8 @@ function AppSettingsLayoutExample() {
 
 ### Useful to know
 
-|                                                  |                                                                                                            |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
-| Don't include a description unless it's helpful. | ![Section header with no description on an app settings page](/images/patterns/app-settings-usage-1.png)   |
-| Place grouped settings within cards.             | ![App settings page with section headings and grouped settings](/images/patterns/app-settings-usage-2.png) |
-| Stack all setting groups vertically on the page. | ![App settings page with two vertically stacked sections](/images/patterns/app-settings-usage-3.png)       |
+- <span>Don't include a description unless it's helpful.</span> ![Section header with no description on an app settings page](/images/patterns/app-settings-usage-1.png)
+- <span>Place grouped settings within cards.</span> ![App settings page with section headings and grouped settings](/images/patterns/app-settings-usage-2.png)
+- <span>Stack all setting groups vertically on the page.</span> ![App settings page with two vertically stacked sections](/images/patterns/app-settings-usage-3.png)
 
 </div>

--- a/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.md
+++ b/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.md
@@ -22,9 +22,128 @@ hideFromNav: true
 </div>
 <div as="Usage">
 
-## Using this pattern
+## Building an app settings page
 
-This pattern uses the [`AlphaStack`](/components/layout-and-structure/alpha-stack), [`AlphaCard`](/components/layout-and-structure/alpha-card), [`Columns`](/components/layout-and-structure/columns) and [`Box`](/components/layout-and-structure/box) components.
+### Scannable descriptions
+
+Keep body text scannable with the `bodyMd` variant, and reduce descriptions to
+at most a single paragraph.
+
+```tsx
+<Text as="p" variant="bodyMd">
+  Interjambs are the rounded protruding bits of your puzzle piece
+</Text>
+```
+
+To make it easier for merchants to scan the page and quickly find what they are looking for, headings should use the `headingMd` variant:
+
+```tsx
+<Text as="h3" variant="headingMd">
+  InterJambs
+</Text>
+```
+
+Combine headings and descriptions with the `<AlphaStack>` component to ensure an
+appropriate gap is used (TODO: better write here):
+
+```tsx
+<AlphaStack gap="4">
+  <Text as="h3" variant="headingMd">
+    InterJambs
+  </Text>
+  <Text as="p" variant="bodyMd">
+    Interjambs are the rounded protruding bits of your puzzlie piece
+  </Text>
+</AlphaStack>
+```
+
+TODO: Learn more about composing layouts with AlphaStack, etc [here]().
+
+### Group related settings
+
+Use the [`AlphaCard`](/components/layout-and-structure/AlphaCard) and
+[`AlphaStack`](/components/layout-and-structure/AlphaStack) components to
+provide the right spacing and visual hierarchy to help merchants more easily
+configure a setting after it's been found. (TODO: why? Scanability? Faster JTBD)
+
+<!-- TODO: highlight relevant lines -->
+
+```tsx
+<AlphaCard>
+  <AlphaStack gap="4">
+    <TextField label="Interjamb style" />
+    <TextField label="Interjamb ratio" />
+  </AlphaStack>
+</AlphaCard>
+```
+
+### Laying it all out
+
+A 2:5 ratio of description:settings is good on desktop. (TODO: why?).
+
+When a merchant is using a mobile device, stacked content is more readable than
+a 2 column layout.
+
+Polaris provides us with the [`Columns`](/components/layout-and-structure/Columns) component that abstracts away the complexity of automatically stacking on mobile for us. Use the `columns` prop to set the ratio at different [breakpoints](TODO)
+
+![TODO: image of mobile stacking]()
+
+<!-- prettier-ignore -->
+```tsx
+<Columns
+  columns={{
+    // On mobile, only a single column is used
+    xs: '1fr',
+    // On medium and above, use a two column layout in a 2:5 ratio
+    md: '2fr 5fr'
+  }}
+  gap="4"
+>
+  {''/* Description goes here. Left column on desktop, Stacked on top on mobile.*/}
+  <Text />
+  {''/* Settings go here. Right column on desktop, Stacked on bottom on mobile */}
+  <AlphaCard />
+</Columns>
+```
+
+### Finishing touches
+
+TODO: When stacked on mobile, align the description text with the settings below by
+wrapping in a box with padding.
+
+```tsx
+<Box
+  as="section"
+  // On mobile when stacked, we want the description to have the same
+  // padding as the Card below.
+  paddingInlineStart={{xs: 4, sm: 0}}
+  paddingInlineEnd={{xs: 4, sm: 0}}
+>
+  <AlphaStack gap="4">
+    <Text as="h3" variant="headingMd">
+      InterJambs
+    </Text>
+    <Text as="p" variant="bodyMd">
+      Interjambs are the rounded protruding bits of your puzzlie piece
+    </Text>
+  </AlphaStack>
+</Box>
+```
+
+TODO: `roundedAbove` on `<AlphaCard>` makes the card full width / look better
+
+```tsx
+<AlphaCard roundedAbove="sm">
+  <AlphaStack gap="4">
+    <TextField label="Interjamb style" />
+    <TextField label="Interjamb ratio" />
+  </AlphaStack>
+</AlphaCard>
+```
+
+### All together
+
+NOTE: Use the `<Page>` component for actions and event listeners
 
 <!-- prettier-ignore -->
 ```javascript {"type":"previewContext","for":"example"}

--- a/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.md
+++ b/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.md
@@ -1,25 +1,9 @@
 ---
+title: Using layout primitives
+slug: using-layout-primitives
 hideFromNav: true
 ---
 
-<div as="HowItHelps">
-
-## How it helps merchants
-
-![App settings page with two columns](/images/patterns/app-settings-cover-image.png)
-
-1. In the left column, glanceable labels and descriptions are listed to make it easier for merchants to scan the page and quickly find what they are looking for.
-2. In the right column, settings are grouped in cards to make it easier for merchants to configure a setting after it's been found, or to configure multiple settings that might belong together.
-
-<div as="DefinitionTable">
-
-### Use when merchants need to:
-
-**Find and change app settings**
-: This pattern is used specifically for finding and updating individual app settings within the Shopify admin.
-
-</div>
-</div>
 <div as="Usage">
 
 ## Building an app settings page
@@ -218,14 +202,5 @@ function AppSettingsLayoutExample() {
   );
 }
 ```
-
-</div>
-<div as="UsefulToKnow">
-
-### Useful to know
-
-- <span>Don't include a description unless it's helpful.</span> ![Section header with no description on an app settings page](/images/patterns/app-settings-usage-1.png)
-- <span>Place grouped settings within cards.</span> ![App settings page with section headings and grouped settings](/images/patterns/app-settings-usage-2.png)
-- <span>Stack all setting groups vertically on the page.</span> ![App settings page with two vertically stacked sections](/images/patterns/app-settings-usage-3.png)
 
 </div>

--- a/polaris.shopify.com/content/patterns/date-picking/variants/date-list.md
+++ b/polaris.shopify.com/content/patterns/date-picking/variants/date-list.md
@@ -120,10 +120,8 @@ function DateListPicker() {
 
 ### Useful to know
 
-|                                                                                                                                 |                                                                                                                                     |
-| ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| In the button preview, set a default date range that a merchant will most likely use.                                           | ![Button showing a calendar icon labeled “Today”](/images/patterns/date-list-usage-1.png)                                           |
-| Single dates should be at the top of the list, followed by date ranges from smallest to largest ranges.                         | ![Option list with common suggested dates followed by ranges](/images/patterns/date-list-usage-2.png)                               |
-| A date list can be modified to serve unique situations, like providing suggested search queries in the customer segment editor. | ![Customer segment editor with a date list showing common ranges and related code snippets](/images/patterns/date-list-usage-3.png) |
+- <span>In the button preview, set a default date range that a merchant will most likely use.</span> ![Button showing a calendar icon labeled “Today”](/images/patterns/date-list-usage-1.png)
+- <span>Single dates should be at the top of the list, followed by date ranges from smallest to largest ranges.</span> ![Option list with common suggested dates followed by ranges](/images/patterns/date-list-usage-2.png)
+- <span>A date list can be modified to serve unique situations, like providing suggested search queries in the customer segment editor.</span> ![Customer segment editor with a date list showing common ranges and related code snippets](/images/patterns/date-list-usage-3.png)
 
 </div>

--- a/polaris.shopify.com/content/patterns/date-picking/variants/date-range.md
+++ b/polaris.shopify.com/content/patterns/date-picking/variants/date-range.md
@@ -389,10 +389,8 @@ function DateRangePicker() {
 
 ### Useful to know
 
-|                                                                                                |                                                                                                      |
-| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Pin any relevant, merchant-specific dates to the top of the option list.                       | ![List of date options such as “BFCM (2023)”](/images/patterns/date-range-usage-1.png)               |
-| If a date cannot be selected, indicate it with the [disabled text color token](/tokens/colors) | ![Single-month calendar with a range of unselectable dates](/images/patterns/date-range-usage-2.png) |
-| If a merchant enters a nonexistent date, revert to the previously selected date.               | ![Calendar with date inputs reading an incorrect date](/images/patterns/date-range-usage-3.png)      |
+- <span>Pin any relevant, merchant-specific dates to the top of the option list.</span> ![List of date options such as “BFCM (2023)”](/images/patterns/date-range-usage-1.png)
+- <span>If a date cannot be selected, indicate it with the [disabled text color token](/tokens/colors)</span> ![Single-month calendar with a range of unselectable dates](/images/patterns/date-range-usage-2.png)
+- <span>If a merchant enters a nonexistent date, revert to the previously selected date.</span> ![Calendar with date inputs reading an incorrect date](/images/patterns/date-range-usage-3.png)
 
 </div>

--- a/polaris.shopify.com/content/patterns/date-picking/variants/single-date.md
+++ b/polaris.shopify.com/content/patterns/date-picking/variants/single-date.md
@@ -137,9 +137,7 @@ function DatePickerExample() {
 
 ### Useful to know
 
-|                                                                                                        |                                                                                                                                                        |
-| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Labels need to simply depict the task at hand. Whether that be a start date, end date, start time etc. | ![Date input labeled “Expiry date”](/images/patterns/single-list-usage-1.png)                                                                          |
-| This pattern can be duplicated to allow users to add an end date or time.                              | ![“Active dates” section with “start date” and “end date” inputs, toggled on with a “Set end date” checkbox](/images/patterns/single-list-usage-2.png) |
+- <span>Labels need to simply depict the task at hand. Whether that be a start date, end date, start time etc.</span> ![Date input labeled “Expiry date”](/images/patterns/single-list-usage-1.png)
+- <span>This pattern can be duplicated to allow users to add an end date or time.</span> ![“Active dates” section with “start date” and “end date” inputs, toggled on with a “Set end date” checkbox](/images/patterns/single-list-usage-2.png)
 
 </div>

--- a/polaris.shopify.com/content/patterns/resource-details-layout/variants/default.md
+++ b/polaris.shopify.com/content/patterns/resource-details-layout/variants/default.md
@@ -142,12 +142,10 @@ function ResourceDetailsLayout() {
 
 ### Useful to know
 
-|                                                                                                  |                                                                                                                                                         |
-| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Always use the default width. Full width tends to waste space and make the page harder to parse. | ![Details page with margins on either side of the main content](/images/patterns/resource-detail-usage-1.png)                                           |
-| Group similar content in the same card.                                                          | ![Diagram showing multiple cards compared to a single card that groups the same content](/images/patterns/resource-detail-usage-2.png)                  |
-| Put information that defines the resource object in the primary column.                          | ![Product detail example](/images/patterns/resource-detail-usage-3.png)                                                                                 |
-| Put supporting information such as status, metadata, and summaries in the secondary column.      | ![Product details page with the secondary column outlined](/images/patterns/resource-detail-usage-4.png)                                                |
-| Arrange content in order of importance.                                                          | ![Product details page with “Very important section” card placed above “Somewhat important section” card](/images/patterns/resource-detail-usage-5.png) |
+- <span>Always use the default width. Full width tends to waste space and make the page harder to parse.</span> ![Details page with margins on either side of the main content](/images/patterns/resource-detail-usage-1.png)
+- <span>Group similar content in the same card.</span> ![Diagram showing multiple cards compared to a single card that groups the same content](/images/patterns/resource-detail-usage-2.png)
+- <span>Put information that defines the resource object in the primary column.</span> ![Product detail example](/images/patterns/resource-detail-usage-3.png)
+- <span>Put supporting information such as status, metadata, and summaries in the secondary column.</span> ![Product details page with the secondary column outlined](/images/patterns/resource-detail-usage-4.png)
+- <span>Arrange content in order of importance.</span> ![Product details page with “Very important section” card placed above “Somewhat important section” card](/images/patterns/resource-detail-usage-5.png)
 
 </div>

--- a/polaris.shopify.com/content/patterns/resource-index-layout/variants/default.md
+++ b/polaris.shopify.com/content/patterns/resource-index-layout/variants/default.md
@@ -56,10 +56,8 @@ This pattern uses the [`Layout`](/components/layout-and-structure/layout), [`Pag
 
 ### Useful to know
 
-|                                                                                                                                   |                                                                                                              |
-| --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| Use the resource type as page title.                                                                                              | ![“Orders” and “Gift cards” pages](/images/patterns/resource-index-usage-1.png)                              |
-| Always use the primary action in the top right corner for resource creation. Remove the button if there is no such functionality. | ![“Add product” primary action button on a resource index page](/images/patterns/resource-index-usage-2.png) |
-| Set the page width to normal if the index doesn’t need full width.                                                                | ![Index page with margins on either side of the main content](/images/patterns/resource-index-usage-3.png)   |
+- <span>Use the resource type as page title.</span> ![“Orders” and “Gift cards” pages](/images/patterns/resource-index-usage-1.png)
+- <span>Always use the primary action in the top right corner for resource creation. Remove the button if there is no such functionality.</span> ![“Add product” primary action button on a resource index page](/images/patterns/resource-index-usage-2.png)
+- <span>Set the page width to normal if the index doesn’t need full width.</span> ![Index page with margins on either side of the main content](/images/patterns/resource-index-usage-3.png)
 
 </div>

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.module.scss
@@ -57,13 +57,6 @@
   }
 }
 
-.UsageTable {
-  td:first-child {
-    width: 0;
-    white-space: nowrap;
-  }
-}
-
 .TabList {
   --border-subdued: rgba(201, 204, 207, 1);
 
@@ -172,54 +165,63 @@
   }
 }
 
-.UsageGuidelinesGrid {
-  display: grid;
-  column-gap: var(--p-space-4);
-  row-gap: var(--p-space-8);
+.UsefulToKnow {
+  & > ul {
+    display: grid;
+    column-gap: var(--p-space-4);
+    row-gap: var(--p-space-8);
 
-  --txt-column-width: 35%;
-  /*
+    --txt-column-width: 35%;
+    /*
    * Rules of the grid:
    * The second (img) column should never be bigger than 30rem.
    * The first (text) column should never shrink below 35% of the container.
    * The first (text) column should grow to fill the remaining space (1fr).
    * The second (img) column should never shrink below 20rem. */
-  grid-template-columns:
-    minmax(
-      // Give this column a minimum width (thin container)
-      var(--txt-column-width),
-      // Grow to fill the remaining space when possible (wide container)
-      1fr
-    )
-    minmax(
-      min(
-        // Minimum size of 20rem to keep it legible
-        20rem,
-        // Except when the container is too thin: let it shrinnk so the text
-        // column can still take up its desired minimum width
-        calc(100% - var(--txt-column-width))
-      ),
-      // Maximum width (wide container) - avoids gigantic images
-      30rem
-    );
+    grid-template-columns:
+      minmax(
+        // Give this column a minimum width (thin container)
+        var(--txt-column-width),
+        // Grow to fill the remaining space when possible (wide container)
+        1fr
+      )
+      minmax(
+        min(
+          // Minimum size of 20rem to keep it legible
+          20rem,
+          // Except when the container is too thin: let it shrinnk so the text
+          // column can still take up its desired minimum width
+          calc(100% - var(--txt-column-width))
+        ),
+        // Maximum width (wide container) - avoids gigantic images
+        30rem
+      );
 
-  @media screen and (max-width: $breakpointMobile) {
-    grid-template-columns: 1fr;
-    row-gap: var(--p-space-4);
-  }
+    @media screen and (max-width: $breakpointMobile) {
+      grid-template-columns: 1fr;
+      row-gap: var(--p-space-4);
+    }
 
-  .UsageGuidelinesRow {
-    display: contents;
-  }
+    & > li {
+      display: contents;
+      &::before {
+        display: none;
+      }
 
-  .ImageWrapper {
-    aspect-ratio: 485/315;
-    position: relative;
-    background: var(--p-surface-depressed);
-    display: block;
-    overflow: hidden;
-    > img {
-      object-fit: cover;
+      & > span {
+        display: contents;
+      }
+    }
+
+    .ImageWrapper {
+      aspect-ratio: 485/315;
+      position: relative;
+      background: var(--p-surface-depressed);
+      display: block;
+      overflow: hidden;
+      > img {
+        object-fit: cover;
+      }
     }
   }
 }

--- a/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
+++ b/polaris.shopify.com/src/components/PatternPage/PatternPage.tsx
@@ -1,10 +1,4 @@
-import React, {
-  Fragment,
-  useState,
-  createContext,
-  useContext,
-  useEffect,
-} from 'react';
+import React, {useState, createContext, useContext, useEffect} from 'react';
 import {Tab} from '@headlessui/react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -181,17 +175,24 @@ const Variants = (props: {patternData: Props['data']}) => {
     <Container patternData={props.patternData}>
       {(variant) => (
         <Stack gap="8" className={styles.Variant}>
-          <VariantMarkdown
+          <PatternMarkdown
+            patternData={props.patternData}
             patternName={`${props.patternData.title}${
               variant.data.title ? ` > ${variant.data.title}` : ''
             }`}
           >
             {variant.content}
-          </VariantMarkdown>
+          </PatternMarkdown>
         </Stack>
       )}
     </Container>
   );
+};
+
+type MDXComponents = {
+  [key: string]: React.ComponentType<
+    React.PropsWithChildren<{[key: string]: any}>
+  >;
 };
 
 const BaseMarkdown = ({
@@ -202,11 +203,7 @@ const BaseMarkdown = ({
 }: {
   children: string;
   components?: React.ComponentProps<typeof Markdown>['components'];
-  mdxComponents?: {
-    [key: string]: React.ComponentType<
-      React.PropsWithChildren<{[key: string]: any}>
-    >;
-  };
+  mdxComponents?: MDXComponents;
   patternName?: string;
 }) => (
   <Markdown
@@ -320,84 +317,48 @@ const BaseMarkdown = ({
   </Markdown>
 );
 
+const defaultMdxComponents: MDXComponents = {
+  Stack: ({gap, children}) => <Stack gap={gap}>{children}</Stack>,
+  Hero: ({children}) => <Box className={styles.Hero}>{children}</Box>,
+  HowItHelps: ({children}) => (
+    <Stack gap="4" className={styles.HowItHelps}>
+      {children}
+    </Stack>
+  ),
+  Usage: ({children}) => (
+    <Stack gap="4" className={styles.Usage}>
+      {children}
+    </Stack>
+  ),
+  UsefulToKnow: ({children}) => (
+    <Stack gap="4" className={styles.UsefulToKnow}>
+      {children}
+    </Stack>
+  ),
+  DefinitionTable: ({children}) => (
+    <Box className={styles.DefinitionTable}>{children}</Box>
+  ),
+};
+
 const PatternMarkdown = ({
   children,
   patternData,
+  patternName,
 }: {
   children: string;
   patternData: Props['data'];
+  patternName?: string;
 }) => (
   <BaseMarkdown
+    patternName={patternName ?? ''}
     mdxComponents={{
+      ...defaultMdxComponents,
       Variants: () => <Variants patternData={patternData} />,
-      Stack: ({gap, children}) => <Stack gap={gap}>{children}</Stack>,
     }}
   >
     {children}
   </BaseMarkdown>
 );
-
-const VariantMarkdown = ({
-  children,
-  patternName,
-}: {
-  children: string;
-  patternName: string;
-}) => {
-  return (
-    <BaseMarkdown
-      patternName={patternName}
-      components={{
-        // We're using table as a handy shortcut for rendering a CSS grid
-        // But that grid is actually rendered as an unordered list of items!
-        // Should probably just be MDX at this point...
-        table: ({children}) => (
-          <Box as="ul" className={styles.UsageGuidelinesGrid}>
-            {children}
-          </Box>
-        ),
-        // don't need this extra wrapping element, so pass it through
-        tbody: ({children}) => <Fragment>{children}</Fragment>,
-        // We don't use theads here
-        thead: () => null,
-        tr: ({children}) => (
-          <Box as="li" className={styles.UsageGuidelinesRow}>
-            {children}
-          </Box>
-        ),
-        td: ({children, node}) =>
-          node?.children?.[0].type === 'text' ? (
-            <p>{children}</p>
-          ) : (
-            <Fragment>{children}</Fragment>
-          ),
-      }}
-      mdxComponents={{
-        Hero: ({children}) => <Box className={styles.Hero}>{children}</Box>,
-        HowItHelps: ({children}) => (
-          <Stack gap="4" className={styles.HowItHelps}>
-            {children}
-          </Stack>
-        ),
-        Usage: ({children}) => (
-          <Stack gap="4" className={styles.Usage}>
-            {children}
-          </Stack>
-        ),
-        UsefulToKnow: ({children}) => (
-          <Stack gap="4" className={styles.UsefulToKnow}>
-            {children}
-          </Stack>
-        ),
-        DefinitionTable: ({children}) => (
-          <Box className={styles.DefinitionTable}>{children}</Box>
-        ),
-      }}
-    >
-      {children}
-    </BaseMarkdown>
-  );
-};
 
 export default function PatternPage(props: Props) {
   const [showCode, toggleCode] = useState(true);


### PR DESCRIPTION
Exploration on how we might best serve engineering builders visiting pattern pages.

This draft uses a "Long Form" _way of writing_ in support of the App Settings Layout _content_.

There are lots of `TODOs` here that we'd want to flesh out more if this is a direction we want to go in.

![draft-longform-app-settings-layout](https://user-images.githubusercontent.com/612020/224197220-8774aedb-0b5f-4946-a082-2601b6f3ce26.png)
