### PR TITLE
[CI] Ensure we filter out deleted files from comment checker

### DIFF
--- a/.github/workflows/migrator-comment.yml
+++ b/.github/workflows/migrator-comment.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           # The "|| true" is used so that matches are saved but it always exit with status 0.
           # Without this, grep will exit with a status of 1 when no matches are found, ending the script.
-          files=$(git diff --name-only origin/${{ github.base_ref }}...origin/${{ github.head_ref }} | grep "\.scss$" || true)
+          files=$(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...origin/${{ github.head_ref }} | grep "\.scss$" || true)
 
           if [ -n "$files" ]; then
             echo "SCSS files where modified."


### PR DESCRIPTION
### WHY are these changes introduced?

After the introduction of https://github.com/Shopify/polaris/pull/8748, the workflow should error if it detects the `generated by polaris-migrator DO NOT COPY` string in any staged SCSS files. In it's current format, it checks deleted diffs too for this, which we do not want otherwise it will always fail when files containing that string are deleted.

This PR updates the command to list the files to utilise the `diff-filter` argument of `git diff` to exclude deleted changes from the result.


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
