### PR TITLE
[Storybook] Use system font in chromatic snapshots

### DIFF
--- a/polaris-react/.storybook/preview-head.html
+++ b/polaris-react/.storybook/preview-head.html
@@ -5,6 +5,7 @@
   crossorigin="anonymous"
 />
 <link
+  id="inter-font-link"
   href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
   rel="stylesheet"
 />

--- a/polaris-react/.storybook/preview.js
+++ b/polaris-react/.storybook/preview.js
@@ -6,6 +6,7 @@ import {GridOverlay} from './GridOverlay';
 import {RenderPerformanceProfiler} from './RenderPerformanceProfiler';
 import {gridOptions, featureFlagOptions} from './manager';
 import {breakpoints} from '@shopify/polaris-tokens';
+import isChromatic from 'chromatic/isChromatic';
 
 function StrictModeDecorator(Story, context) {
   const {strictMode} = context.globals;
@@ -19,6 +20,11 @@ function StrictModeDecorator(Story, context) {
 }
 
 function AppProviderDecorator(Story, context) {
+  // Use system font in chromatic snapshots to avoid async font loading flakiness
+  if (isChromatic()) {
+    document.getElementById('inter-font-link').removeAttribute('href');
+  }
+
   const {
     polarisSummerEditions2023,
     polarisSummerEditions2023ShadowBevelOptOut,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/10038

Use system font in chromatic snapshots (use Inter still in storybook) so that we can use the regression tests without flakiness during our se23 consolidation work.

I made an [issue here](https://github.com/Shopify/polaris/issues/10104) to figure out how to get stories to not load until the font has loaded so we can use the proper font.

### WHAT is this pull request doing?

Using the [`isChromatic`](https://www.chromatic.com/docs/ischromatic) function to only control behaviour in snapshots,  this removes the font loading link from the document preview head.
 
### How to 🎩

* Check the [UI Tests CI](https://shopify.chromatic.com/build?appId=5d559397bae39100201eedc1&number=19503) to see the system font updated in all snapshots
* Check that the published [storybook in CI](https://5d559397bae39100201eedc1-tyfbdvqiif.chromatic.com/) is still using Inter
