### PR TITLE
[AlphaTabs/AlphaFilters] Add style guide examples

### DIFF
--- a/.changeset/tiny-oranges-clean.md
+++ b/.changeset/tiny-oranges-clean.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+'polaris.shopify.com': minor
+---
+
+Added component pages and examples for `AlphaTabs` and `AlphaFilters` on style guide

--- a/polaris-react/src/components/AlphaTabs/AlphaTabs.stories.tsx
+++ b/polaris-react/src/components/AlphaTabs/AlphaTabs.stories.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useState} from 'react';
 import type {ComponentMeta} from '@storybook/react';
-import {LegacyCard, AlphaTabs, Box} from '@shopify/polaris';
+import {LegacyCard, AlphaTabs} from '@shopify/polaris';
 
 export default {
   component: AlphaTabs,
@@ -26,6 +26,33 @@ export function Default() {
   }));
 
   return (
+    <AlphaTabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
+      <LegacyCard.Section title={tabs[selected].content}>
+        <p>Tab {selected} selected</p>
+      </LegacyCard.Section>
+    </AlphaTabs>
+  );
+}
+
+export function InsideOfACard() {
+  const [selected, setSelected] = useState(0);
+
+  const handleTabChange = (selectedTabIndex: number) =>
+    setSelected(selectedTabIndex);
+
+  const tabs = [
+    'All',
+    'Unpaid',
+    'Open',
+    'Closed',
+    'Local delivery',
+    'Local pickup',
+  ].map((item, index) => ({
+    content: item,
+    index,
+    id: `${item}-${index}`,
+  }));
+  return (
     <LegacyCard>
       <AlphaTabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
         <LegacyCard.Section title={tabs[selected].content}>
@@ -40,7 +67,7 @@ export function Fitted() {
   const [selected, setSelected] = useState(0);
 
   const handleTabChange = useCallback(
-    (selectedTabIndex) => setSelected(selectedTabIndex),
+    (selectedTabIndex: number) => setSelected(selectedTabIndex),
     [],
   );
 
@@ -73,6 +100,13 @@ export function Fitted() {
     </LegacyCard>
   );
 }
+
+type AlphaTabAction =
+  | 'rename'
+  | 'edit'
+  | 'edit-columns'
+  | 'duplicate'
+  | 'delete';
 
 export function WithActions() {
   const sleep = (ms: number) =>
@@ -109,22 +143,22 @@ export function WithActions() {
         ? []
         : [
             {
-              type: 'rename',
+              type: 'rename' as AlphaTabAction,
               onAction: () => {},
               onPrimaryAction: () => {},
             },
             {
-              type: 'duplicate',
+              type: 'duplicate' as AlphaTabAction,
               onAction: () => {},
               onPrimaryAction: () => {},
             },
             {
-              type: 'edit',
+              type: 'edit' as AlphaTabAction,
               onAction: () => {},
               onPrimaryAction: () => {},
             },
             {
-              type: 'delete',
+              type: 'delete' as AlphaTabAction,
               onAction: () => {},
               onPrimaryAction: () => {},
             },
@@ -145,7 +179,7 @@ export function WithBadgeContent() {
   const [selected, setSelected] = useState(0);
 
   const handleTabChange = useCallback(
-    (selectedTabIndex) => setSelected(selectedTabIndex),
+    (selectedTabIndex: number) => setSelected(selectedTabIndex),
     [],
   );
 
@@ -185,7 +219,7 @@ export function WithCustomDisclosure() {
   const [selected, setSelected] = useState(0);
 
   const handleTabChange = useCallback(
-    (selectedTabIndex) => setSelected(selectedTabIndex),
+    (selectedTabIndex: number) => setSelected(selectedTabIndex),
     [],
   );
 
@@ -241,33 +275,5 @@ export function WithCustomDisclosure() {
         </LegacyCard.Section>
       </AlphaTabs>
     </LegacyCard>
-  );
-}
-
-export function OutsideOfCard() {
-  const [selected, setSelected] = useState(0);
-
-  const handleTabChange = (selectedTabIndex: number) =>
-    setSelected(selectedTabIndex);
-
-  const tabs = [
-    'All',
-    'Unpaid',
-    'Open',
-    'Closed',
-    'Local delivery',
-    'Local pickup',
-  ].map((item, index) => ({
-    content: item,
-    index,
-    id: `${item}-${index}`,
-  }));
-
-  return (
-    <AlphaTabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
-      <LegacyCard.Section title={tabs[selected].content}>
-        <p>Tab {selected} selected</p>
-      </LegacyCard.Section>
-    </AlphaTabs>
   );
 }

--- a/polaris.shopify.com/content/components/navigation/alpha-tabs.md
+++ b/polaris.shopify.com/content/components/navigation/alpha-tabs.md
@@ -1,0 +1,80 @@
+---
+title: Alpha tabs
+description: Use to alternate among related views within the same context.
+category: Navigation
+keywords:
+  - layout
+  - navigate
+  - organize
+  - list views
+  - list filters
+  - fitted tabs
+  - segmented controls
+  - scrollable
+status:
+  value: Alpha
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+examples:
+  - fileName: alpha-tabs-default.tsx
+    title: Default
+    description: Use for most cases, especially when the number of tabs may be more than three.
+  - fileName: alpha-tabs-inside-of-a-card.tsx
+    title: Inside of a Card
+    description: Use to display tabs inside of a [Card](/components/layout-and-structure/card).
+  - fileName: alpha-tabs-fitted.tsx
+    title: Fitted
+    description: Use when tabs contain a few (2 or 3) items within a narrow column.
+  - fileName: alpha-tabs-with-actions.tsx
+    title: With actions
+    description: Use when tabs can be altered with actions.
+  - fileName: alpha-tabs-with-badge-content.tsx
+    title: With badge content
+    description: Use to inform a piece of information about the tabs.
+  - fileName: alpha-tabs-with-custom-disclosure.tsx
+    title: With custom disclosure
+    description: Use to provide information about the popover contents.
+---
+
+## Best practices
+
+Tabs should:
+
+- Represent the same kind of content, such as a list-view with different filters applied. Don’t use tabs to group content that is dissimilar.
+- Only be active one at a time.
+- Not force merchants to jump back and forth to do a single task. Merchants should be able to complete their work and find what they need under each tab.
+- Not be used for primary navigation.
+
+---
+
+## Content guidelines
+
+### Tabs
+
+Tabs should:
+
+- Be clearly labeled to help differentiate the different sections beneath them.
+- Have short and scannable labels, generally kept to single word.
+- Relate to the section of Shopify they’re on. Imagine the page section title is an invisible noun after the tab. For example, the tabs for the orders section are:
+
+  - All
+  - Open
+  - Unfulfilled
+  - Unpaid
+
+The tabs for the gift cards section are:
+
+- All
+- New
+- Partially used
+- Used
+- Disabled
+
+And for the customers section, the tabs are:
+
+- All
+- New
+- Returning
+- Abandoned checkouts
+- Email subscribers
+
+Where possible, follow this pattern when writing tabs.

--- a/polaris.shopify.com/content/components/navigation/tabs.md
+++ b/polaris.shopify.com/content/components/navigation/tabs.md
@@ -23,7 +23,7 @@ examples:
     description: Use to inform a piece of information about the tabs.
   - fileName: tabs-with-custom-disclosure.tsx
     title: With custom disclosure
-    description: Use to provide information about the popover contents
+    description: Use to provide information about the popover contents.
 ---
 
 ## Best practices

--- a/polaris.shopify.com/content/components/selection-and-input/alpha-filters.md
+++ b/polaris.shopify.com/content/components/selection-and-input/alpha-filters.md
@@ -36,7 +36,7 @@ Merchants use filters to:
 - filter by typing into a text field
 - filter by selecting filters or promoted filters
 
-The way that merchants interact with filters depends on the components that you decide to incorporate. In its simplest form, filters includes a text field and a set of filters, which can be displayed in different ways. For example, you could show promoted filters and a More button that opens a [sheet](https://polaris.shopify.com/components/deprecated/sheet) containing more filters. What the filters are and how they’re exposed to merchants is flexible.
+The way that merchants interact with filters depends on the components that you decide to incorporate. In its simplest form, filters includes a text field and a set of filters, which can be displayed in different ways. What the filters are and how they’re exposed to merchants is flexible.
 
 ---
 
@@ -47,8 +47,6 @@ The filters component relies on the accessibility features of multiple other com
 - [Text field](https://polaris.shopify.com/components/selection-and-input/text-field)
 - [Button](https://polaris.shopify.com/components/actions/button)
 - [Popover](https://polaris.shopify.com/components/overlays/popover)
-- [Sheet](https://polaris.shopify.com/components/deprecated/sheet)
-- [Collapsible](https://polaris.shopify.com/components/collapsible)
 
 ### Maintain accessibility with custom features
 

--- a/polaris.shopify.com/content/components/selection-and-input/alpha-filters.md
+++ b/polaris.shopify.com/content/components/selection-and-input/alpha-filters.md
@@ -1,0 +1,150 @@
+---
+title: Alpha filters
+description: Filters is a composite component that filters the items of a list or table.
+category: Selection and input
+keywords:
+  - filters
+  - filtering
+  - filter control
+  - resource list
+  - index
+  - list filter
+  - table
+status:
+  value: Alpha
+  message: This component is a work in progress and ready for exploratory usage, with breaking changes expected in minor version updates. Please use with caution. Learn more about our [component lifecycles](/getting-started/components-lifecycle).
+examples:
+  - fileName: alpha-filters-with-a-resource-list.tsx
+    title: With a resource list
+  - fileName: alpha-filters-with-a-data-table.tsx
+    title: With a data table
+  - fileName: alpha-filters-with-children-content.tsx
+    title: With children content
+  - fileName: alpha-filters-disabled.tsx
+    title: Disabled
+  - fileName: alpha-filters-with-some-disabled.tsx
+    title: With some disabled
+  - fileName: alpha-filters-with-query-field-hidden.tsx
+    title: With query field hidden
+  - fileName: alpha-filters-with-query-field-disabled.tsx
+    title: With query field disabled
+---
+
+Merchants use filters to:
+
+- view different subsets of items in a list or table
+- filter by typing into a text field
+- filter by selecting filters or promoted filters
+
+The way that merchants interact with filters depends on the components that you decide to incorporate. In its simplest form, filters includes a text field and a set of filters, which can be displayed in different ways. For example, you could show promoted filters and a More button that opens a [sheet](https://polaris.shopify.com/components/deprecated/sheet) containing more filters. What the filters are and how they’re exposed to merchants is flexible.
+
+---
+
+## Accessibility
+
+The filters component relies on the accessibility features of multiple other components:
+
+- [Text field](https://polaris.shopify.com/components/selection-and-input/text-field)
+- [Button](https://polaris.shopify.com/components/actions/button)
+- [Popover](https://polaris.shopify.com/components/overlays/popover)
+- [Sheet](https://polaris.shopify.com/components/deprecated/sheet)
+- [Collapsible](https://polaris.shopify.com/components/collapsible)
+
+### Maintain accessibility with custom features
+
+Since custom HTML can be passed to the component for additional actions, ensure that the filtering system you build is accessible as a whole.
+
+All merchants must:
+
+- be able to identify and understand labels for all controls
+- be notified of state changes
+- be able to complete all actions with the keyboard
+
+---
+
+## Best practices
+
+The filters component should:
+
+- help reduce merchant effort by promoting the filtering categories that are most commonly used
+- include no more than 2 or 3 promoted filters
+- consider small screen sizes when designing the interface for each filter and the total number filters to include
+- use children only for content that’s related or relevant to filtering
+
+---
+
+## Content guidelines
+
+### Text field
+
+The text field should be clearly labeled so it’s obvious to merchants what they should enter into the field.
+
+<!-- dodont -->
+
+#### Do
+
+- Filter orders
+
+#### Don’t
+
+- Enter text here
+
+<!-- end -->
+
+### Filter badges
+
+Use the name of the filter if the purpose of the name is clear on its own. For example, when you see a filter badge that reads **Fulfilled**, it’s intuitive that it falls under the Fulfillment status category.
+
+<!-- dodont -->
+
+#### Do
+
+- Fulfilled, Unfulfilled
+
+#### Don’t
+
+- Fulfillment: Fulfilled, Unfulfilled
+
+<!-- end -->
+
+If the filter name is ambiguous on its own, add a descriptive word related to the status. For example, **Low** doesn’t make sense out of context. Add the word “risk” so that merchants know it’s from the Risk category.
+
+<!-- dodont -->
+
+#### Do
+
+- High risk, Low risk
+
+#### Don’t
+
+- High, Low
+
+<!-- end -->
+
+Group tags from the same category together.
+
+<!-- dodont -->
+
+#### Do
+
+- (Unfulfilled, Fulfilled)
+
+#### Don’t
+
+- (Unfulfilled) (fulfilled)
+
+<!-- end -->
+
+If all tag pills selected: truncate in the middle
+
+<!-- dodont -->
+
+#### Do
+
+- Paid, par… unpaid
+
+#### Don’t
+
+- All payment status filters selected, Paid, unpa…
+
+<!-- end -->

--- a/polaris.shopify.com/pages/examples/alpha-filters-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-filters-disabled.tsx
@@ -1,0 +1,145 @@
+import {
+  TextField,
+  LegacyCard,
+  ResourceList,
+  AlphaFilters,
+  Button,
+  Avatar,
+  Text,
+} from '@shopify/polaris';
+import {useState, useCallback} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function FiltersDisabledExample() {
+  const [taggedWith, setTaggedWith] = useState<string>('');
+  const [queryValue, setQueryValue] = useState<string>('');
+
+  const handleTaggedWithChange = useCallback(
+    (value: string) => setTaggedWith(value),
+    [],
+  );
+  const handleQueryValueChange = useCallback(
+    (value: string) => setQueryValue(value),
+    [],
+  );
+  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+
+  const handleClearAll = useCallback(() => {
+    handleTaggedWithRemove();
+    handleQueryValueRemove();
+  }, [handleQueryValueRemove, handleTaggedWithRemove]);
+
+  const filters = [
+    {
+      key: 'taggedWith',
+      label: 'Tagged with',
+      filter: (
+        <TextField
+          label="Tagged with"
+          value={taggedWith}
+          onChange={handleTaggedWithChange}
+          autoComplete="off"
+          labelHidden
+        />
+      ),
+      shortcut: true,
+    },
+  ];
+
+  const appliedFilters = !isEmpty(taggedWith)
+    ? [
+        {
+          key: 'taggedWith',
+          label: disambiguateLabel('taggedWith', taggedWith),
+          onRemove: handleTaggedWithRemove,
+        },
+      ]
+    : [];
+
+  return (
+    <div style={{height: '568px'}}>
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          filterControl={
+            <AlphaFilters
+              queryValue={queryValue}
+              queryPlaceholder="Searching in all"
+              filters={filters}
+              appliedFilters={appliedFilters}
+              onQueryChange={handleQueryValueChange}
+              onQueryClear={handleQueryValueRemove}
+              onClearAll={handleClearAll}
+              disabled
+            >
+              <div style={{paddingLeft: '8px'}}>
+                <Button
+                  disabled
+                  size="micro"
+                  primary
+                  plain
+                  onClick={() => console.log('New filter saved')}
+                >
+                  Save
+                </Button>
+              </div>
+            </AlphaFilters>
+          }
+          flushFilters
+          items={[
+            {
+              id: '341',
+              url: '#',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            },
+            {
+              id: '256',
+              url: '#',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="medium" name={name} />;
+
+            return (
+              <ResourceList.Item
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <Text as="h3" fontWeight="bold">
+                  {name}
+                </Text>
+                <div>{location}</div>
+              </ResourceList.Item>
+            );
+          }}
+        />
+      </LegacyCard>
+    </div>
+  );
+
+  function disambiguateLabel(key: string, value: string): string {
+    switch (key) {
+      case 'taggedWith':
+        return `Tagged with ${value}`;
+      default:
+        return value;
+    }
+  }
+
+  function isEmpty(value: string): boolean {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else {
+      return value === '' || value == null;
+    }
+  }
+}
+
+export default withPolarisExample(FiltersDisabledExample);

--- a/polaris.shopify.com/pages/examples/alpha-filters-with-a-data-table.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-filters-with-a-data-table.tsx
@@ -1,0 +1,194 @@
+import {
+  ChoiceList,
+  TextField,
+  LegacyCard,
+  AlphaFilters,
+  DataTable,
+} from '@shopify/polaris';
+import {useState, useCallback} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function FiltersWithADataTableExample() {
+  const [availability, setAvailability] = useState<string[]>([]);
+  const [productType, setProductType] = useState<string[]>([]);
+  const [taggedWith, setTaggedWith] = useState<string>('');
+  const [queryValue, setQueryValue] = useState('');
+
+  const handleAvailabilityChange = useCallback(
+    (value: string[]) => setAvailability(value),
+    [],
+  );
+  const handleProductTypeChange = useCallback(
+    (value: string[]) => setProductType(value),
+    [],
+  );
+  const handleTaggedWithChange = useCallback(
+    (value: string) => setTaggedWith(value),
+    [],
+  );
+  const handleFiltersQueryChange = useCallback(
+    (value: string) => setQueryValue(value),
+    [],
+  );
+  const handleAvailabilityRemove = useCallback(() => setAvailability([]), []);
+  const handleProductTypeRemove = useCallback(() => setProductType([]), []);
+  const handleTaggedWithRemove = useCallback(() => setTaggedWith(''), []);
+  const handleQueryValueRemove = useCallback(() => setQueryValue(''), []);
+  const handleFiltersClearAll = useCallback(() => {
+    handleAvailabilityRemove();
+    handleProductTypeRemove();
+    handleTaggedWithRemove();
+    handleQueryValueRemove();
+  }, [
+    handleAvailabilityRemove,
+    handleQueryValueRemove,
+    handleProductTypeRemove,
+    handleTaggedWithRemove,
+  ]);
+
+  const filters = [
+    {
+      key: 'availability',
+      label: 'Availability',
+      filter: (
+        <ChoiceList
+          title="Availability"
+          titleHidden
+          choices={[
+            {label: 'Online Store', value: 'Online Store'},
+            {label: 'Point of Sale', value: 'Point of Sale'},
+            {label: 'Buy Button', value: 'Buy Button'},
+          ]}
+          selected={availability || []}
+          onChange={handleAvailabilityChange}
+          allowMultiple
+        />
+      ),
+      shortcut: true,
+    },
+    {
+      key: 'productType',
+      label: 'Product type',
+      filter: (
+        <ChoiceList
+          title="Product type"
+          titleHidden
+          choices={[
+            {label: 'T-Shirt', value: 'T-Shirt'},
+            {label: 'Accessory', value: 'Accessory'},
+            {label: 'Gift card', value: 'Gift card'},
+          ]}
+          selected={productType || []}
+          onChange={handleProductTypeChange}
+          allowMultiple
+        />
+      ),
+    },
+    {
+      key: 'taggedWith',
+      label: 'Tagged with',
+      filter: (
+        <TextField
+          label="Tagged with"
+          value={taggedWith}
+          onChange={handleTaggedWithChange}
+          autoComplete="off"
+          labelHidden
+        />
+      ),
+    },
+  ];
+
+  const appliedFilters = [];
+  if (!isEmpty(availability)) {
+    const key = 'availability';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, availability),
+      onRemove: handleAvailabilityRemove,
+    });
+  }
+  if (!isEmpty(productType)) {
+    const key = 'productType';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, productType),
+      onRemove: handleProductTypeRemove,
+    });
+  }
+  if (!isEmpty(taggedWith)) {
+    const key = 'taggedWith';
+    appliedFilters.push({
+      key,
+      label: `Tagged with ${taggedWith}`,
+      onRemove: handleTaggedWithRemove,
+    });
+  }
+
+  return (
+    <div style={{height: '568px'}}>
+      <LegacyCard>
+        <AlphaFilters
+          queryValue={queryValue}
+          queryPlaceholder="Searching in all"
+          filters={filters}
+          appliedFilters={appliedFilters}
+          onQueryChange={handleFiltersQueryChange}
+          onQueryClear={handleQueryValueRemove}
+          onClearAll={handleFiltersClearAll}
+        />
+        <DataTable
+          columnContentTypes={[
+            'text',
+            'numeric',
+            'numeric',
+            'numeric',
+            'numeric',
+          ]}
+          headings={[
+            'Product',
+            'Price',
+            'SKU Number',
+            'Net quantity',
+            'Net sales',
+          ]}
+          rows={[
+            ['Emerald Silk Gown', '$875.00', 124689, 140, '$122,500.00'],
+            ['Mauve Cashmere Scarf', '$230.00', 124533, 83, '$19,090.00'],
+            [
+              'Navy Merino Wool Blazer with khaki chinos and yellow belt',
+              '$445.00',
+              124518,
+              32,
+              '$14,240.00',
+            ],
+          ]}
+          totals={['', '', '', 255, '$155,830.00']}
+        />
+      </LegacyCard>
+    </div>
+  );
+
+  function disambiguateLabel(key: string, value: string[]): string {
+    switch (key) {
+      case 'taggedWith':
+        return `Tagged with ${value}`;
+      case 'availability':
+        return value.map((val) => `Available on ${val}`).join(', ');
+      case 'productType':
+        return value.join(', ');
+      default:
+        return value.toString();
+    }
+  }
+
+  function isEmpty(value: string | string[]): boolean {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else {
+      return value === '' || value == null;
+    }
+  }
+}
+
+export default withPolarisExample(FiltersWithADataTableExample);

--- a/polaris.shopify.com/pages/examples/alpha-filters-with-a-resource-list.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-filters-with-a-resource-list.tsx
@@ -1,0 +1,228 @@
+import {
+  ChoiceList,
+  TextField,
+  RangeSlider,
+  LegacyCard,
+  ResourceList,
+  AlphaFilters,
+  Avatar,
+  Text,
+} from '@shopify/polaris';
+import {useState, useCallback} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function FiltersWithAResourceListExample() {
+  const [accountStatus, setAccountStatus] = useState<string[] | undefined>(
+    undefined,
+  );
+  const [moneySpent, setMoneySpent] = useState<[number, number] | undefined>(
+    undefined,
+  );
+  const [taggedWith, setTaggedWith] = useState<string | undefined>(undefined);
+  const [queryValue, setQueryValue] = useState<string | undefined>(undefined);
+
+  const handleAccountStatusChange = useCallback(
+    (value: string[]) => setAccountStatus(value),
+    [],
+  );
+  const handleMoneySpentChange = useCallback(
+    (value: [number, number]) => setMoneySpent(value),
+    [],
+  );
+  const handleTaggedWithChange = useCallback(
+    (value: string) => setTaggedWith(value),
+    [],
+  );
+  const handleFiltersQueryChange = useCallback(
+    (value: string) => setQueryValue(value),
+    [],
+  );
+  const handleAccountStatusRemove = useCallback(
+    () => setAccountStatus(undefined),
+    [],
+  );
+  const handleMoneySpentRemove = useCallback(
+    () => setMoneySpent(undefined),
+    [],
+  );
+  const handleTaggedWithRemove = useCallback(
+    () => setTaggedWith(undefined),
+    [],
+  );
+  const handleQueryValueRemove = useCallback(
+    () => setQueryValue(undefined),
+    [],
+  );
+  const handleFiltersClearAll = useCallback(() => {
+    handleAccountStatusRemove();
+    handleMoneySpentRemove();
+    handleTaggedWithRemove();
+    handleQueryValueRemove();
+  }, [
+    handleAccountStatusRemove,
+    handleMoneySpentRemove,
+    handleQueryValueRemove,
+    handleTaggedWithRemove,
+  ]);
+
+  const filters = [
+    {
+      key: 'accountStatus',
+      label: 'Account status',
+      filter: (
+        <ChoiceList
+          title="Account status"
+          titleHidden
+          choices={[
+            {label: 'Enabled', value: 'enabled'},
+            {label: 'Not invited', value: 'not invited'},
+            {label: 'Invited', value: 'invited'},
+            {label: 'Declined', value: 'declined'},
+          ]}
+          selected={accountStatus || []}
+          onChange={handleAccountStatusChange}
+          allowMultiple
+        />
+      ),
+      shortcut: true,
+      pinned: true,
+    },
+    {
+      key: 'taggedWith',
+      label: 'Tagged with',
+      filter: (
+        <TextField
+          label="Tagged with"
+          value={taggedWith}
+          onChange={handleTaggedWithChange}
+          autoComplete="off"
+          labelHidden
+        />
+      ),
+      shortcut: true,
+      pinned: true,
+    },
+    {
+      key: 'moneySpent',
+      label: 'Money spent',
+      filter: (
+        <RangeSlider
+          label="Money spent is between"
+          labelHidden
+          value={moneySpent || [0, 500]}
+          prefix="$"
+          output
+          min={0}
+          max={2000}
+          step={1}
+          onChange={handleMoneySpentChange}
+        />
+      ),
+    },
+  ];
+
+  const appliedFilters = [];
+  if (!isEmpty(accountStatus)) {
+    const key = 'accountStatus';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, accountStatus),
+      onRemove: handleAccountStatusRemove,
+    });
+  }
+  if (!isEmpty(moneySpent)) {
+    const key = 'moneySpent';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, moneySpent),
+      onRemove: handleMoneySpentRemove,
+    });
+  }
+  if (!isEmpty(taggedWith)) {
+    const key = 'taggedWith';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, taggedWith),
+      onRemove: handleTaggedWithRemove,
+    });
+  }
+
+  return (
+    <div style={{height: '568px'}}>
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          filterControl={
+            <AlphaFilters
+              queryValue={queryValue}
+              queryPlaceholder="Searching in all"
+              filters={filters}
+              appliedFilters={appliedFilters}
+              onQueryChange={handleFiltersQueryChange}
+              onQueryClear={handleQueryValueRemove}
+              onClearAll={handleFiltersClearAll}
+            />
+          }
+          flushFilters
+          items={[
+            {
+              id: '341',
+              url: '#',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            },
+            {
+              id: '256',
+              url: '#',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="medium" name={name} />;
+
+            return (
+              <ResourceList.Item
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <Text as="h3" fontWeight="bold">
+                  {name}
+                </Text>
+                <div>{location}</div>
+              </ResourceList.Item>
+            );
+          }}
+        />
+      </LegacyCard>
+    </div>
+  );
+
+  function disambiguateLabel(key: string, value: any) {
+    switch (key) {
+      case 'moneySpent':
+        return `Money spent is between $${value[0]} and $${value[1]}`;
+      case 'taggedWith':
+        return `Tagged with ${value}`;
+      case 'accountStatus':
+        return value?.map((val: string) => `Customer ${val}`).join(', ');
+      default:
+        return value;
+    }
+  }
+
+  function isEmpty(
+    value: string | string[] | [number, number] | undefined,
+  ): boolean {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else {
+      return value === '' || value == null;
+    }
+  }
+}
+
+export default withPolarisExample(FiltersWithAResourceListExample);

--- a/polaris.shopify.com/pages/examples/alpha-filters-with-children-content.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-filters-with-children-content.tsx
@@ -1,0 +1,150 @@
+import {
+  TextField,
+  LegacyCard,
+  ResourceList,
+  AlphaFilters,
+  Button,
+  Avatar,
+  Text,
+} from '@shopify/polaris';
+import {useState, useCallback} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function FiltersWithChildrenContentExample() {
+  const [taggedWith, setTaggedWith] = useState<string | undefined>(undefined);
+  const [queryValue, setQueryValue] = useState<string | undefined>(undefined);
+
+  const handleTaggedWithChange = useCallback(
+    (value: string) => setTaggedWith(value),
+    [],
+  );
+  const handleQueryValueChange = useCallback(
+    (value: string) => setQueryValue(value),
+    [],
+  );
+  const handleTaggedWithRemove = useCallback(
+    () => setTaggedWith(undefined),
+    [],
+  );
+  const handleQueryValueRemove = useCallback(
+    () => setQueryValue(undefined),
+    [],
+  );
+
+  const handleClearAll = useCallback(() => {
+    handleTaggedWithRemove();
+    handleQueryValueRemove();
+  }, [handleQueryValueRemove, handleTaggedWithRemove]);
+
+  const filters = [
+    {
+      key: 'taggedWith',
+      label: 'Tagged with',
+      filter: (
+        <TextField
+          label="Tagged with"
+          value={taggedWith}
+          onChange={handleTaggedWithChange}
+          autoComplete="off"
+          labelHidden
+        />
+      ),
+      shortcut: true,
+    },
+  ];
+
+  const appliedFilters =
+    taggedWith && !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith',
+            label: disambiguateLabel('taggedWith', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+  return (
+    <div style={{height: '568px'}}>
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          filterControl={
+            <AlphaFilters
+              queryValue={queryValue}
+              queryPlaceholder="Searching in all"
+              filters={filters}
+              appliedFilters={appliedFilters}
+              onQueryChange={handleQueryValueChange}
+              onQueryClear={handleQueryValueRemove}
+              onClearAll={handleClearAll}
+            >
+              <div style={{paddingLeft: '8px'}}>
+                <Button
+                  onClick={() => console.log('New filter saved')}
+                  size="micro"
+                  primary
+                  plain
+                >
+                  Save
+                </Button>
+              </div>
+            </AlphaFilters>
+          }
+          flushFilters
+          items={[
+            {
+              id: '341',
+              url: '#',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            },
+            {
+              id: '256',
+              url: '#',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="medium" name={name} />;
+
+            return (
+              <ResourceList.Item
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <Text as="h3" fontWeight="bold">
+                  {name}
+                </Text>
+                <div>{location}</div>
+              </ResourceList.Item>
+            );
+          }}
+        />
+      </LegacyCard>
+    </div>
+  );
+
+  function disambiguateLabel(key: string, value: string): string {
+    switch (key) {
+      case 'taggedWith':
+        return `Tagged with ${value}`;
+      default:
+        return value;
+    }
+  }
+
+  function isEmpty(value: string): boolean {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else {
+      return value === '' || value == null;
+    }
+  }
+}
+
+export default withPolarisExample(FiltersWithChildrenContentExample);

--- a/polaris.shopify.com/pages/examples/alpha-filters-with-query-field-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-filters-with-query-field-disabled.tsx
@@ -1,0 +1,227 @@
+import {
+  TextField,
+  LegacyCard,
+  ResourceList,
+  AlphaFilters,
+  Avatar,
+  Text,
+  ChoiceList,
+  RangeSlider,
+} from '@shopify/polaris';
+import {useState, useCallback} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function FiltersWithQueryFieldDisabled() {
+  const [accountStatus, setAccountStatus] = useState<string[] | undefined>(
+    undefined,
+  );
+  const [moneySpent, setMoneySpent] = useState<[number, number] | undefined>(
+    undefined,
+  );
+  const [taggedWith, setTaggedWith] = useState<string | undefined>(undefined);
+  const [queryValue, setQueryValue] = useState<string | undefined>(undefined);
+
+  const handleAccountStatusChange = useCallback(
+    (value: string[]) => setAccountStatus(value),
+    [],
+  );
+  const handleMoneySpentChange = useCallback(
+    (value: [number, number]) => setMoneySpent(value),
+    [],
+  );
+  const handleTaggedWithChange = useCallback(
+    (value: string) => setTaggedWith(value),
+    [],
+  );
+  const handleFiltersQueryChange = useCallback(
+    (value: string) => setQueryValue(value),
+    [],
+  );
+  const handleAccountStatusRemove = useCallback(
+    () => setAccountStatus(undefined),
+    [],
+  );
+  const handleMoneySpentRemove = useCallback(
+    () => setMoneySpent(undefined),
+    [],
+  );
+  const handleTaggedWithRemove = useCallback(
+    () => setTaggedWith(undefined),
+    [],
+  );
+  const handleQueryValueRemove = useCallback(
+    () => setQueryValue(undefined),
+    [],
+  );
+  const handleFiltersClearAll = useCallback(() => {
+    handleAccountStatusRemove();
+    handleMoneySpentRemove();
+    handleTaggedWithRemove();
+    handleQueryValueRemove();
+  }, [
+    handleAccountStatusRemove,
+    handleMoneySpentRemove,
+    handleQueryValueRemove,
+    handleTaggedWithRemove,
+  ]);
+
+  const filters = [
+    {
+      key: 'accountStatus',
+      label: 'Account status',
+      filter: (
+        <ChoiceList
+          title="Account status"
+          titleHidden
+          choices={[
+            {label: 'Enabled', value: 'enabled'},
+            {label: 'Not invited', value: 'not invited'},
+            {label: 'Invited', value: 'invited'},
+            {label: 'Declined', value: 'declined'},
+          ]}
+          selected={accountStatus || []}
+          onChange={handleAccountStatusChange}
+          allowMultiple
+        />
+      ),
+      shortcut: true,
+    },
+    {
+      key: 'taggedWith',
+      label: 'Tagged with',
+      filter: (
+        <TextField
+          label="Tagged with"
+          value={taggedWith}
+          onChange={handleTaggedWithChange}
+          autoComplete="off"
+          labelHidden
+        />
+      ),
+      shortcut: true,
+    },
+    {
+      key: 'moneySpent',
+      label: 'Money spent',
+      filter: (
+        <RangeSlider
+          label="Money spent is between"
+          labelHidden
+          value={moneySpent || [0, 500]}
+          prefix="$"
+          output
+          min={0}
+          max={2000}
+          step={1}
+          onChange={handleMoneySpentChange}
+        />
+      ),
+    },
+  ];
+
+  const appliedFilters = [];
+  if (!isEmpty(accountStatus)) {
+    const key = 'accountStatus';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, accountStatus),
+      onRemove: handleAccountStatusRemove,
+    });
+  }
+  if (!isEmpty(moneySpent)) {
+    const key = 'moneySpent';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, moneySpent),
+      onRemove: handleMoneySpentRemove,
+    });
+  }
+  if (!isEmpty(taggedWith)) {
+    const key = 'taggedWith';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, taggedWith),
+      onRemove: handleTaggedWithRemove,
+    });
+  }
+
+  return (
+    <div style={{height: '568px'}}>
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          filterControl={
+            <AlphaFilters
+              queryValue={queryValue}
+              queryPlaceholder="Searching in all"
+              filters={filters}
+              appliedFilters={appliedFilters}
+              onQueryChange={handleFiltersQueryChange}
+              onQueryClear={handleQueryValueRemove}
+              onClearAll={handleFiltersClearAll}
+              disableQueryField
+            />
+          }
+          flushFilters
+          items={[
+            {
+              id: '341',
+              url: '#',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            },
+            {
+              id: '256',
+              url: '#',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="medium" name={name} />;
+
+            return (
+              <ResourceList.Item
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <Text as="h3" fontWeight="bold">
+                  {name}
+                </Text>
+                <div>{location}</div>
+              </ResourceList.Item>
+            );
+          }}
+        />
+      </LegacyCard>
+    </div>
+  );
+
+  function disambiguateLabel(key: string, value: any) {
+    switch (key) {
+      case 'moneySpent':
+        return `Money spent is between $${value[0]} and $${value[1]}`;
+      case 'taggedWith':
+        return `Tagged with ${value}`;
+      case 'accountStatus':
+        return value.map((val: string) => `Customer ${val}`).join(', ');
+      default:
+        return value;
+    }
+  }
+
+  function isEmpty(
+    value: string | string[] | [number, number] | undefined,
+  ): boolean {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else {
+      return value === '' || value == null;
+    }
+  }
+}
+
+export default withPolarisExample(FiltersWithQueryFieldDisabled);

