### PR TITLE
fix: global selector to be less specific

### DIFF
--- a/polaris-react/src/styles/_common.scss
+++ b/polaris-react/src/styles/_common.scss
@@ -18,4 +18,4 @@
 
 @import '../../../node_modules/@shopify/polaris-tokens/dist/scss/media-queries';
 
-$se23: "html[class*='Polaris-Summer-Editions-2023']";
+$se23: ":where(html[class*='Polaris-Summer-Editions-2023'])";

--- a/polaris-tokens/scripts/toStyleSheet.ts
+++ b/polaris-tokens/scripts/toStyleSheet.ts
@@ -79,8 +79,8 @@ export async function toStyleSheet(metadata: Metadata) {
   }
 
   const styles = `
-  :where(html){color-scheme:light;${getStaticCustomProperties(metadata)}}
-  :where(html.Polaris-Summer-Editions-2023){${getStaticCustomPropertiesExperimental(
+  :root{color-scheme:light;${getStaticCustomProperties(metadata)}}
+  :root:where(.Polaris-Summer-Editions-2023){${getStaticCustomPropertiesExperimental(
     metadata,
   )}}
   ${getKeyframes(metadata.motion)}


### PR DESCRIPTION
Previous selector had a specificity of (0,2,1) meaning it would be fairly difficult to override. The new value is (0,1,0)

[Before](https://polypane.app/css-specificity-calculator/#selector=html%5Bclass*%3D'Polaris-Summer-Editions-2023'%5D%20.Link)

[After](https://polypane.app/css-specificity-calculator/#selector=%3Awhere(html%5Bclass*%3D'Polaris-Summer-Editions-2023'%5D)%20.Link)