### PR TITLE
[TextField] Prevent onBlur from triggering when clicking between child components (spinner and input)

### DIFF
--- a/.changeset/rich-ghosts-push.md
+++ b/.changeset/rich-ghosts-push.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Improving onBlur behavior for TextField component

--- a/.changeset/rich-ghosts-push.md
+++ b/.changeset/rich-ghosts-push.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': patch
 ---
 
-Improving onBlur behavior for TextField component
+Fixed `TextField` blurring when interacting with the `Spinner` buttons

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -249,6 +249,7 @@ export function TextField({
   const uniqId = useId();
   const id = idProp ?? uniqId;
 
+  const textFieldRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const prefixRef = useRef<HTMLDivElement>(null);
@@ -603,7 +604,7 @@ export function TextField({
       readOnly={readOnly}
     >
       <Connected left={connectedLeft} right={connectedRight}>
-        <div className={className} onClick={handleClick}>
+        <div className={className} onClick={handleClick} ref={textFieldRef}>
           {prefixMarkup}
           {inputMarkup}
           {suffixMarkup}
@@ -734,6 +735,11 @@ export function TextField({
   }
 
   function handleOnBlur(event: React.FocusEvent) {
+    // Return early if new focus target is inside the TextField component
+    if (textFieldRef.current?.contains(event?.relatedTarget)) {
+      return;
+    }
+
     setFocus(false);
 
     if (onBlur) {

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -735,12 +735,12 @@ export function TextField({
   }
 
   function handleOnBlur(event: React.FocusEvent) {
+    setFocus(false);
+
     // Return early if new focus target is inside the TextField component
     if (textFieldRef.current?.contains(event?.relatedTarget)) {
       return;
     }
-
-    setFocus(false);
 
     if (onBlur) {
       onBlur(event);

--- a/polaris-react/src/components/TextField/tests/TextField.test.tsx
+++ b/polaris-react/src/components/TextField/tests/TextField.test.tsx
@@ -227,6 +227,55 @@ describe('<TextField />', () => {
       element.find('input')!.trigger('onBlur');
       expect(spy).toHaveBeenCalled();
     });
+
+    it('is called when the Spinner is blurred', () => {
+      const spy = jest.fn();
+      const element = mountWithApp(
+        <TextField
+          label="TextField"
+          onBlur={spy}
+          onChange={noop}
+          type="number"
+          autoComplete="off"
+        />,
+      );
+      element.find(Spinner)!.trigger('onBlur');
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('is not called when the input is blurred and focus moves to the Spinner', () => {
+      const spy = jest.fn();
+      const element = mountWithApp(
+        <TextField
+          label="TextField"
+          onBlur={spy}
+          onChange={noop}
+          type="number"
+          autoComplete="off"
+        />,
+      );
+      const relatedTarget = element.find(Spinner)!.domNode;
+
+      element.find('input')!.trigger('onBlur', {relatedTarget});
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('is not called when the Spinner is blurred and focus moves to the input', () => {
+      const spy = jest.fn();
+      const element = mountWithApp(
+        <TextField
+          label="TextField"
+          onBlur={spy}
+          onChange={noop}
+          type="number"
+          autoComplete="off"
+        />,
+      );
+      const relatedTarget = element.find('input')!.domNode;
+
+      element.find(Spinner)!.trigger('onBlur', {relatedTarget});
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 
   describe('id', () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/10948

### WHAT is this pull request doing?

Prevent `onBlur` in TextField from triggering when moving focus between the `<input />` and `<Spinner />` child elements within a `<TextField />`
<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<!-- ℹ️ Delete the following for small / trivial changes -->

### How to 🎩

[Spin HQ](https://web-polaris-text-field.zak-lee.us.spin.dev/)
- `web` checked out on [ZL/quantity-price-break-minimum-quantity-fix](https://github.com/Shopify/web/pull/100618)
- `polaris` checked out on this PR's branch (ZL/text-field-blur)

Tophat steps:
- Observe the buggy behavior here: https://github.com/Shopify/polaris/assets/4310197/f298a261-76ca-452b-b9f0-984d789bcd26
- Go to the [CatalogEditor](https://admin.web.web-polaris-text-field.zak-lee.us.spin.dev/store/shop1/catalogs/9/editor) for a given Catalog
- Open the QuantitySettingsModal by hovering over a row in the table and clicking in the column underneath "Quantity rules" 
- Test against the behavior in the buggy video linked above
  - note: the expected `onBlur` behavior that should occur when manipulating the "Increment" TextField:
    - "Minimum" value "snaps" (adjusts) to match the minimum behavior
    - any relevant "snap" messages should appear below
  - verify that subsequent increases to the "Increment" value via the `<Spinner />` does not trigger `onBlur` logic to occur UNTIL the user blurs off of the entire TextField component
  - verify that changes to "Increment" TextField value via the `<input />` does not trigger `onBlur` logic to occur UNTIL the user blurs off the entire TextField component
    - e.g. set input value to "5", then, without blurring off the "Increment" TextField, click the up arrow to bump the value to "6". this should not trigger any `onBlur` logic



🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
