### PR TITLE
Add direction to inline-stack

### DIFF
--- a/.changeset/empty-waves-wave.md
+++ b/.changeset/empty-waves-wave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+Added `direction` prop to `InlineStack` to allow for reversing the direction of items.

--- a/polaris-react/src/components/InlineStack/InlineStack.module.scss
+++ b/polaris-react/src/components/InlineStack/InlineStack.module.scss
@@ -2,6 +2,7 @@
 
 .InlineStack {
   @include responsive-props('inline-stack', 'gap', 'gap');
+  @include responsive-props('inline-stack', 'flex-direction', 'flex-direction');
   display: flex;
   // stylelint-disable-next-line -- Necessary for layout components
   flex-wrap: var(--pc-inline-stack-wrap);

--- a/polaris-react/src/components/InlineStack/InlineStack.stories.tsx
+++ b/polaris-react/src/components/InlineStack/InlineStack.stories.tsx
@@ -181,3 +181,23 @@ export function WithResponsiveGap() {
     </InlineStack>
   );
 }
+
+export function WithDirectionReversed() {
+  return (
+    <InlineStack direction="row-reverse" gap="200">
+      <Badge>One</Badge>
+      <Badge>Two</Badge>
+      <Badge>Three</Badge>
+    </InlineStack>
+  );
+}
+
+export function WithResponsiveDirectionReversed() {
+  return (
+    <InlineStack direction={{xs: 'row', md: 'row-reverse'}} gap="200">
+      <Badge>One</Badge>
+      <Badge>Two</Badge>
+      <Badge>Three</Badge>
+    </InlineStack>
+  );
+}

--- a/polaris-react/src/components/InlineStack/InlineStack.tsx
+++ b/polaris-react/src/components/InlineStack/InlineStack.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type {SpaceScale} from '@shopify/polaris-tokens';
 
-import {getResponsiveProps} from '../../utilities/css';
+import {getResponsiveProps, getResponsiveValue} from '../../utilities/css';
 import type {ResponsiveProp} from '../../utilities/css';
 
 import styles from './InlineStack.module.scss';
@@ -16,6 +16,7 @@ type Align =
 type BlockAlign = 'start' | 'center' | 'end' | 'baseline' | 'stretch';
 
 type Gap = ResponsiveProp<SpaceScale>;
