### PR TITLE
[Link] Manually migrate `color` custom properties for v11 to v12

### DIFF
--- a/polaris-react/src/components/Link/Link.scss
+++ b/polaris-react/src/components/Link/Link.scss
@@ -9,12 +9,12 @@
   border: 0;
   font-size: inherit;
   font-weight: inherit;
-  color: var(--p-color-text-interactive);
+  color: var(--p-color-text-link);
   text-decoration: underline;
   cursor: pointer;
 
   &:hover {
-    color: var(--p-color-text-interactive-hover);
+    color: var(--p-color-text-link-hover);
     text-decoration: underline;
   }
 
@@ -28,7 +28,7 @@
 
   &:active {
     position: relative;
-    color: var(--p-color-text-interactive-active);
+    color: var(--p-color-text-link-active);
   }
 
   @media print {


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #10487.

### WHAT is this pull request doing?

Manually migrates `Link` component `color` custom properties.

### How to 🎩

[Storybook](https://5d559397bae39100201eedc1-kbsevctiyw.chromatic.com/)
[Next branch storybook](https://5d559397bae39100201eedc1-bpilwyaavo.chromatic.com/?path=/story/all-components-link--default)

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