--- a/polaris.shopify.com/pages/examples/alpha-filters-with-query-field-hidden.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-filters-with-query-field-hidden.tsx
@@ -1,0 +1,237 @@
+import {
+  ChoiceList,
+  TextField,
+  RangeSlider,
+  LegacyCard,
+  ResourceList,
+  AlphaFilters,
+  Avatar,
+  Text,
+  Button,
+} from '@shopify/polaris';
+import {useState, useCallback} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function FiltersWithQueryFieldHiddenExample() {
+  const [accountStatus, setAccountStatus] = useState<string[] | undefined>(
+    undefined,
+  );
+  const [moneySpent, setMoneySpent] = useState<[number, number] | undefined>(
+    undefined,
+  );
+  const [taggedWith, setTaggedWith] = useState<string | undefined>(undefined);
+  const [queryValue, setQueryValue] = useState<string | undefined>(undefined);
+
+  const handleAccountStatusChange = useCallback(
+    (value: string[]) => setAccountStatus(value),
+    [],
+  );
+  const handleMoneySpentChange = useCallback(
+    (value: [number, number]) => setMoneySpent(value),
+    [],
+  );
+  const handleTaggedWithChange = useCallback(
+    (value: string) => setTaggedWith(value),
+    [],
+  );
+  const handleFiltersQueryChange = useCallback(
+    (value: string) => setQueryValue(value),
+    [],
+  );
+  const handleAccountStatusRemove = useCallback(
+    () => setAccountStatus(undefined),
+    [],
+  );
+  const handleMoneySpentRemove = useCallback(
+    () => setMoneySpent(undefined),
+    [],
+  );
+  const handleTaggedWithRemove = useCallback(
+    () => setTaggedWith(undefined),
+    [],
+  );
+  const handleQueryValueRemove = useCallback(
+    () => setQueryValue(undefined),
+    [],
+  );
+  const handleFiltersClearAll = useCallback(() => {
+    handleAccountStatusRemove();
+    handleMoneySpentRemove();
+    handleTaggedWithRemove();
+    handleQueryValueRemove();
+  }, [
+    handleAccountStatusRemove,
+    handleMoneySpentRemove,
+    handleQueryValueRemove,
+    handleTaggedWithRemove,
+  ]);
+
+  const filters = [
+    {
+      key: 'accountStatus',
+      label: 'Account status',
+      filter: (
+        <ChoiceList
+          title="Account status"
+          titleHidden
+          choices={[
+            {label: 'Enabled', value: 'enabled'},
+            {label: 'Not invited', value: 'not invited'},
+            {label: 'Invited', value: 'invited'},
+            {label: 'Declined', value: 'declined'},
+          ]}
+          selected={accountStatus || []}
+          onChange={handleAccountStatusChange}
+          allowMultiple
+        />
+      ),
+      shortcut: true,
+    },
+    {
+      key: 'taggedWith',
+      label: 'Tagged with',
+      filter: (
+        <TextField
+          label="Tagged with"
+          value={taggedWith}
+          onChange={handleTaggedWithChange}
+          autoComplete="off"
+          labelHidden
+        />
+      ),
+      shortcut: true,
+    },
+    {
+      key: 'moneySpent',
+      label: 'Money spent',
+      filter: (
+        <RangeSlider
+          label="Money spent is between"
+          labelHidden
+          value={moneySpent || [0, 500]}
+          prefix="$"
+          output
+          min={0}
+          max={2000}
+          step={1}
+          onChange={handleMoneySpentChange}
+        />
+      ),
+    },
+  ];
+
+  const appliedFilters = [];
+  if (!isEmpty(accountStatus)) {
+    const key = 'accountStatus';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, accountStatus),
+      onRemove: handleAccountStatusRemove,
+    });
+  }
+  if (!isEmpty(moneySpent)) {
+    const key = 'moneySpent';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, moneySpent),
+      onRemove: handleMoneySpentRemove,
+    });
+  }
+  if (!isEmpty(taggedWith)) {
+    const key = 'taggedWith';
+    appliedFilters.push({
+      key,
+      label: disambiguateLabel(key, taggedWith),
+      onRemove: handleTaggedWithRemove,
+    });
+  }
+
+  return (
+    <div style={{height: '568px'}}>
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          filterControl={
+            <AlphaFilters
+              queryValue={queryValue}
+              queryPlaceholder="Searching in all"
+              filters={filters}
+              appliedFilters={appliedFilters}
+              onQueryChange={handleFiltersQueryChange}
+              onQueryClear={handleQueryValueRemove}
+              onClearAll={handleFiltersClearAll}
+              hideQueryField
+            >
+              <Button
+                onClick={() => console.log('New filter saved')}
+                size="micro"
+                primary
+                plain
+              >
+                Save
+              </Button>
+            </AlphaFilters>
+          }
+          flushFilters
+          items={[
+            {
+              id: '341',
+              url: '#',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            },
+            {
+              id: '256',
+              url: '#',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="medium" name={name} />;
+
+            return (
+              <ResourceList.Item
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <Text as="h3" fontWeight="bold">
+                  {name}
+                </Text>
+                <div>{location}</div>
+              </ResourceList.Item>
+            );
+          }}
+        />
+      </LegacyCard>
+    </div>
+  );
+
+  function disambiguateLabel(key: string, value: any) {
+    switch (key) {
+      case 'moneySpent':
+        return `Money spent is between $${value[0]} and $${value[1]}`;
+      case 'taggedWith':
+        return `Tagged with ${value}`;
+      case 'accountStatus':
+        return value.map((val: string) => `Customer ${val}`).join(', ');
+      default:
+        return value;
+    }
+  }
+
+  function isEmpty(
+    value: string | string[] | [number, number] | undefined,
+  ): boolean {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else {
+      return value === '' || value == null;
+    }
+  }
+}
+
+export default withPolarisExample(FiltersWithQueryFieldHiddenExample);

