### PR TITLE
[Navigation] Fix spacing and font sizing

### DIFF
--- a/polaris-react/src/components/Navigation/Navigation.scss
+++ b/polaris-react/src/components/Navigation/Navigation.scss
@@ -124,7 +124,7 @@ $nav-max-width: 360px;
   #{$se23} & {
     // stylelint-disable-next-line selector-max-combinators -- se23
     .Badge {
-      margin-right: 0;
+      margin-right: var(--p-space-04);
     }
   }
 }
@@ -141,6 +141,10 @@ $nav-max-width: 360px;
 .ItemWrapper {
   width: 100%;
   padding: 0 var(--p-space-2);
+
+  #{$se23} & {
+    padding: 0 var(--p-space-3);
+  }
 }
 
 .ItemInnerWrapper {
@@ -558,7 +562,7 @@ $nav-max-width: 360px;
     #{$se23} & {
       position: relative;
       font-weight: var(--p-font-weight-regular);
-      padding-left: var(--p-space-8);
+      padding-left: calc(var(--p-space-8) + var(--p-space-1));
 
       // stylelint-disable-next-line selector-max-combinators -- will no longer be an issue after removing se23
       &:is(:hover, :focus-visible) {
@@ -571,7 +575,7 @@ $nav-max-width: 360px;
         content: '';
         position: absolute;
         top: 0;
-        left: var(--p-space-1);
+        left: var(--p-space-2);
         width: 21px;
         height: 28px;
         border-radius: 0;
@@ -776,7 +780,8 @@ $nav-max-width: 360px;
   }
 
   #{$se23} & {
-    padding-left: var(--p-space-3);
+    padding-left: var(--p-space-5);
+    padding-right: var(--p-space-1);
   }
 
   .Action {

--- a/polaris-react/src/components/Navigation/Navigation.scss
+++ b/polaris-react/src/components/Navigation/Navigation.scss
@@ -124,7 +124,7 @@ $nav-max-width: 360px;
   #{$se23} & {
     // stylelint-disable-next-line selector-max-combinators -- se23
     .Badge {
-      margin-right: var(--p-space-04);
+      margin-right: 0;
     }
   }
 }

--- a/polaris-react/src/components/Navigation/_variables.scss
+++ b/polaris-react/src/components/Navigation/_variables.scss
@@ -55,7 +55,7 @@ $nav-animation-variables: (
   }
 
   #{$se23} & {
-    padding-left: var(--p-space-1);
+    padding-left: var(--p-space-2);
 
     &:focus-visible:not(:active) {
       /* stylelint-disable-next-line polaris/border/polaris/at-rule-disallowed-list -- se23 */

--- a/polaris-react/src/components/Navigation/components/Section/Section.tsx
+++ b/polaris-react/src/components/Navigation/components/Section/Section.tsx
@@ -103,7 +103,7 @@ export function Section({
 
   const sectionHeadingMarkup = title && (
     <li className={styles.SectionHeading}>
-      <Text as="span" variant="headingXs" color="subdued">
+      <Text as="span" variant="bodySm" fontWeight="medium" color="subdued">
         {title}
       </Text>
       {actionMarkup}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris-summer-editions/issues/615

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- Fixes navigation spacing to fit Figma
- Changes SectionHeading to `bodySm`, was incorrectly `headingXs`. Note: this has no visual impact in gen2 because `bodySm` and `headingXs` are identical

![image](https://github.com/Shopify/polaris/assets/67433661/f298bf85-3144-415b-89cd-8fcd309b36f4)

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->


