### PR TITLE
Update .eslintrc.js to use globs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: [
       './tsconfig.eslint.json',
-      '**/tsconfig.json',
+      '*/tsconfig.json',
       '!polaris-icons/tsconfig.json',
     ],
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,9 +17,8 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: [
       './tsconfig.eslint.json',
-      ...packages
-        .filter((pkg) => pkg !== 'polaris-icons')
-        .map((pkg) => `./${pkg}/tsconfig.json`),
+      '**/tsconfig.json',
+      '!polaris-icons/tsconfig.json',
     ],
   },
   settings: {


### PR DESCRIPTION
This pull request includes changes to the `module.exports` in the `.eslintrc.js` file. The main modification is the simplification of the `project` field configuration. Instead of manually filtering and mapping through the `packages` array to generate the `tsconfig.json` paths, a more straightforward glob pattern is used. This change should make the configuration easier to read and maintain.

Notable changes:

* [`.eslintrc.js`](diffhunk://#diff-e2954b558f2aa82baff0e30964490d12942e0e251c1aa56c3294de6ec67b7cf5L20-R21): The `project` field in the `module.exports` object has been simplified. It now uses a glob pattern '`**/tsconfig.json`' to include all `tsconfig.json` files, and explicitly excludes the `polaris-icons/tsconfig.json` file. This change replaces the previous approach of filtering and mapping the `packages` array.