--- a/polaris.shopify.com/pages/examples/alpha-filters-with-some-disabled.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-filters-with-some-disabled.tsx
@@ -1,0 +1,174 @@
+import {
+  TextField,
+  LegacyCard,
+  ResourceList,
+  AlphaFilters,
+  Button,
+  Avatar,
+  Text,
+} from '@shopify/polaris';
+import {useState, useCallback} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function FiltersWithSomeDisabledExample() {
+  const [taggedWith, setTaggedWith] = useState<string | undefined>(undefined);
+  const [queryValue, setQueryValue] = useState<string | undefined>(undefined);
+  const [vendor, setVendor] = useState<string | undefined>(undefined);
+
+  const handleTaggedWithChange = useCallback(
+    (value: string) => setTaggedWith(value),
+    [],
+  );
+  const handleQueryValueChange = useCallback(
+    (value: string) => setQueryValue(value),
+    [],
+  );
+  const handleVendorChange = useCallback(
+    (value: string) => setVendor(value),
+    [],
+  );
+
+  const handleTaggedWithRemove = useCallback(
+    () => setTaggedWith(undefined),
+    [],
+  );
+  const handleQueryValueRemove = useCallback(
+    () => setQueryValue(undefined),
+    [],
+  );
+  const handleVendorRemove = useCallback(() => setVendor(undefined), []);
+
+  const handleClearAll = useCallback(() => {
+    handleTaggedWithRemove();
+    handleQueryValueRemove();
+    handleVendorRemove();
+  }, [handleQueryValueRemove, handleTaggedWithRemove, handleVendorRemove]);
+
+  const filters = [
+    {
+      key: 'taggedWith',
+      label: 'Tagged with',
+      filter: (
+        <TextField
+          label="Tagged with"
+          value={taggedWith}
+          onChange={handleTaggedWithChange}
+          autoComplete="off"
+          labelHidden
+        />
+      ),
+      shortcut: true,
+    },
+    {
+      key: 'vendor',
+      label: 'Vendor',
+      filter: (
+        <TextField
+          label="Vendor"
+          value={vendor}
+          onChange={handleVendorChange}
+          autoComplete="off"
+          labelHidden
+        />
+      ),
+      shortcut: true,
+      disabled: true,
+    },
+  ];
+
+  const appliedFilters =
+    taggedWith && !isEmpty(taggedWith)
+      ? [
+          {
+            key: 'taggedWith',
+            label: disambiguateLabel('taggedWith', taggedWith),
+            onRemove: handleTaggedWithRemove,
+          },
+        ]
+      : [];
+
+  return (
+    <div style={{height: '568px'}}>
+      <LegacyCard>
+        <ResourceList
+          resourceName={{singular: 'customer', plural: 'customers'}}
+          filterControl={
+            <AlphaFilters
+              queryValue={queryValue}
+              queryPlaceholder="Searching in all"
+              filters={filters}
+              appliedFilters={appliedFilters}
+              onQueryChange={handleQueryValueChange}
+              onQueryClear={handleQueryValueRemove}
+              onClearAll={handleClearAll}
+            >
+              <div style={{paddingLeft: '8px'}}>
+                <Button
+                  disabled
+                  size="micro"
+                  primary
+                  plain
+                  onClick={() => console.log('New filter saved')}
+                >
+                  Save
+                </Button>
+              </div>
+            </AlphaFilters>
+          }
+          flushFilters
+          items={[
+            {
+              id: '341',
+              url: '#',
+              name: 'Mae Jemison',
+              location: 'Decatur, USA',
+            },
+            {
+              id: '256',
+              url: '#',
+              name: 'Ellen Ochoa',
+              location: 'Los Angeles, USA',
+            },
+          ]}
+          renderItem={(item) => {
+            const {id, url, name, location} = item;
+            const media = <Avatar customer size="medium" name={name} />;
+
+            return (
+              <ResourceList.Item
+                id={id}
+                url={url}
+                media={media}
+                accessibilityLabel={`View details for ${name}`}
+              >
+                <Text as="h3" fontWeight="bold">
+                  {name}
+                </Text>
+                <div>{location}</div>
+              </ResourceList.Item>
+            );
+          }}
+        />
+      </LegacyCard>
+    </div>
+  );
+
+  function disambiguateLabel(key: string, value: string): string {
+    switch (key) {
+      case 'taggedWith':
+        return `Tagged with ${value}`;
+      default:
+        return value;
+    }
+  }
+
+  function isEmpty(value: string): boolean {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else {
+      return value === '' || value == null;
+    }
+  }
+}
+
+export default withPolarisExample(FiltersWithSomeDisabledExample);

