### PR TITLE
[polaris.shopify.com] Fix video format on mobile browsers

### DIFF
--- a/polaris.shopify.com/content/design/motion/creating-motion.md
+++ b/polaris.shopify.com/content/design/motion/creating-motion.md
@@ -25,6 +25,7 @@ Transitions should be smooth and fluid, guiding merchants’ attention and maint
       height="auto"
       controls
       autoPlay
+      playsInline
       muted
       loop
     >
@@ -49,6 +50,7 @@ Transitions should be smooth and fluid, guiding merchants’ attention and maint
         height="auto"
         controls
         autoPlay
+        playsInline
         muted
         loop
       >
@@ -68,6 +70,7 @@ Transitions should be smooth and fluid, guiding merchants’ attention and maint
         height="auto"
         controls
         autoPlay
+        playsInline
         muted
         loop
       >
@@ -91,7 +94,7 @@ Animations should be simple and purposeful, used to enhance understanding or pro
 
 #### Do
 
-<video width="100%" height="auto" controls autoPlay muted loop>
+<video width="100%" height="auto" controls autoPlay playsInline muted loop>
   <source
     src="/images/design/motion/creating/02-animation-do.mp4"
     type="video/mp4"
@@ -108,6 +111,7 @@ tone of the interface.
     height="auto"
     controls
     autoPlay
+    playsInline
     muted
     loop
   >
@@ -128,7 +132,7 @@ Timing is crucial in motion design. Motion is fast enough to not cause delay, bu
 
 #### Do
 
-<video width="100%" height="auto" controls autoPlay muted loop>
+<video width="100%" height="auto" controls autoPlay playsInline muted loop>
   <source
     src="/images/design/motion/creating/03-timing-do.mp4"
     type="video/mp4"
@@ -145,6 +149,7 @@ the motion to merchant expectations.
     height="auto"
     controls
     autoPlay
+    playsInline
     muted
     loop
   >

--- a/polaris.shopify.com/content/design/motion/index.md
+++ b/polaris.shopify.com/content/design/motion/index.md
@@ -29,7 +29,15 @@ Motion has a clear purpose. It helps merchants understand the interface and the 
 >
   <Grid.Cell area="a">
     <Do>
-      <video width="100%" height="auto" controls autoPlay muted loop>
+      <video
+        width="100%"
+        height="auto"
+        controls
+        autoPlay
+        playsInline
+        muted
+        loop
+      >
         <source
           src="/images/design/motion/overview/01-purposeful-do.mp4"
           type="video/mp4"
@@ -42,7 +50,15 @@ Motion has a clear purpose. It helps merchants understand the interface and the 
   </Grid.Cell>
   <Grid.Cell area="b">
     <Dont>
-      <video width="100%" height="auto" controls autoPlay muted loop>
+      <video
+        width="100%"
+        height="auto"
+        controls
+        autoPlay
+        playsInline
+        muted
+        loop
+      >
         <source
           src="/images/design/motion/overview/01-purposeful-dont.mp4"
           type="video/mp4"
@@ -65,7 +81,15 @@ Motion should be a reaction to merchant interactions, providing immediate visual
 >
   <Grid.Cell area="a">
     <Do>
-      <video width="100%" height="auto" controls autoPlay muted loop>
+      <video
+        width="100%"
+        height="auto"
+        controls
+        autoPlay
+        playsInline
+        muted
+        loop
+      >
         <source
           src="/images/design/motion/overview/02-responsive-do.mp4"
           type="video/mp4"
@@ -78,7 +102,15 @@ Motion should be a reaction to merchant interactions, providing immediate visual
   </Grid.Cell>
   <Grid.Cell area="b">
     <Dont>
-      <video width="100%" height="auto" controls autoPlay muted loop>
+      <video
+        width="100%"
+        height="auto"
+        controls
+        autoPlay
+        playsInline
+        muted
+        loop
+      >
         <source
           src="/images/design/motion/overview/02-responsive-dont.mp4"
           type="video/mp4"
@@ -103,7 +135,15 @@ A snappy animation starts rapidly, and slows down towards the end, making the tr
 >
   <Grid.Cell area="a">
     <Do>
-      <video width="100%" height="auto" controls autoPlay muted loop>
+      <video
+        width="100%"
+        height="auto"
+        controls
+        autoPlay
+        playsInline
+        muted
+        loop
+      >
         <source
           src="/images/design/motion/overview/03-snappy-do.mp4"
           type="video/mp4"
