### PR TITLE
Add `custom-property-disallowed-list` `stylelint-polaris` plugin

### DIFF
--- a/.changeset/sour-parrots-cry.md
+++ b/.changeset/sour-parrots-cry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-polaris': minor
+---
+
+Added `custom-property-disallowed-list` rule

--- a/stylelint-polaris/plugins/custom-property-allowed-list/index.js
+++ b/stylelint-polaris/plugins/custom-property-allowed-list/index.js
@@ -16,18 +16,23 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
    * @type {stylelint.RuleMessageFunc}
    */
   rejected: (prop, value, prefix, isInvalidProp, invalidValues) => {
-    if (isInvalidProp) {
-      return `Unexpected prefix "${prefix}" for defined custom property "${prop}" - Properties with prefixes "--p-" or "--pc-" cannot be defined outside of Polaris"`;
-    }
+    const invalidPropertyMessage = isInvalidProp
+      ? `Unexpected prefix "${prefix}" for defined custom property "${prop}" - Properties with prefixes "--p-" or "--pc-" cannot be defined outside of Polaris"`
+      : null;
 
-    if (invalidValues) {
-      const plural = invalidValues.length > 1;
-      return `Unexpected value "${value}" for property "${prop}" - Token${
-        plural ? 's' : ''
-      } ${invalidValues.map((token) => `"${token}"`).join(', ')} ${
-        plural ? 'are' : 'is'
-      } either private or ${plural ? 'do' : 'does'} not exist`;
-    }
+    const plural = invalidValues?.length > 1;
+
+    const invalidValueMessage = invalidValues
+      ? `Unexpected value "${value}" for property "${prop}" - Token${
+          plural ? 's' : ''
+        } ${invalidValues.map((token) => `"${token}"`).join(', ')} ${
+          plural ? 'are' : 'is'
+        } either private or ${plural ? 'do' : 'does'} not exist`
+      : null;
+
+    return [invalidPropertyMessage, invalidValueMessage]
+      .filter(Boolean)
+      .join('. ');
   },
 });
 
@@ -82,27 +87,12 @@ const {rule} = stylelint.createPlugin(
           value,
         );
 
