### PR TITLE
[Layout foundations] Update Grid examples

### DIFF
--- a/.changeset/wild-moons-travel.md
+++ b/.changeset/wild-moons-travel.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+'polaris.shopify.com': patch
+---
+
+Updated `Grid` custom layout example to use new color tokens

--- a/polaris-react/src/components/Grid/Grid.stories.tsx
+++ b/polaris-react/src/components/Grid/Grid.stories.tsx
@@ -89,7 +89,7 @@ export function CustomLayout() {
             <div
               style={{
                 height: '60px',
-                background: 'aquamarine',
+                background: 'var(--p-color-text-info)',
               }}
             />
           </Grid.Cell>
@@ -97,7 +97,7 @@ export function CustomLayout() {
             <div
               style={{
                 height: '60px',
-                background: 'aquamarine',
+                background: 'var(--p-color-text-info)',
               }}
             />
           </Grid.Cell>
@@ -105,7 +105,7 @@ export function CustomLayout() {
             <div
               style={{
                 height: '60px',
-                background: 'aquamarine',
+                background: 'var(--p-color-text-info)',
               }}
             />
           </Grid.Cell>

--- a/polaris.shopify.com/pages/examples/grid-custom-layout.tsx
+++ b/polaris.shopify.com/pages/examples/grid-custom-layout.tsx
@@ -20,33 +20,30 @@ function GridExample() {
           }}
         >
           <Grid.Cell area="product">
-            <div
-              style={{
-                height: '60px',
-                background: 'aquamarine',
-              }}
-            />
+            <Placeholder height="60px" />
           </Grid.Cell>
           <Grid.Cell area="sales">
-            <div
-              style={{
-                height: '60px',
-                background: 'aquamarine',
-              }}
-            />
+            <Placeholder height="60px" />
           </Grid.Cell>
           <Grid.Cell area="orders">
-            <div
-              style={{
-                height: '60px',
-                background: 'aquamarine',
-              }}
-            />
+            <Placeholder height="60px" />
           </Grid.Cell>
         </Grid>
       </LegacyCard>
     </Page>
   );
 }
+
+const Placeholder = ({height = 'auto', width = 'auto'}) => {
+  return (
+    <div
+      style={{
+        background: 'var(--p-color-text-info)',
+        height: height,
+        width: width,
+      }}
+    />
+  );
+};
 
 export default withPolarisExample(GridExample);


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #8942.
When we undeprecated Grid, I noticed the custom layout story/example was using a color that did not align with the updates we've shipped for all the other layout components previously because it was intended to be removed when we did an overhaul of layout component pages in the style guide.

### WHAT is this pull request doing?

Updates Grid custom layout story/example to use new color tokens and align with UI of other layout component examples. Also refactors the example to use the `Placeholder` to abstract away some of the custom UI for the example.
    <details>
      <summary>Grid custom layout — before</summary>
      <img src="https://user-images.githubusercontent.com/26749317/231822590-f412c364-e1cc-4a9e-ab4b-f4c07cbf35e5.png" alt="Grid custom layout — before">
    </details>
    <details>
      <summary>Grid custom layout — after</summary>
      <img src="https://user-images.githubusercontent.com/26749317/231822584-22a9cd18-3a69-4d94-9144-f1735cbc5cb9.png" alt="Grid custom layout — after">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
