### PR TITLE
[polaris.shopify.com] Add aspect ratios on thumbnail preview

### DIFF
--- a/polaris.shopify.com/src/components/Markdown/components/DirectiveCard/index.tsx
+++ b/polaris.shopify.com/src/components/Markdown/components/DirectiveCard/index.tsx
@@ -91,6 +91,7 @@ const MediaThumbnail = ({
           className={styles.MediaThumbnail}
           src={media?.props?.src}
           alt={media?.props?.alt}
+          aspectRatio="4:3"
         />
       ) : (
         <div className={styles.MediaThumbnail}>{media}</div>

--- a/polaris.shopify.com/src/components/ThumbnailPreview/ThumbnailPreview.module.scss
+++ b/polaris.shopify.com/src/components/ThumbnailPreview/ThumbnailPreview.module.scss
@@ -2,6 +2,6 @@
   aspect-ratio: 16/9;
   border-radius: var(--border-radius-600);
   overflow: hidden;
-  background: var(--p-color-bg-surface-secondary);
+  background: var(--p-color-bg-surface-secondary-hover);
   position: relative;
 }

--- a/polaris.shopify.com/src/components/ThumbnailPreview/index.tsx
+++ b/polaris.shopify.com/src/components/ThumbnailPreview/index.tsx
@@ -4,16 +4,47 @@ import styles from './ThumbnailPreview.module.scss';
 const Preview = ({
   src,
   alt = '',
+  aspectRatio,
   className,
 }: {
   src?: string;
   alt?: string;
+  aspectRatio?: '1:1' | '3:1' | '4:3' | '16:9';
   className?: string;
 }) => {
+  const aspectRatios = {
+    ['1:1']: {
+      width: 900,
+      height: 900,
+    },
+    ['3:1']: {
+      width: 900,
+      height: 300,
+    },
+    ['4:3']: {
+      width: 900,
+      height: 675,
+    },
+    ['16:9']: {
+      width: 900,
+      height: 506,
+    },
+  };
+
   return (
     <Box className={[styles.ThumbnailPreview, className]}>
       {src ? (
-        <Image alt={alt} src={src} fill style={{objectFit: 'cover'}} />
+        <Image
+          alt={alt}
+          src={src}
+          fill={!aspectRatio}
+          {...(aspectRatio && aspectRatios[aspectRatio])}
+          style={{
+            objectFit: aspectRatio ? 'contain' : 'cover',
+            maxHeight: '100%',
+            maxWidth: '100%',
+          }}
+        />
       ) : null}
     </Box>
   );


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/10908

This PR adds the ability to be more specific about which aspect ratios need to be applied to specific images but the issue was sparse so I don't know of other places that need to be fixed. Let me know and I'll update with screenshots

It also fixes a bg color mismatch between image bg and thumbnail bg color

### WHAT is this pull request doing?

Before:
![image](https://github.com/Shopify/polaris/assets/6844391/fee88088-066c-4907-b3f5-af4d89dc3148)

After:
![specific-aspect-ratios](https://github.com/Shopify/polaris/assets/6844391/bb54e847-c554-4637-96b0-46acf9d69f9d)

![localhost_3000_design_colors (1)](https://github.com/Shopify/polaris/assets/6844391/693283fe-b7c0-4ddb-b22c-3b139fb75a7d)

![localhost_3000_design_colors (2)](https://github.com/Shopify/polaris/assets/6844391/81f4b922-26c5-4fb1-a399-d0e588e032f3)