--- a/polaris.shopify.com/pages/examples/alpha-tabs-default.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-tabs-default.tsx
@@ -1,0 +1,33 @@
+import {LegacyCard, AlphaTabs} from '@shopify/polaris';
+import {useState} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function TabsDefaultExample() {
+  const [selected, setSelected] = useState(0);
+
+  const handleTabChange = (selectedTabIndex: number) =>
+    setSelected(selectedTabIndex);
+
+  const tabs = [
+    'All',
+    'Unpaid',
+    'Open',
+    'Closed',
+    'Local delivery',
+    'Local pickup',
+  ].map((item, index) => ({
+    content: item,
+    index,
+    id: `${item}-${index}`,
+  }));
+
+  return (
+    <AlphaTabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
+      <LegacyCard.Section title={tabs[selected].content}>
+        <p>Tab {selected} selected</p>
+      </LegacyCard.Section>
+    </AlphaTabs>
+  );
+}
+
+export default withPolarisExample(TabsDefaultExample);

--- a/polaris.shopify.com/pages/examples/alpha-tabs-fitted.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-tabs-fitted.tsx
@@ -1,0 +1,43 @@
+import {LegacyCard, AlphaTabs} from '@shopify/polaris';
+import {useState, useCallback} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function TabsFittedExample() {
+  const [selected, setSelected] = useState(0);
+
+  const handleTabChange = useCallback(
+    (selectedTabIndex: number) => setSelected(selectedTabIndex),
+    [],
+  );
+
+  const tabs = [
+    {
+      id: 'all-customers-fitted-3',
+      content: 'All',
+      accessibilityLabel: 'All customers',
+      panelID: 'all-customers-fitted-content-3',
+    },
+    {
+      id: 'accepts-marketing-fitted-3',
+      content: 'Accepts marketing',
+      panelID: 'accepts-marketing-fitted-content-3',
+    },
+  ];
+
+  return (
+    <LegacyCard>
+      <AlphaTabs
+        tabs={tabs}
+        selected={selected}
+        onSelect={handleTabChange}
+        fitted
+      >
+        <LegacyCard.Section title={tabs[selected].content}>
+          <p>Tab {selected} selected</p>
+        </LegacyCard.Section>
+      </AlphaTabs>
+    </LegacyCard>
+  );
+}
+
+export default withPolarisExample(TabsFittedExample);

