### PR TITLE
[TextField] Update margins for prefixes

### DIFF
--- a/.changeset/plenty-mice-develop.md
+++ b/.changeset/plenty-mice-develop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Updated margins for TextField prefixes

--- a/polaris-react/src/components/TextField/TextField.module.scss
+++ b/polaris-react/src/components/TextField/TextField.module.scss
@@ -328,7 +328,12 @@ $spinner-icon-size: 12px;
 
 .Prefix {
   margin-left: var(--p-space-300);
-  margin-right: var(--p-space-200);
+  margin-right: var(--p-space-150);
+}
+
+.PrefixIcon {
+  margin-left: var(--p-space-200);
+  margin-right: var(--p-space-100);
 }
 
 .Suffix {

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -313,9 +313,14 @@ export function TextField({
 
   const inputType = type === 'currency' ? 'text' : type;
   const isNumericType = type === 'number' || type === 'integer';
+  const iconPrefix = isIconPrefix();
 
   const prefixMarkup = prefix ? (
-    <div className={styles.Prefix} id={`${id}-Prefix`} ref={prefixRef}>
+    <div
+      className={classNames(styles.Prefix, iconPrefix && styles.PrefixIcon)}
+      id={`${id}-Prefix`}
+      ref={prefixRef}
+    >
       {prefix}
     </div>
   ) : null;
@@ -794,6 +799,11 @@ export function TextField({
       (verticalContentRef.current.contains(target) ||
         verticalContentRef.current.contains(document.activeElement))
     );
+  }
+
+  function isIconPrefix() {
+    if (!prefixRef.current) return false;
+    return Boolean(prefixRef.current.querySelector('svg'));
   }
 }
 

--- a/polaris-react/src/components/TextField/TextField.tsx
+++ b/polaris-react/src/components/TextField/TextField.tsx
@@ -313,7 +313,7 @@ export function TextField({
 
   const inputType = type === 'currency' ? 'text' : type;
   const isNumericType = type === 'number' || type === 'integer';
-  const iconPrefix = isIconPrefix();
+  const iconPrefix = React.isValidElement(prefix) && prefix.type === Icon;
 
   const prefixMarkup = prefix ? (
     <div
@@ -799,11 +799,6 @@ export function TextField({
       (verticalContentRef.current.contains(target) ||
         verticalContentRef.current.contains(document.activeElement))
     );
-  }
-
-  function isIconPrefix() {
-    if (!prefixRef.current) return false;
-    return Boolean(prefixRef.current.querySelector('svg'));
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/Shopify/polaris-internal/issues/1243

### String prefix

|-|[Before (prod)](https://storybook.polaris.shopify.com/?path=/story/all-components-textfield--all) |[After](https://5d559397bae39100201eedc1-hdmjhtkefu.chromatic.com/?path=/story/all-components-textfield--all)|[Figma](https://www.figma.com/file/jLLkmo9r28hiqPvf4s90E4/Polaris-Gen-3-Components?type=design&node-id=28915%3A15501&mode=design&t=CP0WZtujAG18uapr-1)|
|-|-|-|-|
|Right margin|`8px`| `6px` (more space than Figma to account for a smaller text container)| `4px`|
|Screenshot|<img width="306" alt="Screenshot 2023-11-23 at 11 44 59 AM" src="https://github.com/Shopify/polaris/assets/20652326/078e4b81-83e1-4aeb-88a7-d5e273dd9089">|<img width="265" alt="Screenshot 2023-11-23 at 12 01 19 PM" src="https://github.com/Shopify/polaris/assets/20652326/a12ba0a1-3e21-4c5c-bb82-44a17770e6b7">|<img width="360" alt="Screenshot 2023-11-23 at 11 57 05 AM" src="https://github.com/Shopify/polaris/assets/20652326/4f1c7e7e-16a9-40cb-bd0d-d73a53ffd002">|

### Icon prefix

|-|[Before (prod)](https://storybook.polaris.shopify.com/?path=/story/all-components-textfield--all) |[After](https://5d559397bae39100201eedc1-hdmjhtkefu.chromatic.com/?path=/story/all-components-textfield--all)|[Figma](https://www.figma.com/file/jLLkmo9r28hiqPvf4s90E4/Polaris-Gen-3-Components?type=design&node-id=28915%3A15501&mode=design&t=CP0WZtujAG18uapr-1)|
|-|-|-|-|
|Left margin|`12px`| `8px`| `12px`|
|Right margin|`8px`| `4px`| `4px`|
|Screenshot|<img width="290" alt="Screenshot 2023-11-23 at 11 45 03 AM" src="https://github.com/Shopify/polaris/assets/20652326/5e0a2414-4b8c-46f2-bf10-9b3b077d89c1">|<img width="285" alt="Screenshot 2023-11-23 at 11 45 15 AM" src="https://github.com/Shopify/polaris/assets/20652326/c80e6afe-b3f6-4309-8adb-413094133ba4">|<img width="352" alt="Screenshot 2023-11-23 at 11 59 29 AM" src="https://github.com/Shopify/polaris/assets/20652326/63ccda11-5afc-40bc-9e90-b61eb5b16070">|
|In the Admin|<img width="306" alt="Screenshot 2023-11-29 at 11 23 25 AM" src="https://github.com/Shopify/polaris/assets/20652326/78b2c9a6-1bd3-4fc4-8ea8-99bc7bffa282">|<img width="308" alt="Screenshot 2023-11-29 at 11 21 41 AM" src="https://github.com/Shopify/polaris/assets/20652326/6ef4ce3b-be23-4ead-8cfe-7d1a81d26b94">|-|