-        if (isInvalidProperty) {
+        if (isInvalidProperty || invalidValues) {
           stylelint.utils.report({
             message: messages.rejected(
               prop,
               value,
               getCustomPropertyPrefix(prop),
-              isInvalidProperty,
-              invalidValues,
-            ),
-            node: decl,
-            result,
-            ruleName,
-          });
-        }
-
-        if (invalidValues) {
-          stylelint.utils.report({
-            message: messages.rejected(
-              prop,
-              value,
-              undefined,
               isInvalidProperty,
               invalidValues,
             ),
@@ -122,7 +112,9 @@ const {rule} = stylelint.createPlugin(
  * @returns {string}
  */
 function getCustomPropertyPrefix(property) {
-  return `--${property.split('-')[2]}-`;
+  return isCustomProperty(property)
+    ? `--${property.split('-')[2]}-`
+    : undefined;
 }
 
 /**

--- a/stylelint-polaris/plugins/custom-property-allowed-list/index.js
+++ b/stylelint-polaris/plugins/custom-property-allowed-list/index.js
@@ -30,9 +30,11 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
         } either private or ${plural ? 'do' : 'does'} not exist`
       : null;
 
-    return [invalidPropertyMessage, invalidValueMessage]
+    const message = [invalidPropertyMessage, invalidValueMessage]
       .filter(Boolean)
       .join('. ');
+
+    return message;
   },
 });
 

--- a/stylelint-polaris/plugins/custom-property-allowed-list/index.test.js
+++ b/stylelint-polaris/plugins/custom-property-allowed-list/index.test.js
@@ -96,5 +96,16 @@ testRule({
       endLine: 1,
       endColumn: 28,
     },
+    {
+      code: '.a { --pc-foo: var(--pc-bar); }',
+      description: 'Using --pc- prefixed tokens is disallowed',
+      message: messages.rejected('--pc-foo', 'var(--pc-bar)', '--pc-', true, [
+        '--pc-bar',
+      ]),
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 30,
+    },
   ],
 });

--- a/stylelint-polaris/plugins/custom-property-allowed-list/index.test.js
+++ b/stylelint-polaris/plugins/custom-property-allowed-list/index.test.js
@@ -97,15 +97,30 @@ testRule({
       endColumn: 28,
     },
     {
-      code: '.a { --pc-foo: var(--pc-bar); }',
-      description: 'Using --pc- prefixed tokens is disallowed',
-      message: messages.rejected('--pc-foo', 'var(--pc-bar)', '--pc-', true, [
-        '--pc-bar',
+      code: '.a { --p-foo: var(--p-bar); }',
+      description: 'Using disallowed --p- prefixed custom property and value',
+      message: messages.rejected('--p-foo', 'var(--p-bar)', '--p-', true, [
+        '--p-bar',
       ]),
       line: 1,
       column: 6,
       endLine: 1,
-      endColumn: 30,
+      endColumn: 28,
+    },
+    {
+      code: '.a { --p-foo: var(--p-bar) solid var(--p-baz); }',
+      description: 'Using disallowed --p- prefixed custom property and values',
+      message: messages.rejected(
+        '--p-foo',
+        'var(--p-bar) solid var(--p-baz)',
+        '--p-',
+        true,
+        ['--p-bar', '--p-baz'],
+      ),
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 47,
     },
   ],
 });

--- a/stylelint-polaris/plugins/custom-property-disallowed-list/README.md
+++ b/stylelint-polaris/plugins/custom-property-disallowed-list/README.md
@@ -1,0 +1,36 @@
+## Custom property disallowed list plugin
+
+### Options:
+
+```ts
+interface PrimaryOptions {
+  /**
+   * A list of regular expressions or string literals that match disallowed custom properties.
+   */
+  disallowedProperties?: (string | RegExp)[];
+  /**
+   * A map of properties and their disallowed custom properties represented as a list
+   * of regular expressions or string literals.
+   */
+  disallowedValues?: {[property: string]: (string | RegExp)[]};
+}
+```
+
+### Configuration
+
+```js
+const stylelintConfig = {
+  rules: {
+    'polaris/custom-property-disallowed-list': {
+      disallowedProperties: ['--p-foo'],
+      disallowedValues: {
+        width: ['--p-foo', /--p-bar/ /* etc... */],
+        '/.+/': ['--p-foo', /--p-bar/ /* etc... */],
+      },
+    },
+  },
+};
+```
+
+> Note: Property keys for `disallowedValues` are evaluated in order. Please ensure that you
+> order your property keys from most specific to least specific.

--- a/stylelint-polaris/plugins/custom-property-disallowed-list/index.js
+++ b/stylelint-polaris/plugins/custom-property-disallowed-list/index.js
@@ -20,7 +20,7 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
       ? `Unexpected custom property definition "${prop}"`
       : null;
 
-    const plural = (invalidValues?.length ?? 0) > 1;
+    const plural = invalidValues?.length > 1;
 
     const invalidValueMessage = invalidValues
       ? `Unexpected value${plural ? 's' : ''} ${invalidValues

--- a/stylelint-polaris/plugins/custom-property-disallowed-list/index.js
+++ b/stylelint-polaris/plugins/custom-property-disallowed-list/index.js
@@ -23,9 +23,9 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
     const plural = (invalidValues?.length ?? 0) > 1;
 
     const invalidValueMessage = invalidValues
-      ? `Unexpected value${plural ? 's' : ''} "${invalidValues.join(
-          ', ',
-        )}" for property "${prop}"`
+      ? `Unexpected value${plural ? 's' : ''} ${invalidValues
+          .map((token) => `"${token}"`)
+          .join(', ')} for property "${prop}"`
       : null;
 
     const message = [invalidPropertyMessage, invalidValueMessage]

--- a/stylelint-polaris/plugins/custom-property-disallowed-list/index.js
+++ b/stylelint-polaris/plugins/custom-property-disallowed-list/index.js
@@ -1,0 +1,189 @@
+const stylelint = require('stylelint');
+const valueParser = require('postcss-value-parser');
+
+const {
+  vendorUnprefixed,
+  matchesStringOrRegExp,
+  isCustomProperty,
+  isRegExp,
+  isString,
+} = require('../../utils');
+
+const ruleName = 'polaris/custom-property-disallowed-list';
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  /**
+   * @type {stylelint.RuleMessageFunc}
+   */
+  rejected: (prop, value, isInvalidProp, invalidValues) => {
+    const invalidPropertyMessage = isInvalidProp
+      ? `Unexpected custom property definition "${prop}"`
+      : null;
+
+    const plural = (invalidValues?.length ?? 0) > 1;
+
+    const invalidValueMessage = invalidValues
+      ? `Unexpected value${plural ? 's' : ''} "${invalidValues.join(
+          ', ',
+        )}" for property "${prop}"`
+      : null;
+
+    const message = [invalidPropertyMessage, invalidValueMessage]
+      .filter(Boolean)
+      .join('. ');
+
+    return message;
+  },
+});
+
+/** @typedef {(string | RegExp)[]} DisallowedPatterns */
+
+/**
+ * @typedef {Object} PrimaryOptions
+ * @property {DisallowedPatterns} [disallowedProperties]
+ * @property {{[property: string]: DisallowedPatterns}} [disallowedValues]
+ */
+
+const {rule} = stylelint.createPlugin(
+  ruleName,
+  /** @param {PrimaryOptions} primary */
+  (primary) => {
+    return (root, result) => {
+      const validOptions = stylelint.utils.validateOptions(
+        result,
+        ruleName,
+        {
+          actual: primary.disallowedProperties,
+          possible: isDisallowedPatterns,
+          optional: true,
+        },
+        {
+          actual: primary.disallowedValues,
+          possible: validateDisallowedValuesOption,
+          optional: true,
+        },
+      );
+
+      if (!validOptions) {
+        return;
+      }
+
+      const {disallowedProperties = [], disallowedValues = {}} = primary;
+
+      root.walkDecls((decl) => {
+        const prop = decl.prop;
+        const value = decl.value;
+
+        const isInvalidProperty = isInvalidCustomProperty(
+          disallowedProperties,
+          prop,
+        );
+
+        const invalidValues = getInvalidCustomPropertyValues(
+          disallowedValues,
+          prop,
+          value,
+        );
+
+        if (isInvalidProperty || invalidValues) {
+          stylelint.utils.report({
+            message: messages.rejected(
+              prop,
+              value,
+              isInvalidProperty,
+              invalidValues,
+            ),
+            node: decl,
+            result,
+            ruleName,
+          });
+        }
+      });
+    };
+  },
+);
+
+/**
+ * @param {NonNullable<PrimaryOptions['disallowedProperties']>} disallowedProperties
+ * @param {string} property
+ */
+function isInvalidCustomProperty(disallowedProperties, property) {
+  if (!isCustomProperty(property)) return false;
+
+  const isInvalid = disallowedProperties.some((disallowedProperty) => {
+    return matchesStringOrRegExp(property, disallowedProperty);
+  });
+
+  return isInvalid;
+}
+
+/**
+ * @param {NonNullable<PrimaryOptions['disallowedValues']>} disallowedValues
+ * @param {string} prop
+ * @param {string} value
+ * @returns {string[] | undefined}
+ */
+function getInvalidCustomPropertyValues(disallowedValues, prop, value) {
+  const invalidValues = [];
+
+  const unprefixedProp = vendorUnprefixed(prop);
+
+  /** Property key for the disallowed values option */
+  const propKey = Object.keys(disallowedValues).find((propIdentifier) =>
+    matchesStringOrRegExp(unprefixedProp, propIdentifier),
+  );
+
+  if (!propKey) return;
+
+  const disallowedPatterns = disallowedValues[propKey];
+
+  if (!disallowedPatterns.length) return;
+
+  valueParser(value).walk((node) => {
+    if (
+      node.type === 'word' &&
+      isCustomProperty(node.value) &&
+      matchesStringOrRegExp(node.value, disallowedPatterns)
+    ) {
+      invalidValues.push(node.value);
+    }
+  });
+
+  if (invalidValues.length > 0) return invalidValues;
+}
+
+module.exports = {
+  rule,
+  ruleName,
+  messages,
+};
+
+/**
+ * Validates the input is an array of String or RegExp.
+ * @param {unknown} disallowedPatterns
+ * @returns {disallowedPatterns is DisallowedPatterns}
+ */
+function isDisallowedPatterns(disallowedPatterns) {
+  if (!Array.isArray(disallowedPatterns)) return false;
+
+  for (const pattern of disallowedPatterns) {
+    if (!(isString(pattern) || isRegExp(pattern))) return false;
+  }
+
+  return true;
+}
+
+/**
+ * @param {unknown} option - `primary.disallowedValues` option.
+ */
+function validateDisallowedValuesOption(option) {
+  if (typeof option !== 'object' || option === null) return false;
+
+  for (const [property, disallowedPatterns] of Object.entries(option)) {
+    if (!(isString(property) && isDisallowedPatterns(disallowedPatterns))) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/stylelint-polaris/plugins/custom-property-disallowed-list/index.test.js
+++ b/stylelint-polaris/plugins/custom-property-disallowed-list/index.test.js
@@ -20,18 +20,18 @@ testRule({
     },
     {
       code: '.a { color: var(--p-foo-bar); }',
-      description: 'Using allowed custom property value',
+      description: 'Defining allowed custom property value',
     },
     {
       code: '.a { --p-foo-bar: var(--p-foo-bar); }',
-      description: 'Using allowed custom property and value',
+      description: 'Defining allowed custom property and value',
     },
   ],
 
   reject: [
     {
       code: '.a { --p-foo: red; }',
-      description: 'Defining disallowed custom property (literal)',
+      description: 'Defining disallowed custom property (literal match)',
       message: messages.rejected('--p-foo', 'red', true, undefined),
       line: 1,
       column: 6,
@@ -40,7 +40,7 @@ testRule({
     },
     {
       code: '.a { --p-bar-baz: red; }',
-      description: 'Defining disallowed custom property (regex)',
+      description: 'Defining disallowed custom property (regex match)',
       message: messages.rejected('--p-bar-baz', 'red', true, undefined),
       line: 1,
       column: 6,
@@ -49,7 +49,7 @@ testRule({
     },
     {
       code: '.a { color: var(--p-foo); }',
-      description: 'Defining disallowed custom property value (literal)',
+      description: 'Defining disallowed custom property value (literal match)',
       message: messages.rejected('color', 'var(--p-foo)', false, ['--p-foo']),
       line: 1,
       column: 6,
@@ -58,7 +58,7 @@ testRule({
     },
     {
       code: '.a { color: var(--p-bar-baz); }',
-      description: 'Defining disallowed custom property value (regex)',
+      description: 'Defining disallowed custom property value (regex match)',
       message: messages.rejected('color', 'var(--p-bar-baz)', false, [
         '--p-bar-baz',
       ]),
@@ -92,7 +92,7 @@ testRule({
     },
     {
       code: '.a { --p-foo: var(--p-foo) solid var(--p-bar); }',
-      description: 'Defining multiple disallowed custom properties and values',
+      description: 'Defining multiple disallowed custom property and values',
       message: messages.rejected(
         '--p-foo',
         'var(--p-foo) solid var(--p-bar)',

--- a/stylelint-polaris/plugins/custom-property-disallowed-list/index.test.js
+++ b/stylelint-polaris/plugins/custom-property-disallowed-list/index.test.js
@@ -39,9 +39,9 @@ testRule({
       endColumn: 19,
     },
     {
-      code: '.a { --p-bar-foo: red; }',
+      code: '.a { --p-bar-baz: red; }',
       description: 'Defining disallowed custom property (regex)',
-      message: messages.rejected('--p-bar-foo', 'red', true, undefined),
+      message: messages.rejected('--p-bar-baz', 'red', true, undefined),
       line: 1,
       column: 6,
       endLine: 1,
@@ -57,10 +57,10 @@ testRule({
       endColumn: 26,
     },
     {
-      code: '.a { color: var(--p-bar-foo); }',
+      code: '.a { color: var(--p-bar-baz); }',
       description: 'Defining disallowed custom property value (regex)',
-      message: messages.rejected('color', 'var(--p-bar-foo)', false, [
-        '--p-bar-foo',
+      message: messages.rejected('color', 'var(--p-bar-baz)', false, [
+        '--p-bar-baz',
       ]),
       line: 1,
       column: 6,

--- a/stylelint-polaris/plugins/custom-property-disallowed-list/index.test.js
+++ b/stylelint-polaris/plugins/custom-property-disallowed-list/index.test.js
@@ -1,0 +1,108 @@
+const {messages, ruleName} = require('.');
+
+const config = [
+  {
+    disallowedProperties: ['--p-foo', /--p-bar/],
+    disallowedValues: {
+      '/.+/': ['--p-foo', /--p-bar/],
+    },
+  },
+];
+
+testRule({
+  ruleName,
+  plugins: [__dirname],
+  config,
+  accept: [
+    {
+      code: '.a { --p-foo-bar: red; }',
+      description: 'Defining allowed custom property',
+    },
+    {
+      code: '.a { color: var(--p-foo-bar); }',
+      description: 'Using allowed custom property value',
+    },
+    {
+      code: '.a { --p-foo-bar: var(--p-foo-bar); }',
+      description: 'Using allowed custom property and value',
+    },
+  ],
+
+  reject: [
+    {
+      code: '.a { --p-foo: red; }',
+      description: 'Defining disallowed custom property (literal)',
+      message: messages.rejected('--p-foo', 'red', true, undefined),
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 19,
+    },
+    {
+      code: '.a { --p-bar-foo: red; }',
+      description: 'Defining disallowed custom property (regex)',
+      message: messages.rejected('--p-bar-foo', 'red', true, undefined),
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 23,
+    },
+    {
+      code: '.a { color: var(--p-foo); }',
+      description: 'Defining disallowed custom property value (literal)',
+      message: messages.rejected('color', 'var(--p-foo)', false, ['--p-foo']),
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 26,
+    },
+    {
+      code: '.a { color: var(--p-bar-foo); }',
+      description: 'Defining disallowed custom property value (regex)',
+      message: messages.rejected('color', 'var(--p-bar-foo)', false, [
+        '--p-bar-foo',
+      ]),
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 30,
+    },
+    {
+      code: '.a { --p-foo: var(--p-bar); }',
+      description: 'Defining disallowed custom property and value',
+      message: messages.rejected('--p-foo', 'var(--p-bar)', true, ['--p-bar']),
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 28,
+    },
+    {
+      code: '.a { border: var(--p-foo) solid var(--p-bar); }',
+      description: 'Defining multiple disallowed custom property values',
+      message: messages.rejected(
+        'border',
+        'var(--p-foo) solid var(--p-bar)',
+        false,
+        ['--p-foo', '--p-bar'],
+      ),
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 46,
+    },
+    {
+      code: '.a { --p-foo: var(--p-foo) solid var(--p-bar); }',
+      description: 'Defining multiple disallowed custom properties and values',
+      message: messages.rejected(
+        '--p-foo',
+        'var(--p-foo) solid var(--p-bar)',
+        true,
+        ['--p-foo', '--p-bar'],
+      ),
+      line: 1,
+      column: 6,
+      endLine: 1,
+      endColumn: 47,
+    },
+  ],
+});


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR introduces a `custom-property-disallowed-list` plugin as a companion to the existing `custom-property-allowed-list` rule. The plugin will be added to the `stylelint-polaris` config in a follow up PR to disallow a collection of Polaris v10 custom properties prior to the v11 release.

```js
const stylelintConfig = {
  rules: {
    'polaris/custom-property-disallowed-list': {
      disallowedProperties: ['--p-foo'],
      disallowedValues: {
        width: ['--p-foo', /--p-bar/ /* etc... */],
        '/.+/': ['--p-foo', /--p-bar/ /* etc... */],
      },
    },
  },
};
```
```scss
.class {
  --p-foo: red; // ❌
  width: var(--p-foo); // ❌
  color: var(--p-bar-baz); // ❌
}
```