### PR TITLE
Remove migrator from changeset ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,6 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
-    "@shopify/polaris-migrator",
     "polaris.shopify.com",
     "polaris-for-vscode"
   ],


### PR DESCRIPTION
The migrator was accidentally added to the changeset ignore list in `main`. It was initially added to the list in `next` to prevent prereleases for the migrator. It should be added back so we can release snapshots of the migrator package.