### PR TITLE
[Listbox.TextOption] Fix layout for option content when selected

### DIFF
--- a/polaris-react/src/components/Listbox/components/TextOption/TextOption.scss
+++ b/polaris-react/src/components/Listbox/components/TextOption/TextOption.scss
@@ -105,10 +105,6 @@ li:first-of-type > .TextOption {
 .Content {
   flex: 1 1 auto;
   display: flex;
-
-  #{$se23} & {
-    display: block;
-  }
 }
 
 .Checkbox {

--- a/polaris-react/src/components/Listbox/components/TextOption/TextOption.tsx
+++ b/polaris-react/src/components/Listbox/components/TextOption/TextOption.tsx
@@ -1,8 +1,9 @@
 import React, {memo, useContext} from 'react';
 import {TickMinor} from '@shopify/polaris-icons';
 
+import {Box} from '../../../Box';
 import {Checkbox} from '../../../Checkbox';
-import {HorizontalGrid} from '../../../HorizontalGrid';
+import {HorizontalStack} from '../../../HorizontalStack';
 import {Icon} from '../../../Icon';
 import {classNames} from '../../../../utilities/css';
 import {ComboboxListboxOptionContext} from '../../../../utilities/combobox/context';
@@ -36,14 +37,19 @@ export const TextOption = memo(function TextOption({
     isAction && styles.isAction,
   );
 
-  const optionMarkup = polarisSummerEditions2023 ? (
-    <HorizontalGrid columns="1fr auto">
-      {children}
-      {selected ? <Icon source={TickMinor} /> : null}
-    </HorizontalGrid>
-  ) : (
-    <>{children}</>
-  );
+  const optionMarkup =
+    polarisSummerEditions2023 && selected ? (
+      <Box width="100%">
+        <HorizontalStack align="space-between">
+          {children}
+          <HorizontalStack align="end">
+            <Icon source={TickMinor} />
+          </HorizontalStack>
+        </HorizontalStack>
+      </Box>
+    ) : (
+      <>{children}</>
+    );
 
   return (
     <div className={textOptionClassName}>


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#456](https://github.com/Shopify/polaris-summer-editions/issues/456).
Fixes [#94296](https://github.com/Shopify/web/issues/94296).
Fixes [#94443](https://github.com/Shopify/web/issues/94443)
Fixes [#95367](https://github.com/Shopify/web/issues/95367).

### WHAT is this pull request doing?

Refactors text option markup, as it was causing spacing issues for options not selected.
    <details>
      <summary>Tags — before</summary>
      <img src="https://github.com/Shopify/polaris/assets/26749317/06ff5f92-1634-417a-a1d4-d7b55f8d988c" alt="Tags — before">
    </details>
    <details>
      <summary>Tags — after</summary>
      <img src="https://github.com/Shopify/polaris/assets/26749317/5554f21e-a3e8-4b64-8d2f-5358c5d31af6" alt="Tags — after">
    </details>

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

[Listbox mega story](https://5d559397bae39100201eedc1-repopfsvsn.chromatic.com/?path=/story/all-components-listbox--all&globals=polarisSummerEditions2023:true)
[Spin instance](https://admin.web.lo-fix-textoption.lo-kim.us.spin.dev/store/shop1/orders/1)
No visual changes should occur in Listbox stories. 
For example, the Listbox with search should still show a selected option with the TickMinor icon aligned to the right.

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
