### PR TITLE
Remove next branch from release workflow and ignored pacakges

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,10 +7,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [
-    "polaris.shopify.com",
-    "polaris-for-vscode"
-  ],
+  "ignore": [],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "updateInternalDependents": "always"
   }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - next
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Reverts the changes from [here](https://github.com/Shopify/polaris/commit/e34b94e9e106b8acf9d6db7428cbcb60dcd79e91) that were merged into main. We only needed these changes for the `next` branch.