### PR TITLE
Replace `AppProvider` `defaultProps` with `getFeatures` method

### DIFF
--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -95,7 +95,7 @@ export class AppProvider extends Component<AppProviderProps, State> {
 
     document.documentElement.classList.toggle(
       classNamePolarisSummerEditions2023,
-      features?.polarisSummerEditions2023,
+      features.polarisSummerEditions2023,
     );
 
     document.documentElement.classList.toggle(

--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -42,13 +42,6 @@ export interface AppProviderProps {
 }
 
 export class AppProvider extends Component<AppProviderProps, State> {
-  static defaultProps: Partial<AppProviderProps> = {
-    features: {
-      polarisSummerEditions2023: false,
-      polarisSummerEditions2023ShadowBevelOptOut: false,
-    },
-  };
-
   private stickyManager: StickyManager;
   private scrollLockManager: ScrollLockManager;
 
@@ -98,19 +91,33 @@ export class AppProvider extends Component<AppProviderProps, State> {
   };
 
   setRootAttributes = () => {
+    const features = this.getFeatures();
+
     document.documentElement.classList.toggle(
       classNamePolarisSummerEditions2023,
-      this.props.features?.polarisSummerEditions2023,
+      features?.polarisSummerEditions2023,
     );
 
     document.documentElement.classList.toggle(
       classNamePolarisSummerEditions2023ShadowBevelOptOut,
-      this.props.features?.polarisSummerEditions2023ShadowBevelOptOut,
+      features.polarisSummerEditions2023ShadowBevelOptOut,
     );
   };
 
+  getFeatures = () => {
+    const {features} = this.props;
+
+    return {
+      ...features,
+      polarisSummerEditions2023: features?.polarisSummerEditions2023 ?? false,
+      polarisSummerEditions2023ShadowBevelOptOut:
+        features?.polarisSummerEditions2023ShadowBevelOptOut ?? false,
+    };
+  };
+
   render() {
-    const {children, features} = this.props;
+    const {children} = this.props;
+    const features = this.getFeatures();
 
     const {intl, link} = this.state;
 


### PR DESCRIPTION
This PR replaces the previous `AppProvider` `static defaultProps` with a more reliable `getFeatures` method. The issue is  that `defaultProps` does not initialize flags to `false` when a `features` object is provided with `undefined` values. Consequently, beta-flags were set to `undefined` and passed to the `force` argument of `classList.toggle` which toggled class names on each render. By introducing `getFeatures`, we ensure that features are consistently retrieved with their default values set to `false`.