### PR TITLE
Update `body` font-size in `AppProvider`

### DIFF
--- a/polaris-react/src/components/AppProvider/AppProvider.scss
+++ b/polaris-react/src/components/AppProvider/AppProvider.scss
@@ -17,6 +17,10 @@ body {
   color: var(--p-color-text);
 }
 
+#{$se23} body {
+  font-size: var(--p-font-size-80-experimental);
+}
+
 html,
 body,
 button {


### PR DESCRIPTION
This PR updates the "global" `body` font-size to match the new `bodyMd` styles when the beta flag is toggled.