### PR TITLE
[TextField] Automatically set password manager disable props if `autoComplete="off"`

### DIFF
--- a/.changeset/quiet-grapes-end.md
+++ b/.changeset/quiet-grapes-end.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updated the TextField to automatically set password manager disable data attributes based on the autoComplete prop

--- a/polaris-react/src/components/Tabs/components/CreateViewModal/CreateViewModal.tsx
+++ b/polaris-react/src/components/Tabs/components/CreateViewModal/CreateViewModal.tsx
@@ -111,7 +111,6 @@ export function CreateViewModal({
                       )
                     : undefined
                 }
-                disable1Password
               />
             </div>
           </FormLayout>

--- a/polaris-react/src/components/TextField/TextField.stories.tsx
+++ b/polaris-react/src/components/TextField/TextField.stories.tsx
@@ -878,7 +878,6 @@ export function With1PasswordDisabled() {
       value={value}
       onChange={handleChange}
       autoComplete="off"
-      disable1Password
     />
   );
 }

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -173,8 +173,6 @@ interface NonMutuallyExclusiveProps {
   onBlur?(event?: React.FocusEvent): void;
   /** Removes the border around the input. Used in the IndexFilters component. */
   borderless?: boolean;
-  /** Disables the 1password extension on the text field */
-  disable1Password?: boolean;
 }
 
 export type MutuallyExclusiveSelectionProps =
@@ -241,7 +239,6 @@ export function TextField({
   onFocus,
   onBlur,
   borderless,
-  disable1Password,
 }: TextFieldProps) {
   const i18n = useI18n();
   const [height, setHeight] = useState<number | null>(null);
@@ -559,7 +556,12 @@ export function TextField({
     onKeyDown: handleKeyDown,
     onChange: !suggestion ? handleChange : undefined,
     onInput: suggestion ? handleChange : undefined,
-    'data-1p-ignore': disable1Password || undefined,
+    // 1Password disable data attribute
+    'data-1p-ignore': autoComplete === 'off' || undefined,
+    // LastPass disable data attribute
+    'data-lpignore': autoComplete === 'off' || undefined,
+    // Dashlane disable data attribute
+    'data-form-type': autoComplete === 'off' ? 'other' : undefined,
   });
 
   const inputWithVerticalContentMarkup = verticalContent ? (

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -85,18 +85,15 @@ describe('<TextField />', () => {
     });
   });
 
-  it('adds the data-1p-ignore prop if disable1Password is set', () => {
+  it('adds the password manager disabled props if autoComplete="off" is set', () => {
     const textField = mountWithApp(
-      <TextField
-        label="TextField"
-        onChange={noop}
-        autoComplete="off"
-        disable1Password
-      />,
+      <TextField label="TextField" onChange={noop} autoComplete="off" />,
     );
 
     expect(textField).toContainReactComponent('input', {
       'data-1p-ignore': true,
+      'data-lpignore': true,
+      'data-form-type': 'other',
     } as any);
   });
 


### PR DESCRIPTION
### WHY are these changes introduced?

We recently introduced a change to Polaris to remove the 1Password UI based on the `disable1Password` prop. However, we can simplify this and remove the need for the prop entirely, and instead determine whether to add this attribute if the `autoComplete` prop is set to `"off"`.

This PR also expands our supported password managers, to also include Dashlane and LastPass, as well as 1Password. These are an opinionated list of PMs that are both popular, and offer the ability to disable inputs with data attributes.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)


### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
