### PR TITLE
[Form] inherit border radius of parent

### DIFF
--- a/.changeset/tough-sloths-sell.md
+++ b/.changeset/tough-sloths-sell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed `Form` by inheriting border radius of parent

--- a/polaris-react/src/components/Form/Form.scss
+++ b/polaris-react/src/components/Form/Form.scss
@@ -1,0 +1,3 @@
+.Form {
+  border-radius: inherit;
+}

--- a/polaris-react/src/components/Form/Form.tsx
+++ b/polaris-react/src/components/Form/Form.tsx
@@ -3,6 +3,8 @@ import React, {useCallback} from 'react';
 import {Text} from '../Text';
 import {useI18n} from '../../utilities/i18n';
 
+import styles from './Form.scss';
+
 type Enctype =
   | 'application/x-www-form-urlencoded'
   | 'multipart/form-data'
@@ -88,6 +90,7 @@ export function Form({
       noValidate={noValidate}
       target={target}
       onSubmit={handleSubmit}
+      className={styles.Form}
     >
       {submitMarkup}
       {children}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/9252

Prevents Form from overriding parent border radius by inheriting the parent border radius.

### WHAT is this pull request doing?

Adds an inline style to the Form component for inheriting border radius.

### How to 🎩

Navigate to [Inventory Index](https://admin.web.inventory-index-rounded-corners.matt-kubej.us.spin.dev/store/shop1/products/inventory?location_id=1) and validate the bottom corners of the Inventory Index Table are rounded.

[Codesandbox with fix](https://codesandbox.io/s/index-table-form-border-radius-fix-8xd2o9?file=/package.json)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
