### PR TITLE
Add changeset for `space` migration

### DIFF
--- a/.changeset/lemon-bees-confess.md
+++ b/.changeset/lemon-bees-confess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Migrated `space` custom properties from v11 to v12


### PR DESCRIPTION
### WHY are these changes introduced?

Forgot to add a changeset when I merged [this](https://github.com/Shopify/polaris/pull/10585) into `next`.