### PR TITLE
Refine Button styles and use CircularAlert icon

### DIFF
--- a/.changeset/cyan-wolves-punch.md
+++ b/.changeset/cyan-wolves-punch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+empty

--- a/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
+++ b/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.scss
@@ -70,24 +70,84 @@
   display: flex;
   flex-direction: row;
   gap: var(--p-space-2);
+
+  #{$se23} & [class*='Polaris-Icon__Svg'],
+  #{$se23} & [class*='Icon-Svg'] {
+    fill: var(--p-color-text-inverse);
+  }
 }
 
 .ActionContainer {
   flex-shrink: 0;
 
-  #{$se23} & [class*='Button-primaryPlain'] {
-    background-color: var(--p-color-bg-inset-strong);
+  // Button overrides specific to Contextual Save Bar
+  /* stylelint-disable -- summer edition overrides */
+  #{$se23} & [class*='Polaris-Button--primary'],
+  #{$se23} & [class*='Button-primary'] {
+    --pc-color-text: rgba(48, 48, 48, 1);
+    --pc-button-text: var(--pc-color-text);
+    --pc-button-color: rgba(255, 255, 255, 1);
+    --pc-button-color-hover: rgba(250, 250, 250, 1);
+    --pc-button-color-active: rgba(247, 247, 247, 1);
+    --pc-button-color-depressed: rgba(247, 247, 247, 1);
+    --pc-button-color-disabled:  rgba(255, 255, 255, 0.2);
+    --pc-button-shadow-inset: 0px 2px 1px 0px rgba(26, 26, 26, 0.2) inset, 1px 0px 1px 0px rgba(26, 26, 26, 0.12) inset, -1px 0px 1px 0px rgba(26, 26, 26, 0.12) inset;
 
-    /* stylelint-disable selector-max-combinators -- summer edition overrides */
+    &::before {
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+    }
+
     &:hover {
-      background-color: var(--p-color-bg-inverse-hover);
+      --pc-button-text: var(--pc-color-text);
     }
 
     &:active {
-      background-color: var(--p-color-bg-inverse-active);
+      --pc-button-text: var(--pc-color-text);
+      box-shadow: var(--pc-button-shadow-inset);
     }
-    /* stylelint-enable selector-max-combinators */
+
+    &[class*='Polaris-Button--pressed'],
+    &[class*='Button-pressed'] {
+      box-shadow: var(--pc-button-shadow-inset);
+    }
+
+    &[class*='Polaris-Button--disabled'],
+    &[class*='Button-disabled']{
+      --pc-button-text: var(--p-color-text-subdued);
+      background: var(--pc-button-color-disabled);
+    }
   }
+
+  #{$se23} & [class*='Polaris-Button--primaryPlain'],
+  #{$se23} & [class*='Button-primaryPlain'] {
+    --pc-button-color: var(--p-color-bg-inset-strong);
+    --pc-button-color-hover: var(--p-color-bg-inverse-hover);
+    --pc-button-color-active: var(--p-color-bg-inverse-active);
+    --pc-button-text: var(--p-color-text-inverse);
+
+    &::after {
+     content: none;
+    }
+
+    &:hover {
+      --pc-button-text: var(--p-color-text-inverse);
+    }
+
+    &:active {
+      --pc-button-text: var(--p-color-text-inverse);
+      box-shadow: none;
+    }
+
+    &[class*='Polaris-Button--disabled'],
+    &[class*='Button-disabled'] {
+      --pc-button-text: var(--p-color-text-subdued);
+      background: var(--pc-button-color);
+    }
+  }
+  /* stylelint-enable */
 }
 
 .Action {

--- a/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
+++ b/polaris-react/src/components/Frame/components/ContextualSaveBar/ContextualSaveBar.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback} from 'react';
-import {RiskMinor} from '@shopify/polaris-icons';
+import {CircleAlertMajor} from '@shopify/polaris-icons';
 
 import {Button} from '../../../Button';
 import {Image} from '../../../Image';
@@ -129,7 +129,7 @@ export function ContextualSaveBar({
         <div className={contentsClassName}>
           {polarisSummerEditions2023 ? (
             <div className={styles.MessageContainer}>
-              <Icon source={RiskMinor} color="warning" />
+              <Icon source={CircleAlertMajor} />
               {message && (
                 <Text as="h2" variant="headingMd" color="text-inverse" truncate>
                   {message}


### PR DESCRIPTION
### WHY are these changes introduced?

Related to #9800 

### WHAT is this pull request doing?

- Uses the `CircularAlertMajor` icon for the Contextual Save Bar message
- Overrides the styles for the Contextual Save Bar `Discard` and `Save` buttons


[Spin link](https://admin.web.contextual-save-bar.sam-rose.us.spin.dev/store/shop1)

