### PR TITLE
Fix test runner

### DIFF
--- a/polaris-react/tests/utilities/react-testing.tsx
+++ b/polaris-react/tests/utilities/react-testing.tsx
@@ -22,8 +22,13 @@ export const mountWithApp = createMount<
     return options;
   },
   render(element, context) {
+    const {features, ...rest} = context;
     return (
-      <PolarisTestProvider i18n={translations} {...context}>
+      <PolarisTestProvider
+        i18n={translations}
+        features={{...features, polarisSummerEditions2023: false}}
+        {...rest}
+      >
         {element}
       </PolarisTestProvider>
     );


### PR DESCRIPTION
Right now the test runner fails if you use the `useFeatures` hook within a component because `polarisSummerEditions2023` from context is undefined.