### PR TITLE
Fix padding on AlphaFilter in IndexFilter when hideQueryField is true

### DIFF
--- a/.changeset/healthy-deers-burn.md
+++ b/.changeset/healthy-deers-burn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed padding on AlphaFilter in IndexFilter when hideQueryField is true

--- a/polaris-react/src/components/AlphaFilters/AlphaFilters.scss
+++ b/polaris-react/src/components/AlphaFilters/AlphaFilters.scss
@@ -47,6 +47,7 @@
 
 .hideQueryField .FiltersWrapper {
   display: flex;
+  align-items: center;
 }
 
 .FiltersInner {

--- a/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
+++ b/polaris-react/src/components/AlphaFilters/AlphaFilters.tsx
@@ -367,7 +367,7 @@ export function AlphaFilters({
           </div>
         </div>
         {hideQueryField ? (
-          <Box paddingInlineEnd="2" paddingBlockStart="2">
+          <Box paddingInlineEnd="3" paddingBlockStart="2" paddingBlockEnd="2">
             <HorizontalStack
               align="start"
               blockAlign="center"


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #9101

### WHAT is this pull request doing?

- Adds a bottom padding to `AlphaFilters` container
- Aligns the content center to the filter wrapper

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/11774595/234869452-119032ab-ccb2-4c2a-841d-b021e7803b36.gif" alt="befre" />
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/11774595/234869449-654a5b47-2ea1-499f-a54e-eade789d93eb.gif" alt="after" />
</details>

### Tophat instructions

- Add the `hideQueryField` prop to the Default IndexFilters.stories.tsx` example
- Run Storybook with `yarn dev`

Also

- [Spin link](https://admin.web.hide-query-field.sam-rose.us.spin.dev/store/shop1/products?selectedView=all) using snapshot

Demo with fix in spin on Products page:

https://user-images.githubusercontent.com/11774595/235160159-3341d0c2-a653-482d-9d28-1c47d3c17243.mov


