### PR TITLE
[polaris.shopify.com] Fix icon search

### DIFF
--- a/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
+++ b/polaris.shopify.com/src/components/IconsPage/IconsPage.tsx
@@ -115,7 +115,6 @@ function IconsPage() {
       <div className={className(!useModal && styles.PageLayout)}>
         <div className={styles.IconGrids}>
           <SearchField
-            value={searchText}
             onChange={(value) => updateQueryParams(value)}
             placeholder="Search icons"
           />


### PR DESCRIPTION
I've been working quite a bit with icons recently and this has been driving me crazy. Typing quickly in the icon search field often leads to incorrect results. 

This is me typing `add note`. It only registered half the characters

https://github.com/Shopify/polaris/assets/6844391/bc84d0c0-eac7-45dd-9b60-e16343f9d6f1

Simple solution: Maintain logic but it doesn't need to be a controlled component