### PR TITLE
Add `v12-react-update-component-prop-color` migration

### DIFF
--- a/polaris-migrator/src/migrations/react-update-component-prop/transform.ts
+++ b/polaris-migrator/src/migrations/react-update-component-prop/transform.ts
@@ -23,11 +23,11 @@ interface ReplacementOptions {
   toValue?: string;
 }
 
-interface ReplacementMaps {
+export interface ReplacementMaps {
   [componentName: string]: ReplacementOptions[];
 }
 
-export interface MigrationOptions extends Options, ReplacementOptions {
+export interface MigrationOptions extends Options, Partial<ReplacementOptions> {
   relative?: boolean;
   componentName?: string;
   replacementMaps?: ReplacementMaps;

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-color/tests/step1.input.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-color/tests/step1.input.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {Box} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const BoxWrapper = Box;
+
+export function App() {
+  return (
+    <>
+      <Box background="bg" padding="0">
+        Hello
+        <Child background="bg" />
+        <BoxWrapper />
+      </Box>
+      <Box background="bg-app" padding="0">
+        Hello
+        <Child background="bg-app" />
+        <BoxWrapper />
+      </Box>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-color/tests/step1.output.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-color/tests/step1.output.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {Box} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const BoxWrapper =
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
+  Box;
+
+export function App() {
+  return (
+    <>
+      <Box background="bg-surface" padding="0">
+        Hello
+        <Child background="bg" />
+        <BoxWrapper />
+      </Box>
+      <Box background="bg-app" padding="0">
+        Hello
+        <Child background="bg-app" />
+        <BoxWrapper />
+      </Box>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-color/tests/step2.input.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-color/tests/step2.input.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {Box} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const BoxWrapper = Box;
+
+export function App() {
+  return (
+    <>
+      <Box background="bg-surface" padding="0">
+        Hello
+        <Child background="bg" />
+        <BoxWrapper />
+      </Box>
+      <Box background="bg-app" padding="0">
+        Hello
+        <Child background="bg-app" />
+        <BoxWrapper />
+      </Box>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-color/tests/step2.output.tsx
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-color/tests/step2.output.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {Box} from '@shopify/polaris';
+
+declare function Child(props: any): JSX.Element;
+
+const BoxWrapper =
+  /* polaris-migrator: Unable to migrate the following expression. Please upgrade manually. */
+  Box;
+
+export function App() {
+  return (
+    <>
+      <Box background="bg-surface" padding="0">
+        Hello
+        <Child background="bg" />
+        <BoxWrapper />
+      </Box>
+      <Box background="bg" padding="0">
+        Hello
+        <Child background="bg-app" />
+        <BoxWrapper />
+      </Box>
+    </>
+  );
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-color/tests/transform.test.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-color/tests/transform.test.ts
@@ -1,0 +1,25 @@
+import {check} from '../../../utilities/check';
+
+const transform = 'v12-react-update-component-prop-color';
+const fixtures = [
+  {
+    name: 'step1',
+    options: {
+      step: 1,
+    },
+  },
+  {
+    name: 'step2',
+    options: {
+      step: 2,
+    },
+  },
+];
+
+for (const fixture of fixtures) {
+  check(__dirname, {
+    fixture: fixture.name,
+    transform,
+    options: fixture.options,
+  });
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-color/transform.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-color/transform.ts
@@ -6,7 +6,7 @@ import {
   replacementMap2,
 } from '../v12-styles-replace-custom-property-color/transform';
 
-import type {ComponentReplacementOptions} from './utils';
+import type {ComponentFromPropsMap} from './utils';
 import {getReplacementMaps} from './utils';
 
 const normalizedReplacementMap1 = Object.fromEntries(
@@ -23,7 +23,7 @@ const normalizedReplacementMap2 = Object.fromEntries(
   ]),
 );
 
-const componentReplacementOptions: ComponentReplacementOptions = {
+const componentFromPropsMap: ComponentFromPropsMap = {
   Banner: ['textColor'],
   Box: ['background', 'borderColor', 'color', 'outlineColor'],
   Card: ['background'],
@@ -42,14 +42,14 @@ export default function transformer(
   if (options.step === 1) {
     return reactUpdateComponentProp(fileInfo, _, {
       replacementMaps: getReplacementMaps(
-        componentReplacementOptions,
+        componentFromPropsMap,
         normalizedReplacementMap1,
       ),
     });
   } else if (options.step === 2) {
     return reactUpdateComponentProp(fileInfo, _, {
       replacementMaps: getReplacementMaps(
-        componentReplacementOptions,
+        componentFromPropsMap,
         normalizedReplacementMap2,
       ),
     });

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-color/transform.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-color/transform.ts
@@ -1,0 +1,55 @@
+import type {FileInfo, API, Options} from 'jscodeshift';
+
+import reactUpdateComponentProp from '../react-update-component-prop/transform';
+import {
+  replacementMap1,
+  replacementMap2,
+} from '../v12-styles-replace-custom-property-color/transform';
+
+import type {ComponentReplacementOptions} from './utils';
+import {getReplacementMaps} from './utils';
+
+const normalizedReplacementMap1 = Object.fromEntries(
+  Object.entries(replacementMap1).map(([fromValue, toValue]) => [
+    fromValue.replace('--p-color-', ''),
+    toValue.replace('--p-color-', ''),
+  ]),
+);
+
+const normalizedReplacementMap2 = Object.fromEntries(
+  Object.entries(replacementMap2).map(([fromValue, toValue]) => [
+    fromValue.replace('--p-color-', ''),
+    toValue.replace('--p-color-', ''),
+  ]),
+);
+
+const componentReplacementOptions: ComponentReplacementOptions = {
+  Box: ['background'],
+};
+
+export interface MigrationOptions extends Options {
+  step: number;
+}
+
+export default function transformer(
+  fileInfo: FileInfo,
+  _: API,
+  options: MigrationOptions,
+) {
+  if (options.step === 1) {
+    return reactUpdateComponentProp(fileInfo, _, {
+      replacementMaps: getReplacementMaps(
+        componentReplacementOptions,
+        normalizedReplacementMap1,
+      ),
+    });
+  } else if (options.step === 2) {
+    return reactUpdateComponentProp(fileInfo, _, {
+      replacementMaps: getReplacementMaps(
+        componentReplacementOptions,
+        normalizedReplacementMap2,
+      ),
+    });
+  }
+  throw new Error('Invalid step');
+}

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-color/transform.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-color/transform.ts
@@ -24,7 +24,10 @@ const normalizedReplacementMap2 = Object.fromEntries(
 );
 
 const componentReplacementOptions: ComponentReplacementOptions = {
-  Box: ['background'],
+  Banner: ['textColor'],
+  Box: ['background', 'borderColor', 'color', 'outlineColor'],
+  Card: ['background'],
+  Divider: ['borderColor'],
 };
 
 export interface MigrationOptions extends Options {

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-color/utils.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-color/utils.ts
@@ -2,7 +2,7 @@ import type {ReplacementMaps} from '../react-update-component-prop/transform';
 
 type ComponentFromProp = string;
 
-export interface ComponentReplacementOptions {
+export interface ComponentFromPropsMap {
   [componentName: string]: ComponentFromProp[];
 }
 
@@ -13,21 +13,19 @@ interface ReplacementMap {
 }
 
 export function getReplacementMaps(
-  componentReplacementOptions: ComponentReplacementOptions,
+  componentFromPropsMap: ComponentFromPropsMap,
   replacementMap: ReplacementMap,
 ): ReplacementMaps {
   return Object.fromEntries(
-    Object.entries(componentReplacementOptions).map(
-      ([componentName, fromProps]) => [
-        componentName,
-        fromProps.flatMap((fromProp) =>
-          Object.entries(replacementMap).map(([fromValue, toValue]) => ({
-            fromProp,
-            fromValue,
-            toValue,
-          })),
-        ),
-      ],
-    ),
+    Object.entries(componentFromPropsMap).map(([componentName, fromProps]) => [
+      componentName,
+      fromProps.flatMap((fromProp) =>
+        Object.entries(replacementMap).map(([fromValue, toValue]) => ({
+          fromProp,
+          fromValue,
+          toValue,
+        })),
+      ),
+    ]),
   );
 }

--- a/polaris-migrator/src/migrations/v12-react-update-component-prop-color/utils.ts
+++ b/polaris-migrator/src/migrations/v12-react-update-component-prop-color/utils.ts
@@ -1,0 +1,33 @@
+import type {ReplacementMaps} from '../react-update-component-prop/transform';
+
+type ComponentFromProp = string;
+
+export interface ComponentReplacementOptions {
+  [componentName: string]: ComponentFromProp[];
+}
+
+type ReplacementMapToValue = string;
+
+interface ReplacementMap {
+  [fromValue: string]: ReplacementMapToValue;
+}
+
+export function getReplacementMaps(
+  componentReplacementOptions: ComponentReplacementOptions,
+  replacementMap: ReplacementMap,
+): ReplacementMaps {
+  return Object.fromEntries(
+    Object.entries(componentReplacementOptions).map(
+      ([componentName, fromProps]) => [
+        componentName,
+        fromProps.flatMap((fromProp) =>
+          Object.entries(replacementMap).map(([fromValue, toValue]) => ({
+            fromProp,
+            fromValue,
+            toValue,
+          })),
+        ),
+      ],
+    ),
+  );
+}

--- a/polaris-migrator/src/migrations/v12-styles-replace-custom-property-color/transform.ts
+++ b/polaris-migrator/src/migrations/v12-styles-replace-custom-property-color/transform.ts
@@ -21,7 +21,7 @@ export default function transformer(
   throw new Error('Invalid step');
 }
 
-const replacementMap1 = {
+export const replacementMap1 = {
   '--p-color-avatar-background-experimental': '--p-color-avatar-bg-fill',
   '--p-color-avatar-color-experimental': '--p-color-avatar-text-on-bg-fill',
   '--p-color-avatar-style-five-background-experimental':
@@ -180,7 +180,7 @@ const replacementMap1 = {
   '--p-color-text-warning-experimental': '--p-color-text-warning',
 };
 
-const replacementMap2 = {
+export const replacementMap2 = {
   '--p-color-bg-app': '--p-color-bg',
 };
 


### PR DESCRIPTION
This PR introduces a `v12-react-update-component-prop-color` migration that targets and updates a collection of Polaris component props using v11 `color` aliases.

> Note: This is a companion to the [v12-replace-custom-property-color](https://github.com/Shopify/polaris/blob/00952a33a37164110a23e1a6ab7795976b075349/polaris-migrator/src/migrations/v12-styles-replace-custom-property-color/transform.ts#L7) migration and consumes it's replacement maps for consistency.

Example usage:

```sh
npx @shopify/polaris v12-react-update-component-prop-color --step=1 '**/*.{ts,tsx}'
```