### PR TITLE
Fix Action types to match new Button api

### DIFF
--- a/.changeset/odd-candles-study.md
+++ b/.changeset/odd-candles-study.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed type mismatch between Actions and new Button api

--- a/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
+++ b/polaris-react/src/components/ActionMenu/components/SecondaryAction/SecondaryAction.tsx
@@ -2,14 +2,16 @@ import React, {useEffect, useRef} from 'react';
 
 import {classNames} from '../../../../utilities/css';
 import {Tooltip} from '../../../Tooltip';
-import {Button} from '../../../Button';
 import type {ButtonProps} from '../../../Button';
+import {Button} from '../../../Button';
+import type {MenuActionDescriptor} from '../../../../types';
 
 import styles from './SecondaryAction.scss';
 
-interface SecondaryAction extends ButtonProps {
+interface SecondaryAction
+  extends ButtonProps,
+    Omit<MenuActionDescriptor, 'icon' | 'tone' | 'variant'> {
   helpText?: React.ReactNode;
-  onAction?(): void;
   getOffsetWidth?(width: number): void;
 }
 
@@ -30,7 +32,12 @@ export function SecondaryAction({
   }, [getOffsetWidth]);
 
   const buttonMarkup = (
-    <Button onClick={onAction} {...rest}>
+    <Button
+      onClick={onAction}
+      tone={rest.destructive ? 'critical' : undefined}
+      variant={rest.plain || rest.outline ? 'plain' : undefined}
+      {...rest}
+    >
       {children}
     </Button>
   );

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -42,7 +42,7 @@ export interface ButtonProps extends BaseButton {
   /** Sets the color treatment of the Button. */
   tone?: 'critical' | 'success';
   /** Changes the visual appearance of the Button. */
-  variant?: 'plain' | 'primary' | 'tertiary' | 'monochromePlain';
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'plain' | 'monochromePlain';
 }
 
 interface CommonButtonProps

--- a/polaris-react/src/components/Button/Button.tsx
+++ b/polaris-react/src/components/Button/Button.tsx
@@ -41,7 +41,9 @@ export interface ButtonProps extends BaseButton {
   dataPrimaryLink?: boolean;
   /** Sets the color treatment of the Button. */
   tone?: 'critical' | 'success';
-  /** Changes the visual appearance of the Button. */
+  /** Changes the visual appearance of the Button.
+   * @default 'secondary'
+   */
   variant?: 'primary' | 'secondary' | 'tertiary' | 'plain' | 'monochromePlain';
 }
 
@@ -119,7 +121,7 @@ export function Button({
   fullWidth,
   dataPrimaryLink,
   tone,
-  variant,
+  variant = 'secondary',
 }: ButtonProps) {
   const i18n = useI18n();
 

--- a/polaris-react/src/components/Modal/components/Footer/Footer.tsx
+++ b/polaris-react/src/components/Modal/components/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import type {ComplexAction} from '../../../../types';
-import {buttonsFrom} from '../../../Button';
+import {buttonFrom, buttonsFrom} from '../../../Button';
 import {Box} from '../../../Box';
 import {InlineStack} from '../../../InlineStack';
 
@@ -20,9 +20,21 @@ export function Footer({
   children,
 }: FooterProps) {
   const primaryActionButton =
-    (primaryAction && buttonsFrom(primaryAction, {variant: 'primary'})) || null;
+    (primaryAction &&
+      buttonsFrom(primaryAction, {
+        variant: 'primary',
+        tone: primaryAction?.destructive ? 'critical' : primaryAction.tone,
+      })) ||
+    null;
   const secondaryActionButtons =
-    (secondaryActions && buttonsFrom(secondaryActions)) || null;
+    (secondaryActions &&
+      secondaryActions.map((action) =>
+        buttonFrom(action, {
+          tone: action.destructive ? 'critical' : action.tone,
+          variant: action.plain ? 'plain' : action.variant,
+        }),
+      )) ||
+    null;
   const actions =
     primaryActionButton || secondaryActionButtons ? (
       <InlineStack gap="200">

--- a/polaris-react/src/components/Page/Page.stories.tsx
+++ b/polaris-react/src/components/Page/Page.stories.tsx
@@ -110,11 +110,24 @@ export function WithoutPrimaryActionInHeader() {
   );
 }
 
-export function WithDestructiveSecondaryAction() {
+export function WithDestructiveAndPlainSecondaryActions() {
   return (
     <Page
       title="General"
-      secondaryActions={[{content: 'Delete', tone: 'critical'}]}
+      secondaryActions={[
+        {
+          content: 'Edit',
+          variant: 'plain',
+        },
+        {
+          content: 'Delete',
+          destructive: true,
+        },
+        {
+          content: 'Delete',
+          tone: 'critical',
+        },
+      ]}
     >
       <p>Page content</p>
     </Page>

--- a/polaris-react/src/components/Page/Page.stories.tsx
+++ b/polaris-react/src/components/Page/Page.stories.tsx
@@ -120,8 +120,7 @@ export function WithDestructiveAndPlainSecondaryActions() {
           variant: 'plain',
         },
         {
-          content: 'Delete',
-          destructive: true,
+          content: 'Duplicate',
         },
         {
           content: 'Delete',

--- a/polaris-react/src/components/PageActions/PageActions.stories.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.stories.tsx
@@ -14,10 +14,6 @@ export function Default() {
       }}
       secondaryActions={[
         {
-          content: 'Archive',
-          variant: 'primary',
-        },
-        {
           content: 'Delete',
           tone: 'critical',
           variant: 'primary',
@@ -45,6 +41,7 @@ export function WithCustomPrimaryAction() {
         {
           content: 'Delete',
           tone: 'critical',
+          variant: 'primary',
         },
       ]}
     />

--- a/polaris-react/src/components/PageActions/PageActions.stories.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.stories.tsx
@@ -16,7 +16,6 @@ export function Default() {
         {
           content: 'Delete',
           tone: 'critical',
-          variant: 'primary',
         },
       ]}
     />
@@ -41,7 +40,6 @@ export function WithCustomPrimaryAction() {
         {
           content: 'Delete',
           tone: 'critical',
-          variant: 'primary',
         },
       ]}
     />

--- a/polaris-react/src/components/PageActions/PageActions.stories.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.stories.tsx
@@ -14,8 +14,13 @@ export function Default() {
       }}
       secondaryActions={[
         {
+          content: 'Archive',
+          variant: 'primary',
+        },
+        {
           content: 'Delete',
           tone: 'critical',
+          variant: 'primary',
         },
       ]}
     />
@@ -52,7 +57,7 @@ export function WithCustomSecondaryAction() {
       primaryAction={{
         content: 'Save',
       }}
-      secondaryActions={<Button>Save</Button>}
+      secondaryActions={<Button>Cancel</Button>}
     />
   );
 }

--- a/polaris-react/src/components/PageActions/PageActions.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.tsx
@@ -38,12 +38,14 @@ export function PageActions({
   if (isInterface(secondaryActions) && secondaryActions.length > 0) {
     secondaryActionsMarkup = (
       <ButtonGroup>
-        {secondaryActions.map((action) =>
-          buttonFrom(action, {
-            tone: action.destructive ? 'critical' : undefined,
-            variant: action.plain ? 'plain' : undefined,
-          }),
-        )}
+        {secondaryActions.map((action) => {
+          const plainVariant = action.plain ? 'plain' : undefined;
+          const primaryVariant = action.destructive ? 'primary' : undefined;
+          return buttonFrom(action, {
+            tone: action.destructive ? 'critical' : action.tone,
+            variant: plainVariant ?? primaryVariant ?? action.variant,
+          });
+        })}
       </ButtonGroup>
     );
   } else if (isReactElement(secondaryActions)) {

--- a/polaris-react/src/components/PageActions/PageActions.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.tsx
@@ -8,7 +8,7 @@ import type {
 // eslint-disable-next-line import/no-deprecated
 import {LegacyStack} from '../LegacyStack';
 import {ButtonGroup} from '../ButtonGroup';
-import {buttonsFrom} from '../Button';
+import {buttonFrom, buttonsFrom} from '../Button';
 import {isInterface} from '../../utilities/is-interface';
 import {isReactElement} from '../../utilities/is-react-element';
 
@@ -37,7 +37,14 @@ export function PageActions({
   let secondaryActionsMarkup: MaybeJSX = null;
   if (isInterface(secondaryActions) && secondaryActions.length > 0) {
     secondaryActionsMarkup = (
-      <ButtonGroup>{buttonsFrom(secondaryActions)}</ButtonGroup>
+      <ButtonGroup>
+        {secondaryActions.map((action) =>
+          buttonFrom(action, {
+            tone: action.destructive ? 'critical' : action.tone,
+            variant: action.plain ? 'plain' : action.variant,
+          }),
+        )}
+      </ButtonGroup>
     );
   } else if (isReactElement(secondaryActions)) {
     secondaryActionsMarkup = <>{secondaryActions}</>;

--- a/polaris-react/src/components/PageActions/PageActions.tsx
+++ b/polaris-react/src/components/PageActions/PageActions.tsx
@@ -40,8 +40,8 @@ export function PageActions({
       <ButtonGroup>
         {secondaryActions.map((action) =>
           buttonFrom(action, {
-            tone: action.destructive ? 'critical' : action.tone,
-            variant: action.plain ? 'plain' : action.variant,
+            tone: action.destructive ? 'critical' : undefined,
+            variant: action.plain ? 'plain' : undefined,
           }),
         )}
       </ButtonGroup>

--- a/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
+++ b/polaris-react/src/components/PageActions/tests/PageActions.test.tsx
@@ -4,7 +4,7 @@ import {mountWithApp} from 'tests/utilities';
 import {ButtonGroup} from '../../ButtonGroup';
 // eslint-disable-next-line import/no-deprecated
 import {LegacyStack} from '../../LegacyStack';
-import {buttonsFrom} from '../../Button';
+import {Button, buttonsFrom} from '../../Button';
 import {PageActions} from '../PageActions';
 
 jest.mock('../../Button', () => ({
@@ -55,13 +55,17 @@ describe('<PageActions />', () => {
       {
         content: 'Delete',
         destructive: true,
-        outline: true,
       },
     ];
 
     it('renders buttons for each secondaryAction', () => {
-      mountWithApp(<PageActions secondaryActions={mockActions} />);
-      expect(buttonsFrom).toHaveBeenCalledWith(mockActions);
+      const actions = mountWithApp(
+        <PageActions secondaryActions={mockActions} />,
+      );
+      expect(actions).toContainReactComponent(Button, {
+        children: mockActions[0].content,
+        tone: 'critical',
+      });
     });
 
     it('renders a button group when defined', () => {

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -184,6 +184,8 @@ export interface PlainAction extends Action {
   /** Should action be displayed as a plain link */
   /** @deprecated Use variant instead */
   plain?: boolean;
+  /** Should action be displayed as a plain link */
+  variant?: Extract<ButtonProps['variant'], 'plain'>;
 }
 
 export interface TooltipAction {
@@ -218,7 +220,11 @@ export interface ActionListItemDescriptor
   /** Whether the action is active or not */
   active?: boolean;
   /** The item variations */
-  variant?: ButtonProps['variant'] | 'default' | 'menu' | 'indented';
+  variant?:
+    | 'default'
+    | 'menu'
+    | 'indented'
+    | Extract<ButtonProps['variant'], 'plain'>;
   /** Defines a role for the action */
   role?: string;
 }

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -185,7 +185,7 @@ export interface PlainAction extends Action {
   /** @deprecated Use variant instead */
   plain?: boolean;
   /** Should action be displayed as a plain link */
-  variant?: Extract<ButtonProps['variant'], 'plain'>;
+  variant?: Extract<ButtonProps['variant'], 'plain' | 'primary'>;
 }
 
 export interface TooltipAction {
@@ -224,7 +224,7 @@ export interface ActionListItemDescriptor
     | 'default'
     | 'menu'
     | 'indented'
-    | Extract<ButtonProps['variant'], 'plain'>;
+    | Extract<ButtonProps['variant'], 'plain' | 'primary'>;
   /** Defines a role for the action */
   role?: string;
 }

--- a/polaris-react/src/types.ts
+++ b/polaris-react/src/types.ts
@@ -2,6 +2,7 @@ import type React from 'react';
 
 /* eslint-disable @shopify/strict-component-boundaries */
 import type {AvatarProps} from './components/Avatar';
+import type {ButtonProps} from './components/Button';
 import type {IconProps} from './components/Icon';
 import type {ThumbnailProps} from './components/Thumbnail';
 /* eslint-enable @shopify/strict-component-boundaries */
@@ -158,7 +159,9 @@ export interface DisableableAction extends Action {
 
 export interface DestructableAction extends Action {
   /** Destructive action */
+  /** @deprecated Use tone instead */
   destructive?: boolean;
+  tone?: Extract<ButtonProps['tone'], 'critical'>;
 }
 
 export interface IconableAction extends Action {
@@ -173,11 +176,13 @@ export interface LoadableAction extends Action {
 
 export interface OutlineableAction extends Action {
   /** Should action be displayed as an outlined button */
+  /** @deprecated Use variant instead */
   outline?: boolean;
 }
 
 export interface PlainAction extends Action {
   /** Should action be displayed as a plain link */
+  /** @deprecated Use variant instead */
   plain?: boolean;
 }
 
@@ -213,7 +218,7 @@ export interface ActionListItemDescriptor
   /** Whether the action is active or not */
   active?: boolean;
   /** The item variations */
-  variant?: 'default' | 'menu' | 'indented';
+  variant?: ButtonProps['variant'] | 'default' | 'menu' | 'indented';
   /** Defines a role for the action */
   role?: string;
 }

--- a/polaris.shopify.com/pages/examples/page-actions-default.tsx
+++ b/polaris.shopify.com/pages/examples/page-actions-default.tsx
@@ -11,7 +11,8 @@ function PageExample() {
       secondaryActions={[
         {
           content: 'Delete',
-          destructive: true,
+          tone: 'critical',
+          variant: 'primary',
         },
       ]}
     />

--- a/polaris.shopify.com/pages/examples/page-actions-with-custom-primary-action.tsx
+++ b/polaris.shopify.com/pages/examples/page-actions-with-custom-primary-action.tsx
@@ -9,7 +9,8 @@ function PageExample() {
       secondaryActions={[
         {
           content: 'Delete',
-          destructive: true,
+          tone: 'critical',
+          variant: 'primary',
         },
       ]}
     />

--- a/polaris.shopify.com/pages/examples/page-actions-with-custom-secondary-action.tsx
+++ b/polaris.shopify.com/pages/examples/page-actions-with-custom-secondary-action.tsx
@@ -8,7 +8,7 @@ function PageExample() {
       primaryAction={{
         content: 'Save',
       }}
-      secondaryActions={<Button>Save</Button>}
+      secondaryActions={<Button>Cancel</Button>}
     />
   );
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/10995
FIxes https://github.com/Shopify/polaris/issues/11006

This bug affects PageActions Page header actions, Modal actions etc... If I missed any please let me know

Button api was updated in v12. The button story was updated but was failing typecheck. This wasn't caught so we have to retrofit the update and map the old prop values for SecondaryActions
