### PR TITLE
[Button] Fix monochromePlain variant icon fill inheritance

### DIFF
--- a/.changeset/cool-kids-flow.md
+++ b/.changeset/cool-kids-flow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed `monochromePlain` `Button` `variant` SVG fill

--- a/polaris-react/src/components/Button/Button.module.scss
+++ b/polaris-react/src/components/Button/Button.module.scss
@@ -177,7 +177,7 @@
 }
 
 .variantMonochromePlain {
-  --pc-button-icon-fill: var(--p-color-icon);
+  --pc-button-icon-fill: currentColor;
 }
 
 .variantPlain,
@@ -313,8 +313,15 @@
     calc(-1 * var(--pc-button-padding-inline));
 }
 
-.iconOnly:is(.variantTertiary, .variantPlain, .variantMonochromePlain):not(.toneCritical) {
+.iconOnly:is(.variantTertiary, .variantPlain):not(.toneCritical) {
   --pc-button-icon-fill: var(--p-color-icon-secondary);
+  --pc-button-icon-fill_hover: var(--p-color-icon-secondary-hover);
+  --pc-button-icon-fill_active: var(--p-color-icon-secondary-active);
+  --pc-button-icon-fill_disabled: var(--p-color-icon-disabled);
+}
+
+.iconOnly:is(.variantMonochromePlain) {
+  --pc-button-icon-fill: currentColor;
   --pc-button-icon-fill_hover: var(--p-color-icon-secondary-hover);
   --pc-button-icon-fill_active: var(--p-color-icon-secondary-active);
   --pc-button-icon-fill_disabled: var(--p-color-icon-disabled);

--- a/polaris-react/src/components/Button/Button.stories.tsx
+++ b/polaris-react/src/components/Button/Button.stories.tsx
@@ -17,6 +17,7 @@ import {
   XSmallIcon,
   ChevronDownIcon,
   EditIcon,
+  MagicIcon,
 } from '@shopify/polaris-icons';
 
 export default {
@@ -252,6 +253,13 @@ export function MonochromePlain() {
           <Button variant="monochromePlain" disclosure>
             Inherited color
           </Button>
+        </Box>
+        <Box color="text-magic">
+          <Button
+            variant="monochromePlain"
+            icon={MagicIcon}
+            accessibilityLabel="Apply suggestion"
+          />
         </Box>
       </InlineStack>
     </Box>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes `Icon` not inheriting color from parent `Button` when `variant` is `monochromePlain`.

| [Before](https://storybook.polaris.shopify.com/?path=/story/all-components-button--monochrome-plain) | [After]() |
|--------|--------|
|![Screenshot 2024-01-22 at 6 19 25 PM](https://github.com/Shopify/polaris/assets/18447883/dc9f8db3-285f-4214-afc0-15b580d10d9a) |![Screenshot 2024-01-22 at 6 22 00 PM](https://github.com/Shopify/polaris/assets/18447883/96754f83-6f7f-4022-ae9e-043687c0d152) |

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
