### PR TITLE
Fix active state for Button with Popovers

### DIFF
--- a/.changeset/rude-chefs-explode.md
+++ b/.changeset/rude-chefs-explode.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed Button active state regression when used with activators such as Popover

--- a/polaris-react/src/components/Button/Button.module.scss
+++ b/polaris-react/src/components/Button/Button.module.scss
@@ -286,14 +286,17 @@
 
 // ICON
 .iconOnly {
+  --pc-button-padding-block: var(--p-space-100);
   --pc-button-padding-inline: var(--p-space-100);
 }
 
 .iconOnly:is(.sizeLarge) {
+  --pc-button-padding-block: var(--p-space-150);
   --pc-button-padding-inline: var(--p-space-150);
 }
 
 .iconOnly:is(.sizeMicro) {
+  --pc-button-padding-block: var(--p-space-050);
   --pc-button-padding-inline: var(--p-space-050);
 }
 

--- a/polaris-react/src/components/Button/Button.module.scss
+++ b/polaris-react/src/components/Button/Button.module.scss
@@ -64,7 +64,7 @@
 }
 
 .Button:active,
-.Button[aria-expanded='true'] {
+.Button[data-state='open'] {
   background: var(--pc-button-bg_active);
   color: var(--pc-button-color_active);
   box-shadow: var(--pc-button-box-shadow_active);

--- a/polaris-react/src/components/Popover/set-activator-attributes.ts
+++ b/polaris-react/src/components/Popover/set-activator-attributes.ts
@@ -21,6 +21,7 @@ export function setActivatorAttributes(
   activator.setAttribute('aria-controls', id);
   activator.setAttribute('aria-owns', id);
   activator.setAttribute('aria-expanded', String(active));
+  activator.setAttribute('data-state', active ? 'open' : 'closed');
 
   if (ariaHaspopup != null) {
     activator.setAttribute('aria-haspopup', String(ariaHaspopup));


### PR DESCRIPTION
Fix expanded state regression on Button. The button should only apply the active state when used as an activator (i.e., with Popover).

🌀 [Spin URL](https://admin.web.polaris--12-7-0.sam-rose.us.spin.dev/store/shop1)

This PR does the following:

- Keeps the CSS selector to a low specificity by using the `data-state` attribute to apply the active styling.
- Fixes the Popover positioning with tertiary, icon-only Button by applying margin block as well as inline

This separates the styles from the ARIA state and follows the `data-state` pattern used by the [Radix UI Popover](https://www.radix-ui.com/primitives/docs/components/popover).

## Screenshots

| Before | After |
| --- | --- |
| ![Regression](https://private-user-images.githubusercontent.com/6844391/292493632-1dfa6801-4ae3-409a-a50b-2ad9be198c7c.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTEiLCJleHAiOjE3MDMyNTc5MTQsIm5iZiI6MTcwMzI1NzYxNCwicGF0aCI6Ii82ODQ0MzkxLzI5MjQ5MzYzMi0xZGZhNjgwMS00YWUzLTQwOWEtYTUwYi0yYWQ5YmUxOThjN2MucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQUlXTkpZQVg0Q1NWRUg1M0ElMkYyMDIzMTIyMiUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyMzEyMjJUMTUwNjU0WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NDE3ODcyNDQ4MWIyNjk0OTk2OTVmYjZkZWFhZTUzMDhmNzhkNTYwNDQxZjEwNjJhNjljODkzNjU1NmZjMTI1YiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.z6SPMOztr6I1_qAat-DIJCsfAHiV3Xez0RlX6_qfPu0) | <img width="168" alt="Screenshot 2023-12-22 at 11 15 49 AM" src="https://github.com/Shopify/polaris/assets/11774595/2f02b4dc-42cd-4e5f-95d0-b38026656977"> |
