### PR TITLE
[Frame] Fix regression with sidebar styling

### DIFF
--- a/.changeset/tame-hotels-repeat.md
+++ b/.changeset/tame-hotels-repeat.md
@@ -2,4 +2,4 @@
 '@shopify/polaris': minor
 ---
 
-[Frame] Fix regression that caused sidebar to render over Admin app content
+[Frame] Fixed regression that caused sidebar to render over Admin app content

--- a/.changeset/tame-hotels-repeat.md
+++ b/.changeset/tame-hotels-repeat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+[Frame] Fix regression that caused sidebar to render over Admin app content

--- a/polaris-react/src/components/Frame/Frame.module.scss
+++ b/polaris-react/src/components/Frame/Frame.module.scss
@@ -183,6 +183,7 @@ $sidebar-breakpoint: 1200px;
   flex: 1;
   display: flex;
   align-items: stretch;
+  border-inline-end: var(--p-border-width-025) solid var(--p-color-border);
 
   min-width: 0;
   @media (--p-breakpoints-sm-up) {
@@ -224,13 +225,12 @@ $sidebar-breakpoint: 1200px;
   flex: 1;
   min-width: 0;
   max-width: 100%;
-  border-inline-end: var(--p-border-width-025) solid var(--p-color-border);
 
   .hasSidebar & {
     /* stylelint-disable-next-line polaris/media-queries/polaris/media-query-allowed-list -- custom breakpoint */
     @media screen and (min-width: #{$sidebar-breakpoint}) {
       /* stylelint-disable-next-line polaris/conventions/polaris/custom-property-allowed-list -- private token from component */
-      padding-right: var(--pc-sidebar-width);
+      margin-right: var(--pc-sidebar-width);
     }
   }
 }


### PR DESCRIPTION
A previous [PR](https://github.com/Shopify/polaris/pull/11628) attempting to fix an unwanted border next to the sidebar unintentionally caused a regression in Admin: app pages in Admin no longer maintain space on the right for the universal sidebar.

The fix: revert the change from the previous PR which changed margin to padding. Use margin, but instead of rendering `border-inline-end` on `.Content`, which causes the unwanted border, render it on `.Main` instead.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/11694

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Before:

In Storybook, I added some styling to mimic how Admin apps are positioned absolutely. You can see how the sidebar overlaps the page content. This is what we want to fix.

https://screenshot.click/06-40-l8v5g-t7saz.png

After:

In Storybook, I added some styling to mimic how Admin apps are positioned absolutely. You can see how the sidebar spacing is respected and the sidebar does not overlap the content. The border is also correctly on the right side of the sidebar. `Frame` without sidebar also still correctly renders its border.

https://screenshot.click/06-45-4uju3-sn835.png

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
