### PR TITLE
Generate typed site data

### DIFF
--- a/polaris.shopify.com/content/tools/stylelint-polaris.mdx
+++ b/polaris.shopify.com/content/tools/stylelint-polaris.mdx
@@ -3,7 +3,6 @@ title: Stylelint Polaris
 navTitle: Stylelint
 description: A configuration of Stylelint rules that promote adoption of the Polaris design system in consuming apps.
 icon: WandMajor
-collapseChildren: true
 order: 4
 keywords:
   - stylelint

--- a/polaris.shopify.com/pages/api/search/v0/index.tsx
+++ b/polaris.shopify.com/pages/api/search/v0/index.tsx
@@ -10,28 +10,31 @@ import {
   SearchResultCategory,
   FoundationsCategory,
   Status,
-  SiteJSON,
   PatternFrontMatter,
+  FrontMatter,
 } from '../../../../src/types';
 
 import {slugify, stripMarkdownLinks} from '../../../../src/utils/various';
 
-import siteJson from '../../../../.cache/site.json';
+import pages from '../../../../.cache/site';
 
-const pages: SiteJSON = siteJson as unknown as SiteJSON;
+type Slugs = keyof typeof pages;
+type StartsWith<T, Start extends string> = Extract<T, `${Start}${string}`>;
 
 const componentSlugs = Object.keys(pages).filter((slug) =>
   slug.startsWith('components/'),
-);
+) as StartsWith<Slugs, 'components/'>[];
+
 const patternSlugs = Object.keys(pages).filter((slug) =>
   slug.startsWith('patterns/'),
-);
+) as StartsWith<Slugs, 'patterns/'>[];
+
 const foundationSlugs = Object.keys(pages).filter(
   (slug) =>
     slug.startsWith('foundations/') ||
     slug.startsWith('design/') ||
     slug.startsWith('content/'),
-);
+) as StartsWith<Slugs, 'foundations/' | 'design/' | 'content/'>[];
 
 const MAX_RESULTS: {[key in SearchResultCategory]: number} = {
   foundations: 8,
@@ -53,7 +56,7 @@ const getSearchResults = (query?: string) => {
       title,
       description = '',
       category = '',
-    } = pages[slug].frontMatter;
+    } = pages[slug].frontMatter as FrontMatter;
 
     const url = category
       ? `/components/${slugify(category)}/${slugify(title)}`
@@ -126,7 +129,11 @@ const getSearchResults = (query?: string) => {
 
   // Add foundations
   foundationSlugs.forEach((slug) => {
-    const {title, icon = '', description = ''} = pages[slug].frontMatter;
+    const {
+      title,
+      icon = '',
+      description = '',
+    } = pages[slug].frontMatter as FrontMatter;
     const category = slug.split('/')[0].toLowerCase() as FoundationsCategory;
 
     results.push({

--- a/polaris.shopify.com/pages/components/[group]/[component]/index.tsx
+++ b/polaris.shopify.com/pages/components/[group]/[component]/index.tsx
@@ -13,14 +13,10 @@ import Markdown from '../../../../src/components/Markdown';
 import Page from '../../../../src/components/Page';
 import {toPascalCase} from '../../../../src/utils/various';
 import PageMeta from '../../../../src/components/PageMeta';
-import type {
-  Status,
-  FilteredTypes,
-  AllTypes,
-  SerializedMdx,
-} from '../../../../src/types';
+import type {Status, FilteredTypes, SerializedMdx} from '../../../../src/types';
 import PropsTable from '../../../../src/components/PropsTable';
 import {getRelevantTypes} from '../../../../scripts/get-props/src/get-props';
+import allType from '../../../../.cache/props';
 
 type FrontMatter = {
   status?: Status;
@@ -124,10 +120,6 @@ export const getStaticProps: GetStaticProps<
         },
       ),
     );
-
-    const propsFilePath = path.resolve(process.cwd(), `.cache/props.json`);
-    const fileContent = fs.readFileSync(propsFilePath, 'utf8');
-    const allType: AllTypes = JSON.parse(fileContent);
 
     const componentDirName = toPascalCase(`${mdx.frontmatter.title} `);
     const propName = toPascalCase(`${mdx.frontmatter.title} Props`);

--- a/polaris.shopify.com/scripts/gen-colors.ts
+++ b/polaris.shopify.com/scripts/gen-colors.ts
@@ -4,7 +4,11 @@ import * as path from 'node:path';
 import * as colors from '../../polaris-tokens/src/colors';
 
 const cacheDir = path.join(process.cwd(), '.cache');
-const colorJsonFile = path.join(cacheDir, 'colors.json');
+const colorJsonFile = path.join(cacheDir, 'colors.ts');
 
 fs.mkdirSync(cacheDir, {recursive: true});
-fs.writeFileSync(colorJsonFile, JSON.stringify(colors, null, 2));
+fs.writeFileSync(
+  colorJsonFile,
+  `import type {ColorsJSON} from '../src/types';
+export default ${JSON.stringify(colors)} satisfies ColorsJSON;`,
+);

--- a/polaris.shopify.com/scripts/get-props/src/get-props.ts
+++ b/polaris.shopify.com/scripts/get-props/src/get-props.ts
@@ -290,8 +290,9 @@ if (isExecutedThroughCommandLine) {
     }
 
     fs.writeFileSync(
-      path.join(cacheDir, 'props.json'),
-      JSON.stringify(ast, undefined, 2),
+      path.join(cacheDir, 'props.ts'),
+      `import type {AllTypes} from '../src/types';
+export default ${JSON.stringify(ast)} satisfies AllTypes;`,
     );
   });
 }

