### PR TITLE
Add development port so that the opened browser loads the site

### DIFF
--- a/polaris.shopify.com/package.json
+++ b/polaris.shopify.com/package.json
@@ -9,7 +9,7 @@
     "build": "yarn concurrently \"yarn gen-colors\" \"yarn gen-assets\" \"playroom build\" && next build && cp -r public ./.next/standalone/polaris.shopify.com/ && mkdirp ./.next/standalone/polaris.shopify.com/.next && cp -r .next/static ./.next/standalone/polaris.shopify.com/.next/",
     "start": "cd ./.next/standalone/polaris.shopify.com && node ./server.js",
     "dev": "yarn gen-colors && yarn get-props && run-p dev:*",
-    "dev:server": "open http://localhost:${POLARIS_WEBSITE_PORT:=3000} && next dev",
+    "dev:server": "open http://localhost:${POLARIS_WEBSITE_PORT:=3000} && next dev -p 3000",
     "dev:playroom": "rm -rf ./public/playroom && playroom start",
     "dev:watch-md": "ts-node scripts/watch-md.ts",
     "lint": "run-p lint:*",


### PR DESCRIPTION
Before a tab with `localhost:3000` opened and the site did not show because it created the site on port on some random number (like 54231). This now sets the port as 3000 so that the browser opens and the site loads.