### PR TITLE
Migrate deprecated v11 tokens in stylelint docs

### DIFF
--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/border-at-rule-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/border-at-rule-disallowed-list.md
@@ -28,7 +28,7 @@ NOTE: The `focus-ring` at rule does not currently have an equivalent token or co
 ```diff
 // Do
 + &:focus {
-  + outline: var(--p-border-width-050) solid var(--p-color-border-interactive-focus);
+  + outline: var(--p-border-width-050) solid var(--p-color-border-focus);
   + outline-offset: var(--p-space-050);
 + }
 // Don't

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/border-at-rule-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/border-at-rule-disallowed-list.md
@@ -18,7 +18,7 @@ import RulePostamble from '../_postamble.md';
 
 ```diff
 // Do
-+ outline: var(--p-border-width-1) solid transparent;
++ outline: var(--p-border-width-025) solid transparent;
 // Don't
 - @include high-contrast-outline()
 ```
@@ -28,7 +28,7 @@ NOTE: The `focus-ring` at rule does not currently have an equivalent token or co
 ```diff
 // Do
 + &:focus {
-  + outline: var(--p-border-width-2) solid var(--p-color-border-interactive-focus);
+  + outline: var(--p-border-width-050) solid var(--p-color-border-interactive-focus);
   + outline-offset: var(--p-space-050);
 + }
 // Don't

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/border-custom-property-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/border-custom-property-disallowed-list.md
@@ -18,7 +18,7 @@ import RulePostamble from '../_postamble.md';
 
 ```diff
 // Do
-+ border-radius: var(--p-border-radius-2);
++ border-radius: var(--p-border-radius-200);
 // Don't
 - border-radius: var(--p-border-radius-large);
 ```

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/border-declaration-property-unit-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/border-declaration-property-unit-disallowed-list.md
@@ -18,8 +18,8 @@ import RulePostamble from '../_postamble.md';
 
 ```diff
 // Do
-+ border-width: var(--p-border-width-2);
-+ border-radius: var(--p-border-radius-2);
++ border-width: var(--p-border-width-050);
++ border-radius: var(--p-border-radius-200);
 // Don't
 - border-width: 2px;
 - border-radius: 0.5rem;

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/border-function-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/border-function-disallowed-list.md
@@ -18,7 +18,7 @@ import RulePostamble from '../_postamble.md';
 
 ```diff
 // Do
-+ border-radius: var(--p-border-radius-1);
++ border-radius: var(--p-border-radius-100);
 // Don't
 - border-radius: border-radius();
 ```

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/color-at-rule-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/color-at-rule-disallowed-list.md
@@ -19,7 +19,7 @@ import RulePostamble from '../_postamble.md';
 ```diff
 // Do
 + svg {
-+   fill: var(--p-color-icon-subdued);
++   fill: var(--p-color-icon-secondary);
 +}
 
 // Don't

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/color-function-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/color-function-disallowed-list.md
@@ -19,7 +19,7 @@ import RulePostamble from '../_postamble.md';
 ```diff
 // Do
 + color: var(--p-color-text-disabled);
-+ background: var(--p-color-bg-inverse-hover);
++ background: var(--p-color-bg-fill-inverse-hover);
 // Don't
 - color: rgb(140, 145, 150);
 - background: color('hover');

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/conventions-custom-property-allowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/conventions-custom-property-allowed-list.md
@@ -38,7 +38,7 @@ Flags declaration property values using private `--pc-*` tokens.
 
 ```diff
 // Do
-+ background: var(--p-color-bg-inset-strong);
++ background: var(--p-color-bg-fill-inverse);
 // Don't
 - background: var(--pc-button-color-depressed);
 ```

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/conventions-custom-property-allowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/conventions-custom-property-allowed-list.md
@@ -29,7 +29,7 @@ Flags declaration property values using `--p-*` that are not valid Polaris token
 
 ```diff
 // Do
-+ font-size: var(--p-font-size-200);
++ font-size: var(--p-font-size-400);
 // Don't
 - font-size: var(--p-fontsize-200);
 ```

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/shadow-custom-property-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/shadow-custom-property-disallowed-list.md
@@ -18,7 +18,7 @@ import RulePostamble from '../_postamble.md';
 
 ```diff
 // Do
-+ box-shadow: var(--p-shadow-md);
++ box-shadow: var(--p-shadow-300);
 // Don't
 - box-shadow: var(--p-shadow-deep)
 ```

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/shadow-declaration-property-unit-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/shadow-declaration-property-unit-disallowed-list.md
@@ -18,7 +18,7 @@ import RulePostamble from '../_postamble.md';
 
 ```diff
 // Do
-+ box-shadow: var(--p-shadow-md);
++ box-shadow: var(--p-shadow-300);
 // Don't
 - box-shadow: 0px 2px 4px rgba(31, 33, 36, 0.1), 0px 1px 6px rgba(31, 33, 36, 0.05);
 ```

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/shadow-function-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/shadow-function-disallowed-list.md
@@ -18,7 +18,7 @@ import RulePostamble from '../_postamble.md';
 
 ```diff
 // Do
-+ box-shadow: var(--p-shadow-md);
++ box-shadow: var(--p-shadow-300);
 // Don't
 - filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
 ```

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/typography-declaration-property-unit-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/typography-declaration-property-unit-disallowed-list.md
@@ -18,8 +18,8 @@ import RulePostamble from '../_postamble.md';
 
 ```diff
 // Do
-+ font-size: var(--p-font-size-75);
-+ line-height: var(--p-font-line-height-3);
++ font-size: var(--p-font-size-300);
++ line-height: var(--p-font-line-height-600);
 // Don't
 - font-size: 12px;
 - line-height: 1.5rem

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/typography-function-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/typography-function-disallowed-list.md
@@ -20,7 +20,7 @@ import RulePostamble from '../_postamble.md';
 // Do
 + <Text variant="headingXs" as="p" />
 // Do
-+ font-size: var(--p-font-size-75);
++ font-size: var(--p-font-size-300);
 // Don't
 - font-size: font-size('caption');
 ```

--- a/polaris.shopify.com/content/tools/stylelint-polaris/rules/typography-global-disallowed-list.md
+++ b/polaris.shopify.com/content/tools/stylelint-polaris/rules/typography-global-disallowed-list.md
@@ -18,7 +18,7 @@ import RulePostamble from '../_postamble.md';
 
 ```diff
 // Do
-+ font-size: var(--p-font-size-200);
++ font-size: var(--p-font-size-400);
 // Don't
 - font-size: $base-font-size;
 ```


### PR DESCRIPTION
### WHY are these changes introduced?

Removes any deprecated v11 tokens from our polaris.shopify.com stylelint-polaris docs.  

### WHAT is this pull request doing?

Manually migrates values based on our deprecated token maps. 