### PR TITLE
Update `plain` font size

### DIFF
--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -702,6 +702,7 @@
     @include focus-ring;
 
     #{$se23} & {
+      font-size: var(--p-font-size-100);
       // stylelint-disable-next-line -- se23 override
       @include no-focus-ring;
     }

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -702,7 +702,8 @@
     @include focus-ring;
 
     #{$se23} & {
-      font-size: var(--p-font-size-100);
+      line-height: var(--p-font-line-height-2);
+      font-size: var(--p-font-size-80-experimental);
       // stylelint-disable-next-line -- se23 override
       @include no-focus-ring;
     }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/537

### WHAT is this pull request doing?

Updates the font size on `plain` buttons to `100`

### How to 🎩

Review in [Storybook](https://5d559397bae39100201eedc1-fdppmlisyl.chromatic.com/?path=/story/all-components-button--all&globals=polarisSummerEditions2023:true) and verify `plain` buttons font size is larger than all other buttons when behind beta flag.