### PR TITLE
[Banner] Fix no title hidden icon

### DIFF
--- a/.changeset/lazy-apricots-visit.md
+++ b/.changeset/lazy-apricots-visit.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed BannerExperimental no title hidden icon variant

--- a/polaris-react/src/components/Banner/Banner.stories.tsx
+++ b/polaris-react/src/components/Banner/Banner.stories.tsx
@@ -296,6 +296,19 @@ export function All() {
         }
       />
       <Text as="h2" variant="headingMd">
+        No title with hidden icon
+      </Text>
+      <AllBanners
+        title={undefined}
+        hideIcon
+        children={
+          <Text as="p">
+            Changing the phone number for this customer will unsubscribe them
+            from SMS marketing text messages until they provide consent.
+          </Text>
+        }
+      />
+      <Text as="h2" variant="headingMd">
         Only title
       </Text>
       <AllBanners children={undefined} onDismiss={() => {}} />

--- a/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
+++ b/polaris-react/src/components/Banner/components/BannerExperimental/BannerExperimental.tsx
@@ -206,11 +206,13 @@ export function InlineIconBanner({
       >
         <Box width="100%">
           <HorizontalStack gap="2" wrap={false} blockAlign={blockAlign}>
-            <div ref={iconNode}>
-              <Box background={backgroundColor} borderRadius="2" padding="1">
-                {bannerIcon}
-              </Box>
-            </div>
+            {bannerIcon ? (
+              <div ref={iconNode}>
+                <Box background={backgroundColor} borderRadius="2" padding="1">
+                  {bannerIcon}
+                </Box>
+              </div>
+            ) : null}
             <Box ref={contentNode} width="100%">
               <VerticalStack gap="2">
                 <div>{children}</div>


### PR DESCRIPTION
### WHY are these changes introduced?

Hides icon `Box` for the no title Banner variant when `hideIcon` is true

|Before|After|
|-|-|
|<img width="1222" alt="Screenshot 2023-08-14 at 10 31 17 AM" src="https://github.com/Shopify/polaris/assets/20652326/f5b627d9-55b9-4166-9190-8d3dd90cfce1">|<img width="1221" alt="Screenshot 2023-08-14 at 10 31 40 AM" src="https://github.com/Shopify/polaris/assets/20652326/a4c7f8e2-a990-40c7-9649-6eebd230afb2">|