### PR TITLE
[Checkbox and Choice] revert union types

### DIFF
--- a/.changeset/quiet-games-sin.md
+++ b/.changeset/quiet-games-sin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Revert mutually exclusive union types on Choice and Checkbox.

--- a/polaris-react/src/components/Checkbox/Checkbox.tsx
+++ b/polaris-react/src/components/Checkbox/Checkbox.tsx
@@ -13,12 +13,12 @@ import type {ChoiceBleedProps} from '../Choice';
 import {Choice, helpTextID} from '../Choice';
 import {errorTextID} from '../InlineError';
 import {Icon} from '../Icon';
-import type {Error, CheckboxHandles, Never} from '../../types';
+import type {Error, CheckboxHandles} from '../../types';
 import {WithinListboxContext} from '../../utilities/listbox/context';
 
 import styles from './Checkbox.scss';
 
-interface CheckboxBaseProps {
+export interface CheckboxProps extends ChoiceBleedProps {
   /** Indicates the ID of the element that is controlled by the checkbox */
   ariaControls?: string;
   /** Indicates the ID of the element that describes the checkbox */
@@ -47,19 +47,11 @@ interface CheckboxBaseProps {
   labelClassName?: string;
   /** Grow to fill the space. Equivalent to width: 100%; height: 100% */
   fill?: ResponsiveProp<boolean>;
-}
-
-interface CheckboxDescriptionProps {
   /** Additional text to aide in use */
   helpText?: React.ReactNode;
   /** Display an error message */
   error?: Error | boolean;
 }
-
-// "Description" and "Bleed" props are mutually exclusive
-export type CheckboxProps =
-  | (CheckboxBaseProps & ChoiceBleedProps & Never<CheckboxDescriptionProps>)
-  | (CheckboxBaseProps & CheckboxDescriptionProps & Never<ChoiceBleedProps>);
 
 export const Checkbox = forwardRef<CheckboxHandles, CheckboxProps>(
   function Checkbox(
@@ -145,19 +137,15 @@ export const Checkbox = forwardRef<CheckboxHandles, CheckboxProps>(
     );
 
     // passing in mutually exclusive props
-    const extraChoiceProps =
-      helpText || error
-        ? {
-            helpText,
-            error,
-          }
-        : {
-            bleed,
-            bleedBlockStart,
-            bleedBlockEnd,
-            bleedInlineStart,
-            bleedInlineEnd,
-          };
+    const extraChoiceProps = {
+      helpText,
+      error,
+      bleed,
+      bleedBlockStart,
+      bleedBlockEnd,
+      bleedInlineStart,
+      bleedInlineEnd,
+    };
 
     return (
       <Choice

--- a/polaris-react/src/components/Checkbox/Checkbox.tsx
+++ b/polaris-react/src/components/Checkbox/Checkbox.tsx
@@ -136,7 +136,6 @@ export const Checkbox = forwardRef<CheckboxHandles, CheckboxProps>(
       isIndeterminate && styles['Input-indeterminate'],
     );
 
-    // passing in mutually exclusive props
     const extraChoiceProps = {
       helpText,
       error,

--- a/polaris-react/src/components/Choice/Choice.tsx
+++ b/polaris-react/src/components/Choice/Choice.tsx
@@ -8,7 +8,7 @@ import {
   sanitizeCustomProperties,
 } from '../../utilities/css';
 import type {ResponsiveProp} from '../../utilities/css';
-import type {Error, Never} from '../../types';
+import type {Error} from '../../types';
 import {InlineError} from '../InlineError';
 import {Text} from '../Text';
 import {useFeatures} from '../../utilities/features';
@@ -50,7 +50,7 @@ export interface ChoiceBleedProps {
   bleedInlineEnd?: Spacing;
 }
 
-interface ChoiceBaseProps {
+interface ChoiceProps extends ChoiceBleedProps {
   /** A unique identifier for the choice */
   id: string;
   /**	Label for the choice */
@@ -67,24 +67,11 @@ interface ChoiceBaseProps {
   labelClassName?: string;
   /** Grow to fill the space. Equivalent to width: 100%; height: 100% */
   fill?: ResponsiveProp<boolean>;
-}
-
-interface ChoiceDescriptionProps {
   /** Display an error message */
   error?: Error | boolean;
   /** Additional text to aide in use. Will add a wrapping <div> */
   helpText?: React.ReactNode;
 }
-
-type ChoicePropsWithDescriptions = ChoiceBaseProps &
-  ChoiceDescriptionProps &
-  Never<ChoiceBleedProps>;
-
-type ChoicePropsWithBleed = ChoiceBaseProps &
-  ChoiceBleedProps &
-  Never<ChoiceDescriptionProps>;
-
-export type ChoiceProps = ChoicePropsWithDescriptions | ChoicePropsWithBleed;
 
 export function Choice({
   id,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Union types are causing type errors in web in multiple locations: 
* https://buildkite.com/shopify/web-ci-builder/builds/703872#01893e15-9abe-450f-8c68-2fa015a76be9
* https://buildkite.com/shopify/web-ci-builder/builds/703873#01893e4b-8b9e-4aff-a646-4e39b569004c


### WHAT is this pull request doing?
The mutually exclusive types are a good change, we're reverting this temporarily in order to get the Navigation fixes in 11.5.0 in ASAP. 

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
