### PR TITLE
[CI] Only build changed packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Build packages
-        run: yarn build
+        run: yarn build --filter=[HEAD^1]
 
       - name: Lint
         run: yarn lint --filter=[HEAD^1]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
           path: |
             **/.eslintcache
             **/.turbo
-            **/*.tsbuildinfo
             node_modules/.cache/turbo
             polaris.shopify.com/.next/cache
           key: ${{ runner.os }}-node${{ matrix.node-version }}-test-v1-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           path: |
             **/.eslintcache
             **/.turbo
+            **/*.tsbuildinfo
             node_modules/.cache/turbo
             polaris.shopify.com/.next/cache
           key: ${{ runner.os }}-node${{ matrix.node-version }}-test-v1-${{ github.sha }}
@@ -50,7 +51,10 @@ jobs:
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
-      - name: Build packages
+      - name: Build essential packages
+        run: yarn build --filter="@shopify/polaris-icons" --filter="@shopify/polaris-tokens"
+
+      - name: Build only changed packages
         run: yarn build --filter=[HEAD^1]
 
       - name: Lint

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format": "prettier . --write",
     "type-check": "tsc --build",
     "changeset": "changeset",
-    "gen-assets": "turbo run gen-assets --filter=polaris.shopify.com",
+    "gen-assets": "yarn workspace polaris.shopify.com gen-assets",
     "preversion-packages": "node scripts/preversion.js",
     "version-packages": "yarn preversion-packages && changeset version",
     "release": "turbo run build --filter='!polaris.shopify.com' && changeset publish",

--- a/polaris-cli/tsconfig.json
+++ b/polaris-cli/tsconfig.json
@@ -7,5 +7,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "references": [{"path": "../polaris-migrator"}]
 }

--- a/polaris-codemods/package.json
+++ b/polaris-codemods/package.json
@@ -26,7 +26,7 @@
     "build": "tsc --build",
     "lint": "TIMING=1 eslint --cache .",
     "test": "jest",
-    "clean": "rm -f .turbo node_modules dist *.tsbuildinfo",
+    "clean": "rm -rf .turbo node_modules dist *.tsbuildinfo",
     "generate": "plop"
   },
   "dependencies": {

--- a/polaris-codemods/tsconfig.json
+++ b/polaris-codemods/tsconfig.json
@@ -14,6 +14,6 @@
     "types": ["node", "jest"]
   },
   "include": ["src"],
-  "exclude": ["**/tests/*.tsx"],
+  "exclude": ["**/*.test.ts", "**/tests/*.tsx"],
   "references": [{"path": "../polaris-react"}, {"path": "../polaris-tokens"}]
 }

--- a/polaris-codemods/tsconfig.json
+++ b/polaris-codemods/tsconfig.json
@@ -1,13 +1,19 @@
 {
   "extends": "@shopify/typescript-configs/node-base",
   "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "incremental": true,
+    "noEmitOnError": true,
+    "skipLibCheck": true,
     "module": "commonjs",
-    "declaration": false,
     "outDir": "dist",
     "rootDir": "src",
     "jsx": "react",
     "types": ["node", "jest"]
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "**/tests/**", "**/*.test.ts"]
+  "exclude": ["**/tests/*.tsx"],
+  "references": [{"path": "../polaris-react"}, {"path": "../polaris-tokens"}]
 }

--- a/polaris-for-vscode/tsconfig.json
+++ b/polaris-for-vscode/tsconfig.json
@@ -7,5 +7,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [{"path": "../polaris-tokens"}]
 }

--- a/polaris-icons/tsconfig.json
+++ b/polaris-icons/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.options.json",
+  "include": ["dist"]
+}

--- a/polaris-migrator/tsconfig.json
+++ b/polaris-migrator/tsconfig.json
@@ -10,5 +10,5 @@
     "types": ["node", "jest"]
   },
   "include": ["src"],
-  "exclude": ["**/tests/*.tsx"]
+  "exclude": ["**/*.test.ts", "**/tests/*.tsx"]
 }

--- a/polaris-migrator/tsconfig.json
+++ b/polaris-migrator/tsconfig.json
@@ -10,5 +10,5 @@
     "types": ["node", "jest"]
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "**/tests/*.tsx"]
+  "exclude": ["**/tests/*.tsx"]
 }

