### PR TITLE
[IndexTable] Remove border radius of select all wrapper

### DIFF
--- a/.changeset/late-windows-speak.md
+++ b/.changeset/late-windows-speak.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Remove border radius from select all wrapper of `IndexTable`

--- a/polaris-react/src/components/IndexTable/IndexTable.scss
+++ b/polaris-react/src/components/IndexTable/IndexTable.scss
@@ -647,7 +647,6 @@ $loading-panel-height: 53px;
   right: 0;
   padding: 0 var(--p-space-2) 0 var(--p-space-4);
   background: var(--p-color-bg);
-  border-radius: var(--p-border-radius-2);
 
   &.StickyTableHeader-condensed {
     padding-top: calc(var(--p-space-2) + var(--p-space-05));


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/93823

The select all wrapper of the `IndexTable` has a border radius which appears when sticky. This does not align with the sticky table column row behavior. This pull request removes the border radius of this element.

### WHAT is this pull request doing?

Removes the border radius of the select all wrapper of the `IndexTable`

### How to 🎩

[Spin](https://storybook.web.index-table-rounded-corners.matt-kubej.us.spin.dev/?path=/story/all-components-indextable--with-bulk-actions-and-selection-across-pages)

1. Select all resources within the `IndexTable`
2. Scroll down, so the select all wrapper becomes sticky

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
