### PR TITLE
[Card] wrap with WithinContent.Provider, enable inset banner styling

### DIFF
--- a/.changeset/plenty-lizards-decide.md
+++ b/.changeset/plenty-lizards-decide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Added the `WithinContentContext.Provider` to `Card`

--- a/polaris-react/src/components/Banner/Banner.stories.tsx
+++ b/polaris-react/src/components/Banner/Banner.stories.tsx
@@ -5,6 +5,7 @@ import {
   VerticalStack,
   Banner,
   Button,
+  Card,
   LegacyCard,
   HorizontalStack,
   Link,
@@ -12,7 +13,6 @@ import {
   Modal,
   Text,
   TextContainer,
-  Card,
 } from '@shopify/polaris';
 import {DiscountsMajor, DiscountsMinor} from '@shopify/polaris-icons';
 
@@ -177,6 +177,25 @@ export function WithFocus() {
 }
 
 export function InACard() {
+  return (
+    <Card roundedAbove="sm">
+      <VerticalStack gap="3">
+        <Text as="h2" variant="headingMd">
+          Online store dashboard
+        </Text>
+        <Banner onDismiss={() => {}}>
+          <Text as="p">
+            Use your finance report to get detailed information about your
+            business. <Link url="">Let us know what you think</Link>
+          </Text>
+        </Banner>
+        <Text as="p">View a summary of your online store’s performance.</Text>
+      </VerticalStack>
+    </Card>
+  );
+}
+
+export function InALegacyCard() {
   return (
     <LegacyCard title="Online store dashboard" sectioned>
       <TextContainer>

--- a/polaris-react/src/components/Card/Card.tsx
+++ b/polaris-react/src/components/Card/Card.tsx
@@ -10,6 +10,7 @@ import {useBreakpoints} from '../../utilities/breakpoints';
 import type {ResponsiveProp} from '../../utilities/css';
 import {Box} from '../Box';
 import {useFeatures} from '../../utilities/features';
+import {WithinContentContext} from '../../utilities/within-content-context';
 
 type Spacing = ResponsiveProp<SpaceScale>;
 
@@ -60,15 +61,17 @@ export const Card = ({
   }
 
   return (
-    <Box
-      background={background}
-      padding={finalPadding}
-      shadow={polarisSummerEditions2023 ? 'card-sm-experimental' : 'md'}
-      borderRadius={hasBorderRadius ? defaultBorderRadius : undefined}
-      overflowX="hidden"
-      overflowY="hidden"
-    >
-      {children}
-    </Box>
+    <WithinContentContext.Provider value>
+      <Box
+        background={background}
+        padding={finalPadding}
+        shadow={polarisSummerEditions2023 ? 'card-sm-experimental' : 'md'}
+        borderRadius={hasBorderRadius ? defaultBorderRadius : undefined}
+        overflowX="hidden"
+        overflowY="hidden"
+      >
+        {children}
+      </Box>
+    </WithinContentContext.Provider>
   );
 };

--- a/polaris-react/src/components/Card/tests/Card.test.tsx
+++ b/polaris-react/src/components/Card/tests/Card.test.tsx
@@ -3,6 +3,7 @@ import {mountWithApp} from 'tests/utilities';
 import {matchMedia} from '@shopify/jest-dom-mocks';
 import {setMediaWidth} from 'tests/utilities/breakpoints';
 
+import {WithinContentContext} from '../../../utilities/within-content-context';
 import {Card} from '..';
 
 const heading = <p>Online store dashboard</p>;
@@ -15,6 +16,27 @@ describe('Card', () => {
 
   afterEach(() => {
     matchMedia.restore();
+  });
+
+  it('has a child with prop withinContentContainer set to true', () => {
+    function TestComponent(_: {withinContentContainer: any}) {
+      return null;
+    }
+
+    const card = mountWithApp(
+      <Card>
+        <WithinContentContext.Consumer>
+          {(withinContentContext) => {
+            return (
+              <TestComponent withinContentContainer={withinContentContext} />
+            );
+          }}
+        </WithinContentContext.Consumer>
+      </Card>,
+    );
+    expect(card).toContainReactComponent(TestComponent, {
+      withinContentContainer: true,
+    });
   });
 
   it('renders children', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses https://github.com/Shopify/polaris-summer-editions/issues/97

Wraps the `Card` component with the WithinContentContext.Provider, which the `Banner` depends on to set it's inset styling (i.e. flat style). This also puts the `Card` component in line with the `LegacyCard` component.


### WHAT is this pull request doing?

`Banner` children within the `Card` component will share the same style as `Banner` children within the `LegacyCard` component, which results in a flat style with a colored background.

### How to 🎩

1. Validate the [Banner In A Card](https://storybook.web.polaris-card-withincontent.matt-kubej.us.spin.dev/?path=/story/all-components-banner--in-a-card&globals=polarisSummerEditions2023:true) story renders the `Banner` with the inset style (i.e. flat)
2. Validate no regressions with the [Card](https://storybook.web.polaris-card-withincontent.matt-kubej.us.spin.dev/?path=/story/all-components-card--default) stories

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
