### PR TITLE
[Pagination] Update height

### DIFF
--- a/.changeset/strange-rats-shake.md
+++ b/.changeset/strange-rats-shake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Updated Pagination to be correct height of 40px when in the table variant

--- a/polaris-react/src/components/Pagination/Pagination.scss
+++ b/polaris-react/src/components/Pagination/Pagination.scss
@@ -27,7 +27,7 @@
     border-top: 1px solid var(--p-color-border);
 
     button {
-      --button-min-height: 28px;
+      --button-min-height: var(--p-height-700);
       background-color: var(--p-color-bg-surface-secondary);
       min-height: var(--button-min-height);
       min-width: var(--button-min-height);

--- a/polaris-react/src/components/Pagination/Pagination.scss
+++ b/polaris-react/src/components/Pagination/Pagination.scss
@@ -27,7 +27,7 @@
     border-top: 1px solid var(--p-color-border);
 
     button {
-      --button-min-height: var(--p-space-600);
+      --button-min-height: 28px;
       background-color: var(--p-color-bg-surface-secondary);
       min-height: var(--button-min-height);
       min-width: var(--button-min-height);


### PR DESCRIPTION
### WHY are these changes introduced?

Pagination when in table mode is currently 36px, whereas it should be 40px.
### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
