### PR TITLE
[Navigation] Add alternative icon for matched item

### DIFF
--- a/.changeset/olive-ghosts-check.md
+++ b/.changeset/olive-ghosts-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added `matchedItemIcon` prop to the Navigation Item component. It takes an icon source that will be used when the item is selected.

--- a/polaris-react/src/components/Navigation/Navigation.stories.tsx
+++ b/polaris-react/src/components/Navigation/Navigation.stories.tsx
@@ -17,6 +17,8 @@ import {
   ProductsMajor,
   ProductsMinor,
   ViewMinor,
+  StarFilledMinor,
+  StarOutlineMinor,
 } from '@shopify/polaris-icons';
 
 export default {
@@ -1164,6 +1166,110 @@ export function WithBadgeAndSecondaryAction() {
               label: 'Products',
               icon: ProductsMinor,
               selected: true,
+              onClick: () => setSelected('products'),
+              matches: selected === 'products',
+              subNavigationItems: [
+                {
+                  url: '#',
+                  excludePaths: ['#'],
+                  disabled: false,
+                  label: 'Collections',
+                  onClick: () => setSelected('collections'),
+                  matches: selected === 'collections',
+                },
+                {
+                  url: '#',
+                  disabled: false,
+                  label: 'Inventory',
+                  onClick: () => setSelected('inventory'),
+                  matches: selected === 'inventory',
+                },
+              ],
+            },
+          ]}
+        />
+      </Navigation>
+    </Frame>
+  );
+}
+
+export function ItemWithMatchedIcon() {
+  const [selected, setSelected] = React.useState('home');
+
+  return (
+    <Frame>
+      <Navigation location="/">
+        <Navigation.Section
+          items={[
+            {
+              url: '#',
+              excludePaths: ['#'],
+              label: 'Home',
+              icon: StarFilledMinor,
+              matchedItemIcon: StarOutlineMinor,
+              onClick: () => setSelected('home'),
+              matches: selected === 'home',
+            },
+            {
+              url: '#',
+              excludePaths: ['#'],
+              label: 'Orders',
+              icon: StarFilledMinor,
+              matchedItemIcon: StarOutlineMinor,
+              badge: '15',
+              onClick: () => setSelected('orders'),
+              matches: selected === 'orders',
+              subNavigationItems: [
+                {
+                  url: '#',
+                  excludePaths: ['#'],
+                  disabled: false,
+                  label: 'Drafts',
+                  onClick: () => setSelected('drafts'),
+                  matches: selected === 'drafts',
+                },
+                {
+                  url: '#',
+                  excludePaths: ['#'],
+                  disabled: false,
+                  label: 'Shipping labels',
+                  onClick: () => setSelected('shippinglabels'),
+                  matches: selected === 'shippinglabels',
+                },
+              ],
+            },
+            {
+              url: '#',
+              excludePaths: ['#'],
+              label: 'Marketing',
+              icon: StarFilledMinor,
+              matchedItemIcon: StarOutlineMinor,
+              onClick: () => setSelected('marketing'),
+              matches: selected === 'marketing',
+              subNavigationItems: [
+                {
+                  url: '#',
+                  excludePaths: ['#'],
+                  disabled: false,
+                  label: 'Reports',
+                  onClick: () => setSelected('reports'),
+                  matches: selected === 'reports',
+                },
+                {
+                  url: '#',
+                  excludePaths: ['#'],
+                  disabled: false,
+                  label: 'Live view',
+                  onClick: () => setSelected('liveView'),
+                  matches: selected === 'liveView',
+                },
+              ],
+            },
+            {
+              url: '#',
+              label: 'Products',
+              icon: StarFilledMinor,
+              matchedItemIcon: StarOutlineMinor,
               onClick: () => setSelected('products'),
               matches: selected === 'products',
               subNavigationItems: [

--- a/polaris-react/src/components/Navigation/components/Item/Item.tsx
+++ b/polaris-react/src/components/Navigation/components/Item/Item.tsx
@@ -109,7 +109,9 @@ export function Item({
       : selectedOverride;
 
   const icon =
-    selected || childIsActive ? matchedItemIcon || baseIcon : baseIcon;
+    polarisSummerEditions2023 && (selected || childIsActive)
+      ? matchedItemIcon || baseIcon
+      : baseIcon;
 
   const iconMarkup = icon ? (
     <div

--- a/polaris-react/src/components/Navigation/components/Item/Item.tsx
+++ b/polaris-react/src/components/Navigation/components/Item/Item.tsx
@@ -24,7 +24,8 @@ const TOOLTIP_HOVER_DELAY = 1000;
 
 export function Item({
   url,
-  icon,
+  icon: baseIcon,
+  matchedItemIcon,
   label,
   subNavigationItems = [],
   secondaryAction,
@@ -83,6 +84,20 @@ export function Item({
       <Indicator pulse />
     </span>
   ) : null;
+
+  const matchState = matchStateForItem(
+    {url, matches, exactMatch, matchPaths, excludePaths},
+    location,
+  );
+
+  const selected =
+    selectedOverride == null
+      ? matchState === MatchState.MatchForced ||
+        matchState === MatchState.MatchUrl ||
+        matchState === MatchState.MatchPaths
+      : selectedOverride;
+
+  const icon = selected ? matchedItemIcon || baseIcon : baseIcon;
 
   const iconMarkup = icon ? (
     <div
@@ -205,11 +220,6 @@ export function Item({
     <>{secondaryActionMarkup ? wrappedBadgeMarkup : null}</>
   );
 
-  const matchState = matchStateForItem(
-    {url, matches, exactMatch, matchPaths, excludePaths},
-    location,
-  );
-
   const matchingSubNavigationItems = subNavigationItems.filter((item) => {
     const subMatchState = matchStateForItem(item, location);
     return (
@@ -220,13 +230,6 @@ export function Item({
   });
 
   const childIsActive = matchingSubNavigationItems.length > 0;
-
-  const selected =
-    selectedOverride == null
-      ? matchState === MatchState.MatchForced ||
-        matchState === MatchState.MatchUrl ||
-        matchState === MatchState.MatchPaths
-      : selectedOverride;
 
   const showExpanded = selected || expanded || childIsActive;
 

--- a/polaris-react/src/components/Navigation/components/Item/Item.tsx
+++ b/polaris-react/src/components/Navigation/components/Item/Item.tsx
@@ -90,6 +90,17 @@ export function Item({
     location,
   );
 
+  const matchingSubNavigationItems = subNavigationItems.filter((item) => {
+    const subMatchState = matchStateForItem(item, location);
+    return (
+      subMatchState === MatchState.MatchForced ||
+      subMatchState === MatchState.MatchUrl ||
+      subMatchState === MatchState.MatchPaths
+    );
+  });
+
+  const childIsActive = matchingSubNavigationItems.length > 0;
+
   const selected =
     selectedOverride == null
       ? matchState === MatchState.MatchForced ||
@@ -97,7 +108,8 @@ export function Item({
         matchState === MatchState.MatchPaths
       : selectedOverride;
 
-  const icon = selected ? matchedItemIcon || baseIcon : baseIcon;
+  const icon =
+    selected || childIsActive ? matchedItemIcon || baseIcon : baseIcon;
 
   const iconMarkup = icon ? (
     <div
@@ -219,17 +231,6 @@ export function Item({
   const outerContentMarkup = (
     <>{secondaryActionMarkup ? wrappedBadgeMarkup : null}</>
   );
-
-  const matchingSubNavigationItems = subNavigationItems.filter((item) => {
-    const subMatchState = matchStateForItem(item, location);
-    return (
-      subMatchState === MatchState.MatchForced ||
-      subMatchState === MatchState.MatchUrl ||
-      subMatchState === MatchState.MatchPaths
-    );
-  });
-
-  const childIsActive = matchingSubNavigationItems.length > 0;
 
   const showExpanded = selected || expanded || childIsActive;
 

--- a/polaris-react/src/components/Navigation/components/Item/Item.tsx
+++ b/polaris-react/src/components/Navigation/components/Item/Item.tsx
@@ -110,7 +110,7 @@ export function Item({
 
   const icon =
     polarisSummerEditions2023 && (selected || childIsActive)
-      ? matchedItemIcon || baseIcon
+      ? matchedItemIcon ?? baseIcon
       : baseIcon;
 
   const iconMarkup = icon ? (

--- a/polaris-react/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -168,6 +168,31 @@ describe('<Nav.Item />', () => {
     });
   });
 
+  it('renders matchedItemIcon when sub-navigation item is selected', () => {
+    const item = mountWithNavigationProvider(
+      <Item
+        label="some label"
+        url="foo"
+        icon={StarFilledMinor}
+        matchedItemIcon={StarOutlineMinor}
+        subNavigationItems={[
+          {
+            url: 'bar',
+            disabled: false,
+            label: 'sub-navigation item label',
+          },
+        ]}
+      />,
+      {
+        location: 'bar',
+      },
+    );
+
+    expect(item).toContainReactComponent(Icon, {
+      source: StarOutlineMinor,
+    });
+  });
+
   describe('with secondaryAction', () => {
     it('renders an UnstyledLink with props delegated', () => {
       const item = mountWithNavigationProvider(
@@ -508,7 +533,7 @@ describe('<Nav.Item />', () => {
 
       expect(item).toContainReactComponent('a', {
         'aria-expanded': false,
-        'aria-controls': expect.stringMatching(/^:r\d+:$/),
+        'aria-controls': expect.stringMatching(/^:r\d[a-z]?:$/),
       });
     });
 

--- a/polaris-react/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -7,6 +7,7 @@ import {
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {mountWithApp} from 'tests/utilities';
 
+import type {WithPolarisTestProviderOptions} from '../../../../PolarisTestProvider';
 import {PolarisTestProvider} from '../../../../PolarisTestProvider';
 import type {MediaQueryContext} from '../../../../../utilities/media-query';
 import {Badge} from '../../../../Badge';
@@ -161,6 +162,7 @@ describe('<Nav.Item />', () => {
       {
         location: 'foo',
       },
+      {features: {polarisSummerEditions2023: true}},
     );
 
     expect(item).toContainReactComponent(Icon, {
@@ -186,6 +188,7 @@ describe('<Nav.Item />', () => {
       {
         location: 'bar',
       },
+      {features: {polarisSummerEditions2023: true}},
     );
 
     expect(item).toContainReactComponent(Icon, {
@@ -979,11 +982,13 @@ function itemForLocation(location: string, overrides: Partial<ItemProps> = {}) {
 function mountWithNavigationProvider(
   node: React.ReactElement,
   context: React.ContextType<typeof NavigationContext> = {location: ''},
+  options?: WithPolarisTestProviderOptions,
 ) {
   return mountWithApp(
     <NavigationContext.Provider value={context}>
       {node}
     </NavigationContext.Provider>,
+    {...options},
   );
 }
 

--- a/polaris-react/src/components/Navigation/components/Item/tests/Item.test.tsx
+++ b/polaris-react/src/components/Navigation/components/Item/tests/Item.test.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import {PlusMinor} from '@shopify/polaris-icons';
+import {
+  PlusMinor,
+  StarFilledMinor,
+  StarOutlineMinor,
+} from '@shopify/polaris-icons';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {mountWithApp} from 'tests/utilities';
 
@@ -143,6 +147,24 @@ describe('<Nav.Item />', () => {
 
       expect(item).toContainReactComponentTimes(Badge, 1);
       expect(item.find(Badge)).toContainReactText('New');
+    });
+  });
+
+  it('renders matchedItemIcon when item is selected', () => {
+    const item = mountWithNavigationProvider(
+      <Item
+        label="some label"
+        url="foo"
+        icon={StarFilledMinor}
+        matchedItemIcon={StarOutlineMinor}
+      />,
+      {
+        location: 'foo',
+      },
+    );
+
+    expect(item).toContainReactComponent(Icon, {
+      source: StarOutlineMinor,
     });
   });
 
@@ -486,7 +508,7 @@ describe('<Nav.Item />', () => {
 
       expect(item).toContainReactComponent('a', {
         'aria-expanded': false,
-        'aria-controls': ':r18:',
+        'aria-controls': expect.stringMatching(/^:r\d+:$/),
       });
     });
 

--- a/polaris-react/src/components/Navigation/types.ts
+++ b/polaris-react/src/components/Navigation/types.ts
@@ -14,6 +14,7 @@ export interface ItemURLDetails {
 
 export interface ItemProps extends ItemURLDetails {
   icon?: IconProps['source'];
+  matchedItemIcon?: IconProps['source'];
   badge?: ReactNode;
   label: string;
   disabled?: boolean;


### PR DESCRIPTION
### WHAT is this pull request doing?

Introduce a new prop called `matchedItemIcon` for the `Item` component within the `Navigation`. This prop accepts an icon source that will be displayed when the item is selected. Although the `icon` prop can be used to toggle the icon by the consumer, in most cases the selected item is determined by the `pathname` provided to the `Navigation`. As a result, the decision to display the appropriate icon should be made by the `Item` component itself.



https://github.com/Shopify/polaris/assets/2091116/f980f42d-81a0-4566-a7b4-73a8064faaee





[Figma](https://www.figma.com/file/jLLkmo9r28hiqPvf4s90E4/Polaris-Uplift-Components-%5Bgen3%E2%80%93alpha%5D?type=design&node-id=48-108&mode=design&t=wvAxGDVK27h6diwG-0)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
