### PR TITLE
Add support for `@custom-media` for using breakpoints in CSS

### DIFF
--- a/.changeset/proud-cooks-fly.md
+++ b/.changeset/proud-cooks-fly.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris-tokens': minor
+'@shopify/polaris': patch
+---
+
+Add support for using breakpoint tokens in CSS by using `@custom-media`

--- a/polaris-react/config/postcss-plugins.js
+++ b/polaris-react/config/postcss-plugins.js
@@ -1,7 +1,20 @@
+const path = require('path');
+
 const postcssShopify = require('@shopify/postcss-plugin');
 const pxtorem = require('postcss-pxtorem');
+const postcssCustomMedia = require('postcss-custom-media');
+const postcssGlobalData = require('@csstools/postcss-global-data');
+
+const mediaQueriesCssPath = path.resolve(
+  __dirname,
+  '../../node_modules/@shopify/polaris-tokens/dist/css/media-queries.css',
+);
 
 module.exports = [
+  postcssGlobalData({
+    files: [mediaQueriesCssPath],
+  }),
+  postcssCustomMedia(),
   postcssShopify,
   pxtorem({
     rootValue: 16,

--- a/polaris-react/package.json
+++ b/polaris-react/package.json
@@ -70,6 +70,7 @@
   },
   "devDependencies": {
     "@changesets/get-release-plan": "^3.0.13",
+    "@csstools/postcss-global-data": "2.1.0",
     "@shopify/jest-dom-mocks": "^3.0.5",
     "@shopify/postcss-plugin": "^5.0.1",
     "@shopify/react-testing": "^4.1.0",
@@ -89,6 +90,7 @@
     "js-yaml": "^4.1.0",
     "node-sass": "^7.0.1",
     "postcss": "^8.3.1",
+    "postcss-custom-media": "^10.0.1",
     "postcss-loader": "^4.2.0",
     "postcss-modules": "^4.2.2",
     "postcss-pxtorem": "^5.1.1",

--- a/polaris-react/src/components/Text/Text.scss
+++ b/polaris-react/src/components/Text/Text.scss
@@ -77,7 +77,7 @@
   line-height: var(--p-font-line-height-600);
   font-weight: var(--p-font-weight-bold);
 
-  @media #{$p-breakpoints-md-up} {
+  @media (--p-breakpoints-md-up) {
     font-size: var(--p-text-heading-lg-font-size);
     line-height: var(--p-text-heading-lg-font-line-height);
   }
@@ -88,7 +88,7 @@
   line-height: var(--p-font-line-height-600);
   font-weight: var(--p-font-weight-bold);
 
-  @media #{$p-breakpoints-md-up} {
+  @media (--p-breakpoints-md-up) {
     font-size: var(--p-text-heading-xl-font-size);
     line-height: var(--p-text-heading-xl-font-line-height);
   }
@@ -99,7 +99,7 @@
   line-height: var(--p-font-line-height-800);
   font-weight: var(--p-font-weight-bold);
 
-  @media #{$p-breakpoints-md-up} {
+  @media (--p-breakpoints-md-up) {
     font-size: var(--p-text-heading-2xl-font-size);
     line-height: var(--p-text-heading-2xl-font-line-height);
   }
@@ -110,7 +110,7 @@
   line-height: var(--p-font-line-height-1000);
   font-weight: var(--p-font-weight-bold);
 
-  @media #{$p-breakpoints-md-up} {
+  @media (--p-breakpoints-md-up) {
     font-size: var(--p-text-heading-3xl-font-size);
     line-height: var(--p-text-heading-3xl-font-line-height);
   }

--- a/polaris-tokens/scripts/toMediaConditions.ts
+++ b/polaris-tokens/scripts/toMediaConditions.ts
@@ -5,32 +5,64 @@ import {getMediaConditions} from '../src';
 import {metaThemeDefault} from '../src/themes';
 import {extractMetaTokenGroupValues} from '../src/themes/utils';
 
+const cssOutputDir = path.join(__dirname, '../dist/css');
+const cssOutputPath = path.join(cssOutputDir, 'media-queries.css');
+
 const scssOutputDir = path.join(__dirname, '../dist/scss');
 const scssOutputPath = path.join(scssOutputDir, 'media-queries.scss');
 
+const mediaConditionEntries = Object.entries(
+  getMediaConditions(extractMetaTokenGroupValues(metaThemeDefault.breakpoints)),
+);
+
 export async function toMediaConditions() {
+  await Promise.all([
+    generateCssMediaCondition(),
+    generateScssMediaCondition(),
+  ]);
+}
+
+async function generateCssMediaCondition() {
+  await fs.promises.mkdir(cssOutputDir, {recursive: true}).catch((error) => {
+    if (error.code !== 'EEXIST') {
+      throw error;
+    }
+  });
+  const cssStyles = generateMediaConditionStyles(
+    (token, direction, mediaCondition) =>
+      `@custom-media --p-${token}-${direction} ${mediaCondition};`,
+  );
+  await fs.promises.writeFile(cssOutputPath, cssStyles);
+}
+
+// Remove this function once we no longer need to support SCSS
+async function generateScssMediaCondition() {
   await fs.promises.mkdir(scssOutputDir, {recursive: true}).catch((error) => {
     if (error.code !== 'EEXIST') {
       throw error;
     }
   });
-
-  const mediaConditionEntries = Object.entries(
-    getMediaConditions(
-      extractMetaTokenGroupValues(metaThemeDefault.breakpoints),
-    ),
+  const scssStyles = generateMediaConditionStyles(
+    (token, direction, mediaCondition) =>
+      `$p-${token}-${direction}: '${mediaCondition}';`,
   );
+  await fs.promises.writeFile(scssOutputPath, scssStyles);
+}
 
-  const styles = mediaConditionEntries
+function generateMediaConditionStyles(
+  styleGenerator: (
+    token: string,
+    direction: string,
+    mediaCondition: string,
+  ) => string,
+): string {
+  return mediaConditionEntries
     .map(([token, mediaConditions]) =>
       Object.entries(mediaConditions)
-        .map(
-          ([direction, mediaCondition]) =>
-            `$p-${token}-${direction}: '${mediaCondition}';`,
+        .map(([direction, mediaCondition]) =>
+          styleGenerator(token, direction, mediaCondition),
         )
         .join('\n'),
     )
     .join('\n\n');
-
-  await fs.promises.writeFile(scssOutputPath, styles);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,6 +1477,31 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
+"@csstools/cascade-layer-name-parser@^1.0.4":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-1.0.5.tgz#c4d276e32787651df0007af22c9fa70d9c9ca3c2"
+  integrity sha512-v/5ODKNBMfBl0us/WQjlfsvSlYxfZLhNMVIsuCPib2ulTwGKYbKJbwqw671+qH9Y4wvWVnu7LBChvml/wBKjFg==
+
+"@csstools/css-parser-algorithms@^2.3.1":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.2.tgz#1e0d581dbf4518cb3e939c3b863cb7180c8cedad"
+  integrity sha512-sLYGdAdEY2x7TSw9FtmdaTrh2wFtRJO5VMbBrA8tEqEod7GEggFmxTSK9XqExib3yMuYNcvcTdCZIP6ukdjAIA==
+
+"@csstools/css-tokenizer@^2.2.0":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-2.2.1.tgz#9dc431c9a5f61087af626e41ac2a79cce7bb253d"
+  integrity sha512-Zmsf2f/CaEPWEVgw29odOj+WEVoiJy9s9NOv5GgNY9mZ1CZ7394By6wONrONrTsnNDv6F9hR02nvFihrGVGHBg==
+
+"@csstools/media-query-list-parser@^2.1.4":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.5.tgz#94bc8b3c3fd7112a40b7bf0b483e91eba0654a0f"
+  integrity sha512-IxVBdYzR8pYe89JiyXQuYk4aVVoCPhMJkz6ElRwlVysjwURTsTk/bmY/z4FfeRE+CRBMlykPwXEVUg8lThv7AQ==
+
+"@csstools/postcss-global-data@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/postcss-global-data/-/postcss-global-data-2.1.0.tgz#617cf3a1a549de8c62cbd111868b35a7ca2c6cc1"
+  integrity sha512-n8SoAaapXATQ/fI8c0GVM+VNfvpNo6fN/79GGTjqatEG8bZNh72b2r+KKLVMcQHvRKjDlXxzurxnf6L5nsxDGA==
+
 "@csstools/selector-specificity@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz#1bfafe4b7ed0f3e4105837e056e0a89b108ebe36"
@@ -16832,6 +16857,16 @@ postcss-convert-values@^5.1.0:
   integrity sha512-GkyPbZEYJiWtQB0KZ0X6qusqFHUepguBCNFi9t5JJc7I2OTXG7C0twbTLvCfaKOLl3rSXmpAwV7W5txd91V84g==
   dependencies:
     postcss-value-parser "^4.2.0"
+
+postcss-custom-media@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-custom-media/-/postcss-custom-media-10.0.1.tgz#48a4597451a69b1098e6eb11eb1166202171f9ed"
+  integrity sha512-fil7cosvzlIAYmZJPtNFcTH0Er7a3GveEK4q5Y/L24eWQHmiw8Fv/E5DMkVpdbNjkGzJxrvowOSt/Il9HZ06VQ==
+  dependencies:
+    "@csstools/cascade-layer-name-parser" "^1.0.4"
+    "@csstools/css-parser-algorithms" "^2.3.1"
+    "@csstools/css-tokenizer" "^2.2.0"
+    "@csstools/media-query-list-parser" "^2.1.4"
 
 postcss-discard-comments@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
Adds support for `@custom-media` using the [postcss-global-data](https://github.com/csstools/postcss-plugins/blob/main/plugins/postcss-global-data/README.md) and [postcss-custom-media](https://github.com/csstools/postcss-plugins/blob/main/plugins/postcss-custom-media/README.md) plugins.

See `Text` component example of how this will migrate our breakpoints away from the current SCSS method:

<img width="630" alt="Screenshot 2023-10-02 at 3 05 03 PM" src="https://github.com/Shopify/polaris/assets/11774595/613b1f32-eb96-4a14-8dc8-188536493efe">
