### PR TITLE
Apply smaller focus ring to plain and monochrome buttons

### DIFF
--- a/.changeset/fuzzy-dancers-hug.md
+++ b/.changeset/fuzzy-dancers-hug.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed focus ring size for plain and plain monochrome Button variants

--- a/polaris-react/src/components/Button/Button.module.scss
+++ b/polaris-react/src/components/Button/Button.module.scss
@@ -174,8 +174,7 @@
   --pc-button-color_active: var(--p-color-text-link-active);
 }
 
-.variantPlain:hover,
-.variantPlain:active {
+.variantPlain:is(:hover, :active, :focus-visible) {
   text-decoration: underline;
 }
 
@@ -192,6 +191,12 @@
   font-size: var(--p-font-size-325);
   font-weight: var(--p-font-weight-regular);
   line-height: var(--p-font-line-height-400);
+}
+
+.variantPlain:focus-visible,
+.variantMonochromePlain:focus-visible {
+  border-radius: var(--p-border-radius-300);
+  outline-offset: calc(-1 * var(--pc-button-padding-block));
 }
 
 // TONES


### PR DESCRIPTION
Closes #11422

Reduces the focus ring closer to the original size for the `plain` and `plainMonochrome` button variants. This PR also applied the underline text decoration styles when focused for the `plain` varaint.

### `plain`

https://github.com/Shopify/polaris/assets/11774595/a46629d5-d0e5-414d-8296-7caba60d0831

### `plainMonochrome`

https://github.com/Shopify/polaris/assets/11774595/785757b2-7b9b-4f15-b3b0-53b0b2ce8285
