### PR TITLE
Fix type error in the TextField component

### DIFF
--- a/.changeset/short-items-bathe.md
+++ b/.changeset/short-items-bathe.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed a type error in the TextField component

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -697,7 +697,7 @@ function getRows(multiline?: boolean | number) {
 function normalizeAriaMultiline(multiline?: boolean | number) {
   if (!multiline) return undefined;
 
-  return Boolean(multiline) || multiline > 0
+  return Boolean(multiline) || (typeof multiline === 'number' && multiline > 0)
     ? {'aria-multiline': true}
     : undefined;
 }


### PR DESCRIPTION
`multiline > 0` can't be checked because multiline is typed as `number | boolean`. This PR adds a small type check around that logic.