### PR TITLE
Apply shadow-bevel to BulkActions component

### DIFF
--- a/polaris-react/src/components/BulkActions/BulkActions.scss
+++ b/polaris-react/src/components/BulkActions/BulkActions.scss
@@ -60,7 +60,10 @@ $bulk-actions-button-stacking-order: (
   pointer-events: auto;
 
   #{$se23} & {
-    box-shadow: var(--p-shadow-card-lg-experimental);
+    @include shadow-bevel(
+      $boxShadow: var(--p-shadow-md),
+      $borderRadius: var(--p-border-radius-2)
+    );
   }
 
   @media #{$p-breakpoints-sm-down} {


### PR DESCRIPTION
Part of https://github.com/Shopify/polaris-summer-editions/issues/711

## IndexTable with BulkActions

| Before | After |
| --- | --- |
| <img width="494" alt="before" src="https://github.com/Shopify/polaris/assets/11774595/052920e8-f55a-4a6c-9d24-365380188e7c"> | <img width="491" alt="after" src="https://github.com/Shopify/polaris/assets/11774595/95cfd761-1c07-463f-aae3-17530a1176ec"> |
 