### PR TITLE
[AlphaTabs -> TabMeasurer] Fix measurement bug caused by incorrect style class.

### DIFF
--- a/.changeset/ten-eels-hunt.md
+++ b/.changeset/ten-eels-hunt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+FIxed a bug where the `AlphaTabs` component was referencing an incorrect CSS class name

--- a/polaris-react/src/components/AlphaTabs/AlphaTabs.scss
+++ b/polaris-react/src/components/AlphaTabs/AlphaTabs.scss
@@ -7,10 +7,9 @@
 }
 
 .Outer {
-  overflow: hidden;
-
   @media #{$p-breakpoints-md-down} {
     max-width: 100%;
+    overflow: hidden;
     height: 56px;
     padding: 0;
   }

--- a/polaris-react/src/components/AlphaTabs/AlphaTabs.scss
+++ b/polaris-react/src/components/AlphaTabs/AlphaTabs.scss
@@ -7,9 +7,10 @@
 }
 
 .Outer {
+  overflow: hidden;
+
   @media #{$p-breakpoints-md-down} {
     max-width: 100%;
-    overflow: hidden;
     height: 56px;
     padding: 0;
   }

--- a/polaris-react/src/components/AlphaTabs/components/TabMeasurer/TabMeasurer.tsx
+++ b/polaris-react/src/components/AlphaTabs/components/TabMeasurer/TabMeasurer.tsx
@@ -82,7 +82,7 @@ export const TabMeasurer = memo(function TabMeasurer({
     );
   });
 
-  const classname = classNames(styles.Tabs, styles.TabsMeasurer);
+  const classname = classNames(styles.AlphaTabs, styles.TabsMeasurer);
 
   useEventListener('resize', handleMeasurement);
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes a bug where the tab measurer returns incorrect values due to an incorrect CSS class name being applied to the container of the `TabMeasurer` component within the `AlphaTabs` component.

### Before

<img width="2186" alt="Screenshot 2023-03-28 at 15 47 42" src="https://user-images.githubusercontent.com/2562596/228277001-ddb8e983-c684-4086-b373-5bf4ff8c2d7f.png">

### After

<img width="2186" alt="Screenshot 2023-03-28 at 15 47 45" src="https://user-images.githubusercontent.com/2562596/228277057-463cf504-87fb-4b0c-9213-3de7e4b944ac.png">



### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
