### PR TITLE
Fix conflicting tertiary button styles

### DIFF
--- a/.changeset/green-badgers-switch.md
+++ b/.changeset/green-badgers-switch.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Fixes an issue with the `primary` variant styles conflicting with the `tertiary` variant in `Button`
+Fixed an issue with the `primary` variant styles conflicting with the `tertiary` variant in `Button`

--- a/.changeset/green-badgers-switch.md
+++ b/.changeset/green-badgers-switch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixes an issue with the `primary` variant styles conflicting with the `tertiary` variant in `Button`

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -129,7 +129,6 @@ export function Button({
     styles.Button,
     variant === 'primary' && styles.primary,
     variant === 'plain' && styles.plain,
-    variant === 'tertiary' && styles.primary,
     variant === 'tertiary' && styles.tertiary,
     variant === 'monochromePlain' && styles.monochrome,
     variant === 'monochromePlain' && styles.plain,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes issue 4 in #10897

The incorrect font-weight is being applied to the `tertiary` variant in the `Button` component. This issue occurs because the primary button styles are being used when the `tertiary` variant is specified, which causes the `font-weight` to be overwritten.

### WHAT is this pull request doing?
This PR aims to resolve this issue by removing `line 132`, since this isn't needed. The primary button styles are imported from `styles.Button`, and the overrides for the `tertiary` variant  are on `line 133`  `variant === 'tertiary' && styles.tertiary`
```tsx 
variant === 'tertiary' && styles.primary
```

| Before      | After |
| ----------- | ----------- |
|  <img width="381" alt="Screenshot 2023-10-09 at 21 07 48" src="https://github.com/Shopify/polaris/assets/50641262/e6b70c3a-c3d8-4979-baed-9949485c6684">| <img width="391" alt="Screenshot 2023-10-09 at 21 07 24" src="https://github.com/Shopify/polaris/assets/50641262/80434414-da42-4a14-8308-14d21604fb8e">|

### 🎩 checklist

- [X] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [X] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [X] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
