### PR TITLE
[Banner] No title updates

### DIFF
--- a/polaris-react/src/components/Banner/Banner.stories.tsx
+++ b/polaris-react/src/components/Banner/Banner.stories.tsx
@@ -252,7 +252,30 @@ export function All() {
       <Text as="h2" variant="headingMd">
         No title
       </Text>
-      <AllBanners title={undefined} />
+      <AllBanners
+        title={undefined}
+        onDismiss={() => {}}
+        children={
+          <Text as="p">
+            Changing the phone number for this customer will unsubscribe them
+            from SMS marketing text messages until they provide consent.
+          </Text>
+        }
+      />
+      <Text as="h2" variant="headingMd">
+        No title with actions
+      </Text>
+      <AllBanners
+        title={undefined}
+        action={{content: 'Primary action'}}
+        secondaryAction={{content: 'Secondary action'}}
+        children={
+          <Text as="p">
+            Changing the phone number for this customer will unsubscribe them
+            from SMS marketing text messages until they provide consent.
+          </Text>
+        }
+      />
       <Text as="h2" variant="headingMd">
         Only title
       </Text>

--- a/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
+++ b/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
@@ -1,10 +1,20 @@
-import React, {useContext} from 'react';
+import type {PropsWithChildren} from 'react';
+import React, {
+  useEffect,
+  useState,
+  useRef,
+  useContext,
+  useCallback,
+} from 'react';
+import type {ColorTextAlias} from '@shopify/polaris-tokens';
 
 import {Text} from '../../../Text';
 import {VerticalStack} from '../../../VerticalStack';
+import type {HorizontalStackProps} from '../../../HorizontalStack';
 import {HorizontalStack} from '../../../HorizontalStack';
 import {useBreakpoints} from '../../../../utilities/breakpoints';
 import {WithinContentContext} from '../../../../utilities/within-content-context';
+import type {BoxProps} from '../../../Box';
 import {Box} from '../../../Box';
 import {Button} from '../../../Button';
 import {ButtonGroup} from '../../../ButtonGroup';
@@ -13,6 +23,16 @@ import {Icon} from '../../../Icon';
 import {useI18n} from '../../../../utilities/i18n';
 
 import {useBannerColors} from './utilities';
+
+interface BannerLayoutProps {
+  backgroundColor: BoxProps['background'];
+  textColor: ColorTextAlias;
+  bannerTitle: React.ReactNode;
+  bannerIcon: React.ReactNode;
+  actionButtons: React.ReactNode;
+  dismissButton: React.ReactNode;
+  onDismiss: BannerProps['onDismiss'];
+}
 
 export function BannerExperimental({
   status = 'info',
@@ -26,12 +46,12 @@ export function BannerExperimental({
 }: BannerProps) {
   const i18n = useI18n();
   const withinContentContainer = useContext(WithinContentContext);
-  const {smDown} = useBreakpoints();
+  const isNoTitleBanner = !title && !withinContentContainer;
   const {iconRGBA, backgroundColor, textColor, statusIcon, closeIcon} =
-    useBannerColors(status);
+    useBannerColors(status, isNoTitleBanner);
 
   const bannerIcon = hideIcon ? null : (
-    <Box paddingInlineStart="05">
+    <Box paddingInlineStart={isNoTitleBanner ? '0' : '05'}>
       {icon ? (
         <span style={{fill: iconRGBA}}>
           <Icon source={icon} />
@@ -73,33 +93,44 @@ export function BannerExperimental({
     </Text>
   ) : null;
 
-  const hasContent = children || action || secondaryAction;
+  const bannerLayoutProps: BannerLayoutProps = {
+    onDismiss,
+    backgroundColor,
+    textColor,
+    bannerTitle,
+    bannerIcon,
+    actionButtons,
+    dismissButton,
+  };
 
-  return withinContentContainer ? (
-    <Box
-      width="100%"
-      background={backgroundColor}
-      padding="2"
-      borderRadius="2"
-      color={textColor}
-    >
-      <HorizontalStack align="space-between" blockAlign="start" wrap={false}>
-        <Box paddingInlineEnd={onDismiss ? '2' : undefined}>
-          <HorizontalStack gap="2" wrap={false}>
-            {bannerIcon}
-            <VerticalStack gap="2">
-              <VerticalStack gap="05">
-                {bannerTitle}
-                <div>{children}</div>
-              </VerticalStack>
-              {actionButtons}
-            </VerticalStack>
-          </HorizontalStack>
-        </Box>
-        {dismissButton}
-      </HorizontalStack>
-    </Box>
-  ) : (
+  if (withinContentContainer) {
+    return (
+      <WithinContentContainerBanner {...bannerLayoutProps}>
+        {children}
+      </WithinContentContainerBanner>
+    );
+  }
+
+  if (isNoTitleBanner) {
+    return <NoTitleBanner {...bannerLayoutProps}>{children}</NoTitleBanner>;
+  }
+
+  return <DefaultBanner {...bannerLayoutProps}>{children}</DefaultBanner>;
+}
+
+function DefaultBanner({
+  backgroundColor,
+  textColor,
+  bannerTitle,
+  bannerIcon,
+  actionButtons,
+  dismissButton,
+  children,
+}: PropsWithChildren<Omit<BannerLayoutProps, 'onDismiss'>>) {
+  const {smDown} = useBreakpoints();
+  const hasContent = children || actionButtons;
+
+  return (
     <Box width="100%">
       <VerticalStack align="space-between">
         <Box
@@ -134,6 +165,105 @@ export function BannerExperimental({
           </Box>
         )}
       </VerticalStack>
+    </Box>
+  );
+}
+
+function NoTitleBanner({
+  onDismiss,
+  backgroundColor,
+  bannerIcon,
+  actionButtons,
+  dismissButton,
+  children,
+}: PropsWithChildren<Omit<BannerLayoutProps, 'textColor' | 'bannerTitle'>>) {
+  const [blockAlign, setBlockAlgin] =
+    useState<HorizontalStackProps['blockAlign']>('center');
+  const contentNode = useRef<HTMLDivElement>(null);
+  const iconNode = useRef<HTMLDivElement>(null);
+
+  const handleResize = useCallback(() => {
+    const contentHeight = contentNode?.current?.offsetHeight;
+    const iconBoxHeight = iconNode?.current?.offsetHeight;
+
+    if (!contentHeight || !iconBoxHeight) return;
+
+    if (contentHeight > iconBoxHeight) {
+      setBlockAlgin('start');
+    } else {
+      setBlockAlgin('center');
+    }
+  }, []);
+
+  useEffect(() => handleResize(), [handleResize]);
+
+  useEffect(() => {
+    if (!contentNode.current) return;
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [handleResize]);
+
+  return (
+    <Box width="100%" padding="3" borderRadius="2">
+      <HorizontalStack align="space-between" blockAlign="start" wrap={false}>
+        <Box paddingInlineEnd={onDismiss ? '2' : undefined}>
+          <HorizontalStack gap="2" wrap={false} blockAlign={blockAlign}>
+            <div ref={iconNode}>
+              <Box background={backgroundColor} borderRadius="2" padding="1">
+                {bannerIcon}
+              </Box>
+            </div>
+            <div ref={contentNode}>
+              <VerticalStack gap="2">
+                <div>{children}</div>
+                {actionButtons}
+              </VerticalStack>
+            </div>
+          </HorizontalStack>
+        </Box>
+        {dismissButton}
+      </HorizontalStack>
+    </Box>
+  );
+}
+
+function WithinContentContainerBanner({
+  onDismiss,
+  backgroundColor,
+  textColor,
+  bannerTitle,
+  bannerIcon,
+  actionButtons,
+  dismissButton,
+  children,
+}: PropsWithChildren<BannerLayoutProps>) {
+  return (
+    <Box
+      width="100%"
+      background={backgroundColor}
+      padding="2"
+      borderRadius="2"
+      color={textColor}
+    >
+      <HorizontalStack align="space-between" blockAlign="start" wrap={false}>
+        <Box paddingInlineEnd={onDismiss ? '2' : undefined}>
+          <HorizontalStack gap="2" wrap={false}>
+            {bannerIcon}
+            <VerticalStack gap="2">
+              <VerticalStack gap="05">
+                {bannerTitle}
+                <div>{children}</div>
+              </VerticalStack>
+              {actionButtons}
+            </VerticalStack>
+          </HorizontalStack>
+        </Box>
+        {dismissButton}
+      </HorizontalStack>
     </Box>
   );
 }

--- a/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
+++ b/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
@@ -65,6 +65,7 @@ export function BannerExperimental({
   const dismissButton = onDismiss ? (
     <Button
       plain
+      primary
       icon={closeIcon}
       onClick={onDismiss}
       accessibilityLabel={i18n.translate('Polaris.Banner.dismissButton')}
@@ -127,7 +128,7 @@ function DefaultBanner({
   dismissButton,
   children,
 }: PropsWithChildren<Omit<BannerLayoutProps, 'onDismiss'>>) {
-  const {smDown} = useBreakpoints();
+  const {smUp} = useBreakpoints();
   const hasContent = children || actionButtons;
 
   return (
@@ -136,12 +137,12 @@ function DefaultBanner({
         <Box
           background={backgroundColor}
           color={textColor}
-          borderRadiusStartStart={smDown ? undefined : '2'}
-          borderRadiusStartEnd={smDown ? undefined : '2'}
-          borderRadiusEndStart={hasContent || smDown ? undefined : '2'}
-          borderRadiusEndEnd={hasContent || smDown ? undefined : '2'}
-          padding={{xs: '2', sm: '3'}}
-          paddingInlineEnd={{xs: '3', sm: '4'}}
+          borderRadiusStartStart={smUp ? '2' : undefined}
+          borderRadiusStartEnd={smUp ? '2' : undefined}
+          borderRadiusEndStart={!hasContent && smUp ? '2' : undefined}
+          borderRadiusEndEnd={!hasContent && smUp ? '2' : undefined}
+          padding={{xs: '2', md: '3'}}
+          paddingInlineEnd={{xs: '3', md: '4'}}
         >
           <HorizontalStack
             align="space-between"
@@ -157,7 +158,7 @@ function DefaultBanner({
           </HorizontalStack>
         </Box>
         {hasContent && (
-          <Box padding={{xs: '3', sm: '4'}} paddingBlockStart="3">
+          <Box padding={{xs: '3', md: '4'}} paddingBlockStart="3">
             <VerticalStack gap="2">
               <div>{children}</div>
               {actionButtons}
@@ -208,7 +209,12 @@ function NoTitleBanner({
   }, [handleResize]);
 
   return (
-    <Box width="100%" padding="3" borderRadius="2">
+    <Box
+      width="100%"
+      padding="3"
+      paddingInlineStart={{xs: '2', md: '3'}}
+      borderRadius="2"
+    >
       <HorizontalStack align="space-between" blockAlign="start" wrap={false}>
         <Box paddingInlineEnd={onDismiss ? '2' : undefined}>
           <HorizontalStack gap="2" wrap={false} blockAlign={blockAlign}>
@@ -262,7 +268,7 @@ function WithinContentContainerBanner({
             </VerticalStack>
           </HorizontalStack>
         </Box>
-        {dismissButton}
+        <Box padding="1">{dismissButton}</Box>
       </HorizontalStack>
     </Box>
   );

--- a/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
+++ b/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
@@ -65,7 +65,6 @@ export function BannerExperimental({
   const dismissButton = onDismiss ? (
     <Button
       plain
-      primary
       icon={closeIcon}
       onClick={onDismiss}
       accessibilityLabel={i18n.translate('Polaris.Banner.dismissButton')}
@@ -178,7 +177,7 @@ function NoTitleBanner({
   dismissButton,
   children,
 }: PropsWithChildren<Omit<BannerLayoutProps, 'textColor' | 'bannerTitle'>>) {
-  const [blockAlign, setBlockAlgin] =
+  const [blockAlign, setBlockAlign] =
     useState<HorizontalStackProps['blockAlign']>('center');
   const contentNode = useRef<HTMLDivElement>(null);
   const iconNode = useRef<HTMLDivElement>(null);
@@ -190,9 +189,9 @@ function NoTitleBanner({
     if (!contentHeight || !iconBoxHeight) return;
 
     if (contentHeight > iconBoxHeight) {
-      setBlockAlgin('start');
+      setBlockAlign('start');
     } else {
-      setBlockAlgin('center');
+      setBlockAlign('center');
     }
   }, []);
 

--- a/polaris-react/src/components/Banner/components/BannerExperimental/utilities.ts
+++ b/polaris-react/src/components/Banner/components/BannerExperimental/utilities.ts
@@ -20,20 +20,26 @@ interface BannerColors {
   withinContentContainer: BannerColorAliases;
 }
 
-export function useBannerColors(status: BannerProps['status'] = 'info') {
+export function useBannerColors(
+  status: BannerProps['status'] = 'info',
+  subduedClose = false,
+) {
   const withinContentContainer = useContext(WithinContentContext);
   const bannerColors =
     colorsByStatus[status][
       withinContentContainer ? 'withinContentContainer' : 'withinPage'
     ];
   const iconRGBA = color[`color-${bannerColors.icon}`];
+  const noTitleCloseIconColor = color[`color-icon-subdued`];
 
   return {
     iconRGBA,
     backgroundColor: bannerColors.background,
     textColor: bannerColors.text,
     statusIcon: polarisSummerEditions2023StatusIcon(status, iconRGBA),
-    closeIcon: `<svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M6.28033 5.21967C5.98744 4.92678 5.51256 4.92678 5.21967 5.21967C4.92678 5.51256 4.92678 5.98744 5.21967 6.28033L8.93934 10L5.21967 13.7197C4.92678 14.0126 4.92678 14.4874 5.21967 14.7803C5.51256 15.0732 5.98744 15.0732 6.28033 14.7803L10 11.0607L13.7197 14.7803C14.0126 15.0732 14.4874 15.0732 14.7803 14.7803C15.0732 14.4874 15.0732 14.0126 14.7803 13.7197L11.0607 10L14.7803 6.28033C15.0732 5.98744 15.0732 5.51256 14.7803 5.21967C14.4874 4.92678 14.0126 4.92678 13.7197 5.21967L10 8.93934L6.28033 5.21967Z" fill="${iconRGBA}"/></svg>`,
+    closeIcon: `<svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M6.28033 5.21967C5.98744 4.92678 5.51256 4.92678 5.21967 5.21967C4.92678 5.51256 4.92678 5.98744 5.21967 6.28033L8.93934 10L5.21967 13.7197C4.92678 14.0126 4.92678 14.4874 5.21967 14.7803C5.51256 15.0732 5.98744 15.0732 6.28033 14.7803L10 11.0607L13.7197 14.7803C14.0126 15.0732 14.4874 15.0732 14.7803 14.7803C15.0732 14.4874 15.0732 14.0126 14.7803 13.7197L11.0607 10L14.7803 6.28033C15.0732 5.98744 15.0732 5.51256 14.7803 5.21967C14.4874 4.92678 14.0126 4.92678 13.7197 5.21967L10 8.93934L6.28033 5.21967Z" fill="${
+      subduedClose ? noTitleCloseIconColor : iconRGBA
+    }"/></svg>`,
   };
 }
 


### PR DESCRIPTION
### WHAT is this pull request doing?

> Note: For context, `ExperimentalBanner` was created in a previous PR instead of modifying css because of the structural changes. The coding pattern I've used is creating slots and slotting them into one of three different Banner layouts

|Before|After|Mobile|
|-|-|-|
| <img width="1248" alt="Screenshot 2023-06-08 at 10 48 16 AM" src="https://github.com/Shopify/polaris/assets/20652326/fcf43098-83a2-42f9-b17e-44b2bf0faf5b"> | <img width="1244" alt="Screenshot 2023-06-08 at 11 03 47 AM" src="https://github.com/Shopify/polaris/assets/20652326/ed1855e4-a06e-4d23-aaf1-4d36b6d2d7fa"> | <img width="321" alt="Screenshot 2023-06-08 at 11 44 58 AM" src="https://github.com/Shopify/polaris/assets/20652326/a518ff67-44a6-474f-ae61-415b7f6249cf">|


### How to 🎩

Compare:
* [Figma](https://www.figma.com/file/jLLkmo9r28hiqPvf4s90E4/Polaris-Uplift-Components-%5Bgen3%E2%80%93alpha%5D?type=design&node-id=20-21&t=JpSsS48V58ltSaxB-0)
* [Storybook](https://5d559397bae39100201eedc1-ssqswlhdpw.chromatic.com/?path=/story/all-components-banner--all&globals=polarisSummerEditions2023:true) (scroll down to `No title`)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
