### PR TITLE
Update `Text` component styles

### DIFF
--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -88,7 +88,7 @@
 
   #{$se23} & {
     font-size: var(--p-font-size-100);
-    line-height: var(--p-font-line-height-7);
+    line-height: var(--p-font-line-height-2);
   }
 }
 
@@ -192,10 +192,6 @@
 .bodySm {
   font-size: var(--p-font-size-75);
   line-height: var(--p-font-line-height-1);
-
-  #{$se23} & {
-    font-size: var(--p-font-size-80-experimental);
-  }
 }
 
 .bodyMd {

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -56,22 +56,40 @@
   color: var(--p-color-text-inverse);
 }
 
+@mixin se23-headingSm {
+  font-size: var(--p-font-size-80-experimental);
+  line-height: var(--p-font-line-height-2);
+}
+
 .headingXs {
   font-size: var(--p-font-size-75);
   line-height: var(--p-font-line-height-1);
   font-weight: var(--p-font-weight-semibold);
+
+  #{$se23} & {
+    @include se23-headingSm;
+  }
 }
 
 .headingSm {
   font-size: var(--p-font-size-100);
   line-height: var(--p-font-line-height-2);
   font-weight: var(--p-font-weight-semibold);
+
+  #{$se23} & {
+    @include se23-headingSm;
+  }
 }
 
 .headingMd {
   font-size: var(--p-font-size-200);
   line-height: var(--p-font-line-height-3);
   font-weight: var(--p-font-weight-semibold);
+
+  #{$se23} & {
+    font-size: var(--p-font-size-100);
+    line-height: var(--p-font-line-height-7);
+  }
 }
 
 .headingLg {
@@ -79,9 +97,17 @@
   line-height: var(--p-font-line-height-2);
   font-weight: var(--p-font-weight-semibold);
 
+  #{$se23} & {
+    font-size: var(--p-font-size-300);
+    line-height: var(--p-font-line-height-3);
+    font-weight: var(--p-font-weight-bold);
+  }
+
   @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-300);
     line-height: var(--p-font-line-height-3);
+
+    // TODO: Add beta flagged responsive styles
   }
 }
 
@@ -90,9 +116,17 @@
   line-height: var(--p-font-line-height-3);
   font-weight: var(--p-font-weight-semibold);
 
+  #{$se23} & {
+    font-size: var(--p-font-size-400);
+    line-height: var(--p-font-line-height-5);
+    font-weight: var(--p-font-weight-bold);
+  }
+
   @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-400);
     line-height: var(--p-font-line-height-4);
+
+    // TODO: Add beta flagged responsive styles
   }
 }
 
@@ -101,10 +135,24 @@
   line-height: var(--p-font-line-height-3);
   font-weight: var(--p-font-weight-semibold);
 
+  #{$se23} & {
+    font-size: var(--p-font-size-500);
+    line-height: var(--p-font-line-height-6);
+    font-weight: var(--p-font-weight-bold);
+  }
+
   @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-500);
     line-height: var(--p-font-line-height-5);
+
+    // TODO: Add beta flagged responsive styles
   }
+}
+
+@mixin se23-heading3xl {
+  font-size: var(--p-font-size-600);
+  line-height: var(--p-font-line-height-7);
+  font-weight: var(--p-font-weight-bold);
 }
 
 .heading3xl {
@@ -112,9 +160,15 @@
   line-height: var(--p-font-line-height-4);
   font-weight: var(--p-font-weight-semibold);
 
+  #{$se23} & {
+    @include se23-heading3xl;
+  }
+
   @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-600);
     line-height: var(--p-font-line-height-6);
+
+    // TODO: Add beta flagged responsive styles
   }
 }
 
@@ -123,25 +177,45 @@
   line-height: var(--p-font-line-height-6);
   font-weight: var(--p-font-weight-bold);
 
+  #{$se23} & {
+    @include se23-heading3xl;
+  }
+
   @media #{$p-breakpoints-md-up} {
     font-size: var(--p-font-size-700);
     line-height: var(--p-font-line-height-7);
+
+    // TODO: Add beta flagged responsive styles
   }
 }
 
 .bodySm {
   font-size: var(--p-font-size-75);
   line-height: var(--p-font-line-height-1);
+
+  #{$se23} & {
+    font-size: var(--p-font-size-80-experimental);
+  }
 }
 
 .bodyMd {
   font-size: var(--p-font-size-100);
   line-height: var(--p-font-line-height-2);
+
+  #{$se23} & {
+    font-size: var(--p-font-size-80-experimental);
+  }
 }
 
 .bodyLg {
   font-size: var(--p-font-size-200);
   line-height: var(--p-font-line-height-2);
+  // TODO: Should weight be here (even if regular is the default)?
+
+  #{$se23} & {
+    font-size: var(--p-font-size-100);
+    line-height: var(--p-font-line-height-2);
+  }
 }
 
 // font-weight must be below variant styles so

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -206,7 +206,6 @@
 .bodyLg {
   font-size: var(--p-font-size-200);
   line-height: var(--p-font-line-height-2);
-  // TODO: Should weight be here (even if regular is the default)?
 
   #{$se23} & {
     font-size: var(--p-font-size-100);


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-summer-editions/issues/15

Important callouts:
- `heading4xl` is mapped to `heading3xl` when the beta flag is `true`
- `headingXs` is mapped to `headingSm` when the beta flag is `true`
- `bodyXs` is not being implemented in this iteration (if that changes we briefly discussed using the `-experimental` prefix)
- Responsive styles will be added in a follow up PR

https://github.com/Shopify/polaris/assets/32409546/52be49c7-7012-4bf6-8965-854268f26ca7
