### PR TITLE
[Icon] Deprecate backdrop prop

### DIFF
--- a/.changeset/twenty-shrimps-act.md
+++ b/.changeset/twenty-shrimps-act.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Deprecated backdrop prop on Icon

--- a/polaris-react/src/components/Icon/Icon.stories.tsx
+++ b/polaris-react/src/components/Icon/Icon.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {Icon} from '@shopify/polaris';
+import {AlphaStack, Box, BoxProps, Icon} from '@shopify/polaris';
 import {CirclePlusMinor} from '@shopify/polaris-icons';
 
 export default {
@@ -27,14 +27,24 @@ export function Colored() {
 }
 
 export function WithBackdrop() {
+  const BackdropIcon = ({color, backdrop = undefined}: any) => (
+    <Box
+      background={`surface-${backdrop ?? color}` as BoxProps['background']}
+      padding="1"
+      width="28px"
+      borderRadius="full"
+    >
+      <Icon source={CirclePlusMinor} color={color} />
+    </Box>
+  );
   return (
-    <div>
-      <Icon source={CirclePlusMinor} color="base" backdrop />
-      <Icon source={CirclePlusMinor} color="highlight" backdrop />
-      <Icon source={CirclePlusMinor} color="success" backdrop />
-      <Icon source={CirclePlusMinor} color="warning" backdrop />
-      <Icon source={CirclePlusMinor} color="critical" backdrop />
-    </div>
+    <AlphaStack gap="1">
+      <BackdropIcon color="base" backdrop="neutral" />
+      <BackdropIcon color="highlight" />
+      <BackdropIcon color="success" />
+      <BackdropIcon color="warning" />
+      <BackdropIcon color="critical" />
+    </AlphaStack>
   );
 }
 

--- a/polaris-react/src/components/Icon/Icon.tsx
+++ b/polaris-react/src/components/Icon/Icon.tsx
@@ -30,7 +30,7 @@ export interface IconProps {
   source: IconSource;
   /** Set the color for the SVG fill */
   color?: Color;
-  /** Show a backdrop behind the icon */
+  /** @deprecated Use the Box component to create a backdrop */
   backdrop?: boolean;
   /** Descriptive text to be read to screenreaders */
   accessibilityLabel?: string;


### PR DESCRIPTION
Backdropped icons were a part of the old design language and aren't widely used in the admin. The backdrop prop doesn't work with all colors, but can easily be recreated using the Box component (see story examples).