### PR TITLE
[Button] Fix tertiary button focus state

### DIFF
--- a/.changeset/forty-frogs-rule.md
+++ b/.changeset/forty-frogs-rule.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': patch
+'polaris.shopify.com': patch
+---
+
+Fixed `tertiary` `Button` focus state

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -48,8 +48,8 @@
   }
 
   // stylelint-disable selector-max-specificity -- focus styles
-  &:focus:not(.primary):not(.plain),
-  &:focus-visible:not(.primary):not(.plain) {
+  &:focus:not(.primary):not(.plain):not(.tertiary),
+  &:focus-visible:not(.primary):not(.plain):not(.tertiary) {
     // stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- custom property
     box-shadow: var(--pc-button-shadow);
   }
@@ -1021,7 +1021,7 @@
   > :last-child:first-child .Button::after {
     border-radius: var(--p-border-radius-200);
   }
-
+  // Primary segmented button groups need the negative margin-left applied directly on the button element. They have inset shine via shadow bevels that cause the appearance of double borders when composed in a segmented ButtonGroup, which flattens the joint between them and ruins the illusion of dimension.
   > :not(:first-child) .Button.primary {
     margin-left: calc(-1 * var(--p-space-025));
   }

--- a/polaris-react/src/components/Button/Button.scss
+++ b/polaris-react/src/components/Button/Button.scss
@@ -1021,6 +1021,10 @@
   > :last-child:first-child .Button::after {
     border-radius: var(--p-border-radius-200);
   }
+
+  > :not(:first-child) .Button.primary {
+    margin-left: calc(-1 * var(--p-space-025));
+  }
 }
 
 [data-buttongroup-connected-top='true'] {

--- a/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
+++ b/polaris-react/src/components/ButtonGroup/ButtonGroup.scss
@@ -41,11 +41,6 @@
 
     &:not(:first-child) {
       margin-left: calc(-1 * var(--p-space-025));
-
-      /* stylelint-disable-next-line selector-max-specificity, selector-no-qualifying-type, selector-max-combinators -- Primary buttons segment groups need the negative margin-left applied directly on the button element. They have inset shine via shadow bevels that cause the appearance of double borders when composed in a segmented ButtonGroup, which flattens the joint between them and ruins the illusion of dimension. */
-      button[class*='Button-primary'] {
-        margin-left: calc(-1 * var(--p-space-025));
-      }
     }
   }
 

--- a/polaris-react/src/components/Modal/Modal.stories.tsx
+++ b/polaris-react/src/components/Modal/Modal.stories.tsx
@@ -15,6 +15,7 @@ import {
   Frame,
   FrameContext,
 } from '@shopify/polaris';