+type Direction = ResponsiveProp<'row' | 'row-reverse'>;
 type Element = 'div' | 'span' | 'li' | 'ol' | 'ul';
 export interface InlineStackProps extends React.AriaAttributes {
   children?: React.ReactNode;
@@ -25,6 +26,8 @@ export interface InlineStackProps extends React.AriaAttributes {
   as?: Element;
   /** Horizontal alignment of children */
   align?: Align;
+  /** Horizontal direction in which children are laid out */
+  direction?: Direction;
   /** Vertical alignment of children */
   blockAlign?: BlockAlign;
   /** The spacing between elements. Accepts a spacing token or an object of spacing tokens for different screen sizes.
@@ -42,6 +45,7 @@ export interface InlineStackProps extends React.AriaAttributes {
 export const InlineStack = function InlineStack({
   as: Element = 'div',
   align,
+  direction = 'row',
   blockAlign,
   gap,
   wrap = true,
@@ -52,6 +56,7 @@ export const InlineStack = function InlineStack({
     '--pc-inline-stack-block-align': blockAlign,
     '--pc-inline-stack-wrap': wrap ? 'wrap' : 'nowrap',
     ...getResponsiveProps('inline-stack', 'gap', 'space', gap),
+    ...getResponsiveValue('inline-stack', 'flex-direction', direction),
   } as React.CSSProperties;
 
   return (

--- a/polaris-react/src/components/InlineStack/tests/InlineStack.test.tsx
+++ b/polaris-react/src/components/InlineStack/tests/InlineStack.test.tsx
@@ -28,13 +28,19 @@ describe('<InlineStack />', () => {
     expect(inlineStack).toContainReactComponent('div', {
       style: expect.objectContaining({
         '--pc-inline-stack-wrap': 'wrap',
+        '--pc-inline-stack-flex-direction-xs': 'row',
       }) as React.CSSProperties,
     });
   });
 
   it('overrides custom properties if they are passed in', () => {
     const inlineStack = mountWithApp(
-      <InlineStack align="center" blockAlign="start" gap="1000">
+      <InlineStack
+        align="center"
+        blockAlign="start"
+        gap="1000"
+        direction="row-reverse"
+      >
         {renderChildren()}
       </InlineStack>,
     );
@@ -45,6 +51,7 @@ describe('<InlineStack />', () => {
         '--pc-inline-stack-block-align': 'start',
         '--pc-inline-stack-wrap': 'wrap',
         '--pc-inline-stack-gap-xs': 'var(--p-space-1000)',
+        '--pc-inline-stack-flex-direction-xs': 'row-reverse',
       }) as React.CSSProperties,
     });
   });
@@ -61,6 +68,21 @@ describe('<InlineStack />', () => {
         '--pc-inline-stack-wrap': 'wrap',
         '--pc-inline-stack-gap-xs': 'var(--p-space-200)',
         '--pc-inline-stack-gap-md': 'var(--p-space-800)',
+      }) as React.CSSProperties,
+    });
+  });
+
+  it('accepts direction based on breakpoints', () => {
+    const inlineStack = mountWithApp(
+      <InlineStack direction={{xs: 'row', md: 'row-reverse'}}>
+        {renderChildren()}
+      </InlineStack>,
+    );
+
+    expect(inlineStack).toContainReactComponent('div', {
+      style: expect.objectContaining({
+        '--pc-inline-stack-flex-direction-xs': 'row',
+        '--pc-inline-stack-flex-direction-md': 'row-reverse',
       }) as React.CSSProperties,
     });
   });

--- a/polaris.shopify.com/content/components/layout-and-structure/inline-stack.mdx
+++ b/polaris.shopify.com/content/components/layout-and-structure/inline-stack.mdx
@@ -30,6 +30,10 @@ examples:
     title: Align
     description: >-
       Control the horizontal alignment of children using the `align` prop.
+  - fileName: inline-stack-with-direction.tsx
+    title: Direction
+    description: >-
+      Control the horizontal direction of children using the `direction` prop. The `direction` prop supports responsive spacing with the [Breakpoints tokens](https://polaris.shopify.com/tokens/breakpoints).
 previewImg: /images/components/layout-and-structure/inline-stack.png
 ---
 

--- a/polaris.shopify.com/pages/examples/inline-stack-with-direction.tsx
+++ b/polaris.shopify.com/pages/examples/inline-stack-with-direction.tsx
@@ -6,7 +6,7 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 function InlineWithDirectionExample() {
   return (
     <BlockStack gap="1600">
-      <InlineStack direction="row">
+      <InlineStack direction="row" align="center">
         <Placeholder width="106px" label="1" />
         <Placeholder width="106px" height="20px" showBorder />
         <Placeholder width="106px" height="20px" showBorder />
@@ -16,14 +16,14 @@ function InlineWithDirectionExample() {
         <Placeholder width="106px" height="20px" showBorder />
       </InlineStack>
       <Divider />
-      <InlineStack direction="row-reverse">
-        <Placeholder width="106px" label="1" />
+      <InlineStack direction="row-reverse" align="center">
+        <Placeholder width="106px" label="1" showBorder />
         <Placeholder width="106px" height="20px" showBorder />
         <Placeholder width="106px" height="20px" showBorder />
         <Placeholder width="106px" height="20px" showBorder />
         <Placeholder width="106px" height="20px" showBorder />
         <Placeholder width="106px" height="20px" showBorder />
-        <Placeholder width="106px" height="20px" showBorder />
+        <Placeholder width="106px" height="20px" />
       </InlineStack>
     </BlockStack>
   );

--- a/polaris.shopify.com/pages/examples/inline-stack-with-direction.tsx
+++ b/polaris.shopify.com/pages/examples/inline-stack-with-direction.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import {BlockStack, InlineStack, Text, Divider} from '@shopify/polaris';
+
+import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
+
+function InlineWithDirectionExample() {
+  return (
+    <BlockStack gap="1600">
+      <InlineStack direction="row">
+        <Placeholder width="106px" label="1" />
+        <Placeholder width="106px" height="20px" showBorder />
+        <Placeholder width="106px" height="20px" showBorder />
+        <Placeholder width="106px" height="20px" showBorder />
+        <Placeholder width="106px" height="20px" showBorder />
+        <Placeholder width="106px" height="20px" showBorder />
+        <Placeholder width="106px" height="20px" showBorder />
+      </InlineStack>
+      <Divider />
+      <InlineStack direction="row-reverse">
+        <Placeholder width="106px" label="1" />
+        <Placeholder width="106px" height="20px" showBorder />
+        <Placeholder width="106px" height="20px" showBorder />
+        <Placeholder width="106px" height="20px" showBorder />
+        <Placeholder width="106px" height="20px" showBorder />
+        <Placeholder width="106px" height="20px" showBorder />
+        <Placeholder width="106px" height="20px" showBorder />
+      </InlineStack>
+    </BlockStack>
+  );
+}
+
+const Placeholder = ({
+  label = '',
+  height = 'auto',
+  width = 'auto',
+  showBorder = false,
+  showBorderTop = false,
+}) => {
+  return (
+    <div
+      style={{
+        padding: '6px 0',
+        background: 'var(--p-color-text-info)',
+        height: height,
+        width: width,
+        borderInlineStart: showBorder
+          ? '1px dashed var(--p-color-bg-surface-success)'
+          : 'none',
+        borderBlockStart: showBorderTop
+          ? '1px dashed var(--p-color-bg-surface-success)'
+          : 'none',
+      }}
+    >
+      <InlineStack align="center">
+        <div
+          style={{
+            color: 'var(--p-color-text-info-on-bg-fill)',
+          }}
+        >
+          <Text
+            as="h2"
+            variant="bodyMd"
+            fontWeight="medium"
+            tone="text-inverse"
+          >
+            {label}
+          </Text>
+        </div>
+      </InlineStack>
+    </div>
+  );
+};
+
+export default withPolarisExample(InlineWithDirectionExample);


### PR DESCRIPTION
This PR adds the functionality to reverse the order of items in an `InlineStack` by adding a responsive flex-direction prop with options `row` and `row-reverse` with `row` being the default.

Use case: Sometimes designers want to flip the order of columns on mobile 
<img width="545" alt="Screenshot 2024-02-05 at 11 52 31 AM" src="https://github.com/Shopify/polaris/assets/7470936/854b5366-43d6-4c0b-9796-5456a687851a">


### WHY are these changes introduced?

This change allows for layouts to be created where the order of elements can change between desktop and mobile. 

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