--- a/polaris.shopify.com/pages/examples/alpha-tabs-inside-of-a-card.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-tabs-inside-of-a-card.tsx
@@ -1,0 +1,35 @@
+import {LegacyCard, AlphaTabs} from '@shopify/polaris';
+import {useState} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function TabsInsideOfACardExample() {
+  const [selected, setSelected] = useState(0);
+
+  const handleTabChange = (selectedTabIndex: number) =>
+    setSelected(selectedTabIndex);
+
+  const tabs = [
+    'All',
+    'Unpaid',
+    'Open',
+    'Closed',
+    'Local delivery',
+    'Local pickup',
+  ].map((item, index) => ({
+    content: item,
+    index,
+    id: `${item}-${index}`,
+  }));
+
+  return (
+    <LegacyCard>
+      <AlphaTabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
+        <LegacyCard.Section title={tabs[selected].content}>
+          <p>Tab {selected} selected</p>
+        </LegacyCard.Section>
+      </AlphaTabs>
+    </LegacyCard>
+  );
+}
+
+export default withPolarisExample(TabsInsideOfACardExample);

--- a/polaris.shopify.com/pages/examples/alpha-tabs-with-actions.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-tabs-with-actions.tsx
@@ -1,0 +1,77 @@
+import {AlphaTabs} from '@shopify/polaris';
+import {useState} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+type AlphaTabAction =
+  | 'rename'
+  | 'edit'
+  | 'edit-columns'
+  | 'duplicate'
+  | 'delete';
+
+function TabsWithActionsExample() {
+  const [selected, setSelected] = useState(0);
+
+  const handleTabChange = (selectedTabIndex: number) =>
+    setSelected(selectedTabIndex);
+
+  const tabs = [
+    'All',
+    'Unpaid',
+    'Open',
+    'Closed',
+    'Local delivery',
+    'Local pickup',
+    'Returning customers',
+    'New customers',
+    'Abandoned checkouts',
+    'Online store',
+    'POS',
+    'Facebook',
+    'Instagram',
+    'Twitter',
+    'Pinterest',
+    'Google',
+    'Referral',
+  ].map((item, index) => ({
+    content: item,
+    index,
+    id: `${item}-${index}`,
+    actions:
+      index === 0
+        ? []
+        : [
+            {
+              type: 'rename' as AlphaTabAction,
+              onAction: () => {},
+              onPrimaryAction: () => {},
+            },
+            {
+              type: 'duplicate' as AlphaTabAction,
+              onAction: () => {},
+              onPrimaryAction: () => {},
+            },
+            {
+              type: 'edit' as AlphaTabAction,
+              onAction: () => {},
+              onPrimaryAction: () => {},
+            },
+            {
+              type: 'delete' as AlphaTabAction,
+              onAction: () => {},
+              onPrimaryAction: () => {},
+            },
+          ],
+  }));
+
+  return (
+    <AlphaTabs
+      tabs={tabs as any}
+      selected={selected}
+      onSelect={handleTabChange}
+      canCreateNewView
+    />
+  );
+}
+
+export default withPolarisExample(TabsWithActionsExample);