@@ -116,7 +156,15 @@ A snappy animation starts rapidly, and slows down towards the end, making the tr
   </Grid.Cell>
   <Grid.Cell area="b">
     <Dont>
-      <video width="100%" height="auto" controls autoPlay muted loop>
+      <video
+        width="100%"
+        height="auto"
+        controls
+        autoPlay
+        playsInline
+        muted
+        loop
+      >
         <source
           src="/images/design/motion/overview/03-snappy-dont.mp4"
           type="video/mp4"

--- a/polaris.shopify.com/content/design/motion/using-motion.md
+++ b/polaris.shopify.com/content/design/motion/using-motion.md
@@ -25,6 +25,7 @@ Motion can be used to provide feedback, helping merchants understand the results
       height="auto"
       controls
       autoPlay
+      playsInline
       muted
       loop
     >
@@ -49,6 +50,7 @@ Motion can be used to provide feedback, helping merchants understand the results
         height="auto"
         controls
         autoPlay
+        playsInline
         muted
         loop
       >
@@ -70,6 +72,7 @@ Motion can be used to provide feedback, helping merchants understand the results
         height="auto"
         controls
         autoPlay
+        playsInline
         muted
         loop
       >
@@ -98,6 +101,7 @@ Motion can guide merchant attention during navigation, helping to maintain conte
       height="auto"
       controls
       autoPlay
+      playsInline
       muted
       loop
     >
@@ -123,6 +127,7 @@ Motion can guide merchant attention during navigation, helping to maintain conte
         height="auto"
         controls
         autoPlay
+        playsInline
         muted
         loop
       >
@@ -144,6 +149,7 @@ Motion can guide merchant attention during navigation, helping to maintain conte
         height="auto"
         controls
         autoPlay
+        playsInline
         muted
         loop
       >
@@ -172,6 +178,7 @@ Motion can be used to indicate loading states, keeping merchants informed and en
       height="auto"
       controls
       autoPlay
+      playsInline
       muted
       loop
     >
@@ -205,6 +212,7 @@ Motion can be used to indicate loading states, keeping merchants informed and en
         height="auto"
         controls
         autoPlay
+        playsInline
         muted
         loop
       >

--- a/polaris.shopify.com/content/design/pro-design-language.md
+++ b/polaris.shopify.com/content/design/pro-design-language.md
@@ -181,7 +181,7 @@ status: New
 
       <Grid.Cell columnSpan={{xs: 6, sm: 6, md: 6, lg: 8, xl: 8}}>
 
-        <video width="100%" style={{borderRadius: '8px'}} height="auto" controls autoPlay muted loop>
+        <video width="100%" style={{borderRadius: '8px'}} height="auto" controls autoPlay playsInline muted loop>
           <source src="/images/design/pro/pro-design-language-08-juicy-realness.mp4" type="video/mp4" />
 
           A series of buttons in every state, default, hovered and clicked
@@ -202,7 +202,7 @@ status: New
 
       <Grid.Cell columnSpan={{xs: 6, sm: 6, md: 6, lg: 8, xl: 8}}>
 
-        <video width="100%" style={{borderRadius: '8px'}} height="auto" controls autoPlay muted loop>
+        <video width="100%" style={{borderRadius: '8px'}} height="auto" controls autoPlay playsInline muted loop>
           <source src="/images/design/pro/pro-design-language-09-juicy-quick.mp4" type="video/mp4" />
 
           Navigation opening/closing animation
@@ -223,7 +223,7 @@ status: New
 
       <Grid.Cell columnSpan={{xs: 6, sm: 6, md: 6, lg: 8, xl: 8}}>
 
-        <video width="100%" style={{borderRadius: '8px'}} height="auto" controls autoPlay muted loop>
+        <video width="100%" style={{borderRadius: '8px'}} height="auto" controls autoPlay playsInline muted loop>
           <source src="/images/design/pro/pro-design-language-10-juicy-animation.mp4" type="video/mp4" />
 
           Animation of a checkbox being ticked in an index page


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/10936
<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Adds the `playsinline` attribute to markdown videos. `playsInline` gets mapped to `playsinline` via React I believe, or next compiler...confusingly. I've tested on mobile and it works. Can't easily upload a video unfortunately because of the disconnect between work / personal devices
