### PR TITLE
[ProgressBar] Fix critical color

### DIFF
--- a/polaris-react/src/components/ProgressBar/ProgressBar.scss
+++ b/polaris-react/src/components/ProgressBar/ProgressBar.scss
@@ -59,7 +59,7 @@
 .colorCritical {
   // stylelint-disable -- Polaris component custom properties
   --pc-progress-bar-background: var(--p-color-bg-strong);
-  --pc-progress-bar-indicator: var(--p-color-border-critical);
+  --pc-progress-bar-indicator: var(--p-color-bg-critical-strong);
   // stylelint-enable
 }
 

--- a/polaris-react/src/components/ProgressBar/ProgressBar.scss
+++ b/polaris-react/src/components/ProgressBar/ProgressBar.scss
@@ -59,7 +59,7 @@
 .colorCritical {
   // stylelint-disable -- Polaris component custom properties
   --pc-progress-bar-background: var(--p-color-bg-strong);
-  --pc-progress-bar-indicator: var(--p-color-bg-interactive-critical);
+  --pc-progress-bar-indicator: var(--p-color-border-critical);
   // stylelint-enable
 }
 

--- a/polaris-react/src/components/ProgressBar/ProgressBar.scss
+++ b/polaris-react/src/components/ProgressBar/ProgressBar.scss
@@ -59,7 +59,7 @@
 .colorCritical {
   // stylelint-disable -- Polaris component custom properties
   --pc-progress-bar-background: var(--p-color-bg-strong);
-  --pc-progress-bar-indicator: var(--p-color-bg-critical-strong);
+  --pc-progress-bar-indicator: var(--p-color-bg-critical);
   // stylelint-enable
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #8877 

The `critical` color for the `ProgressBar` is currently gray due to an undefined CSS color property that's being referenced.

### WHAT is this pull request doing?

Uses the `--p-color-border-critical` color token similar to the other `color` props.

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