--- a/polaris.shopify.com/pages/examples/alpha-tabs-with-badge-content.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-tabs-with-badge-content.tsx
@@ -1,0 +1,45 @@
+import {LegacyCard, AlphaTabs} from '@shopify/polaris';
+import {useState, useCallback} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function TabsWithBadgeContentExample() {
+  const [selected, setSelected] = useState(0);
+
+  const handleTabChange = useCallback(
+    (selectedTabIndex: number) => setSelected(selectedTabIndex),
+    [],
+  );
+
+  const tabs = [
+    {
+      id: 'all-customers-fitted-3',
+      badge: '10+',
+      content: 'All',
+      accessibilityLabel: 'All customers',
+      panelID: 'all-customers-fitted-content-3',
+    },
+    {
+      id: 'accepts-marketing-fitted-3',
+      badge: '4',
+      content: 'Accepts marketing',
+      panelID: 'accepts-marketing-fitted-content-3',
+    },
+  ];
+
+  return (
+    <LegacyCard>
+      <AlphaTabs
+        tabs={tabs}
+        selected={selected}
+        onSelect={handleTabChange}
+        fitted
+      >
+        <LegacyCard.Section title={tabs[selected].content}>
+          <p>Tab {selected} selected</p>
+        </LegacyCard.Section>
+      </AlphaTabs>
+    </LegacyCard>
+  );
+}
+
+export default withPolarisExample(TabsWithBadgeContentExample);

