### PR TITLE
Remove negative margins from FilterPill button

### DIFF
--- a/polaris-react/src/components/Filters/components/FilterPill/FilterPill.scss
+++ b/polaris-react/src/components/Filters/components/FilterPill/FilterPill.scss
@@ -157,4 +157,10 @@
 .PopoverWrapper {
   min-width: 185px;
   max-width: 300px;
+
+  #{$se23} & button {
+    min-height: 0;
+    padding: 0;
+    margin: 0;
+  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes issue as outlined in the [comment here](https://github.com/Shopify/polaris-summer-editions/issues/915#issuecomment-1641219869)

### WHAT is this pull request doing?

Removes the margin and padding of the plain Button used in the IndexFilter > FilterPill component. This fixes an issue where the scroll bar is being shown unnecessarily when the popover is active.

| Before | After |
| --- | --- |
| <img width="477" alt="0-before" src="https://github.com/Shopify/polaris/assets/11774595/47b1ab1c-048a-4e17-afe3-e92869d307ba"> | <img width="477" alt="1-after" src="https://github.com/Shopify/polaris/assets/11774595/a8c628f8-d437-48ff-a2c9-6b5053efa335"> |