--- a/polaris.shopify.com/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/polaris.shopify.com/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,13 +1,10 @@
 import Link from 'next/link';
 import {useRouter} from 'next/router';
-import navJSON from '../../../.cache/nav.json';
-import {NavJSON} from '../../types';
+import nav from '../../../.cache/nav';
 import get from 'lodash.get';
 
 import styles from './Breadcrumbs.module.scss';
 import {deslugify} from '../../utils/various';
-
-const nav = navJSON as NavJSON;
 
 function Breadcrumbs() {
   const {asPath} = useRouter();

--- a/polaris.shopify.com/src/components/Frame/Frame.tsx
+++ b/polaris.shopify.com/src/components/Frame/Frame.tsx
@@ -5,8 +5,8 @@ import {DarkMode} from 'use-dark-mode';
 import {motion, AnimatePresence} from 'framer-motion';
 
 import GlobalSearch from '../GlobalSearch';
-import navJSON from '../../../.cache/nav.json';
-import {NavJSON, NavItem, Breakpoints} from '../../types';
+import nav from '../../../.cache/nav';
+import {NavItem, Breakpoints} from '../../types';
 
 import styles from './Frame.module.scss';
 import {className} from '../../utils/various';
@@ -18,8 +18,6 @@ interface Props {
   darkMode: DarkMode;
   children: React.ReactNode;
 }
-
-const nav = navJSON as NavJSON;
 
 function Frame({darkMode, children}: Props) {
   const [showSkipToContentLink, setShowSkipToContentLink] = useState(true);

--- a/polaris.shopify.com/src/components/Markdown/components/Colors/index.tsx
+++ b/polaris.shopify.com/src/components/Markdown/components/Colors/index.tsx
@@ -4,35 +4,7 @@ import {capitalize} from '../../../../utils/various';
 import {Card} from '../../../Card';
 import styles from './Colors.module.scss';
 
-import palette from '../../../../../.cache/colors.json';
-
-type ColorScale =
-  | '1'
-  | '2'
-  | '3'
-  | '4'
-  | '5'
-  | '6'
-  | '7'
-  | '8'
-  | '9'
-  | '10'
-  | '11'
-  | '12'
-  | '13'
-  | '14'
-  | '15'
-  | '16';
-
-type ColorValue = {
-  [index in ColorScale]: string;
-};
-
-interface Colors {
-  [key: string]: ColorValue;
-}
-
-const colors = palette as unknown as Colors;
+import colors from '../../../../../.cache/colors';
 
 const COLOR_ORDER = [
   'red',
@@ -47,7 +19,7 @@ const COLOR_ORDER = [
   'purple',
   'magenta',
   'rose',
-];
+] as const;
 
 export function Colors() {
   const [selectOne, setSelectOne] = useState(true);
@@ -97,20 +69,25 @@ export function Colors() {
   };
 
   const colorMap = COLOR_ORDER.map((color) => {
-    const shades: ColorValue = colors[color] ?? [];
-    const swatches = Object.entries(shades).map(([shade, value]) => (
-      <div
-        key={value}
-        className={[
-          styles.ColorsSwatch,
-          colorOne.id === color + shade || colorTwo.id === color + shade
-            ? styles.ColorsSelected
-            : undefined,
-        ].join(' ')}
-        style={{backgroundColor: value}}
-        onClick={() => selectColor(value, color + shade)}
-      />
-    ));
+    const shades = colors[color];
+    let swatches: React.JSX.Element[] | null;
+    if (shades) {
+      swatches = Object.entries(shades).map(([shade, value]) => (
+        <div
+          key={value}
+          className={[
+            styles.ColorsSwatch,
+            colorOne.id === color + shade || colorTwo.id === color + shade
+              ? styles.ColorsSelected
+              : undefined,
+          ].join(' ')}
+          style={{backgroundColor: value}}
+          onClick={() => selectColor(value, color + shade)}
+        />
+      ));
+    } else {
+      swatches = null;
+    }
 
     return (
       <div key={color} className={styles.Colors}>

--- a/polaris.shopify.com/src/components/PropsTable/PropsTable.tsx
+++ b/polaris.shopify.com/src/components/PropsTable/PropsTable.tsx
@@ -1,5 +1,5 @@
 import {createContext, useContext, useState} from 'react';
-import {Type, FilteredTypes, StatusName} from '../../types';
+import {Type, FilteredTypes} from '../../types';
 import styles from './PropsTable.module.scss';
 import Longform from '../Longform';
 import {motion, AnimatePresence} from 'framer-motion';
@@ -218,7 +218,7 @@ function TypeTable({
                         )}
                         {deprecationMessage && (
                           <div className={styles.DeprecationNotice}>
-                            <StatusBadge status={StatusName.Deprecated} />{' '}
+                            <StatusBadge status="Deprecated" />{' '}
                             {endWithPeriod(deprecationMessage)}
                           </div>
                         )}

--- a/polaris.shopify.com/src/components/Subnav/Subnav.tsx
+++ b/polaris.shopify.com/src/components/Subnav/Subnav.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 
-import navJSON from '../../../.cache/nav.json';
+import navJSON from '../../../.cache/nav';
 import {NavJSON, NavItem} from '../../types';
 import {className} from '../../utils/various';
 

--- a/polaris.shopify.com/src/types.ts
+++ b/polaris.shopify.com/src/types.ts
@@ -56,6 +56,7 @@ export interface Example extends FrontMatter {
 
 export type FrontMatter = {
   title: string;
+  navTitle?: string;
   draft?: boolean;
   noIndex?: boolean;
   category?: string;
@@ -63,18 +64,24 @@ export type FrontMatter = {
   description?: string;
   shortDescription?: string;
   seoDescription?: string;
+  lede?: string;
+  githubDiscussionsLink?: string;
   examples?: Example[];
   icon?: string;
   order?: number;
   keywords?: (string | number)[];
   status?: Status;
   hideFromNav?: boolean;
+  hideChildren?: true;
   featured?: boolean;
   previewImg?: string;
   expanded?: boolean;
   releasedIn?: string | number;
   showTOC?: boolean;
   collapsibleTOC?: boolean;
+  newSection?: true;
+  primitives?: string[];
+  variants?: string[];
 };
 
 export type PatternFrontMatter = Omit<FrontMatter, 'description'> & {
@@ -180,15 +187,14 @@ export enum Breakpoints {
   DesktopLarge = 1600,
 }
 
-export enum StatusName {
-  New = 'New',
-  Deprecated = 'Deprecated',
-  Alpha = 'Alpha',
-  Beta = 'Beta',
-  Information = 'Information',
-  Legacy = 'Legacy',
-  Warning = 'Warning',
-}
+export type StatusName =
+  | 'New'
+  | 'Deprecated'
+  | 'Alpha'
+  | 'Beta'
+  | 'Information'
+  | 'Legacy'
+  | 'Warning';
 
 export type Status = StatusName;
 
@@ -238,11 +244,39 @@ export interface NavItem {
   order?: number;
   icon?: string;
   color?: string;
-  hideChildren?: false;
+  hideChildren?: true;
   newSection?: true;
   status?: Status;
-  children?: NavJSON;
+  children?: {
+    [key: string]: NavItem;
+  };
   expanded?: boolean;
   hideFromNav?: boolean;
   featured?: boolean;
+}
+
+type ColorScale =
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | '11'
+  | '12'
+  | '13'
+  | '14'
+  | '15'
+  | '16';
+
+export type ColorValue = {
+  [index in ColorScale]: string;
+};
+
+export interface ColorsJSON {
+  [key: string]: ColorValue;
 }

--- a/polaris.shopify.com/src/utils/various.ts
+++ b/polaris.shopify.com/src/utils/various.ts
@@ -1,5 +1,5 @@
-import siteJson from '../../.cache/site.json';
-import {PatternFrontMatter, SiteJSON} from '../types';
+import pages from '../../.cache/site';
+import type {PatternFrontMatter} from '../types';
 import type {BreakpointsAlias} from '@shopify/polaris-tokens';
 import {breakpointsAliases} from '@shopify/polaris-tokens';
 
@@ -13,8 +13,6 @@ interface PatternJSON {
     frontMatter: PatternFrontMatter;
   };
 }
-
-const pages: SiteJSON = siteJson as unknown as SiteJSON;
 
 export const patterns: PatternJSON = Object.keys(pages)
   .filter((slug) => slug.startsWith('patterns/'))

--- a/polaris.shopify.com/tsconfig.json
+++ b/polaris.shopify.com/tsconfig.json
@@ -25,7 +25,7 @@
   "include": [
     "src",
     "pages",
-    ".cache/*.json",
+    ".cache/*",
     "**/*.json",
     "next-env.d.ts",
     "scripts/get-props/src/get-props.ts",


### PR DESCRIPTION
Instead of dumping out plain JSON, then having to force a type on it later, we can instead dump out typed JSON which retains its types on import.