### PR TITLE
[Updating Patterns/New feature] When to remove "New" feature badge completely for all users

### DIFF
--- a/.changeset/eleven-phones-protect.md
+++ b/.changeset/eleven-phones-protect.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+updating new features pattern docs

--- a/polaris.shopify.com/content/patterns/new-features/variants/default.md
+++ b/polaris.shopify.com/content/patterns/new-features/variants/default.md
@@ -43,3 +43,5 @@ They should have a short lifespan. The badge should disappear:
 - When the user has clicked on the interactive element it’s attached to, or
 - 5 days after they first saw it, or
 - after 3 sessions, such as landing on a page 3 times
+
+They should be removed completely for all users ~1 month after launching to avoid visual clutter building up


### PR DESCRIPTION
### WHY are these changes introduced?

<img width="490" alt="image" src="https://github.com/Shopify/polaris/assets/7477411/6294907d-d3bf-49dc-b10f-0d284c27e2f6">


### WHAT is this pull request doing?

Updates the "New features" pattern doc to mention removing these badges for all users a month after launch to avoid visual clutter

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
