### PR TITLE
1278/satori over puppeteer

### DIFF
--- a/polaris-icons/package.json
+++ b/polaris-icons/package.json
@@ -61,7 +61,6 @@
     "hast-util-select": "^3.0.0",
     "js-yaml": "^4.0.0",
     "rehype-parse": "^7.0.1",
-    "svgo": "^2.8.0",
     "unified": "^9.2.1"
   }
 }

--- a/polaris.shopify.com/content/components/index.mdx
+++ b/polaris.shopify.com/content/components/index.mdx
@@ -2,7 +2,6 @@
 title: Components
 order: 7
 icon: AppsMajor
-previewImg: /images/components.png
 ---
 
 # {frontmatter.title}

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -20,7 +20,7 @@
     "create-component": "generact --root src/components src/components/Template/Template.tsx",
     "gen-sitemap": "yarn next-sitemap",
     "get-props": "./scripts/get-props/src/get-props.ts",
-    "gen-assets": "yarn get-props && node scripts/gen-cache-json.mjs && ts-node scripts/gen-site-map.ts && ts-node scripts/gen-og-images.ts",
+    "gen-assets": "yarn get-props && node scripts/gen-cache-json.mjs && ts-node scripts/gen-site-map.ts && ts-node scripts/gen-og-images.tsx",
     "gen-colors": "ts-node ./scripts/gen-colors.ts"
   },
   "dependencies": {
@@ -91,10 +91,11 @@
     "ora": "^5.4.1",
     "p-map": "^5.5.0",
     "playroom": "^0.28.0",
-    "puppeteer": "^16.0.0",
     "sass": "^1.49.9",
+    "satori": "^0.10.11",
     "style-loader": "^3.3.1",
     "ts-node": "^10.7.0",
-    "typescript": "^4.9.3"
+    "typescript": "^4.9.3",
+    "wawoff2": "^2.0.1"
   }
 }

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@esm2cjs/p-map": "^5.5.0",
+    "@napi-rs/image": "^1.7.0",
     "@types/base-64": "^1.0.0",
     "@types/gtag.js": "^0.0.10",
     "@types/js-yaml": "^4.0.5",
@@ -86,6 +87,7 @@
     "generact": "^0.4.0",
     "get-site-urls": "3.0.0-alpha.1",
     "globby": "^11.1.0",
+    "inter-ui": "3.19.3",
     "is-ci": "^3.0.1",
     "js-yaml": "^4.1.0",
     "lodash.set": "^4.3.2",

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -74,10 +74,8 @@
     "@types/marked": "^4.0.3",
     "@types/prismjs": "^1.26.0",
     "@types/react": "^18.2.0",
-    "@types/tmp": "^0.2.6",
     "@types/uuid": "^9.0.1",
     "babel-plugin-preval": "^5.1.0",
-    "canvas": "^2.11.2",
     "chalk": "^5.2.0",
     "chokidar": "^3.5.3",
     "eslint": "8.10.0",
@@ -98,9 +96,7 @@
     "sass": "^1.49.9",
     "satori": "^0.10.11",
     "style-loader": "^3.3.1",
-    "tmp": "^0.2.1",
     "ts-node": "^10.7.0",
-    "typescript": "^4.9.3",
-    "wawoff2": "^2.0.1"
+    "typescript": "^4.9.3"
   }
 }

--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -73,8 +73,10 @@
     "@types/marked": "^4.0.3",
     "@types/prismjs": "^1.26.0",
     "@types/react": "^18.2.0",
+    "@types/tmp": "^0.2.6",
     "@types/uuid": "^9.0.1",
     "babel-plugin-preval": "^5.1.0",
+    "canvas": "^2.11.2",
     "chalk": "^5.2.0",
     "chokidar": "^3.5.3",
     "eslint": "8.10.0",
@@ -94,6 +96,7 @@
     "sass": "^1.49.9",
     "satori": "^0.10.11",
     "style-loader": "^3.3.1",
+    "tmp": "^0.2.1",
     "ts-node": "^10.7.0",
     "typescript": "^4.9.3",
     "wawoff2": "^2.0.1"

--- a/polaris.shopify.com/scripts/gen-og-images.tsx
+++ b/polaris.shopify.com/scripts/gen-og-images.tsx
@@ -169,7 +169,9 @@ const generateSvg = async (url, frontMatter, satoriConfig: SatoriOptions) => {
 };
 
 const genOgImages = async () => {
-  const spinner = ora('Generating Open Graph images from sitemap').start();
+  const spinner = ora(
+    'Generating Open Graph images from .cache/site.ts',
+  ).start();
   if (fs.existsSync(imgDir)) {
     await rm(imgDir, {recursive: true});
   }
@@ -221,15 +223,16 @@ const genOgImages = async () => {
         await writeFile(`${imgDir}${imgPath}.svg`, svg);
         await writeFile(imgFile, pngData);
         completed++;
-        spinner.text = `Generated ${completed} Open Graph images from .cache/site.ts`;
       } catch (error) {
         spinner.fail(`Failed to generate Open Graph png for ${url}`);
         throw error;
       }
     }),
-  );
+  ).then(() => {
+    spinner.succeed(
+      `Generated ${completed} Open Graph images from .cache/site.ts`,
+    );
+  });
 };
 
-genOgImages().then(() => {
-  console.log('✅ OG Image creation done');
-});
+genOgImages().then(() => {});

--- a/polaris.shopify.com/scripts/gen-og-images.tsx
+++ b/polaris.shopify.com/scripts/gen-og-images.tsx
@@ -13,10 +13,10 @@ import {optimize} from 'svgo';
 const WIDTH = 1200;
 const HEIGHT = 630;
 const PADDING = 60;
+const LOGO_SCALE = 0.9;
 // To maintain a 1:1 aspect ratio, we can't use regular CSS (we're using a
 // limited set of yoga), so we calculate it manually here.
