### PR TITLE
Fix `dev` run-script for `polaris.shopify.com`

### DIFF
--- a/polaris.shopify.com/scripts/gen-cache-json.mjs
+++ b/polaris.shopify.com/scripts/gen-cache-json.mjs
@@ -1,3 +1,4 @@
+import * as url from 'node:url';
 import path from 'path';
 import globby from 'globby';
 import {existsSync} from 'fs';
@@ -103,7 +104,7 @@ const getMdContent = async (filePath) => {
   return {frontMatter: data, slug};
 };
 
-const genCacheJson = async () => {
+export default async function genCacheJson() {
   const spinner = ora('Generating .cache/nav.ts and .cache/site.ts').start();
 
   if (!existsSync(cacheDir)) {
@@ -125,6 +126,21 @@ const genCacheJson = async () => {
   await genNavJson(markdownFiles);
 
   spinner.succeed('Generated .cache/nav.ts and .cache/site.ts');
-};
+}
 
-await genCacheJson();
+if (isMain(import.meta)) {
+  await genCacheJson();
+}
+
+// https://exploringjs.com/nodejs-shell-scripting/ch_nodejs-path.html#determining-if-an-esm-module-is-main
+function isMain(importMeta) {
+  if (import.meta.url.startsWith('file:')) {
+    const modulePath = url.fileURLToPath(import.meta.url);
+
+    if (process.argv[1] === modulePath) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
This PR re-applies the `genCacheJson` export (for use in the `dev` watch script) and introduces an `isMain` util (to conditionally run the `genCacheJson` script)

![Screenshot 2023-12-15 at 2 17 56 PM](https://github.com/Shopify/polaris/assets/32409546/0d2367e7-98b7-4c6d-bec9-b8dffe9f312d)
