### PR TITLE
[SkeletonPage] Update title font weight to match Page on uplift

### DIFF
--- a/.changeset/little-worms-decide.md
+++ b/.changeset/little-worms-decide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+`Aligned the `SkeletonPage` `title`font-weight with the`Page` title

--- a/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
+++ b/polaris-react/src/components/SkeletonPage/SkeletonPage.scss
@@ -14,6 +14,10 @@ $primary-action-button-width: 6.25rem;
   font-weight: var(--p-font-weight-semibold);
   font-size: var(--p-font-size-300);
   line-height: var(--p-font-line-height-4);
+
+  #{$se23} & {
+    font-weight: var(--p-font-weight-bold);
+  }
 }
 
 .SkeletonTitle {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

The font weight on `SkeletonPage`'s title is semibold with uplift enabled but `Page`'s title is `bold` with uplift enabled. 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Updates CSS on `.Title` to match [CSS from Page component](https://github.com/Shopify/polaris/blob/main/polaris-react/src/components/Page/components/Header/components/Title/Title.scss#L10).

| Before | After |
|--------|--------|
| ![SCR-20230803-ibpp-2](https://github.com/Shopify/polaris/assets/2466523/2c26a140-e72a-45b3-85d6-80f2796ef11b)|![SCR-20230803-nepy](https://github.com/Shopify/polaris/assets/2466523/ceb8947d-8bec-45b2-9b94-7f77a2603b05)| 

[Spin URL](https://admin.web.skeleton-page-fix.brent-sharrow.us.spin.dev/store/shop1/orders/10/edit)

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
~~- [ ] Updated the component's `README.md` with documentation changes~~
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
