### PR TITLE
[Frame] Applies margin to Content when using sidebar

### DIFF
--- a/.changeset/twenty-candles-bathe.md
+++ b/.changeset/twenty-candles-bathe.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+[Frame] Applies margin to Content when using sidebar

--- a/polaris-react/src/components/Frame/Frame.scss
+++ b/polaris-react/src/components/Frame/Frame.scss
@@ -3,8 +3,10 @@
 $sidebar-breakpoint: 1200px;
 
 .Frame {
-  // stylelint-disable-next-line -- Polaris component custom properties
+  // stylelint-disable -- Polaris component custom properties
   --pc-frame-button-size: var(--p-space-8);
+  --pc-sidebar-width: calc(356px + var(--p-space-4));
+  // stylelint-enable
   width: 100%;
   min-height: 100vh;
   min-height: 100svh; // For mobile browsers, fill the screen taking into account dynamic browser chrome
@@ -218,6 +220,14 @@ $sidebar-breakpoint: 1200px;
   flex: 1;
   min-width: 0;
   max-width: 100%;
+
+  .hasSidebar & {
+    /* stylelint-disable-next-line polaris/media-queries/polaris/media-query-allowed-list -- custom breakpoint */
+    @media screen and (min-width: #{$sidebar-breakpoint}) {
+      /* stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- private token from component */
+      margin-right: var(--pc-sidebar-width);
+    }
+  }
 }
 
 .GlobalRibbonContainer {

--- a/polaris-react/src/components/Frame/Frame.stories.tsx
+++ b/polaris-react/src/components/Frame/Frame.stories.tsx
@@ -743,3 +743,378 @@ function WithAnOffsetComponent({
     </div>
   );
 }
+
+export const WithSidebar = {
+  render: (_args: Args, {globals: {polarisSummerEditions2023}}) => (
+    <WithSidebarEnabled polarisSummerEditions2023={polarisSummerEditions2023} />
+  ),
+};
+
+function WithSidebarEnabled({
+  polarisSummerEditions2023,
+}: {
+  polarisSummerEditions2023: boolean;
+}) {
+  const defaultState = useRef({
+    emailFieldValue: 'dharma@jadedpixel.com',
+    nameFieldValue: 'Jaded Pixel',
+  });
+  const skipToContentRef = useRef(null);
+
+  const [toastActive, setToastActive] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const [searchActive, setSearchActive] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
+  const [userMenuActive, setUserMenuActive] = useState(false);
+  const [mobileNavigationActive, setMobileNavigationActive] = useState(false);
+  const [modalActive, setModalActive] = useState(false);
+  const [nameFieldValue, setNameFieldValue] = useState(
+    defaultState.current.nameFieldValue,
+  );
+  const [emailFieldValue, setEmailFieldValue] = useState(
+    defaultState.current.emailFieldValue,
+  );
+  const [storeName, setStoreName] = useState(
+    defaultState.current.nameFieldValue,
+  );
+  const [supportSubject, setSupportSubject] = useState('');
+  const [supportMessage, setSupportMessage] = useState('');
+
+  const handleSubjectChange = useCallback(
+    (value) => setSupportSubject(value),
+    [],
+  );
+  const handleMessageChange = useCallback(
+    (value) => setSupportMessage(value),
+    [],
+  );
+  const handleDiscard = useCallback(() => {
+    setEmailFieldValue(defaultState.current.emailFieldValue);
+    setNameFieldValue(defaultState.current.nameFieldValue);
+    setIsDirty(false);
+  }, []);
+  const handleSave = useCallback(() => {
+    defaultState.current.nameFieldValue = nameFieldValue;
+    defaultState.current.emailFieldValue = emailFieldValue;
+
+    setIsDirty(false);
+    setToastActive(true);
+    setStoreName(defaultState.current.nameFieldValue);
+  }, [emailFieldValue, nameFieldValue]);
+  const handleNameFieldChange = useCallback((value) => {
+    setNameFieldValue(value);
+    value && setIsDirty(true);
+  }, []);
+  const handleEmailFieldChange = useCallback((value) => {
+    setEmailFieldValue(value);
+    value && setIsDirty(true);
+  }, []);
+  const handleSearchResultsDismiss = useCallback(() => {
+    setSearchActive(false);
+    setSearchValue('');
+  }, []);
+  const handleSearchFieldChange = useCallback((value) => {
+    setSearchValue(value);
+    setSearchActive(value.length > 0);
+  }, []);
+  const toggleToastActive = useCallback(
+    () => setToastActive((toastActive) => !toastActive),
+    [],
+  );
+  const toggleUserMenuActive = useCallback(
+    () => setUserMenuActive((userMenuActive) => !userMenuActive),
+    [],
+  );
+  const toggleMobileNavigationActive = useCallback(
+    () =>
+      setMobileNavigationActive(
+        (mobileNavigationActive) => !mobileNavigationActive,
+      ),
+    [],
+  );
+  const toggleIsLoading = useCallback(
+    () => setIsLoading((isLoading) => !isLoading),
+    [],
+  );
+  const toggleModalActive = useCallback(
+    () => setModalActive((modalActive) => !modalActive),
+    [],
+  );
+
+  const toastMarkup = toastActive ? (
+    <Toast onDismiss={toggleToastActive} content="Changes saved" />
+  ) : null;
+
+  const userMenuActions = [
+    {
+      items: [{content: 'Community forums'}],
+    },
+  ];
+
+  const contextualSaveBarMarkup = isDirty ? (
+    <ContextualSaveBar
+      message="Unsaved changes"
+      saveAction={{
+        onAction: handleSave,
+      }}
+      discardAction={{
+        onAction: handleDiscard,
+      }}
+    />
+  ) : null;
+
+  const userMenuMarkup = (
+    <TopBar.UserMenu
+      actions={userMenuActions}
+      name="Dharma"
+      detail={storeName}
+      initials="D"
+      open={userMenuActive}
+      onToggle={toggleUserMenuActive}
+    />
+  );
+
+  const searchResultsMarkup = (
+    <ActionList
+      items={[{content: 'Shopify help center'}, {content: 'Community forums'}]}
+    />
+  );
+
+  const searchFieldMarkup = (
+    <TopBar.SearchField
+      onChange={handleSearchFieldChange}
+      value={searchValue}
+      placeholder="Search"
+    />
+  );
+
+  const topBarMarkup = (
+    <TopBar
+      showNavigationToggle
+      userMenu={userMenuMarkup}
+      searchResultsVisible={searchActive}
+      searchField={searchFieldMarkup}
+      searchResults={searchResultsMarkup}
+      onSearchResultsDismiss={handleSearchResultsDismiss}
+      onNavigationToggle={toggleMobileNavigationActive}
+    />
+  );
+
+  const navigationMarkup = (
+    <Navigation location="/">
+      <Navigation.Section
+        items={[
+          {
+            label: 'Back to Shopify',
+            icon: ArrowLeftMinor,
+          },
+        ]}
+      />
+      <Navigation.Section
+        separator
+        title="Jaded Pixel App"
+        items={[
+          {
+            label: 'Dashboard',
+            icon: HomeMajor,
+            onClick: toggleIsLoading,
+          },
+          {
+            label: 'Jaded Pixel Orders',
+            icon: OrdersMajor,
+            onClick: toggleIsLoading,
+          },
+        ]}
+        action={{
+          icon: ConversationMinor,
+          accessibilityLabel: 'Contact support',
+          onClick: toggleModalActive,
+        }}
+      />
+    </Navigation>
+  );
+
+  const loadingMarkup = isLoading ? <Loading /> : null;
+
+  const skipToContentTarget = (
+    <Text as="span" visuallyHidden>
+      <a
+        id="SkipToContentTarget"
+        ref={skipToContentRef}
+        tabIndex={-1}
+        href="#SkipLink"
+      >
+        Account details
+      </a>
+    </Text>
+  );
+
+  const actualPageMarkup = (
+    <Page title="Account">
+      <Layout>
+        {skipToContentTarget}
+        <Layout.AnnotatedSection
+          title="Account details"
+          description="Jaded Pixel will use this as your account information."
+        >
+          <LegacyCard sectioned>
+            <FormLayout>
+              <TextField
+                label="Full name"
+                value={nameFieldValue}
+                onChange={handleNameFieldChange}
+                autoComplete="name"
+              />
+              <TextField
+                type="email"
+                label="Email"
+                value={emailFieldValue}
+                onChange={handleEmailFieldChange}
+                autoComplete="email"
+              />
+            </FormLayout>
+          </LegacyCard>
+          <LegacyCard sectioned>
+            <div
+              style={{
+                height: '1000px',
+              }}
+            >
+              Spacer to test contextual save bar in a scrolling page
+            </div>
+          </LegacyCard>
+        </Layout.AnnotatedSection>
+      </Layout>
+    </Page>
+  );
+
+  const loadingPageMarkup = (
+    <SkeletonPage>
+      <Layout>
+        <Layout.Section>
+          <LegacyCard sectioned>
+            <TextContainer>
+              <SkeletonDisplayText size="small" />
+              <SkeletonBodyText lines={9} />
+            </TextContainer>
+          </LegacyCard>
+        </Layout.Section>
+      </Layout>
+    </SkeletonPage>
+  );
+
+  const pageMarkup = isLoading ? loadingPageMarkup : actualPageMarkup;
+
+  const modalMarkup = (
+    <Modal
+      open={modalActive}
+      onClose={toggleModalActive}
+      title="Contact support"
+      primaryAction={{
+        content: 'Send',
+        onAction: toggleModalActive,
+      }}
+    >
+      <Modal.Section>
+        <FormLayout>
+          <TextField
+            label="Subject"
+            value={supportSubject}
+            onChange={handleSubjectChange}
+            autoComplete="off"
+          />
+          <TextField
+            label="Message"
+            value={supportMessage}
+            onChange={handleMessageChange}
+            autoComplete="off"
+            multiline
+          />
+        </FormLayout>
+      </Modal.Section>
+    </Modal>
+  );
+
+  const logo = {
+    width: 124,
+    topBarSource:
+      'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-color.svg?6215648040070010999',
+    contextualSaveBarSource:
+      'https://cdn.shopify.com/s/files/1/0446/6937/files/jaded-pixel-logo-gray.svg?6215648040070010999',
+    url: '#',
+    accessibilityLabel: 'Jaded Pixel',
+  };
+
+  return (
+    <div style={{height: '500px'}}>
+      <AppProvider
+        i18n={{
+          Polaris: {
+            Avatar: {
+              label: 'Avatar',
+              labelWithInitials: 'Avatar with initials {initials}',
+            },
+            ContextualSaveBar: {
+              save: 'Save',
+              discard: 'Discard',
+            },
+            TextField: {
+              characterCount: '{count} characters',
+            },
+            TopBar: {
+              toggleMenuLabel: 'Toggle menu',
+
+              SearchField: {
+                clearButtonLabel: 'Clear',
+                search: 'Search',
+              },
+            },
+            Modal: {
+              iFrameTitle: 'body markup',
+            },
+            Frame: {
+              skipToContent: 'Skip to content',
+              navigationLabel: 'Navigation',
+              Navigation: {
+                closeMobileNavigationLabel: 'Close navigation',
+              },
+            },
+          },
+        }}
+        features={{polarisSummerEditions2023}}
+      >
+        <Frame
+          logo={logo}
+          topBar={topBarMarkup}
+          navigation={navigationMarkup}
+          showMobileNavigation={mobileNavigationActive}
+          onNavigationDismiss={toggleMobileNavigationActive}
+          skipToContentTarget={skipToContentRef.current}
+          sidebar
+        >
+          {contextualSaveBarMarkup}
+          {loadingMarkup}
+          {pageMarkup}
+          {toastMarkup}
+          {modalMarkup}
+          <div
+            style={{
+              position: 'fixed',
+              bottom: 'var(--p-space-2)',
+              right: 'var(--p-space-2)',
+              width: 'calc(var(--pc-sidebar-width) - var(--p-space-4))',
+              height: 'calc(100vh - 3.5rem - var(--p-space-4))',
+              background: 'var(--p-color-bg)',
+              padding: 'var(--p-space-2)',
+              boxShadow: 'var(--p-shadow-md)',
+              borderRadius: 'var(--p-border-radius-3)',
+            }}
+          >
+            This is a sidebar
+          </div>
+        </Frame>
+      </AppProvider>
+    </div>
+  );
+}

--- a/polaris-react/src/components/Frame/Frame.tsx
+++ b/polaris-react/src/components/Frame/Frame.tsx
@@ -116,6 +116,7 @@ class FrameInner extends PureComponent<CombinedProps, State> {
       showMobileNavigation = false,
       skipToContentTarget,
       i18n,
+      sidebar,
       mediaQuery: {isNavigationCollapsed},
     } = this.props;
     const navClassName = classNames(
@@ -234,6 +235,7 @@ class FrameInner extends PureComponent<CombinedProps, State> {
       styles.Frame,
       navigation && styles.hasNav,
       topBar && styles.hasTopBar,
+      sidebar && styles.hasSidebar,
     );
 
     const contextualSaveBarMarkup = (


### PR DESCRIPTION
### WHY are these changes introduced?

Follows up on #9800 

This PR fixes the Frame content margin-right to not overlap with a sidebar when present.

<img width="1680" alt="image" src="https://github.com/Shopify/polaris/assets/167921/557f6cba-1ecf-41ff-bd61-a93e04db8815">

For reviewers: do we need to have a hardcoded breakpoint or can we use a polaris one?

### WHAT is this pull request doing?

This PR ensures the sidebar prop still applies a margin-right to the Frame contents to account for the sidebar space.

For the story I copied the styles from https://github.com/Shopify/web/blob/main/app/shared/components/UniversalSidebar/UniversalSidebar.scss.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

Check the Frame > With Sidebar story.

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
