### PR TITLE
Add public primitive `height` token scale

### DIFF
--- a/.changeset/fast-bulldogs-raise.md
+++ b/.changeset/fast-bulldogs-raise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris-tokens': minor
+---
+
+Added public primitive `height` token scale

--- a/polaris-for-vscode/src/server.ts
+++ b/polaris-for-vscode/src/server.ts
@@ -80,6 +80,7 @@ const tokenGroupPatterns: TokenGroupPatterns = {
   color:
     /color|background|shadow|border|column-rule|filter|opacity|outline|text-decoration/,
   font: /font|line-height/,
+  height: /height|min-height|max-height/,
   motion: /animation/,
   shadow: /shadow/,
   space: /margin|padding|gap|top|left|right|bottom/,

--- a/polaris-tokens/src/index.ts
+++ b/polaris-tokens/src/index.ts
@@ -43,6 +43,12 @@ export type {
 } from './token-groups/font';
 
 export type {
+  HeightTokenGroup,
+  HeightTokenName,
+  HeightScale,
+} from './token-groups/height';
+
+export type {
   MotionTokenGroup,
   MotionTokenName,
   MotionDurationScale,

--- a/polaris-tokens/src/themes/base.ts
+++ b/polaris-tokens/src/themes/base.ts
@@ -3,6 +3,7 @@ import {border} from '../token-groups/border';
 import {breakpoints} from '../token-groups/breakpoints';
 import {color} from '../token-groups/color';
 import {font} from '../token-groups/font';
+import {height} from '../token-groups/height';
 import {motion} from '../token-groups/motion';
 import {shadow} from '../token-groups/shadow';
 import {space} from '../token-groups/space';
@@ -17,6 +18,7 @@ export const metaThemeBase = createMetaThemeBase({
   border: tokensToRems(border),
   color,
   font: tokensToRems(font),
+  height: tokensToRems(height),
   motion,
   shadow: tokensToRems(shadow),
   space: tokensToRems(space),

--- a/polaris-tokens/src/token-groups/height.ts
+++ b/polaris-tokens/src/token-groups/height.ts
@@ -1,0 +1,95 @@
+import {size} from '../size';
+import type {MetadataProperties} from '../types';
+
+export type HeightScale =
+  | '0'
+  | '025'
+  | '050'
+  | '100'
+  | '150'
+  | '200'
+  | '300'
+  | '400'
+  | '500'
+  | '600'
+  | '700'
+  | '800'
+  | '900'
+  | '1000'
+  | '1200'
+  | '1600'
+  | '2000'
+  | '2400'
+  | '2800'
+  | '3200';
+
+export type HeightTokenName = `height-${HeightScale}`;
+
+export type HeightTokenGroup = {
+  [TokenName in HeightTokenName]: string;
+};
+
+export const height: {
+  [TokenName in HeightTokenName]: MetadataProperties;
+} = {
+  'height-0': {
+    value: size[0],
+  },
+  'height-025': {
+    value: size['025'],
+  },
+  'height-050': {
+    value: size['050'],
+  },
+  'height-100': {
+    value: size[100],
+  },
+  'height-150': {
+    value: size[150],
+  },
+  'height-200': {
+    value: size[200],
+  },
+  'height-300': {
+    value: size[300],
+  },
+  'height-400': {
+    value: size[400],
+  },
+  'height-500': {
+    value: size[500],
+  },
+  'height-600': {
+    value: size[600],
+  },
+  'height-700': {
+    value: size[700],
+  },
+  'height-800': {
+    value: size[800],
+  },
+  'height-900': {
+    value: size[900],
+  },
+  'height-1000': {
+    value: size[1000],
+  },
+  'height-1200': {
+    value: size[1200],
+  },
+  'height-1600': {
+    value: size[1600],
+  },
+  'height-2000': {
+    value: size[2000],
+  },
+  'height-2400': {
+    value: size[2400],
+  },
+  'height-2800': {
+    value: size[2800],
+  },
+  'height-3200': {
+    value: size[3200],
+  },
+};


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #10437 

### WHAT is this pull request doing?

Adds the following values to new public primitive `height` token scale: 

| New Token          | Value        | Value (in px)
| ------------------------- | ------------------------ |  ------------------------ |
| `--p-height-0` | `size['0']`  | `0px`    |
| `--p-height-025` | `size['025']`  | `1px`    |
| `--p-height-050` | `size['050']`  | `2px`    |
| `--p-height-100` | `size[100]`  | `4px`    |
| `--p-height-150` | `size[150]`  | `6px`    |
| `--p-height-200` | `size[200]`  | `8px`    |
| `--p-height-300` | `size[300]`  | `12px`    |
| `--p-height-400` | `size[400]`  | `16px`    |
| `--p-height-500` | `size[500]`  | `20px`    |
| `--p-height-600` | `size[600]`  | `24px`    |
| `--p-height-700` | `size[700]`  | `28px`    |
| `--p-height-800` | `size[800]`  | `32px`    |
| `--p-height-900` | `size[900]`  | `36px`    |
| `--p-height-1000` | `size[1000]`  | `40px`    |
| `--p-height-1200` | `size[1200]`  | `48px`    |
| `--p-height-1600` | `size[1600]`  | `64px`    |
| `--p-height-2000` | `size[2000]`  | `80px`    |
| `--p-height-2400` | `size[2400]`  | `96px`    |
| `--p-height-2800` | `size[2800]`  | `112px`    |
| `--p-height-3200` | `size[3200]`  | `128px`    |
