### PR TITLE
[SkeletonPage] Remove deprecated `breadcrumbs` prop

### DIFF
--- a/.changeset/metal-spies-serve.md
+++ b/.changeset/metal-spies-serve.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': major
+---
+
+Removed deprecated `breadcrumbs` prop from `SkeletonPage`

--- a/documentation/guides/migrating-from-v10-to-v11.md
+++ b/documentation/guides/migrating-from-v10-to-v11.md
@@ -10,6 +10,7 @@ Polaris v11.0.0 ([full release notes](https://github.com/Shopify/polaris/release
 - [TypeScript](#typescript)
 - [Components](#components)
   - [Removed `Collapsible` deprecated `preventMeasuringOnChildrenUpdate` prop](#removed-collapsible-deprecated-preventmeasuringonchildrenupdate-prop)
+  - [Removed `SkeletonPage` deprecated `breadcrumbs` prop](#removed-skeletonpage-deprecated-breadcrumbs-prop)
   - [Removed `Page` deprecated `breadcrumbs` prop](#removed-page-deprecated-breadcrumbs-prop)
   - [Removed `Breadcrumbs` deprecated `breadcrumbs` prop](#removed-breadcrumbs-deprecated-breadcrumbs-prop)
   - [Removed `KonamiCode`](#removed-konamicode)
@@ -65,6 +66,31 @@ The following components have either been renamed, migrated, or removed. Please 
 ### Removed `Collapsible` deprecated `preventMeasuringOnChildrenUpdate` prop
 
 The deprecated `preventMeasuringOnChildrenUpdate` prop has been removed from the `Collapsible` component and is no longer supported.
+
+### Removed `SkeletonPage` deprecated `breadcrumbs` prop
+
+The deprecated `breadcrumbs` prop has been removed from the `SkeletonPage` component and is no longer supported. The new `backAction` prop serves the same functionality and accepts a boolean.
+
+#### Migration
+
+To replace the `breadcrumbs` prop with `backAction`, you can run the generic [react-rename-component-prop](https://polaris.shopify.com/tools/polaris-migrator#generic-migrations) migration. Please reference the [recommended component migration workflow](#recommended-component-migration-workflow) section below for additional migration support.
+
+```diff
+- <SkeletonPage breadcrumbs>
++ <SkeletonPage backAction>
+```
+
+```sh
+npx @shopify/polaris-migrator react-rename-component-prop --componentName="SkeletonPage" --from="breadcrumbs" --to="backAction" <path>
+```
+
+#### Post-migration validation
+
+After migrating you can use the following RegExp to check for any additional instances of `<SkeletonPage breadcrumbs />` across all file types:
+
+```regex
+<SkeletonPage[^>\w](?:[^>]|\n)*?breadcrumbs
+```
 
 ### Removed `Page` deprecated `breadcrumbs` prop
 

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.tsx
@@ -16,8 +16,6 @@ export interface SkeletonPageProps {
   narrowWidth?: boolean;
   /** Shows a skeleton over the primary action */
   primaryAction?: boolean;
-  /** @deprecated Use backAction instead */
-  breadcrumbs?: boolean;
   /** Shows a skeleton over the backAction */
   backAction?: boolean;
   /** The child elements to render in the skeleton page. */
@@ -31,7 +29,6 @@ export function SkeletonPage({
   primaryAction,
   title = '',
   backAction,
-  breadcrumbs,
 }: SkeletonPageProps) {
   const i18n = useI18n();
 
@@ -58,16 +55,15 @@ export function SkeletonPage({
     />
   ) : null;
 
-  const breadcrumbMarkup =
-    breadcrumbs || backAction ? (
-      <Box
-        borderRadius="1"
-        background="bg-strong"
-        minHeight="2.25rem"
-        minWidth="2.25rem"
-        maxWidth="2.25rem"
-      />
-    ) : null;
+  const backActionMarkup = backAction ? (
+    <Box
+      borderRadius="1"
+      background="bg-strong"
+      minHeight="2.25rem"
+      minWidth="2.25rem"
+      maxWidth="2.25rem"
+    />
+  ) : null;
 
   return (
     <VerticalStack gap="4" inlineAlign="center">
@@ -96,7 +92,7 @@ export function SkeletonPage({
           >
             <HorizontalStack gap="4" align="space-between" blockAlign="center">
               <HorizontalStack gap="4">
-                {breadcrumbMarkup}
+                {backActionMarkup}
                 <Box paddingBlockStart="1" paddingBlockEnd="1">
                   {titleContent}
                 </Box>

--- a/polaris-react/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
+++ b/polaris-react/src/components/SkeletonPage/tests/SkeletonPage.test.tsx
@@ -65,8 +65,8 @@ describe('<SkeletonPage />', () => {
     });
   });
 
-  it('renders breadcrumbs', () => {
-    const skeletonPage = mountWithApp(<SkeletonPage breadcrumbs />);
+  it('renders backAction', () => {
+    const skeletonPage = mountWithApp(<SkeletonPage backAction />);
     expect(skeletonPage).toContainReactComponent(Box, {
       background: 'bg-strong',
       minWidth: '2.25rem',


### PR DESCRIPTION
### WHAT is this pull request doing?

This PR removes the deprecated `breadcrumbs` prop from `SkeletonPage` that's also being removed from `Page` and `Breadcrumbs` in v11.

**NOTE: The UI tests are flagging regressions because the `v11-major` branch is behind `main`.**