--- a/polaris-react/tsconfig.json
+++ b/polaris-react/tsconfig.json
@@ -20,5 +20,6 @@
     ".storybook/**/*.ts",
     ".storybook/**/*.tsx"
   ],
-  "exclude": ["./src/components/**/*.stories.tsx"]
+  "exclude": ["./src/components/**/*.stories.tsx"],
+  "references": [{"path": "../polaris-icons"}, {"path": "../polaris-tokens"}]
 }

--- a/polaris.shopify.com/tsconfig.json
+++ b/polaris.shopify.com/tsconfig.json
@@ -30,5 +30,5 @@
     "scripts/get-props/src/get-props.ts",
     "constants.js"
   ],
-  "exclude": ["node_modules", "scripts/get-props/testData"]
+  "exclude": ["scripts/get-props/testData"]
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,13 +1,14 @@
 {
   // Root config used to specify which TS files to lint
   // https://typescript-eslint.io/docs/linting/monorepo/#one-root-tsconfigjson
-
+  "extends": "./tsconfig.options.json",
   "compilerOptions": {
     // Ensures this config is not used for a build
-    "noEmit": true
+    "noEmit": true,
   },
   "include": [
     // Paths to lint
+    "**/.eslintrc.js",
     "polaris-codemods",
     "polaris-for-vscode",
     "polaris-migrator",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
+  "extends": "./tsconfig.options.json",
   "files": [],
   "references": [
     {"path": "./polaris-cli"},
     {"path": "./polaris-codemods"},
     {"path": "./polaris-for-vscode"},
+    {"path": "./polaris-icons"},
     {"path": "./polaris-migrator"},
     {"path": "./polaris-react"},
-    {"path": "./polaris-tokens"},
-    {"path": "./polaris.shopify.com"},
-    {"path": "./stylelint-polaris"}
+    {"path": "./polaris-tokens"}
   ]
 }

--- a/tsconfig.options.json
+++ b/tsconfig.options.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "incremental": true,
+    "noEmitOnError": true,
+    "skipLibCheck": true
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,28 +1,22 @@
 {
   "$schema": "https://turborepo.org/schema.json",
-  "baseBranch": "origin/main",
   "pipeline": {
     "build": {
-      "outputs": ["dist/**", ".next/**", "build/**", ".cache/**"],
+      "outputs": ["dist/**", "build/**", ".next/**", "!.next/cache/**"],
       "dependsOn": ["^build"]
     },
-    "test": {
-      "outputs": [],
-      "dependsOn": []
-    },
+    "test": {},
     "lint": {
       "outputs": [".eslintcache"]
     },
     "dev": {
-      "cache": false
+      "cache": false,
+      "persistent": true
     },
     "clean": {
       "cache": false
     },
     "preversion": {
-      "cache": false
-    },
-    "gen-assets": {
       "cache": false
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,8 @@
   "pipeline": {
     "build": {
       "outputs": ["dist/**", "build/**", ".next/**", "!.next/cache/**"],
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "outputMode": "new-only"
     },
     "test": {},
     "lint": {


### PR DESCRIPTION
### WHY are these changes introduced?

We are currently building ALL packages and the website in our CI. The primary CI task is taking about ~15 minutes. We could reduce this drastically by only building the changed packages related to the PR. 

**For a change in Polaris React, this will reduce CI workflow times from ~15min to ~6m** ⚡ 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

This PR:

- Adds a new CI step to build essential packages that will need to be built regardless in order to perform a proper type check using project references.
- Adds a branch filter on the CI `turbo build` command

See [this Test PR](https://github.com/Shopify/polaris/pull/8914) and [CI run](https://github.com/Shopify/polaris/actions/runs/4668575238) which only modifies the `@shopify/polaris` package (`./polaris-react`) and will only run `build`, `lint`, and `test` for changed packages.

<img width="1219" alt="Screenshot 2023-04-11 at 10 04 54 AM" src="https://user-images.githubusercontent.com/11774595/231188972-2df4ee3f-af5f-436e-8128-a4a4e8b31a06.png">
