### PR TITLE
[polaris-migrator] Add a migration to change interpolation in media queries by env

### DIFF
--- a/polaris-migrator/codeshift.config.js
+++ b/polaris-migrator/codeshift.config.js
@@ -7,6 +7,9 @@ module.exports = {
     'react-rename-component': resolve('react-rename-component'),
     'react-rename-component-prop': resolve('react-rename-component-prop'),
     'scss-remove-unused-at-use': resolve('scss-remove-unused-at-use'),
+    'scss-replace-media-query-interpolation': resolve(
+      'scss-replace-media-query-interpolation',
+    ),
     'styles-insert-stylelint-disable': resolve(
       'styles-insert-stylelint-disable',
     ),

--- a/polaris-migrator/src/migrations/scss-replace-media-query-interpolation/tests/scss-replace-media-query-interpolation.input.scss
+++ b/polaris-migrator/src/migrations/scss-replace-media-query-interpolation/tests/scss-replace-media-query-interpolation.input.scss
@@ -1,0 +1,29 @@
+@use 'global-styles/media-queries';
+
+.Selector {
+  max-width: 100px;
+
+  @media #{media-queries.$p-breakpoints-md-down} {
+    max-width: 200px;
+  }
+
+  @media only screen and #{media-queries.$p-breakpoints-md-only} {
+    max-width: 300px;
+  }
+
+  @media #{media-queries.$p-breakpoints-md-up} and #{media-queries.$p-breakpoints-lg-down} {
+    max-width: 400px;
+  }
+
+  @container app-card #{media-queries.$p-breakpoints-sm-down} {
+    max-width: 500px;
+  }
+
+  @media #{media-queries.$p-breakpoints-md-up} and #{legacy-polaris-v8.breakpoints-down(variables.$home-scroll-greeting-sidebar-hidden)} {
+    max-width: 600px;
+  }
+
+  @media #{legacy-polaris-v8.breakpoints-down(variables.$home-scroll-greeting-sidebar-hidden)} and #{media-queries.$p-breakpoints-md-up} {
+    max-width: 700px;
+  }
+}

--- a/polaris-migrator/src/migrations/scss-replace-media-query-interpolation/tests/scss-replace-media-query-interpolation.output.scss
+++ b/polaris-migrator/src/migrations/scss-replace-media-query-interpolation/tests/scss-replace-media-query-interpolation.output.scss
@@ -1,0 +1,27 @@
+.Selector {
+  max-width: 100px;
+
+  @media (env(--p-breakpoints-md-down)) {
+    max-width: 200px;
+  }
+
+  @media only screen and (env(--p-breakpoints-md-only)) {
+    max-width: 300px;
+  }
+
+  @media (env(--p-breakpoints-md-up)) and (env(--p-breakpoints-lg-down)) {
+    max-width: 400px;
+  }
+
+  @container app-card (env(--p-breakpoints-sm-down)) {
+    max-width: 500px;
+  }
+
+  @media (env(--p-breakpoints-md-up)) and #{legacy-polaris-v8.breakpoints-down(variables.$home-scroll-greeting-sidebar-hidden)} {
+    max-width: 600px;
+  }
+
+  @media #{legacy-polaris-v8.breakpoints-down(variables.$home-scroll-greeting-sidebar-hidden)} and (env(--p-breakpoints-md-up)) {
+    max-width: 700px;
+  }
+}

--- a/polaris-migrator/src/migrations/scss-replace-media-query-interpolation/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/scss-replace-media-query-interpolation/tests/transform.test.ts
@@ -1,0 +1,17 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'scss-replace-media-query-interpolation';
+const fixtures = ['scss-replace-media-query-interpolation'];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture,
+    transform,
+    extension: 'scss',
+    options: {
+      customSyntax: 'postcss-scss',
+      reportDescriptionlessDisables: true,
+      rules: {},
+    },
+  });
+}

--- a/polaris-migrator/src/migrations/scss-replace-media-query-interpolation/transform.ts
+++ b/polaris-migrator/src/migrations/scss-replace-media-query-interpolation/transform.ts
@@ -1,0 +1,47 @@
+import type {API, FileInfo, Options} from 'jscodeshift';
+import type {Plugin} from 'postcss';
+import postcss from 'postcss';
+import stylelint from 'stylelint';
+
+const plugin = (): Plugin => {
+  return {
+    postcssPlugin: 'scss-replace-media-query-interpolation',
+    AtRule(atRule) {
+      if (atRule.name === 'media' || atRule.name === 'container') {
+        atRule.params = atRule.params.replace(
+          /#\{media-queries\.\$(?<breakpoint>[^}]*)}/g,
+          '(env(--$1))',
+        );
+      }
+
+      if (
+        atRule.name === 'use' &&
+        atRule.params === "'global-styles/media-queries'"
+      ) {
+        atRule.remove();
+      }
+    },
+  };
+};
+
+export default async function transformer(
+  file: FileInfo,
+  _: API,
+  options: Options,
+) {
+  return postcss([
+    stylelint({
+      config: {
+        extends: [options.config ?? '@shopify/stylelint-polaris'],
+      },
+    }) as Plugin,
+    plugin(),
+  ])
+    .process(file.source, {
+      from: file.path,
+      syntax: require('postcss-scss'),
+    })
+    .then((result) => {
+      return result.css;
+    });
+}


### PR DESCRIPTION
### WHY are these changes introduced?

In the context of `shopify/web`'s code yellow, we are looking to drop sass.

### WHAT is this pull request doing?

Creates a new migration `scss-replace-media-query-interpolation` that replaces breakpoint interpolation in media queries by [env()](https://developer.mozilla.org/en-US/docs/Web/CSS/env) which can be used there natively.

In web, we will be providing the breakpoints through postcss for now using [poscss-env-function](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-env-function)

In essence, the migration turns this `scss`

```scss
@use 'global-styles/media-queries';

.EmptyPage {
  max-width: 250px;

  @media #{media-queries.$p-breakpoints-md-down} {
    max-width: 300px;
  }
}
```

into this `css`

```css
.EmptyPage {
  max-width: 250px;

  @media (env(--p-breakpoints-md-down)) {
    max-width: 300px;
  }
}
```

I'd also love to get 👀 from the polaris team about this approach. Are we missing something here? If we think it works, we could expose the breakpoints through JS and even share them across css and js. We could also update the docs on [breakpoints](https://polaris.shopify.com/tokens/breakpoints)

### How to 🎩

I think tests should be enough, but you can look at https://github.com/Shopify/web/pull/105405/commits/184829d27da0b80ccf320ab7d76722027f73ffb9 as a reference of the output of running the codemod over a fraction of the `shopify/web` codebase

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
