### PR TITLE
[BulkActions] Consolidate se23 logic and styles

### DIFF
--- a/polaris-react/src/components/BulkActions/BulkActions.scss
+++ b/polaris-react/src/components/BulkActions/BulkActions.scss
@@ -59,12 +59,10 @@ $bulk-actions-button-stacking-order: (
   max-width: 100%;
   pointer-events: auto;
 
-  #{$se23} & {
-    @include shadow-bevel(
-      $boxShadow: var(--p-shadow-md),
-      $borderRadius: var(--p-border-radius-2)
-    );
-  }
+  @include shadow-bevel(
+    $boxShadow: var(--p-shadow-md),
+    $borderRadius: var(--p-border-radius-2)
+  );
 
   @media #{$p-breakpoints-sm-down} {
     // stylelint-disable-next-line selector-max-combinators, selector-max-type -- the first item of button group on small screen needs to fill the space


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/9921

### WHAT is this pull request doing?

Consolidates se23 beta styles for `BulkActions`.

### How to 🎩

Compare the bulk actions shadow bevel (make sure they are the same):

* This PR's [Storybook](https://5d559397bae39100201eedc1-vxezcfotko.chromatic.com/?path=/story/all-components-indextable--default)
* [Production Storybook](https://storybook.polaris.shopify.com/?path=/story/all-components-indextable--default&globals=polarisSummerEditions2023:true)