### PR TITLE
[Polaris Patterns] Fix app settings layout pattern sandbox example

### DIFF
--- a/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.md
+++ b/polaris.shopify.com/content/patterns/app-settings-layout/variants/default.md
@@ -33,6 +33,11 @@ This pattern uses the [`VerticalStack`](/components/layout-and-structure/vertica
 </div>
 ```
 
+<!-- prettier-ignore -->
+```javascript {"type":"sandboxContext","for":"example"}
+{(____CODE____)()}
+```
+
 ```javascript {"type":"livePreview","id":"example"}
 function AppSettingsLayoutExample() {
   const {smUp} = useBreakpoints();


### PR DESCRIPTION
### WHY are these changes introduced?
When you select `Edit in Sandbox` on the [App Settings Layout pattern](https://polaris.shopify.com/patterns/app-settings-layout) the sandbox doesn't work. This adds in the missing mdx for the pattern page that gets the sandbox to work correctly.

### WHAT is this pull request doing?

#### Before
<img width="1498" alt="Screenshot 2023-05-12 at 1 08 02 PM" src="https://github.com/Shopify/polaris/assets/20652326/6aa07263-9039-430c-bddc-f2232b46d265">

#### After
<img width="1500" alt="Screenshot 2023-05-12 at 1 08 32 PM" src="https://github.com/Shopify/polaris/assets/20652326/2d76b69f-99f7-41c6-83b7-a26bf4ec87b5">
