### PR TITLE
[IndexFiltering] 

### DIFF
--- a/.changeset/poor-kids-drive.md
+++ b/.changeset/poor-kids-drive.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-- Set initial focus state of filters input to true
+- Initialized filters focus based on mode state

--- a/.changeset/poor-kids-drive.md
+++ b/.changeset/poor-kids-drive.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+- Set initial focus state of filters input to true

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -144,7 +144,7 @@ export function IndexFilters({
     value: filtersFocused,
     setFalse: setFiltersUnFocused,
     setTrue: setFiltersFocused,
-  } = useToggle(false);
+  } = useToggle(true);
   const {polarisSummerEditions2023} = useFeatures();
 
   useOnValueChange(mode, (newMode) => {

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -144,16 +144,18 @@ export function IndexFilters({
     value: filtersFocused,
     setFalse: setFiltersUnFocused,
     setTrue: setFiltersFocused,
-  } = useToggle(true);
+  } = useToggle(mode === IndexFiltersMode.Filtering);
   const {polarisSummerEditions2023} = useFeatures();
 
-  useOnValueChange(mode, (newMode) => {
+  const handleModeChange = (newMode: IndexFiltersMode) => {
     if (newMode === IndexFiltersMode.Filtering) {
       setFiltersFocused();
     } else {
       setFiltersUnFocused();
     }
-  });
+  };
+
+  useOnValueChange(mode, handleModeChange);
 
   useEventListener('keydown', (event) => {
     if (disableKeyboardShortcuts) return;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/pull/100983

- Currently when navigating to a given index table with the  query included in the URL, the input field will contain the value but will not be focused
- Since only indexes containing queries have the state of `mode` as Filtering, it makes sense to initialize with `mode`. This way when the URL includes a query, the input field is focused without accessibility trade-offs.
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

- This PR sets the initial focus of the input fields to true when `IndexFiltersMode` is `Filtering`.

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

- [Spin URL](https://admin.web.df.zakaria-warsame.us.spin.dev/store/shop1/products?query=aero) with query
  - Ensure the input is focus when you go to the page or refresh with the query included

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>


</details>

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
~ - [ ] Updated the component's `README.md` with documentation changes~ 
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
