### PR TITLE
[IndexFilters] Fix types in stories

### DIFF
--- a/.changeset/tender-llamas-deny.md
+++ b/.changeset/tender-llamas-deny.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed types to ues `AlphaTabs` in `IndexFilter` stories

--- a/polaris-react/src/components/IndexFilters/IndexFilters.stories.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.stories.tsx
@@ -10,8 +10,7 @@ import {
   TextField,
   Card,
 } from '@shopify/polaris';
-
-import type {TabProps} from '../Tabs';
+import type {AlphaTabProps} from '@shopify/polaris';
 
 import {useSetIndexFiltersMode} from './hooks';
 import type {IndexFiltersProps} from './IndexFilters';
@@ -120,7 +119,7 @@ export function Default() {
     return true;
   };
 
-  const tabs: TabProps[] = itemStrings.map((item, index) => ({
+  const tabs: AlphaTabProps[] = itemStrings.map((item, index) => ({
     content: item,
     index,
     onAction: () => {},
@@ -405,7 +404,7 @@ export function WithPinnedFilters() {
     return true;
   };
 
-  const tabs: TabProps[] = itemStrings.map((item, index) => ({
+  const tabs: AlphaTabProps[] = itemStrings.map((item, index) => ({
     content: item,
     index,
     onAction: () => {},
@@ -692,7 +691,7 @@ export function Disabled() {
     return true;
   };
 
-  const tabs: TabProps[] = itemStrings.map((item, index) => ({
+  const tabs: AlphaTabProps[] = itemStrings.map((item, index) => ({
     content: item,
     index,
     onAction: () => {},


### PR DESCRIPTION
### WHY are these changes introduced?

Updates IndexFilters stories to use `AlphaTabsProps` as type instead of `TabProps`.

### WHAT is this pull request doing?

Fixes types to resolve errors.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
