### PR TITLE
Update github profile links in changelogs

### DIFF
--- a/polaris-migrator/CHANGELOG.md
+++ b/polaris-migrator/CHANGELOG.md
@@ -319,11 +319,11 @@
 
 ### Minor Changes
 
-- [#7726](https://github.com/Shopify/polaris/pull/7726) [`22c4107b3`](https://github.com/Shopify/polaris/commit/22c4107b3c369eb68da31980d208c09b3fc4ba37) Thanks [@qt314](https://github.com/qt314)! - Added migration to insert disable comments for @shopify/stylelint-polaris
+- [#7726](https://github.com/Shopify/polaris/pull/7726) [`22c4107b3`](https://github.com/Shopify/polaris/commit/22c4107b3c369eb68da31980d208c09b3fc4ba37) Thanks [@sophschneider](https://github.com/sophschneider)! - Added migration to insert disable comments for @shopify/stylelint-polaris
 
 ### Patch Changes
 
-- [#7836](https://github.com/Shopify/polaris/pull/7836) [`77736370e`](https://github.com/Shopify/polaris/commit/77736370eeddde18a2c11da102b88646f2263d99) Thanks [@qt314](https://github.com/qt314)! - Decouple polaris migrator test from stylelint config so it's easier to maintain
+- [#7836](https://github.com/Shopify/polaris/pull/7836) [`77736370e`](https://github.com/Shopify/polaris/commit/77736370eeddde18a2c11da102b88646f2263d99) Thanks [@sophschneider](https://github.com/sophschneider)! - Decouple polaris migrator test from stylelint config so it's easier to maintain
 
 - Updated dependencies [[`38b2a00a6`](https://github.com/Shopify/polaris/commit/38b2a00a6aa0c95d5df777c7d51023a8193f8090)]:
   - @shopify/stylelint-polaris@5.0.0

--- a/polaris-react/CHANGELOG.md
+++ b/polaris-react/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Patch Changes
 
-- [#9847](https://github.com/Shopify/polaris/pull/9847) [`85b68a358`](https://github.com/Shopify/polaris/commit/85b68a358a0390c243216ad8059d9bccf5f00594) Thanks [@qt314](https://github.com/qt314)! - Added `role` prop to `VerticalStack`
+- [#9847](https://github.com/Shopify/polaris/pull/9847) [`85b68a358`](https://github.com/Shopify/polaris/commit/85b68a358a0390c243216ad8059d9bccf5f00594) Thanks [@sophschneider](https://github.com/sophschneider)! - Added `role` prop to `VerticalStack`
 
 * [#9863](https://github.com/Shopify/polaris/pull/9863) [`4061fd04d`](https://github.com/Shopify/polaris/commit/4061fd04db5458549b5743c61cf39ca9e67ab721) Thanks [@zakwarsame](https://github.com/zakwarsame)! - Fixed ActionList item overflow and tooltip zIndex
 
@@ -25,7 +25,7 @@
 
 ### Patch Changes
 
-- [#9839](https://github.com/Shopify/polaris/pull/9839) [`34349e61f`](https://github.com/Shopify/polaris/commit/34349e61f970e9f387e8fc74a42e4f0fe41ab955) Thanks [@qt314](https://github.com/qt314)! - Fix banner bug
+- [#9839](https://github.com/Shopify/polaris/pull/9839) [`34349e61f`](https://github.com/Shopify/polaris/commit/34349e61f970e9f387e8fc74a42e4f0fe41ab955) Thanks [@sophschneider](https://github.com/sophschneider)! - Fix banner bug
 
 ## 11.10.0
 
@@ -144,13 +144,13 @@
 
 ### Patch Changes
 
-- [#9647](https://github.com/Shopify/polaris/pull/9647) [`bdeaea99b`](https://github.com/Shopify/polaris/commit/bdeaea99b464d25659da2816ced6a8e267bb4469) Thanks [@qt314](https://github.com/qt314)! - LegacyCard fixed xs screen section border radii
+- [#9647](https://github.com/Shopify/polaris/pull/9647) [`bdeaea99b`](https://github.com/Shopify/polaris/commit/bdeaea99b464d25659da2816ced6a8e267bb4469) Thanks [@sophschneider](https://github.com/sophschneider)! - LegacyCard fixed xs screen section border radii
 
 ## 11.4.4
 
 ### Patch Changes
 
-- [#9634](https://github.com/Shopify/polaris/pull/9634) [`d3b75154f`](https://github.com/Shopify/polaris/commit/d3b75154f8df45752532f374c13f015dd3045054) Thanks [@qt314](https://github.com/qt314)! - Legacy card update experimental padding
+- [#9634](https://github.com/Shopify/polaris/pull/9634) [`d3b75154f`](https://github.com/Shopify/polaris/commit/d3b75154f8df45752532f374c13f015dd3045054) Thanks [@sophschneider](https://github.com/sophschneider)! - Legacy card update experimental padding
 
 ## 11.4.3
 
@@ -311,15 +311,15 @@
 
 ### Patch Changes
 
-- [#9342](https://github.com/Shopify/polaris/pull/9342) [`6dcd69ab6`](https://github.com/Shopify/polaris/commit/6dcd69ab6efca522cf02b3585543792efb51476a) Thanks [@qt314](https://github.com/qt314)! - Fixed small screen horizontal overflow by changing `Banner` focus ring from `box-shadow` to `outline`
+- [#9342](https://github.com/Shopify/polaris/pull/9342) [`6dcd69ab6`](https://github.com/Shopify/polaris/commit/6dcd69ab6efca522cf02b3585543792efb51476a) Thanks [@sophschneider](https://github.com/sophschneider)! - Fixed small screen horizontal overflow by changing `Banner` focus ring from `box-shadow` to `outline`
 
-* [#9342](https://github.com/Shopify/polaris/pull/9342) [`6dcd69ab6`](https://github.com/Shopify/polaris/commit/6dcd69ab6efca522cf02b3585543792efb51476a) Thanks [@qt314](https://github.com/qt314)! - Removed unused transition delay param from focus-ring mixin
+* [#9342](https://github.com/Shopify/polaris/pull/9342) [`6dcd69ab6`](https://github.com/Shopify/polaris/commit/6dcd69ab6efca522cf02b3585543792efb51476a) Thanks [@sophschneider](https://github.com/sophschneider)! - Removed unused transition delay param from focus-ring mixin
 
-- [#9342](https://github.com/Shopify/polaris/pull/9342) [`6dcd69ab6`](https://github.com/Shopify/polaris/commit/6dcd69ab6efca522cf02b3585543792efb51476a) Thanks [@qt314](https://github.com/qt314)! - Add polarisSummerEditions2023 feature flag to AppProvider context.
+- [#9342](https://github.com/Shopify/polaris/pull/9342) [`6dcd69ab6`](https://github.com/Shopify/polaris/commit/6dcd69ab6efca522cf02b3585543792efb51476a) Thanks [@sophschneider](https://github.com/sophschneider)! - Add polarisSummerEditions2023 feature flag to AppProvider context.
 
-* [#9361](https://github.com/Shopify/polaris/pull/9361) [`52edd1faa`](https://github.com/Shopify/polaris/commit/52edd1faaf3b252e3344e5c23e3ea05c4e799180) Thanks [@qt314](https://github.com/qt314)! - Added `disabled` variant prop to Labelled
+* [#9361](https://github.com/Shopify/polaris/pull/9361) [`52edd1faa`](https://github.com/Shopify/polaris/commit/52edd1faaf3b252e3344e5c23e3ea05c4e799180) Thanks [@sophschneider](https://github.com/sophschneider)! - Added `disabled` variant prop to Labelled
 
-- [#9342](https://github.com/Shopify/polaris/pull/9342) [`6dcd69ab6`](https://github.com/Shopify/polaris/commit/6dcd69ab6efca522cf02b3585543792efb51476a) Thanks [@qt314](https://github.com/qt314)! - Add `primarySuccess` variant prop to `Button`
+- [#9342](https://github.com/Shopify/polaris/pull/9342) [`6dcd69ab6`](https://github.com/Shopify/polaris/commit/6dcd69ab6efca522cf02b3585543792efb51476a) Thanks [@sophschneider](https://github.com/sophschneider)! - Add `primarySuccess` variant prop to `Button`
 
 - Updated dependencies [[`9c9e80ed1`](https://github.com/Shopify/polaris/commit/9c9e80ed132715e1c91ee2dc0b9fcc13adb3afea), [`f907a55a1`](https://github.com/Shopify/polaris/commit/f907a55a1e144fb9d448ad55c5009b535bc598a4)]:
   - @shopify/polaris-tokens@7.1.0
@@ -335,7 +335,7 @@
 
 - [#9295](https://github.com/Shopify/polaris/pull/9295) [`7e21fe093`](https://github.com/Shopify/polaris/commit/7e21fe093c021d0531e256b678221cfbb79e4412) Thanks [@chloerice](https://github.com/chloerice)! - Fixed `initials` overflowing when `Avatar` is round
 
-* [#9343](https://github.com/Shopify/polaris/pull/9343) [`ae3208332`](https://github.com/Shopify/polaris/commit/ae32083324390a0012981a24f4b1e3c23f166735) Thanks [@qt314](https://github.com/qt314)! - Alphabetized locale files
+* [#9343](https://github.com/Shopify/polaris/pull/9343) [`ae3208332`](https://github.com/Shopify/polaris/commit/ae32083324390a0012981a24f4b1e3c23f166735) Thanks [@sophschneider](https://github.com/sophschneider)! - Alphabetized locale files
 
 - [#9314](https://github.com/Shopify/polaris/pull/9314) [`e7d836819`](https://github.com/Shopify/polaris/commit/e7d836819ac33936136df2a79093c2a0e73146b4) Thanks [@FCalabria](https://github.com/FCalabria)! - Removed focus styles on TextField while disabled
 
@@ -343,7 +343,7 @@
 
 - [#9229](https://github.com/Shopify/polaris/pull/9229) [`821535820`](https://github.com/Shopify/polaris/commit/821535820c97e1ea29ddf8421d52242322c18b17) Thanks [@aeperea](https://github.com/aeperea)! - Tabs update disabled state
 
-* [#9323](https://github.com/Shopify/polaris/pull/9323) [`cd43c8b47`](https://github.com/Shopify/polaris/commit/cd43c8b4747f97269c2710031bd0dda16386c224) Thanks [@qt314](https://github.com/qt314)! - Added internationalized accessibility label to Banner dismiss button
+* [#9323](https://github.com/Shopify/polaris/pull/9323) [`cd43c8b47`](https://github.com/Shopify/polaris/commit/cd43c8b4747f97269c2710031bd0dda16386c224) Thanks [@sophschneider](https://github.com/sophschneider)! - Added internationalized accessibility label to Banner dismiss button
 
 - [#9263](https://github.com/Shopify/polaris/pull/9263) [`a3f3462a6`](https://github.com/Shopify/polaris/commit/a3f3462a66b2bb4bc0dbf23b336fa57d473ba190) Thanks [@mattkubej](https://github.com/mattkubej)! - Protect border radius of `LegacyCard` with overflow clip
 
@@ -492,7 +492,7 @@
 
 ### Patch Changes
 
-- [#9057](https://github.com/Shopify/polaris/pull/9057) [`65db7dd2b`](https://github.com/Shopify/polaris/commit/65db7dd2be650b49b54350ba458700d7c29e7c0d) Thanks [@qt314](https://github.com/qt314)! - Fixed PopoverOverlay not closing
+- [#9057](https://github.com/Shopify/polaris/pull/9057) [`65db7dd2b`](https://github.com/Shopify/polaris/commit/65db7dd2be650b49b54350ba458700d7c29e7c0d) Thanks [@sophschneider](https://github.com/sophschneider)! - Fixed PopoverOverlay not closing
 
 - Updated dependencies [[`13b1a9109`](https://github.com/Shopify/polaris/commit/13b1a9109b996dd19f996b9bdf2a15b96c519c49)]:
   - @shopify/polaris-icons@6.14.0
@@ -901,7 +901,7 @@
 
 - [#8383](https://github.com/Shopify/polaris/pull/8383) [`955832a3b`](https://github.com/Shopify/polaris/commit/955832a3bb653a334d782edd396b9519625134c1) Thanks [@chazdean](https://github.com/chazdean)! - Remove default spacing from `AlphaStack`
 
-* [#8349](https://github.com/Shopify/polaris/pull/8349) [`160d9c15b`](https://github.com/Shopify/polaris/commit/160d9c15b433bf01370c1244c5d725808562c673) Thanks [@qt314](https://github.com/qt314)! - Add hideIcon prop to Banner and update Banner styles for mobile web
+* [#8349](https://github.com/Shopify/polaris/pull/8349) [`160d9c15b`](https://github.com/Shopify/polaris/commit/160d9c15b433bf01370c1244c5d725808562c673) Thanks [@sophschneider](https://github.com/sophschneider)! - Add hideIcon prop to Banner and update Banner styles for mobile web
 
 ## 10.28.2
 
@@ -1201,7 +1201,7 @@
 
 - [#7890](https://github.com/Shopify/polaris/pull/7890) [`53d836dc2`](https://github.com/Shopify/polaris/commit/53d836dc22740d1f5ff22e9a8d3ce5604418ebeb) Thanks [@mrcthms](https://github.com/mrcthms)! - Fixed display bug with `BulkActions` when content in the table changes at the same time the bulk actions bar is visible
 
-* [#7846](https://github.com/Shopify/polaris/pull/7846) [`65131df18`](https://github.com/Shopify/polaris/commit/65131df18033e2f218b5a5e61c4ed0123584fb71) Thanks [@qt314](https://github.com/qt314)! - - Changed border radius of `focus-ring` to use shape tokens instead of adding an extra `1px`
+* [#7846](https://github.com/Shopify/polaris/pull/7846) [`65131df18`](https://github.com/Shopify/polaris/commit/65131df18033e2f218b5a5e61c4ed0123584fb71) Thanks [@sophschneider](https://github.com/sophschneider)! - - Changed border radius of `focus-ring` to use shape tokens instead of adding an extra `1px`
   - Updated `TextField` placeholder text to not change to a custom color on error
   - Delete an unused class in the `DataTable` and `IndexTable`
   - Replace some `px` values with tokens
@@ -1457,7 +1457,7 @@
 
 - [#7361](https://github.com/Shopify/polaris/pull/7361) [`b1b576403`](https://github.com/Shopify/polaris/commit/b1b5764035c6f138e24ad42c9c033c7ca7369a93) Thanks [@kyledurand](https://github.com/kyledurand)! - Use state callback in page actions
 
-* [#7319](https://github.com/Shopify/polaris/pull/7319) [`4b95fdc64`](https://github.com/Shopify/polaris/commit/4b95fdc64b4d30a39333e09623d347735636e771) Thanks [@qt314](https://github.com/qt314)! - Update the `VideoThumbnail` play button user experience
+* [#7319](https://github.com/Shopify/polaris/pull/7319) [`4b95fdc64`](https://github.com/Shopify/polaris/commit/4b95fdc64b4d30a39333e09623d347735636e771) Thanks [@sophschneider](https://github.com/sophschneider)! - Update the `VideoThumbnail` play button user experience
 
 ## 10.5.0
 

--- a/polaris.shopify.com/CHANGELOG.md
+++ b/polaris.shopify.com/CHANGELOG.md
@@ -910,7 +910,7 @@
 
 ### Minor Changes
 
-- [#8027](https://github.com/Shopify/polaris/pull/8027) [`8fc0fefdf`](https://github.com/Shopify/polaris/commit/8fc0fefdfcedd92830639d040a042055a0105f71) Thanks [@qt314](https://github.com/qt314)! - Add tooling section to document tools help build and maintain Polaris in consuming applications.
+- [#8027](https://github.com/Shopify/polaris/pull/8027) [`8fc0fefdf`](https://github.com/Shopify/polaris/commit/8fc0fefdfcedd92830639d040a042055a0105f71) Thanks [@sophschneider](https://github.com/sophschneider)! - Add tooling section to document tools help build and maintain Polaris in consuming applications.
 
 ### Patch Changes
 

--- a/stylelint-polaris/CHANGELOG.md
+++ b/stylelint-polaris/CHANGELOG.md
@@ -183,7 +183,7 @@
 
 ### Major Changes
 
-- [#8451](https://github.com/Shopify/polaris/pull/8451) [`581f33144`](https://github.com/Shopify/polaris/commit/581f33144561f4cbcc2de0d6301e49693d43e05c) Thanks [@qt314](https://github.com/qt314)! - report descriptionless disables
+- [#8451](https://github.com/Shopify/polaris/pull/8451) [`581f33144`](https://github.com/Shopify/polaris/commit/581f33144561f4cbcc2de0d6301e49693d43e05c) Thanks [@sophschneider](https://github.com/sophschneider)! - report descriptionless disables
 
 ## 6.0.2
 
@@ -230,7 +230,7 @@
 
 ### Patch Changes
 
-- [#8208](https://github.com/Shopify/polaris/pull/8208) [`69d27dbf6`](https://github.com/Shopify/polaris/commit/69d27dbf63d360a7cb3722fa8cd16e605288b3b9) Thanks [@qt314](https://github.com/qt314)! - Re-enable non layout component related layout rules
+- [#8208](https://github.com/Shopify/polaris/pull/8208) [`69d27dbf6`](https://github.com/Shopify/polaris/commit/69d27dbf63d360a7cb3722fa8cd16e605288b3b9) Thanks [@sophschneider](https://github.com/sophschneider)! - Re-enable non layout component related layout rules
 
 ## 5.1.2
 
@@ -246,7 +246,7 @@
 
 ### Patch Changes
 
-- [#8097](https://github.com/Shopify/polaris/pull/8097) [`cd150396b`](https://github.com/Shopify/polaris/commit/cd150396b11f1a0abf6d4419c5c594dfdae3185d) Thanks [@qt314](https://github.com/qt314)! - Fix incorrect unit function categorization
+- [#8097](https://github.com/Shopify/polaris/pull/8097) [`cd150396b`](https://github.com/Shopify/polaris/commit/cd150396b11f1a0abf6d4419c5c594dfdae3185d) Thanks [@sophschneider](https://github.com/sophschneider)! - Fix incorrect unit function categorization
 
 ## 5.1.0
 
@@ -264,7 +264,7 @@
 
 - [#7954](https://github.com/Shopify/polaris/pull/7954) [`af0ceb8c6`](https://github.com/Shopify/polaris/commit/af0ceb8c6fae30c6aaa45bf89eef660ea45fd78e) Thanks [@aaronccasanova](https://github.com/aaronccasanova)! - Use RegExp pattern to exclude reporting invalid scope disables and address memory issues
 
-* [#7919](https://github.com/Shopify/polaris/pull/7919) [`e7712e7a5`](https://github.com/Shopify/polaris/commit/e7712e7a57fddac939e65510fb257ac82442faa4) Thanks [@qt314](https://github.com/qt314)! - Deduped converage rules that were in multiple categories
+* [#7919](https://github.com/Shopify/polaris/pull/7919) [`e7712e7a5`](https://github.com/Shopify/polaris/commit/e7712e7a57fddac939e65510fb257ac82442faa4) Thanks [@sophschneider](https://github.com/sophschneider)! - Deduped converage rules that were in multiple categories
 
 ## 5.0.1
 
@@ -272,13 +272,13 @@
 
 - [#7866](https://github.com/Shopify/polaris/pull/7866) [`4b96147b3`](https://github.com/Shopify/polaris/commit/4b96147b32a89a393e8b6c5f7df1442f875248a0) Thanks [@aaronccasanova](https://github.com/aaronccasanova)! - Updated `stylelint-polaris` to allow disabling specific coverage rules instead of entire categories
 
-* [#7906](https://github.com/Shopify/polaris/pull/7906) [`c8a294f51`](https://github.com/Shopify/polaris/commit/c8a294f51baae53b131a5f9014f6223fdf3ef5ee) Thanks [@qt314](https://github.com/qt314)! - Fixed config atRule and function regex to match whole word
+* [#7906](https://github.com/Shopify/polaris/pull/7906) [`c8a294f51`](https://github.com/Shopify/polaris/commit/c8a294f51baae53b131a5f9014f6223fdf3ef5ee) Thanks [@sophschneider](https://github.com/sophschneider)! - Fixed config atRule and function regex to match whole word
 
 - [#7868](https://github.com/Shopify/polaris/pull/7868) [`6cd75fd9a`](https://github.com/Shopify/polaris/commit/6cd75fd9a089791a79fe8aa7e43f6b54add47a45) Thanks [@aaronccasanova](https://github.com/aaronccasanova)! - Update `package.json` to define a single entry point
 
 * [#7696](https://github.com/Shopify/polaris/pull/7696) [`bdf04a289`](https://github.com/Shopify/polaris/commit/bdf04a289e7a5b4c1e4717f5e162d00ea87c807b) Thanks [@chloerice](https://github.com/chloerice)! - Implemented custom message configuration support for polaris/coverage plugin
 
-- [#7898](https://github.com/Shopify/polaris/pull/7898) [`9206b7b13`](https://github.com/Shopify/polaris/commit/9206b7b130cb4d5b0a6ec110693d8b45248f8dcf) Thanks [@qt314](https://github.com/qt314)! - Bug fix to wrap z-index 'declaration-property-value-allowed-list' token value with "var"
+- [#7898](https://github.com/Shopify/polaris/pull/7898) [`9206b7b13`](https://github.com/Shopify/polaris/commit/9206b7b130cb4d5b0a6ec110693d8b45248f8dcf) Thanks [@sophschneider](https://github.com/sophschneider)! - Bug fix to wrap z-index 'declaration-property-value-allowed-list' token value with "var"
 
 ## 5.0.0
 


### PR DESCRIPTION
I renamed myself in github but I noticed someone already took my old username. Updating the changelog links to my profile to limit confusion 