### PR TITLE
[TooltipOverlay] Consolidate se23 styles and logic

### DIFF
--- a/polaris-react/src/components/Pagination/Pagination.stories.tsx
+++ b/polaris-react/src/components/Pagination/Pagination.stories.tsx
@@ -27,13 +27,13 @@ export function WithKeyboardNavigation() {
       <Pagination
         hasPrevious
         previousKeys={[74]}
-        previousTooltip="j"
+        previousTooltip="Previous (J)"
         onPrevious={() => {
           console.log('Previous');
         }}
         hasNext
         nextKeys={[75]}
-        nextTooltip="k"
+        nextTooltip="Next (K)"
         onNext={() => {
           console.log('Next');
         }}

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
@@ -21,29 +21,11 @@
   @include shadow-bevel(
     $boxShadow: var(--p-shadow-md),
     $borderRadius: var(--pc-tooltip-border-radius),
-    $zIndex: var(--pc-tooltip-shadow-bevel-z-index),
-    // The following arguments explicitly ignore the shadow-bevel opt out
-    $border: none,
-    $content: ''
+    $zIndex: var(--pc-tooltip-shadow-bevel-z-index)
   );
 
   @media screen and (-ms-high-contrast: active) {
     border: var(--p-border-width-2) solid windowText;
-  }
-
-  &::after {
-    content: none;
-    position: absolute;
-    top: calc(var(--p-space-4) * -1);
-    // stylelint-disable-next-line -- No Polaris layout component offers this
-    left: calc(
-      var(--pc-tooltip-chevron-x-pos) - var(--p-space-2) - var(--p-space-4)
-    );
-    height: 0;
-    width: 0;
-    border-width: var(--p-space-2);
-    border-style: solid;
-    border-color: transparent transparent var(--p-color-bg) transparent;
   }
 
   // TailUp

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.scss
@@ -18,23 +18,21 @@
   transform: none;
   transition: none;
 
-  #{$se23} & {
-    @include shadow-bevel(
-      $boxShadow: var(--p-shadow-md),
-      $borderRadius: var(--pc-tooltip-border-radius),
-      $zIndex: var(--pc-tooltip-shadow-bevel-z-index),
-      // The following arguments explicitly ignore the shadow-bevel opt out
-      $border: none,
-      $content: ''
-    );
-  }
+  @include shadow-bevel(
+    $boxShadow: var(--p-shadow-md),
+    $borderRadius: var(--pc-tooltip-border-radius),
+    $zIndex: var(--pc-tooltip-shadow-bevel-z-index),
+    // The following arguments explicitly ignore the shadow-bevel opt out
+    $border: none,
+    $content: ''
+  );
 
   @media screen and (-ms-high-contrast: active) {
     border: var(--p-border-width-2) solid windowText;
   }
 
   &::after {
-    content: '';
+    content: none;
     position: absolute;
     top: calc(var(--p-space-4) * -1);
     // stylelint-disable-next-line -- No Polaris layout component offers this
@@ -46,10 +44,6 @@
     border-width: var(--p-space-2);
     border-style: solid;
     border-color: transparent transparent var(--p-color-bg) transparent;
-
-    #{$se23} & {
-      content: none;
-    }
   }
 
   // TailUp
@@ -60,7 +54,7 @@
     left: calc(
       var(--pc-tooltip-chevron-x-pos) - var(--p-space-2) - var(--p-space-4)
     );
-    // stylelint-disable-next-line -- se23 overrides
+    // stylelint-disable-next-line -- set z-index
     z-index: var(--pc-tooltip-tail-z-index);
   }
 
@@ -72,11 +66,11 @@
     }
 
     // TailDown
-    // stylelint-disable-next-line -- se23 overrides
+    // stylelint-disable-next-line -- TailDown styles
     .Tail {
       top: unset;
       bottom: calc(-1 * var(--p-space-2));
-      // stylelint-disable-next-line -- se23 overrides
+      // stylelint-disable-next-line -- set filter styles
       filter: drop-shadow(0 3px 2px rgba(26, 26, 26, 0.1));
     }
   }

--- a/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
+++ b/polaris-react/src/components/Tooltip/components/TooltipOverlay/TooltipOverlay.tsx
@@ -6,7 +6,6 @@ import {PositionedOverlay} from '../../../PositionedOverlay';
 import type {PositionedOverlayProps} from '../../../PositionedOverlay';
 import {useI18n} from '../../../../utilities/i18n';
 import type {Width, Padding, BorderRadius} from '../../Tooltip';
-import {useFeatures} from '../../../../utilities/features';
 
 import styles from './TooltipOverlay.scss';
 
@@ -66,7 +65,6 @@ export function TooltipOverlay({
   zIndexOverride,
   instant,
 }: TooltipOverlayProps) {
-  const {polarisSummerEditions2023} = useFeatures();
   const i18n = useI18n();
   const markup = active ? (
     <PositionedOverlay
@@ -112,11 +110,9 @@ export function TooltipOverlay({
 
     return (
       <div style={style} className={containerClassName} {...layer.props}>
-        {polarisSummerEditions2023 && (
-          <svg className={styles.Tail} width="19" height="11" fill="none">
-            {positioning === 'above' ? tailDownPaths : tailUpPaths}
-          </svg>
-        )}
+        <svg className={styles.Tail} width="19" height="11" fill="none">
+          {positioning === 'above' ? tailDownPaths : tailUpPaths}
+        </svg>
         <div
           id={id}
           role="tooltip"


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #9974.

### WHAT is this pull request doing?

Consolidates se23 beta styles and logic for `TooltipOverlay`.
Updates copy for keyboard nav tooltips in `Pagination` to match copy in admin.

### How to 🎩
[Storybook](https://5d559397bae39100201eedc1-tewmslxdlb.chromatic.com/?path=/story/all-components-tooltip--all)
[Prod Storybook](https://storybook.polaris.shopify.com/?path=/story/all-components-tooltip--all&globals=polarisSummerEditions2023:true)

[Pagination Storybook](https://5d559397bae39100201eedc1-tewmslxdlb.chromatic.com/?path=/story/all-components-pagination--with-keyboard-navigation)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
