### PR TITLE
chore: remove nav tag from breadcrumbs

### DIFF
--- a/.changeset/unlucky-geese-warn.md
+++ b/.changeset/unlucky-geese-warn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Removed nav wrapper from breadcrumbs since it now only renders a single link

--- a/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/polaris-react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -13,7 +13,7 @@ export interface BreadcrumbsProps {
 export function Breadcrumbs({backAction}: BreadcrumbsProps) {
   const {content} = backAction;
 
-  const breadcrumbMarkup = (
+  return (
     <Button
       key={content}
       url={'url' in backAction ? backAction.url : undefined}
@@ -23,6 +23,4 @@ export function Breadcrumbs({backAction}: BreadcrumbsProps) {
       accessibilityLabel={backAction.accessibilityLabel ?? content}
     />
   );
-
-  return <nav role="navigation">{breadcrumbMarkup}</nav>;
 }


### PR DESCRIPTION
This shouldn't be needed any longer since back action is singular. I don't think it's a breaking change, technically. Open to other opinions but I think it's an a11y improvement 