### PR TITLE
[BlockStack, InlineStack] Add `as` prop to InlineStack and span, li to BlockStack

### DIFF
--- a/.changeset/strong-tables-whisper.md
+++ b/.changeset/strong-tables-whisper.md
@@ -1,0 +1,6 @@
+---
+'@shopify/polaris': minor
+---
+
+Added as prop to InlineStack
+Added span and list item element types to BlockStack

--- a/polaris-react/src/components/BlockStack/BlockStack.tsx
+++ b/polaris-react/src/components/BlockStack/BlockStack.tsx
@@ -20,7 +20,7 @@ type Align =
 
 type InlineAlign = 'start' | 'center' | 'end' | 'baseline' | 'stretch';
 
-type Element = 'div' | 'ul' | 'ol' | 'fieldset';
+type Element = 'div' | 'span' | 'ul' | 'ol' | 'li' | 'fieldset';
 
 type Gap = ResponsiveProp<SpaceScale>;
 

--- a/polaris-react/src/components/InlineStack/InlineStack.tsx
+++ b/polaris-react/src/components/InlineStack/InlineStack.tsx
@@ -16,9 +16,13 @@ type Align =
 type BlockAlign = 'start' | 'center' | 'end' | 'baseline' | 'stretch';
 
 type Gap = ResponsiveProp<SpaceScale>;
-
+type Element = 'div' | 'span' | 'li' | 'ol' | 'ul';
 export interface InlineStackProps extends React.AriaAttributes {
   children?: React.ReactNode;
+  /** HTML Element type
+   * @default 'div'
+   */
+  as?: Element;
   /** Horizontal alignment of children */
   align?: Align;
   /** Vertical alignment of children */
@@ -36,6 +40,7 @@ export interface InlineStackProps extends React.AriaAttributes {
 }
 
 export const InlineStack = function InlineStack({
+  as: Element = 'div',
   align,
   blockAlign,
   gap,
@@ -50,8 +55,8 @@ export const InlineStack = function InlineStack({
   } as React.CSSProperties;
 
   return (
-    <div className={styles.InlineStack} style={style}>
+    <Element className={styles.InlineStack} style={style}>
       {children}
-    </div>
+    </Element>
   );
 };


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue I'm having in web where I need a span vs block inside of a button. Can't nest block level elements inside of buttons

Brings parity to InlineStack and BlockStack as prop

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
