### PR TITLE
[TextField] skip call to onChange if value is at already at max or min

### DIFF
--- a/.changeset/tidy-cars-nail.md
+++ b/.changeset/tidy-cars-nail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Skip onChange call when numeric value is already at max or min and value will not change

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -373,6 +373,9 @@ export function TextField({
         return;
       }
 
+      if (numericValue === normalizedMin && steps < 0) return;
+      if (numericValue === normalizedMax && steps > 0) return;
+
       // Making sure the new value has the same length of decimal places as the
       // step / value has.
       const decimalPlaces =

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -800,6 +800,52 @@ describe('<TextField />', () => {
         expect(spy).not.toHaveBeenCalled();
       });
 
+      it('does not call the onChange if the value is incremented and already at max', () => {
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField
+            id="MyTextField"
+            label="TextField"
+            type="number"
+            value="5"
+            max={5}
+            onChange={spy}
+            autoComplete="off"
+          />,
+        );
+
+        element!
+          .find('div', {
+            role: 'button',
+          })!
+          .trigger('onClick');
+
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      it('does not call the onChange if the value is decremented and already at min', () => {
+        const spy = jest.fn();
+        const element = mountWithApp(
+          <TextField
+            id="MyTextField"
+            label="TextField"
+            type="number"
+            value="-1"
+            min={-1}
+            onChange={spy}
+            autoComplete="off"
+          />,
+        );
+
+        element
+          .findAll('div', {
+            role: 'button',
+          })[1]!
+          .trigger('onClick');
+
+        expect(spy).not.toHaveBeenCalled();
+      });
+
       it('handles incrementing from no value', () => {
         const spy = jest.fn();
         const element = mountWithApp(
@@ -866,7 +912,8 @@ describe('<TextField />', () => {
             label="TextField"
             type="number"
             min={2}
-            value="2"
+            value="3"
+            step={3}
             onChange={spy}
             autoComplete="off"
           />,
@@ -884,7 +931,7 @@ describe('<TextField />', () => {
             role: 'button',
           })[0]!
           .trigger('onClick');
-        expect(spy).toHaveBeenLastCalledWith('3', 'MyTextField');
+        expect(spy).toHaveBeenLastCalledWith('6', 'MyTextField');
       });
 
       it('respects a max value', () => {
@@ -895,7 +942,8 @@ describe('<TextField />', () => {
             label="TextField"
             type="number"
             max={2}
-            value="2"
+            value="1"
+            step={3}
             onChange={spy}
             autoComplete="off"
           />,
@@ -913,7 +961,7 @@ describe('<TextField />', () => {
             role: 'button',
           })[1]!
           .trigger('onClick');
-        expect(spy).toHaveBeenLastCalledWith('1', 'MyTextField');
+        expect(spy).toHaveBeenLastCalledWith('-2', 'MyTextField');
       });
 
       it('brings an invalid value up to the min', () => {
@@ -1572,7 +1620,8 @@ describe('<TextField />', () => {
             label="TextField"
             type="integer"
             min={2}
-            value="2"
+            value="3"
+            step={3}
             onChange={spy}
             autoComplete="off"
           />,
@@ -1590,7 +1639,7 @@ describe('<TextField />', () => {
             role: 'button',
           })[0]!
           .trigger('onClick');
-        expect(spy).toHaveBeenLastCalledWith('3', 'MyTextField');
+        expect(spy).toHaveBeenLastCalledWith('6', 'MyTextField');
       });
 
       it('respects a max value', () => {
@@ -1601,7 +1650,8 @@ describe('<TextField />', () => {
             label="TextField"
             type="integer"
             max={2}
-            value="2"
+            value="1"
+            step={2}
             onChange={spy}
             autoComplete="off"
           />,
@@ -1619,7 +1669,7 @@ describe('<TextField />', () => {
             role: 'button',
           })[1]!
           .trigger('onClick');
-        expect(spy).toHaveBeenLastCalledWith('1', 'MyTextField');
+        expect(spy).toHaveBeenLastCalledWith('-1', 'MyTextField');
       });
 
       it('brings an invalid value up to the min', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/core-issues/issues/58718

While using the Polaris [TextField component](https://polaris.shopify.com/components/selection-and-input/text-field), the onChange handler is still called [even if the field's value is at the min/max and the stepper buttons are used to try and decrease/increase the values unsuccessfully](https://codesandbox.io/s/interesting-williams-hqwgsy?file=/App.tsx)). This can cause queries that are using these fields to re-request when there is no change in input.

### WHAT is this pull request doing?

No visual changes.

This pull request checks the max and min against the current input and if we are already at the ends of our input, onChange is skipped

📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<details>
<summary>Playground code</summary>

```
import React, {useCallback, useState} from 'react';

import {Page, TextField} from '../src';

export function Playground() {
  const [value, setValue] = useState('1');

  const handleChange = useCallback(
    (newValue: string) => {
      setValue(newValue);
      console.log('onChange called', newValue)
    },
    [],
  );

  return (
    <Page title="Playground">
      <TextField
      label="Quantity"
      type="number"
      value={value}
      onChange={handleChange}
      autoComplete="off"
      max={3}
      min={-3}
      step={2}
    />
    </Page>
  );
}
```

</details>

https://github.com/Shopify/polaris/assets/113911518/b89d959f-3bcb-4804-8556-01c1214d8957



