### PR TITLE
Tooltip: Change easing function to `ease-out`

### DIFF
--- a/.changeset/silent-cheetahs-jog.md
+++ b/.changeset/silent-cheetahs-jog.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Changed easing of Tooltips to use ease-out instead of ease-in

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
@@ -49,7 +49,7 @@
 
 .measured:not(.instant) {
   animation: var(--p-keyframes-appear-below) var(--p-duration-50)
-    var(--p-ease-in) var(--p-duration-100) 1 both;
+    var(--p-ease-out) var(--p-duration-100) 1 both;
 
   @media (prefers-reduced-motion) {
     animation: none;
@@ -58,7 +58,7 @@
 
 .measured.positionedAbove:not(.instant) {
   animation: var(--p-keyframes-appear-above) var(--p-duration-50)
-    var(--p-ease-in) var(--p-duration-100) 1 both;
+    var(--p-ease-out) var(--p-duration-100) 1 both;
 
   @media (prefers-reduced-motion) {
     animation: none;


### PR DESCRIPTION
Changes the easing of tooltips from `ease-in` to `ease-out`.

IMO, the using `ease-in` causes the tooltip to "slam" into its final position. Replacing it with `ease-out` makes for a softer entry animation. Hardly noticeable with the naked eye, but it feels better.

---

Before: (slowed down, 50% speed)

https://user-images.githubusercontent.com/875708/229754881-58959ea9-a463-4fa7-a465-f66d289f723e.mp4

---

After: (slowed down, 50% speed)

https://user-images.githubusercontent.com/875708/229754932-0bed8fa6-d479-4b2a-ab5a-a90e07c840d7.mp4