-// The image is meant to be 20% width.
-const IMG_WIDTH = (WIDTH - PADDING * 2) * 0.45;
+const IMG_SIZE = (HEIGHT - PADDING * 2) * LOGO_SCALE;
 
 const interDir = path.join(
   path.dirname(require.resolve('inter-ui')),
@@ -55,7 +55,14 @@ const defaultImage = (
   <svg
     viewBox="0 0 99 99"
     xmlns="http://www.w3.org/2000/svg"
-    style={{width: IMG_WIDTH, height: IMG_WIDTH, opacity: 0.2}}
+    style={{
+      width: IMG_SIZE,
+      height: IMG_SIZE,
+      opacity: 0.15,
+      position: 'absolute',
+      right: `${PADDING}px`,
+      top: `${PADDING}px`,
+    }}
   >
     <path
       d="M98.9999 49.5C98.9999 76.838 76.838 98.9999 49.5 98.9999C22.1619 98.9999 0 76.838 0 49.5C0 22.1619 22.1619 0 49.5 0C76.838 0 98.9999 22.1619 98.9999 49.5Z"
@@ -89,17 +96,7 @@ const generateSvg = async (url, frontMatter, satoriConfig: SatoriOptions) => {
         color: '#fff',
       }}
     >
-      <div
-        style={{
-          position: 'absolute',
-          display: 'flex',
-          width: '45%',
-          right: `${PADDING}px`,
-          top: `${PADDING}px`,
-        }}
-      >
-        {defaultImage}
-      </div>
+      {defaultImage}
       <div
         style={{
           display: 'flex',

--- a/polaris.shopify.com/scripts/gen-og-images.tsx
+++ b/polaris.shopify.com/scripts/gen-og-images.tsx
@@ -16,7 +16,7 @@ const PADDING = 60;
 // To maintain a 1:1 aspect ratio, we can't use regular CSS (we're using a
 // limited set of yoga), so we calculate it manually here.
 // The image is meant to be 20% width.
-const IMG_WIDTH = (WIDTH - PADDING * 2) * 0.2;
+const IMG_WIDTH = (WIDTH - PADDING * 2) * 0.45;
 
 const interDir = path.join(
   path.dirname(require.resolve('inter-ui')),
@@ -74,93 +74,70 @@ const defaultImage = (
 
 const generateSvg = async (url, frontMatter, satoriConfig: SatoriOptions) => {
   const title = frontMatter.title;
-  let inner = defaultImage;
   let logo = shopifyLogo;
-
-  if (frontMatter.previewImg) {
-    const imgPath = path.join(process.cwd(), `public`, frontMatter.previewImg);
-    const rawImageData = fs.readFileSync(imgPath);
-    // Later conversion from svg to png fails when the final base64 encoded
-    // embedded image is too large, so we resize it down here before embedding
-    // it.
-    const image = await new Transformer(rawImageData)
-      .resize(IMG_WIDTH, null, ResizeFilterType.Lanczos3)
-      .png();
-    const base64 = Buffer.from(image).toString('base64');
-    inner = (
-      /* eslint-disable-next-line */
-      <img
-        alt=""
-        src={`data:image/png;base64,${base64}`}
-        width="100%"
-        style={{
-          borderRadius: '8px',
-          width: IMG_WIDTH,
-        }}
-      />
-    );
-  } else if (frontMatter.icon && frontMatter.icon in polarisIcons) {
-    const Icon = polarisIcons[frontMatter.icon];
-    inner = (
-      <Icon
-        fill="white"
-        style={{width: IMG_WIDTH, height: IMG_WIDTH, opacity: 0.2}}
-      />
-    );
-  }
 
   return satori(
     <div
       style={{
-        display: 'flex',
-        flexDirection: 'column',
-        flex: 'auto',
+        width: `${WIDTH}px`,
+        height: `${HEIGHT}px`,
         padding: `${PADDING}px`,
+        position: 'relative',
+        display: 'flex',
         background: '#000',
         fontFamily: 'Inter',
         color: '#fff',
-        width: `${WIDTH}px`,
-        height: `${HEIGHT}px`,
       }}
     >
       <div
         style={{
+          position: 'absolute',
           display: 'flex',
-          flexDirection: 'row',
-          flex: 'auto',
+          width: '45%',
+          right: `${PADDING}px`,
+          top: `${PADDING}px`,
         }}
       >
-        <h1
-          style={{
-            flexGrow: '1',
-            fontSize: '80px',
-            fontWeight: '700',
-            letterSpacing: '-0.01rem',
-            margin: '0',
-          }}
-        >
-          {title}
-        </h1>
-        <div
-          style={{
-            display: 'flex',
-            width: '20%',
-          }}
-        >
-          {inner}
-        </div>
+        {defaultImage}
       </div>
       <div
         style={{
           display: 'flex',
-          alignItems: 'flex-start',
-          gap: '12px',
-          opacity: '.5',
-          fontSize: '24px',
-          fontWeight: '500',
+          flexDirection: 'column',
+          flex: 'auto',
         }}
       >
-        {logo} Polaris
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            flex: 'auto',
+          }}
+        >
+          <h1
+            style={{
+              flexGrow: '1',
+              fontSize: '80px',
+              fontWeight: '700',
+              letterSpacing: '-0.01rem',
+              margin: '0',
+            }}
+          >
+            {title}
+          </h1>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: '12px',
+            opacity: '.5',
+            fontSize: '24px',
+            fontWeight: '500',
+          }}
+        >
+          {logo} Polaris
+        </div>
       </div>
     </div>,
 
@@ -180,8 +157,8 @@ const genOgImages = async () => {
   const interBold = fs.readFileSync(path.join(interDir, 'Inter-Bold.woff'));
 
   const satoriConfig: SatoriOptions = {
-    width: 1200,
-    height: 630,
+    width: WIDTH,
+    height: HEIGHT,
     fonts: [
       {
         name: 'Inter',

--- a/polaris.shopify.com/scripts/gen-og-images.tsx
+++ b/polaris.shopify.com/scripts/gen-og-images.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
 import * as polarisIcons from '@shopify/polaris-icons';
-import tmp from 'tmp';
-import {registerFont, createCanvas} from 'canvas';
-import wawoff2 from 'wawoff2';
 import {Transformer} from '@napi-rs/image';
 
 import fs from 'node:fs';
@@ -13,13 +10,10 @@ import ora from 'ora';
 import satori, {type SatoriOptions} from 'satori';
 import typedSiteJSON from '../.cache/site';
 
-const interFolder = path.join(
+const interDir = path.join(
   path.dirname(require.resolve('inter-ui')),
   'Inter (web)',
 );
-
-// Automatically cleanup the temporary files/directories when the process exits
-tmp.setGracefulCleanup();
 
 const imgDir = path.join(process.cwd(), 'public/og-images');
 
@@ -252,10 +246,8 @@ const genOgImages = async () => {
   // });
   //
 
-  const interMedium = fs.readFileSync(
-    path.join(interFolder, 'Inter-Medium.woff'),
-  );
-  const interBold = fs.readFileSync(path.join(interFolder, 'Inter-Bold.woff'));
+  const interMedium = fs.readFileSync(path.join(interDir, 'Inter-Medium.woff'));
+  const interBold = fs.readFileSync(path.join(interDir, 'Inter-Bold.woff'));
 
   const satoriConfig: SatoriOptions = {
     width: 1200,
@@ -296,14 +288,6 @@ const genOgImages = async () => {
       if (!fs.existsSync(`${imgDir}${imgPath}`)) {
         await mkdir(`${imgDir}${imgPath}`, {recursive: true});
       }
-
-      // const out = fs.createWriteStream(`${imgDir}${imgPath}.png`);
-      // const stream = canvas.createPNGStream();
-      // stream.pipe(out);
-      // await new Promise((resolve, reject) => {
-      //   out.on('finish', resolve);
-      //   out.on('error', reject);
-      // });
 
       const trasformer = Transformer.fromSvg(svg);
       const pngData = await trasformer.png();

--- a/polaris.shopify.com/scripts/gen-og-images.tsx
+++ b/polaris.shopify.com/scripts/gen-og-images.tsx
@@ -4,8 +4,7 @@ import {Transformer, ResizeFilterType} from '@napi-rs/image';
 
 import fs from 'node:fs';
 import path from 'node:path';
-import {writeFile, readFile, mkdir, rm} from 'fs/promises';
-import pMap from '@esm2cjs/p-map';
+import {writeFile, mkdir, rm} from 'fs/promises';
 import ora from 'ora';
 import satori, {type SatoriOptions} from 'satori';
 import typedSiteJSON from '../.cache/site';
@@ -18,12 +17,6 @@ const PADDING = 60;
 // limited set of yoga), so we calculate it manually here.
 // The image is meant to be 20% width.
 const IMG_WIDTH = (WIDTH - PADDING * 2) * 0.2;
-const IMG_HEIGHT = IMG_WIDTH;
-
-const imageStyles = {
-  width: IMG_WIDTH,
-  height: IMG_HEIGHT,
-};
 
 const interDir = path.join(
   path.dirname(require.resolve('inter-ui')),
@@ -91,11 +84,10 @@ const generateSvg = async (url, frontMatter, satoriConfig: SatoriOptions) => {
     // Later conversion from svg to png fails when the final base64 encoded
     // embedded image is too large, so we resize it down here before embedding
     // it.
-    // const image = await new Transformer(rawImageData)
-    //   .resize(100, null, ResizeFilterType.Lanczos3)
-    //   .webp(75);
-    // const base64 = Buffer.from(image).toString('base64');
-    const base64 = Buffer.from(rawImageData).toString('base64');
+    const image = await new Transformer(rawImageData)
+      .resize(IMG_WIDTH, null, ResizeFilterType.Lanczos3)
+      .png();
+    const base64 = Buffer.from(image).toString('base64');
     inner = (
       /* eslint-disable-next-line */
       <img

--- a/polaris.shopify.com/scripts/gen-og-images.tsx
+++ b/polaris.shopify.com/scripts/gen-og-images.tsx
@@ -55,7 +55,7 @@ const defaultImage = (
   <svg
     viewBox="0 0 99 99"
     xmlns="http://www.w3.org/2000/svg"
-    style={{width: IMG_WIDTH, height: IMG_WIDTH}}
+    style={{width: IMG_WIDTH, height: IMG_WIDTH, opacity: 0.2}}
   >
     <path
       d="M98.9999 49.5C98.9999 76.838 76.838 98.9999 49.5 98.9999C22.1619 98.9999 0 76.838 0 49.5C0 22.1619 22.1619 0 49.5 0C76.838 0 98.9999 22.1619 98.9999 49.5Z"
@@ -94,12 +94,20 @@ const generateSvg = async (url, frontMatter, satoriConfig: SatoriOptions) => {
         alt=""
         src={`data:image/png;base64,${base64}`}
         width="100%"
-        style={{width: IMG_WIDTH}}
+        style={{
+          borderRadius: '8px',
+          width: IMG_WIDTH,
+        }}
       />
     );
   } else if (frontMatter.icon && frontMatter.icon in polarisIcons) {
     const Icon = polarisIcons[frontMatter.icon];
-    inner = <Icon fill="white" style={{width: IMG_WIDTH, height: IMG_WIDTH}} />;
+    inner = (
+      <Icon
+        fill="white"
+        style={{width: IMG_WIDTH, height: IMG_WIDTH, opacity: 0.2}}
+      />
+    );
   }
 
   return satori(

--- a/polaris.shopify.com/scripts/gen-og-images.tsx
+++ b/polaris.shopify.com/scripts/gen-og-images.tsx
@@ -17,8 +17,16 @@ const interDir = path.join(
 
 const imgDir = path.join(process.cwd(), 'public/og-images');
 
-const shopifyLogo = `<svg height="30" width="30" viewBox="0 0 109.5 124.5" xmlns="http://www.w3.org/2000/svg" fill="#fff">
-<path d="M74.7,14.8c0,0-1.4,0.4-3.7,1.1c-0.4-1.3-1-2.8-1.8-4.4c-2.6-5-6.5-7.7-11.1-7.7c0,0,0,0,0,0
+const shopifyLogo = (
+  <svg
+    height="30"
+    width="30"
+    viewBox="0 0 109.5 124.5"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="#fff"
+  >
+    <path
+      d="M74.7,14.8c0,0-1.4,0.4-3.7,1.1c-0.4-1.3-1-2.8-1.8-4.4c-2.6-5-6.5-7.7-11.1-7.7c0,0,0,0,0,0
   c-0.3,0-0.6,0-1,0.1c-0.1-0.2-0.3-0.3-0.4-0.5c-2-2.2-4.6-3.2-7.7-3.1c-6,0.2-12,4.5-16.8,12.2c-3.4,5.4-6,12.2-6.7,17.5
   c-6.9,2.1-11.7,3.6-11.8,3.7c-3.5,1.1-3.6,1.2-4,4.5C9.1,40.7,0,111.2,0,111.2l75.6,13.1V14.6C75.2,14.7,74.9,14.7,74.7,14.8z
     M57.2,20.2c-4,1.2-8.4,2.6-12.7,3.9c1.2-4.7,3.6-9.4,6.4-12.5c1.1-1.1,2.6-2.4,4.3-3.2C56.9,12,57.3,16.9,57.2,20.2z M49.1,4.3
@@ -26,25 +34,99 @@ const shopifyLogo = `<svg height="30" width="30" viewBox="0 0 109.5 124.5" xmlns
   C31.7,19.1,39.8,4.6,49.1,4.3z M37.4,59.3c0.4,6.4,17.3,7.8,18.3,22.9c0.7,11.9-6.3,20-16.4,20.6c-12.2,0.8-18.9-6.4-18.9-6.4
   l2.6-11c0,0,6.7,5.1,12.1,4.7c3.5-0.2,4.8-3.1,4.7-5.1c-0.5-8.4-14.3-7.9-15.2-21.7C23.8,51.8,31.4,40.1,48.2,39
   c6.5-0.4,9.8,1.2,9.8,1.2l-3.8,14.4c0,0-4.3-2-9.4-1.6C37.4,53.5,37.3,58.2,37.4,59.3z M61.2,19c0-3-0.4-7.3-1.8-10.9
-  c4.6,0.9,6.8,6,7.8,9.1C65.4,17.7,63.4,18.3,61.2,19z"/>
-<path d="M78.1,123.9l31.4-7.8c0,0-13.5-91.3-13.6-91.9c-0.1-0.6-0.6-1-1.1-1c-0.5,0-9.3-0.2-9.3-0.2s-5.4-5.2-7.4-7.2
-  V123.9z"/>
-</svg>
-`;
+  c4.6,0.9,6.8,6,7.8,9.1C65.4,17.7,63.4,18.3,61.2,19z"
+    />
+    <path
+      d="M78.1,123.9l31.4-7.8c0,0-13.5-91.3-13.6-91.9c-0.1-0.6-0.6-1-1.1-1c-0.5,0-9.3-0.2-9.3-0.2s-5.4-5.2-7.4-7.2
+  V123.9z"
+    />
+  </svg>
+);
 
-const defaultImage = `<svg viewBox="0 0 99 99" xmlns="http://www.w3.org/2000/svg">
-<path d="M98.9999 49.5C98.9999 76.838 76.838 98.9999 49.5 98.9999C22.1619 98.9999 0 76.838 0 49.5C0 22.1619 22.1619 0 49.5 0C76.838 0 98.9999 22.1619 98.9999 49.5Z" fill="#fff"/>
-<path d="M99.0001 49.6709C99.0001 76.9144 76.9149 98.9996 49.6714 98.9996C49.6714 71.7561 71.7566 49.6709 99.0001 49.6709Z" fill="#fff"/>
-<path d="M49.5 0C49.5 27.3381 27.3381 49.5 0 49.5C27.3381 49.5 49.5 71.6618 49.5 98.9999C49.5 71.6618 71.6618 49.5 98.9999 49.5C71.6618 49.5 49.5 27.3381 49.5 0Z" fill="#000"/>
-</svg>
-`;
+const defaultImage = (
+  <svg
+    viewBox="0 0 99 99"
+    xmlns="http://www.w3.org/2000/svg"
+    width="400px"
+    height="400px"
+  >
+    <path
+      d="M98.9999 49.5C98.9999 76.838 76.838 98.9999 49.5 98.9999C22.1619 98.9999 0 76.838 0 49.5C0 22.1619 22.1619 0 49.5 0C76.838 0 98.9999 22.1619 98.9999 49.5Z"
+      fill="#fff"
+    />
+    <path
+      d="M99.0001 49.6709C99.0001 76.9144 76.9149 98.9996 49.6714 98.9996C49.6714 71.7561 71.7566 49.6709 99.0001 49.6709Z"
+      fill="#fff"
+    />
+    <path
+      d="M49.5 0C49.5 27.3381 27.3381 49.5 0 49.5C27.3381 49.5 49.5 71.6618 49.5 98.9999C49.5 71.6618 71.6618 49.5 98.9999 49.5C71.6618 49.5 49.5 27.3381 49.5 0Z"
+      fill="#000"
+    />
+  </svg>
+);
 
 const generateSvg = async (url, frontMatter, satoriConfig: SatoriOptions) => {
   const title = frontMatter.title;
+  let inner = (
+    <div
+      style={{
+        display: 'flex',
+        position: 'absolute',
+        left: '600px',
+        top: '50%',
+        transform: 'translateY(-50%)',
+        opacity: '.2',
+        filter: 'brightness(1000%)',
+      }}
+    >
+      {defaultImage}
+    </div>
+  );
+  let logo = shopifyLogo;
+
+  if (frontMatter.previewImg) {
+    const imgPath = path.join(process.cwd(), `public`, frontMatter.previewImg);
+    const image = await readFile(imgPath);
+    const base64 = Buffer.from(image).toString('base64');
+    inner = (
+      /* eslint-disable-next-line */
+      <img
+        alt=""
+        src={`data:image/png;base64,${base64}`}
+        width="1418"
+        height="810"
+        style={{
+          position: 'absolute',
+          left: '100px',
+          top: '50%',
+          filter: 'contrast(1.1) invert(1) saturate(0) hue-rotate(180deg)',
+          opacity: '.33',
+          transform: 'rotateY(-60deg) translateY(-50%) scale(.9)',
+        }}
+      />
+    );
+  } else if (frontMatter.icon && frontMatter.icon in polarisIcons) {
+    const Icon = polarisIcons[frontMatter.icon];
+    inner = (
+      <div
+        style={{
+          display: 'flex',
+          position: 'absolute',
+          left: '600px',
+          top: '50%',
+          transform: 'translateY(-50%)',
+          opacity: '.2',
+        }}
+      >
+        <Icon fill="white" width="400" height="400" />
+      </div>
+    );
+  }
 
   return satori(
     <div
       style={{
+        position: 'relative',
         display: 'flex',
         fontFamily: 'Inter',
         width: '1200px',
@@ -65,10 +147,12 @@ const generateSvg = async (url, frontMatter, satoriConfig: SatoriOptions) => {
       >
         {title}
       </h1>
+      {inner}
       <div
         style={{
           position: 'absolute',
           bottom: '55px',
+          left: '60px',
           display: 'flex',
           alignItems: 'center',
           gap: '12px',
@@ -77,139 +161,9 @@ const generateSvg = async (url, frontMatter, satoriConfig: SatoriOptions) => {
           fontWeight: '500',
         }}
       >
-        {shopifyLogo} Polaris
+        {logo} Polaris
       </div>
     </div>,
-    satoriConfig,
-  );
-
-  // const canvas = createCanvas(200, 200);
-  // const ctx = canvas.getContext('2d');
-
-  // ctx.
-
-  // // Write "Awesome!"
-  // ctx.save();
-  // ctx.font = '80px Inter';
-  // ctx.rotate(0.1);
-  // ctx.fillText(title, 50, 100);
-  // ctx.restore();
-
-  // return canvas;
-
-  const Container = ({title, children, logo}) => {
-    return (
-      <div
-        style={{
-          fontFamily: 'apple-system, BlinkMacSystemFont, sans-serif',
-          width: '1200px',
-          height: '630px',
-          padding: '60px',
-          background: '#000',
-          color: '#fff',
-          perspective: '1800px',
-        }}
-      >
-        <h1
-          style={{
-            fontSize: '80px',
-            fontWeight: '700',
-            letterSpacing: '-0.01rem',
-            maxWidth: '520px',
-          }}
-        >
-          {title}
-        </h1>
-        {children}
-        <div
-          style={{
-            position: 'absolute',
-            bottom: '55px',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '12px',
-            opacity: '.5',
-            fontSize: '24px',
-            fontWeight: '500',
-          }}
-        >
-          {logo} Polaris
-        </div>
-      </div>
-    );
-  };
-
-  if (url.startsWith('/components/')) {
-    const imgPath = path.join(process.cwd(), `public/images${url}.png`);
-    const image = await readFile(imgPath);
-    const base64 = Buffer.from(image).toString('base64');
-    /* eslint-disable-next-line */
-    return satori(
-      <Container title={title} logo={shopifyLogo}>
-        <img
-          alt=""
-          src={`data:image/png;base64,${base64}`}
-          style={{
-            position: 'absolute',
-            left: '100px',
-            top: '50%',
-            filter: 'contrast(1.1) invert(1) saturate(0) hue-rotate(180deg)',
-            opacity: '.33',
-            height: 'auto',
-            transform: 'rotateY(-60deg) translateY(-50%) scale(.9)',
-          }}
-        />
-      </Container>,
-      satoriConfig,
-    );
-  }
-
-  if (
-    url.startsWith('/foundations/') ||
-    url.startsWith('/design/') ||
-    url.startsWith('/content/')
-  ) {
-    if (frontMatter?.icon && frontMatter?.icon in polarisIcons) {
-      const iconFilePath = path.join(
-        process.cwd(),
-        `../polaris-icons/dist/svg/${frontMatter.icon}.svg`,
-      );
-      const iconData = await readFile(iconFilePath);
-      return satori(
-        <Container title={title} logo={shopifyLogo}>
-          <div
-            style={{
-              position: 'absolute',
-              left: '600px',
-              top: '50%',
-              transform: 'translateY(-50%)',
-              opacity: '.2',
-              filter: 'invert()',
-            }}
-          >
-            ${iconData}
-          </div>
-        </Container>,
-        satoriConfig,
-      );
-    }
-  }
-
-  return satori(
-    <Container title={title} logo={shopifyLogo}>
-      <div
-        style={{
-          position: 'absolute',
-          left: '600px',
-          top: '50%',
-          transform: 'translateY(-50%)',
-          opacity: '.2',
-          filter: 'brightness(1000%)',
-        }}
-      >
-        ${defaultImage}
-      </div>
-    </Container>,
     satoriConfig,
   );
 };
@@ -219,32 +173,6 @@ const genOgImages = async () => {
   if (fs.existsSync(imgDir)) {
     await rm(imgDir, {recursive: true});
   }
-
-  // const interFontArrayBuffer = await (
-  //   await fetch(
-  //     'https://cdn.shopify.com/static/fonts/inter/Inter-roman.var.woff2?v=3.19',
-  //     {
-  //       headers: {
-  //         accept: '*/*',
-  //       },
-  //     },
-  //   )
-  // ).arrayBuffer();
-
-  // const ttfFileData = await wawoff2.decompress(
-  //   Buffer.from(interFontArrayBuffer),
-  // );
-
-  // const fontFile = tmp.fileSync({postfix: '.ttf'});
-
-  // fs.writeFileSync(fontFile.fd, ttfFileData);
-
-  // registerFont(fontFile.name, {
-  //   family: 'Inter',
-  //   weight: '700',
-  //   style: 'normal',
-  // });
-  //
 
   const interMedium = fs.readFileSync(path.join(interDir, 'Inter-Medium.woff'));
   const interBold = fs.readFileSync(path.join(interDir, 'Inter-Bold.woff'));
@@ -268,37 +196,38 @@ const genOgImages = async () => {
     ],
   };
 
-  await mkdir(imgDir, {recursive: true});
-
   let completed = 0;
-  Object.entries({
-    '/home': {
-      frontMatter: {
-        title: 'Polaris',
+  return Promise.all(
+    Object.entries({
+      '/home': {
+        frontMatter: {
+          title: 'Polaris',
+        },
       },
-    },
-    ...typedSiteJSON,
-  }).forEach(async ([url, {frontMatter}]) => {
-    try {
-      const imgPath =
-        url === ''
-          ? '/home'
-          : new URL(url, 'https://polaris.shopify.com').pathname;
-      const svg = await generateSvg(url, frontMatter, satoriConfig);
-      if (!fs.existsSync(`${imgDir}${imgPath}`)) {
-        await mkdir(`${imgDir}${imgPath}`, {recursive: true});
-      }
+      ...typedSiteJSON,
+    }).map(async ([url, {frontMatter}]) => {
+      try {
+        const imgPath =
+          url === ''
+            ? '/home'
+            : new URL(url, 'https://polaris.shopify.com').pathname;
+        const svg = await generateSvg(url, frontMatter, satoriConfig);
 
-      const trasformer = Transformer.fromSvg(svg);
-      const pngData = await trasformer.png();
-      await writeFile(`${imgDir}${imgPath}.png`, pngData);
-      completed++;
-      spinner.text = `Generated ${completed} Open Graph images from .cache/site.ts`;
-    } catch (error) {
-      spinner.fail(`Failed to generate Open Graph png for ${url}`);
-      throw error;
-    }
-  });
+        const imgFile = `${imgDir}${imgPath}.png`;
+        await mkdir(path.dirname(imgFile), {recursive: true});
+
+        const trasformer = Transformer.fromSvg(svg);
+        const pngData = await trasformer.png();
+        await writeFile(`${imgDir}${imgPath}.svg`, svg);
+        await writeFile(imgFile, pngData);
+        completed++;
+        spinner.text = `Generated ${completed} Open Graph images from .cache/site.ts`;
+      } catch (error) {
+        spinner.fail(`Failed to generate Open Graph png for ${url}`);
+        throw error;
+      }
+    }),
+  );
 };
 
 genOgImages().then(() => {

--- a/polaris.shopify.com/scripts/gen-og-images.tsx
+++ b/polaris.shopify.com/scripts/gen-og-images.tsx
@@ -8,7 +8,6 @@ import {writeFile, mkdir, rm} from 'fs/promises';
 import ora from 'ora';
 import satori, {type SatoriOptions} from 'satori';
 import typedSiteJSON from '../.cache/site';
-import {optimize} from 'svgo';
 
 const WIDTH = 1200;
 const HEIGHT = 630;
@@ -187,15 +186,12 @@ const genOgImages = async () => {
           url === ''
             ? '/home'
             : new URL(url, 'https://polaris.shopify.com').pathname;
-        const svg = optimize(
-          await generateSvg(url, frontMatter, satoriConfig),
-          {},
-        );
+        const svg = await generateSvg(url, frontMatter, satoriConfig);
 
         const imgFile = `${imgDir}${imgPath}.png`;
         await mkdir(path.dirname(imgFile), {recursive: true});
 
-        const pngData = await Transformer.fromSvg(svg.data)
+        const pngData = await Transformer.fromSvg(svg)
           // svg comes in at 2x size for some reason.
           .crop(0, 0, WIDTH, HEIGHT)
           .png();

--- a/polaris.shopify.com/scripts/gen-og-images.tsx
+++ b/polaris.shopify.com/scripts/gen-og-images.tsx
@@ -46,7 +46,7 @@ const generateSvg = async (url, frontMatter, satoriConfig: SatoriOptions) => {
     <div
       style={{
         display: 'flex',
-        fontFamily: 'apple-system, BlinkMacSystemFont, sans-serif',
+        fontFamily: 'Inter',
         width: '1200px',
         height: '630px',
         padding: '60px',

--- a/polaris.shopify.com/scripts/gen-og-images.tsx
+++ b/polaris.shopify.com/scripts/gen-og-images.tsx
@@ -80,7 +80,6 @@ const generateSvg = async (url, frontMatter, satoriConfig: SatoriOptions) => {
   if (frontMatter.previewImg) {
     const imgPath = path.join(process.cwd(), `public`, frontMatter.previewImg);
     const rawImageData = fs.readFileSync(imgPath);
-    // console.log('scaling image', imgPath);
     // Later conversion from svg to png fails when the final base64 encoded
     // embedded image is too large, so we resize it down here before embedding
     // it.
@@ -226,7 +225,6 @@ const genOgImages = async () => {
           // svg comes in at 2x size for some reason.
           .crop(0, 0, WIDTH, HEIGHT)
           .png();
-        await writeFile(`${imgDir}${imgPath}.svg`, svg.data);
         await writeFile(imgFile, pngData);
         completed++;
       } catch (error) {

--- a/polaris.shopify.com/tsconfig.json
+++ b/polaris.shopify.com/tsconfig.json
@@ -37,7 +37,8 @@
     "transpileOnly": true,
     "files": true,
     "compilerOptions": {
-      "module": "CommonJS"
+      "module": "CommonJS",
+      "jsx": "react"
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2078,21 +2078,6 @@
     globby "^11.0.0"
     read-yaml-file "^1.1.0"
 
-"@mapbox/node-pre-gyp@^1.0.0":
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz#417db42b7f5323d79e93b34a6d7a2a12c0df43fa"
-  integrity sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==
-  dependencies:
-    detect-libc "^2.0.0"
-    https-proxy-agent "^5.0.0"
-    make-dir "^3.1.0"
-    node-fetch "^2.6.7"
-    nopt "^5.0.0"
-    npmlog "^5.0.1"
-    rimraf "^3.0.2"
-    semver "^7.3.5"
-    tar "^6.1.11"
-
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.6.22.tgz#8a723157bf90e78f17dc0f27995398e6c731f1ba"
@@ -4473,11 +4458,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/tmp@^0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.6.tgz#d785ee90c52d7cc020e249c948c36f7b32d1e217"
-  integrity sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==
-
 "@types/uglify-js@*":
   version "3.13.2"
   resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.13.2.tgz#1044c1713fb81cb1ceef29ad8a9ee1ce08d690ef"
@@ -6741,15 +6721,6 @@ caniuse-lite@^1.0.30001449:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz#a8d11f6a814c75c9ce9d851dc53eb1d1dfbcd657"
   integrity sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==
 
-canvas@^2.11.2:
-  version "2.11.2"
-  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.11.2.tgz#553d87b1e0228c7ac0fc72887c3adbac4abbd860"
-  integrity sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==
-  dependencies:
-    "@mapbox/node-pre-gyp" "^1.0.0"
-    nan "^2.17.0"
-    simple-get "^3.0.3"
-
 capital-case@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.4.tgz#9d130292353c9249f6b00fa5852bee38a717e669"
@@ -8192,13 +8163,6 @@ decode-uri-component@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
-
-decompress-response@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
-  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
-  dependencies:
-    mimic-response "^2.0.0"
 
 decompress-response@^6.0.0:
   version "6.0.0"
@@ -15129,11 +15093,6 @@ mimic-response@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-mimic-response@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
-  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
-
 mimic-response@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
@@ -19335,15 +19294,6 @@ simple-concat@^1.0.0:
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
 
-simple-get@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.1.tgz#cc7ba77cfbe761036fbfce3d021af25fc5584d55"
-  integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
-  dependencies:
-    decompress-response "^4.2.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
-
 simple-get@^4.0.0, simple-get@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
@@ -21917,13 +21867,6 @@ watchpack@^2.2.0, watchpack@^2.4.0:
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
-
-wawoff2@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/wawoff2/-/wawoff2-2.0.1.tgz#474d8ccae33da3863abad0ee64b70b6db51acac2"
-  integrity sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==
-  dependencies:
-    argparse "^2.0.1"
 
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2215,6 +2215,84 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@napi-rs/image-android-arm-eabi@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/image-android-arm-eabi/-/image-android-arm-eabi-1.7.0.tgz#cc0a09aef43e4b529e9116d6305c683a936b26de"
+  integrity sha512-lpyqxaIYUrdk096xoJjvPGin5jY1Ehor0RxryqDvowGUhVU3TDgolsjjuFPEki3cfvV6zzAm7bWUkmxIci2zaw==
+
+"@napi-rs/image-android-arm64@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/image-android-arm64/-/image-android-arm64-1.7.0.tgz#57d38856946348eeabf1b907a09610be83573523"
+  integrity sha512-ojzi1ORsFZ53upLh0YVF1J8Qxvq+V2s6Xwbi4p4+ZLgk3MMd9ephERxxNExOf3/nyj4k+izEz6C/RbJwnSJXpw==
+
+"@napi-rs/image-darwin-arm64@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/image-darwin-arm64/-/image-darwin-arm64-1.7.0.tgz#972e8e6443e7e84b0f66c3b71dc7dfb350e8a10a"
+  integrity sha512-SadObhsP0E/og6FGDzwafWFEwePSkdEKmwh7ssWePopwN2PfTnIyQq4MfVE/iSLgHfiHgQwwwssY6j815P8YwA==
+
+"@napi-rs/image-darwin-x64@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/image-darwin-x64/-/image-darwin-x64-1.7.0.tgz#dfd58c53b3b0c50d35805ff6d50d75e811c87b3a"
+  integrity sha512-lbUpy3deqxsbGMZRRwkSAMs4uWN+f8RER4BI7kwVK9rjUwvmnI+JMC+TCD03j+AMviANhsR/umDjSTS4HAbKdQ==
+
+"@napi-rs/image-freebsd-x64@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/image-freebsd-x64/-/image-freebsd-x64-1.7.0.tgz#02c508296beca1acdd532ce23844c20ecd9e783f"
+  integrity sha512-DCFov4Ibk7pNUI30dBAR2SqtBSKTEtlsqkOJGWRiqGlTSqt7xPR3YcdM3N8JYN1lFHCN2SoJnInV3/p3yiKVLQ==
+
+"@napi-rs/image-linux-arm-gnueabihf@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/image-linux-arm-gnueabihf/-/image-linux-arm-gnueabihf-1.7.0.tgz#c3a6c978fa89874d92abbace684ca63bf356314a"
+  integrity sha512-392foWTx3vIsBs5lNDZt0H0qn/x3PLR92GCbY1SWNtbE11+D47IDxHauLqcU/18IVule9nODFZ6KLLhuLjdqJA==
+
+"@napi-rs/image-linux-arm64-gnu@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/image-linux-arm64-gnu/-/image-linux-arm64-gnu-1.7.0.tgz#4fee6e9a95fd85e5bf891ee0f462fa3e894c2a23"
+  integrity sha512-oYTCK6VsyywMPjcOJh5hk8vTA7i2coekXnkfHErBbyKm7v5F+3pdOXrhmKQHYojENHT/LkWWKlkr0jF8QB4U3w==
+
+"@napi-rs/image-linux-arm64-musl@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/image-linux-arm64-musl/-/image-linux-arm64-musl-1.7.0.tgz#4be9b48ad8d9336540bc80952964c305fee840d2"
+  integrity sha512-x3Z3YmhdMut2ULdXSjxAihp3rGcTvxUG5bhHMVc7bfezhGOViqfPJ5Qknra8egEZpXe6C0PKkBcIBm7hSlaubg==
+
+"@napi-rs/image-linux-x64-gnu@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/image-linux-x64-gnu/-/image-linux-x64-gnu-1.7.0.tgz#a528578a6e46a6ba2a3b2451c0c5412c4dae45c0"
+  integrity sha512-5+FEzLr7yNGljdXXPyMJLJAQG8z9c1rawFTnT4dUidFjtpP/C4AP923eWDeo7B2Zz2psT7A8hgXhK+uAqyj4WQ==
+
+"@napi-rs/image-linux-x64-musl@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/image-linux-x64-musl/-/image-linux-x64-musl-1.7.0.tgz#592abcf1b0ff9e19f6e3026f9011e7ffe4d193a8"
+  integrity sha512-LhzaYQ/z3axPUDPZefdyvgHz1qQ3NF2oDUHHFkVgpWNLJ3wGxa4GpM5TD+/jJCOChACAGYcZPpx96XLJGKNZfQ==
+
+"@napi-rs/image-win32-ia32-msvc@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/image-win32-ia32-msvc/-/image-win32-ia32-msvc-1.7.0.tgz#62ce6b1426656d093ee633c1236d2ce7b6ae66ea"
+  integrity sha512-taCxMQTssuZW2hviOzJxo1iji0cAwjXY9m7CkiAAM8KftVUxAbmDGkPyEGRyt43ftYJ/rXRMz1vEEz/gxiZ5rQ==
+
+"@napi-rs/image-win32-x64-msvc@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/image-win32-x64-msvc/-/image-win32-x64-msvc-1.7.0.tgz#238b3f1d1e239335fd2253a6bf86325b0698a3a9"
+  integrity sha512-hfnpTipEv6mrvhaNHRHBdYoVPUPyWnJ5KDpPAabJbTcsVb4x2TUiVI54r5GzF8zQ0RJc5mGtWdu9KFvyEBVJkg==
+
+"@napi-rs/image@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@napi-rs/image/-/image-1.7.0.tgz#b66e8f406d5300c7e1fb5fb874ee0638dc38f9f8"
+  integrity sha512-UI8bJKz4MwYsf2toiyxodbXeyHNe9yxhXz0KJdiDgliYs7ObCiu7DatPA899yuNscOApkweKV6yx2ag1lpVbbw==
+  optionalDependencies:
+    "@napi-rs/image-android-arm-eabi" "1.7.0"
+    "@napi-rs/image-android-arm64" "1.7.0"
+    "@napi-rs/image-darwin-arm64" "1.7.0"
+    "@napi-rs/image-darwin-x64" "1.7.0"
+    "@napi-rs/image-freebsd-x64" "1.7.0"
+    "@napi-rs/image-linux-arm-gnueabihf" "1.7.0"
+    "@napi-rs/image-linux-arm64-gnu" "1.7.0"
+    "@napi-rs/image-linux-arm64-musl" "1.7.0"
+    "@napi-rs/image-linux-x64-gnu" "1.7.0"
+    "@napi-rs/image-linux-x64-musl" "1.7.0"
+    "@napi-rs/image-win32-ia32-msvc" "1.7.0"
+    "@napi-rs/image-win32-x64-msvc" "1.7.0"
+
 "@next/env@13.0.6":
   version "13.0.6"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-13.0.6.tgz#3fcab11ffbe95bff127827d9f7f3139bc5e6adff"
@@ -11806,6 +11884,11 @@ inquirer@^8.2.2, inquirer@^8.2.4:
     strip-ansi "^6.0.0"
     through "^2.3.6"
     wrap-ansi "^7.0.0"
+
+inter-ui@3.19.3:
+  version "3.19.3"
+  resolved "https://registry.yarnpkg.com/inter-ui/-/inter-ui-3.19.3.tgz#cf4b4b6d30de8d5463e2462588654b325206488c"
+  integrity sha512-5FG9fjuYOXocIfjzcCBhICL5cpvwEetseL3FU6tP3d6Bn7g8wODhB+I9RNGRTizCT7CUG4GOK54OPxqq3msQgg==
 
 internal-slot@^1.0.3, internal-slot@^1.0.5:
   version "1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2078,6 +2078,21 @@
     globby "^11.0.0"
     read-yaml-file "^1.1.0"
 
+"@mapbox/node-pre-gyp@^1.0.0":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz#417db42b7f5323d79e93b34a6d7a2a12c0df43fa"
+  integrity sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==
+  dependencies:
+    detect-libc "^2.0.0"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.7"
+    nopt "^5.0.0"
+    npmlog "^5.0.1"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.11"
+
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.6.22.tgz#8a723157bf90e78f17dc0f27995398e6c731f1ba"
@@ -4380,6 +4395,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/tmp@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.6.tgz#d785ee90c52d7cc020e249c948c36f7b32d1e217"
+  integrity sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==
+
 "@types/uglify-js@*":
   version "3.13.2"
   resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.13.2.tgz#1044c1713fb81cb1ceef29ad8a9ee1ce08d690ef"
@@ -6643,6 +6663,15 @@ caniuse-lite@^1.0.30001449:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz#a8d11f6a814c75c9ce9d851dc53eb1d1dfbcd657"
   integrity sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==
 
+canvas@^2.11.2:
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.11.2.tgz#553d87b1e0228c7ac0fc72887c3adbac4abbd860"
+  integrity sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==
+  dependencies:
+    "@mapbox/node-pre-gyp" "^1.0.0"
+    nan "^2.17.0"
+    simple-get "^3.0.3"
+
 capital-case@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.4.tgz#9d130292353c9249f6b00fa5852bee38a717e669"
@@ -8086,6 +8115,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
+decompress-response@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
+  integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
+  dependencies:
+    mimic-response "^2.0.0"
+
 decompress-response@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
@@ -8294,11 +8330,6 @@ devtools-protocol@0.0.1001819:
   version "0.0.1001819"
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz#0a98f44cefdb02cc684f3d5e6bd898a1690231d9"
   integrity sha512-G6OsIFnv/rDyxSqBa2lDLR6thp9oJioLsb2Gl+LbQlyoA9/OBAkrTU9jiCcQ8Pnh7z4d6slDiLaogR5hzgJLmQ==
-
-devtools-protocol@0.0.1019158:
-  version "0.0.1019158"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1019158.tgz#4b08d06108a784a2134313149626ba55f030a86f"
-  integrity sha512-wvq+KscQ7/6spEV7czhnZc9RM/woz1AY+/Vpd8/h2HFMwJSdTliu7f/yr1A6vDdJfKICZsShqsYpEQbdhg8AFQ==
 
 devtools-protocol@0.0.981744:
   version "0.0.981744"
@@ -15015,6 +15046,11 @@ mimic-response@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
+mimic-response@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
+  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+
 mimic-response@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
@@ -17689,24 +17725,6 @@ puppeteer@^14.4.1:
     unbzip2-stream "1.4.3"
     ws "8.7.0"
 
-puppeteer@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-16.0.0.tgz#9efb6cdb57e3e51cf060a33f6289e88200dd4672"
-  integrity sha512-FgSe21IHNHkqv1SiJiob4ANsxVujcINa4p3MaDEMyoZsocbgSgwYE0c9lnF8eoinw4id3vx4DOXwhFdOOwVlDg==
-  dependencies:
-    cross-fetch "3.1.5"
-    debug "4.3.4"
-    devtools-protocol "0.0.1019158"
-    extract-zip "2.0.1"
-    https-proxy-agent "5.0.1"
-    pkg-dir "4.2.0"
-    progress "2.0.3"
-    proxy-from-env "1.1.0"
-    rimraf "3.0.2"
-    tar-fs "2.1.1"
-    unbzip2-stream "1.4.3"
-    ws "8.8.1"
-
 qs@6.11.0, qs@^6.10.0, qs@^6.9.1:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
@@ -19233,6 +19251,15 @@ simple-concat@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-3.1.1.tgz#cc7ba77cfbe761036fbfce3d021af25fc5584d55"
+  integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
+  dependencies:
+    decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 simple-get@^4.0.0, simple-get@^4.0.1:
   version "4.0.1"
@@ -22294,15 +22321,15 @@ ws@8.7.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.7.0.tgz#eaf9d874b433aa00c0e0d8752532444875db3957"
   integrity sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==
 
-ws@8.8.1, ws@^8.2.3, ws@^8.4.2:
-  version "8.8.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
-  integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
-
 ws@^7.3.1, ws@^7.4.6:
   version "7.5.7"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
   integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
+
+ws@^8.2.3, ws@^8.4.2:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
+  integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
 
 x-default-browser@^0.4.0:
   version "0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20248,7 +20248,7 @@ svg-tags@^1.0.0:
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
   integrity sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=
 
-svgo@^2.7.0, svgo@^2.8.0:
+svgo@^2.7.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-2.8.0.tgz#4ff80cce6710dc2795f0c7c74101e6764cfccd24"
   integrity sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2800,6 +2800,14 @@
   resolved "https://registry.yarnpkg.com/@shopify/useful-types/-/useful-types-5.0.0.tgz#1a06976ecff33de9b36c822c4f2f89a92940f27b"
   integrity sha512-3T9AZNKK3Tjxz++Z10DFtNnAXfdoE9kPkJTiCfsRcxZ3IVfFORzAUKTv4mgKT5P8IyRbIRtmxfzZzRCxn4fIgQ==
 
+"@shuding/opentype.js@1.4.0-beta.0":
+  version "1.4.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz#5d1e7e9e056f546aad41df1c5043f8f85d39e24b"
+  integrity sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==
+  dependencies:
+    fflate "^0.7.3"
+    string.prototype.codepointat "^0.2.1"
+
 "@sinclair/typebox@^0.23.3":
   version "0.23.4"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.23.4.tgz#6ff93fd2585ce44f7481c9ff6af610fbb5de98a4"
@@ -5901,6 +5909,11 @@ base-64@^1.0.0:
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-1.0.0.tgz#09d0f2084e32a3fd08c2475b973788eee6ae8f4a"
   integrity sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==
 
+base64-js@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"
+  integrity sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==
+
 base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -6600,6 +6613,11 @@ camelcase@^6.2.0, camelcase@^6.3.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
+camelize@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
+  integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
+
 caniuse-api@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
@@ -7181,7 +7199,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -7714,6 +7732,21 @@ crypto-random-string@^4.0.0:
   dependencies:
     type-fest "^1.0.1"
 
+css-background-parser@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/css-background-parser/-/css-background-parser-0.1.0.tgz#48a17f7fe6d4d4f1bca3177ddf16c5617950741b"
+  integrity sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==
+
+css-box-shadow@1.0.0-3:
+  version "1.0.0-3"
+  resolved "https://registry.yarnpkg.com/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz#9eaeb7140947bf5d649fc49a19e4bbaa5f602713"
+  integrity sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==
+
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
+
 css-declaration-sorter@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz#bfd2f6f50002d6a3ae779a87d3a0c5d5b10e0f02"
@@ -7782,6 +7815,15 @@ css-selector-parser@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/css-selector-parser/-/css-selector-parser-1.4.1.tgz#03f9cb8a81c3e5ab2c51684557d5aaf6d2569759"
   integrity sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==
+
+css-to-react-native@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.2.0.tgz#cdd8099f71024e149e4f6fe17a7d46ecd55f1e32"
+  integrity sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^4.0.2"
 
 css-tree@^1.1.2, css-tree@^1.1.3:
   version "1.1.3"
@@ -8537,6 +8579,11 @@ emittery@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860"
   integrity sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==
+
+emoji-regex@^10.2.1:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.3.0.tgz#76998b9268409eb3dae3de989254d456e70cfe23"
+  integrity sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -9675,6 +9722,11 @@ fetch-retry@^5.0.2:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/fetch-retry/-/fetch-retry-5.0.3.tgz#edfa3641892995f9afee94f25b168827aa97fe3d"
   integrity sha512-uJQyMrX5IJZkhoEUBQ3EjxkeiZkppBd5jS/fMTJmfZxLSiaQjv2zD0kTvuvkSH89uFvgSlB6ueGpjD3HWN7Bxw==
+
+fflate@^0.7.3:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.7.4.tgz#61587e5d958fdabb5a9368a302c25363f4f69f50"
+  integrity sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -11096,6 +11148,11 @@ header-case@^2.0.4:
   dependencies:
     capital-case "^1.0.4"
     tslib "^2.0.3"
+
+hex-rgb@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/hex-rgb/-/hex-rgb-4.3.0.tgz#af5e974e83bb2fefe44d55182b004ec818c07776"
+  integrity sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==
 
 hey-listen@^1.0.8:
   version "1.0.8"
@@ -13489,6 +13546,14 @@ lilconfig@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.5.tgz#19e57fd06ccc3848fd1891655b5a447092225b25"
   integrity sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==
+
+linebreak@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/linebreak/-/linebreak-1.1.0.tgz#831cf378d98bced381d8ab118f852bd50d81e46b"
+  integrity sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==
+  dependencies:
+    base64-js "0.0.8"
+    unicode-trie "^2.0.0"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -15982,7 +16047,7 @@ ora@^1.2.0, ora@^1.3.0:
     cli-spinners "^1.0.1"
     log-symbols "^2.1.0"
 
-ora@^5.4.1, ora@^v5.4.1:
+ora@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
   integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
@@ -16228,6 +16293,11 @@ pacote@^2.7.36:
     unique-filename "^1.1.0"
     which "^1.2.12"
 
+pako@^0.2.5:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+  integrity sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==
+
 pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -16274,6 +16344,14 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.6:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
+
+parse-css-color@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/parse-css-color/-/parse-css-color-0.2.1.tgz#b687a583f2e42e66ffdfce80a570706966e807c9"
+  integrity sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==
+  dependencies:
+    color-name "^1.1.4"
+    hex-rgb "^4.1.0"
 
 parse-entities@^2.0.0:
   version "2.0.0"
@@ -17209,7 +17287,7 @@ postcss-unique-selectors@^5.1.1:
   dependencies:
     postcss-selector-parser "^6.0.5"
 
-postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
+postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
@@ -18778,6 +18856,22 @@ sass@^1.49.9:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
+satori@^0.10.11:
+  version "0.10.11"
+  resolved "https://registry.yarnpkg.com/satori/-/satori-0.10.11.tgz#4d198beef405668120566d29a554411c534d8a5d"
+  integrity sha512-yLm1xPRPZUaKcBZJ6nmezoJjHB4MqV8x7Mu0PyZUJodRWRDD27UbeMwzuY9LEGG57WYLO4CQsGPlbHWV1Ex9TQ==
+  dependencies:
+    "@shuding/opentype.js" "1.4.0-beta.0"
+    css-background-parser "^0.1.0"
+    css-box-shadow "1.0.0-3"
+    css-to-react-native "^3.0.0"
+    emoji-regex "^10.2.1"
+    escape-html "^1.0.3"
+    linebreak "^1.1.0"
+    parse-css-color "^0.2.1"
+    postcss-value-parser "^4.2.0"
+    yoga-wasm-web "^0.3.3"
+
 sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -19720,6 +19814,11 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string.prototype.codepointat@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz#004ad44c8afc727527b108cd462b4d971cd469bc"
+  integrity sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==
+
 "string.prototype.matchall@^4.0.0 || ^3.0.1", string.prototype.matchall@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz#8e6ecb0d8a1fb1fda470d81acecb2dba057a481d"
@@ -20431,6 +20530,11 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tiny-inflate@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
+  integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
+
 tiny-lru@^10.0.0:
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-10.3.0.tgz#2ddc88bbe8d9a2c761df673ebef52a82182a64b3"
@@ -20943,6 +21047,14 @@ unicode-property-aliases-ecmascript@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8"
   integrity sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==
+
+unicode-trie@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-trie/-/unicode-trie-2.0.0.tgz#8fd8845696e2e14a8b67d78fa9e0dd2cad62fec8"
+  integrity sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==
+  dependencies:
+    pako "^0.2.5"
+    tiny-inflate "^1.0.0"
 
 unified@9.2.0:
   version "9.2.0"
@@ -21696,6 +21808,13 @@ watchpack@^2.2.0, watchpack@^2.4.0:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
+wawoff2@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/wawoff2/-/wawoff2-2.0.1.tgz#474d8ccae33da3863abad0ee64b70b6db51acac2"
+  integrity sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==
+  dependencies:
+    argparse "^2.0.1"
+
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
@@ -22360,6 +22479,11 @@ yocto-queue@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
+
+yoga-wasm-web@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz#eb8e9fcb18e5e651994732f19a220cb885d932ba"
+  integrity sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==
 
 zip-stream@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
### WHY are these changes introduced?

- Fixes https://github.com/Shopify/polaris-internal/issues/1278

Our existing `gen-og-images` script creates an og-image layout using HTML markup and then runs puppeteer to take snapshots of each generated layout. This is relatively slow, this PR aims to swap this logic out for [Satori](https://github.com/vercel/satori) vercel's library for doing the exact same markup to og-image procedure but without having to spin up a puppeteer instance. 


### WHAT is this pull request doing?
* Convert our HTML markup to JSX 
* Convert `<style>` tag CSS to inline css for each of our JSX elements. (This is a limitation of satori, in that it does not support global <style> tags
* Remove puppeteer logic in favor of a single call to satori 
```tsx
satori(someMarkup, someConfig)
```
* Leverage [@inter-ui](https://www.npmjs.com/package/inter-ui) to download non-variable versions of Inter for use in our generated layout. (A limitation of the underlying library that Satori leverages for type support (opentype.js) is that it does not support variable fonts) 
* Leverage [@napi-rs/image](https://www.npmjs.com/package/@napi-rs/image) to convert our generated svg from satori into a png file for use as an og-image. 

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