+import {EditMajor} from '@shopify/polaris-icons';
 
 export default {
   component: Modal,
@@ -25,7 +26,9 @@ export function Default() {
 
   const handleChange = useCallback(() => setActive(!active), [active]);
 
-  const activator = <Button onClick={handleChange}>Open</Button>;
+  const activator = (
+    <Button variant="tertiary" onClick={handleChange} icon={EditMajor} />
+  );
 
   return (
     <Frame>
@@ -444,7 +447,7 @@ export function WithActivatorRef() {
 
   const activator = (
     <div ref={buttonRef}>
-      <Button onClick={handleOpen}>Open</Button>
+      <Button variant="tertiary" onClick={handleOpen} icon={EditMajor} />
     </div>
   );
 

--- a/polaris-react/src/components/Modal/Modal.stories.tsx
+++ b/polaris-react/src/components/Modal/Modal.stories.tsx
@@ -15,7 +15,6 @@ import {
   Frame,
   FrameContext,
 } from '@shopify/polaris';
-import {EditMajor} from '@shopify/polaris-icons';
 
 export default {
   component: Modal,
@@ -26,9 +25,7 @@ export function Default() {
 
   const handleChange = useCallback(() => setActive(!active), [active]);
 
-  const activator = (
-    <Button variant="tertiary" onClick={handleChange} icon={EditMajor} />
-  );
+  const activator = <Button onClick={handleChange}>Open</Button>;
 
   return (
     <Frame>
@@ -447,7 +444,7 @@ export function WithActivatorRef() {
 
   const activator = (
     <div ref={buttonRef}>
-      <Button variant="tertiary" onClick={handleOpen} icon={EditMajor} />
+      <Button onClick={handleOpen}>Open</Button>
     </div>
   );
 

--- a/polaris.shopify.com/pages/examples/button-split.tsx
+++ b/polaris.shopify.com/pages/examples/button-split.tsx
@@ -1,57 +1,70 @@
-import {ActionList, Button, ButtonGroup, Popover} from '@shopify/polaris';
+import {
+  ActionList,
+  InlineStack,
+  Button,
+  ButtonGroup,
+  Popover,
+} from '@shopify/polaris';
 import React from 'react';
 import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 import {ChevronDownMinor} from '@shopify/polaris-icons';
 
 function ButtonExample() {
-  const [active, setActive] = React.useState(false);
+  const [active, setActive] = React.useState<string | null>(null);
+
+  const toggleActive = (id: string) => () => {
+    setActive((activeId) => (activeId !== id ? id : null));
+  };
   return (
     <div style={{height: '100px'}}>
-      <ButtonGroup variant="segmented">
-        <Button variant="primary">Save</Button>
-        <div style={{width: '3px'}} />
-        <Popover
-          active={active}
-          preferredAlignment="right"
-          activator={
-            <Button
-              variant="primary"
-              onClick={() => setActive(true)}
-              icon={ChevronDownMinor}
-              accessibilityLabel="Other save actions"
-            />
-          }
-          autofocusTarget="first-node"
-          onClose={() => setActive(false)}
-        >
-          <ActionList
-            actionRole="menuitem"
-            items={[{content: 'Save as draft'}]}
-          />
-        </Popover>
-      </ButtonGroup>
+      <InlineStack gap="500">
+        <ButtonGroup variant="segmented">
+          <Button variant="primary">Save</Button>
 
-      <ButtonGroup variant="segmented">
-        <Button>Save</Button>
-        <Popover
-          active={active}
-          preferredAlignment="right"
-          activator={
-            <Button
-              onClick={() => setActive(true)}
-              icon={ChevronDownMinor}
-              accessibilityLabel="Other save actions"
+          <Popover
+            active={active === 'popover1'}
+            preferredAlignment="right"
+            activator={
+              <Button
+                variant="primary"
+                onClick={toggleActive('popover1')}
+                icon={ChevronDownMinor}
+                accessibilityLabel="Other save actions"
+              />
+            }
+            autofocusTarget="first-node"
+            onClose={toggleActive('popover1')}
+          >
+            <ActionList
+              actionRole="menuitem"
+              items={[{content: 'Save as draft'}]}
             />
-          }
-          autofocusTarget="first-node"
-          onClose={() => setActive(false)}
-        >
-          <ActionList
-            actionRole="menuitem"
-            items={[{content: 'Save as draft'}]}
-          />
-        </Popover>
-      </ButtonGroup>
+          </Popover>
+        </ButtonGroup>
+
+        <ButtonGroup variant="segmented">
+          <Button>Save</Button>
+
+          <Popover
+            active={active === 'popover2'}
+            preferredAlignment="right"
+            activator={
+              <Button
+                onClick={toggleActive('popover2')}
+                icon={ChevronDownMinor}
+                accessibilityLabel="Other save actions"
+              />
+            }
+            autofocusTarget="first-node"
+            onClose={toggleActive('popover2')}
+          >
+            <ActionList
+              actionRole="menuitem"
+              items={[{content: 'Save as draft'}]}
+            />
+          </Popover>
+        </ButtonGroup>
+      </InlineStack>
     </div>
   );
 }


### PR DESCRIPTION
### WHAT is this pull request doing?

Fixes: 

- Split button example in the website Button docs
- Tertiary icon only Button focus state having unwanted box-shadow

|Before|After|
|---|---|
|<img width="53" alt="Screenshot 2023-10-31 at 8 27 13 PM" src="https://github.com/Shopify/polaris/assets/18447883/7ab08f63-3382-4249-9acc-3c10e03515c6">|<img width="34" alt="Screenshot 2023-10-31 at 8 23 11 PM" src="https://github.com/Shopify/polaris/assets/18447883/635d1da0-777a-4e75-ab1d-ed7b579482b5">|

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#local-development)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

<!--
  Give as much information as needed to experiment with the component
  in the playground.
-->

<details>
<summary>Copy-paste this code in <code>playground/Playground.tsx</code>:</summary>

```jsx
import React from 'react';
import {Page} from '../src';

export function Playground() {
  return (
    <Page title="Playground">
      {/* Add the code you want to test in here */}
    </Page>
  );
}
```

</details>

### 🎩 checklist

- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