--- a/polaris.shopify.com/pages/examples/alpha-tabs-with-custom-disclosure.tsx
+++ b/polaris.shopify.com/pages/examples/alpha-tabs-with-custom-disclosure.tsx
@@ -1,0 +1,68 @@
+import {LegacyCard, AlphaTabs} from '@shopify/polaris';
+import {useState, useCallback} from 'react';
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function TabsWithCustomDisclosureExample() {
+  const [selected, setSelected] = useState(0);
+
+  const handleTabChange = useCallback(
+    (selectedTabIndex: number) => setSelected(selectedTabIndex),
+    [],
+  );
+
+  const tabs = [
+    {
+      id: 'all-customers-4',
+      content: 'All',
+      accessibilityLabel: 'All customers',
+      panelID: 'all-customers-content-4',
+    },
+    {
+      id: 'accepts-marketing-4',
+      content: 'Accepts marketing',
+      panelID: 'accepts-marketing-content-4',
+    },
+    {
+      id: 'repeat-customers-4',
+      content: 'Repeat customers',
+      panelID: 'repeat-customers-content-4',
+    },
+    {
+      id: 'prospects-4',
+      content: 'Prospects',
+      panelID: 'prospects-content-4',
+    },
+    {
+      id: 'opt-out-marketing-4',
+      content: 'Opted out of marketing',
+      panelID: 'opt-out-content-4',
+    },
+    {
+      id: 'net-new-customers-4',
+      content: 'Net new customers',
+      panelID: 'net-new-customers-content-4',
+    },
+    {
+      id: 'churned-customers-4',
+      content: 'Churned customers',
+      panelID: 'churned=customers-content-4',
+    },
+  ];
+
+  return (
+    <LegacyCard>
+      <AlphaTabs
+        tabs={tabs}
+        selected={selected}
+        onSelect={handleTabChange}
+        disclosureText="Extra views"
+      >
+        <LegacyCard.Section title={tabs[selected].content}>
+          <p>Tab {selected} selected</p>
+        </LegacyCard.Section>
+      </AlphaTabs>
+    </LegacyCard>
+  );
+}
+
+export default withPolarisExample(TabsWithCustomDisclosureExample);


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #9072.
We have documentation for Filters, LegacyFilters, Tabs, and LegacyTabs but no documentation for AlphaTabs and AlphaFilters despite having storybook examples for them. 

### WHAT is this pull request doing?

Adds component pages and examples for AlphaFilters and AlphaTabs on the style guide.
Adds `alpha` badge and banner to Tabs and Filters.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
