### PR TITLE
[Picker] Refresh options on options change

### DIFF
--- a/.changeset/loud-worms-explain.md
+++ b/.changeset/loud-worms-explain.md
@@ -1,5 +1,0 @@
----
-'@shopify/polaris': patch
----
-
-Added useEffect to Picker to watch for added options

--- a/.changeset/loud-worms-explain.md
+++ b/.changeset/loud-worms-explain.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Added useEffect to Picker to watch for added options

--- a/polaris-react/playground/DetailsPage.tsx
+++ b/polaris-react/playground/DetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useRef, useState} from 'react';
+import React, {useMemo, useCallback, useRef, useState} from 'react';
 import {
   ChartVerticalIcon,
   AppsIcon,
@@ -76,6 +76,44 @@ export function DetailsPage() {
   const [emailFieldValue, setEmailFieldValue] = useState(
     defaultState.current.emailFieldValue,
   );
+
+  const [addedTags, setAddedTags] = useState<
+    {value: string; children: string}[]
+  >([]);
+
+  const tags = useMemo(
+    () => [
+      {value: 'Outdoors', children: 'Outdoors'},
+      {value: 'Adventure', children: 'Adventure'},
+      {value: 'Hiking', children: 'Hiking'},
+      {value: 'Camping', children: 'Camping'},
+      {value: 'Backpacking', children: 'Backpacking'},
+      {value: 'Mountaineering', children: 'Mountaineering'},
+      {value: 'Skiing', children: 'Skiing'},
+      {value: 'Snowboarding', children: 'Snowboarding'},
+      ...addedTags,
+    ],
+    [addedTags],
+  );
+
+  const handleTagSelect = useCallback(
+    (newTag: string) => {
+      console.log('tag select');
+      if (
+        tags.some((tag) => tag.value === newTag) ||
+        addedTags.some((tag) => tag.value === newTag)
+      ) {
+        return;
+      }
+      setAddedTags((addedTags) => [
+        ...addedTags,
+        {value: newTag, children: newTag},
+      ]);
+      setQuery('');
+    },
+    [addedTags, tags],
+  );
+
   const [storeName, setStoreName] = useState(
     defaultState.current.nameFieldValue,
   );
@@ -651,16 +689,8 @@ export function DetailsPage() {
                     value: query,
                     onChange: (value) => setQuery(value),
                   }}
-                  options={[
-                    {value: 'Outdoors', children: 'Outdoors'},
-                    {value: 'Adventure', children: 'Adventure'},
-                    {value: 'Hiking', children: 'Hiking'},
-                    {value: 'Camping', children: 'Camping'},
-                    {value: 'Backpacking', children: 'Backpacking'},
-                    {value: 'Mountaineering', children: 'Mountaineering'},
-                    {value: 'Skiing', children: 'Skiing'},
-                    {value: 'Snowboarding', children: 'Snowboarding'},
-                  ]}
+                  options={tags}
+                  onSelect={handleTagSelect}
                   addAction={{
                     value: query,
                     children: `Add ${query}`,
@@ -691,6 +721,7 @@ export function DetailsPage() {
                     {value: 'Salomon', children: 'Salomon'},
                     {value: 'Burton', children: 'Burton'},
                   ]}
+                  onSelect={(value) => console.log(value)}
                   addAction={{
                     value: query,
                     children: `Add ${query}`,

--- a/polaris-react/playground/DetailsPage.tsx
+++ b/polaris-react/playground/DetailsPage.tsx
@@ -98,7 +98,6 @@ export function DetailsPage() {
 
   const handleTagSelect = useCallback(
     (newTag: string) => {
-      console.log('tag select');
       if (
         tags.some((tag) => tag.value === newTag) ||
         addedTags.some((tag) => tag.value === newTag)

--- a/polaris-react/playground/DetailsPage.tsx
+++ b/polaris-react/playground/DetailsPage.tsx
@@ -76,8 +76,10 @@ export function DetailsPage() {
   const [emailFieldValue, setEmailFieldValue] = useState(
     defaultState.current.emailFieldValue,
   );
-
   const [addedTags, setAddedTags] = useState<
+    {value: string; children: string}[]
+  >([]);
+  const [addedVendors, setAddedVendors] = useState<
     {value: string; children: string}[]
   >([]);
 
@@ -96,6 +98,24 @@ export function DetailsPage() {
     [addedTags],
   );
 
+  const vendors = useMemo(
+    () => [
+      {value: 'The North Face', children: 'The North Face'},
+      {value: 'Patagonia', children: 'Patagonia'},
+      {value: 'Arc’teryx', children: 'Arc’teryx'},
+      {value: 'Marmot', children: 'Marmot'},
+      {value: 'Black Diamond', children: 'Black Diamond'},
+      {value: 'Mountain Hardwear', children: 'Mountain Hardwear'},
+      {value: 'Columbia', children: 'Columbia'},
+      {value: 'Canada Goose', children: 'Canada Goose'},
+      {value: 'Merrell', children: 'Merrell'},
+      {value: 'Salomon', children: 'Salomon'},
+      {value: 'Burton', children: 'Burton'},
+      ...addedVendors,
+    ],
+    [addedVendors],
+  );
+
   const handleTagSelect = useCallback(
     (newTag: string) => {
       if (
@@ -111,6 +131,23 @@ export function DetailsPage() {
       setQuery('');
     },
     [addedTags, tags],
+  );
+
+  const handleVendorSelect = useCallback(
+    (newVendor: string) => {
+      if (
+        vendors.some((vendor) => vendor.value === newVendor) ||
+        addedVendors.some((vendor) => vendor.value === newVendor)
+      ) {
+        return;
+      }
+      setAddedVendors((addedVendors) => [
+        ...addedVendors,
+        {value: newVendor, children: newVendor},
+      ]);
+      setQuery('');
+    },
+    [addedVendors, vendors],
   );
 
   const [storeName, setStoreName] = useState(
@@ -707,20 +744,8 @@ export function DetailsPage() {
                     value: query,
                     onChange: (value) => setQuery(value),
                   }}
-                  options={[
-                    {value: 'The North Face', children: 'The North Face'},
-                    {value: 'Patagonia', children: 'Patagonia'},
-                    {value: 'Arc’teryx', children: 'Arc’teryx'},
-                    {value: 'Marmot', children: 'Marmot'},
-                    {value: 'Black Diamond', children: 'Black Diamond'},
-                    {value: 'Mountain Hardwear', children: 'Mountain Hardwear'},
-                    {value: 'Columbia', children: 'Columbia'},
-                    {value: 'Canada Goose', children: 'Canada Goose'},
-                    {value: 'Merrell', children: 'Merrell'},
-                    {value: 'Salomon', children: 'Salomon'},
-                    {value: 'Burton', children: 'Burton'},
-                  ]}
-                  onSelect={(value) => console.log(value)}
+                  options={vendors}
+                  onSelect={handleVendorSelect}
                   addAction={{
                     value: query,
                     children: `Add ${query}`,

--- a/polaris-react/src/components/Picker/Picker.tsx
+++ b/polaris-react/src/components/Picker/Picker.tsx
@@ -1,4 +1,10 @@
-import React, {useState, useMemo, useCallback, isValidElement} from 'react';
+import React, {
+  useState,
+  useMemo,
+  useCallback,
+  isValidElement,
+  useEffect,
+} from 'react';
 import {SearchIcon} from '@shopify/polaris-icons';
 
 import {Popover} from '../Popover';
@@ -27,7 +33,7 @@ export interface PickerProps extends Omit<ListboxProps, 'children'> {
   activator: ActivatorProps;
   /** Allows more than one option to be selected */
   allowMultiple?: boolean;
-  /** The options to be listed within the picker */
+  /** The options to be listed within the picker. Options should be memoized */
   options?: OptionProps[];
   /** Used to add a new picker option that isn't listed */
   addAction?: OptionProps & {icon?: IconProps['source']};
@@ -66,11 +72,11 @@ export function Picker({
   const [textFieldLabelId, setTextFieldLabelId] = useState<string>();
   const [listboxId, setListboxId] = useState<string>();
   const [query, setQuery] = useState<string>('');
-  const [filteredOptions, setFilteredOptions] = useState<OptionProps[] | null>(
-    options,
-  );
-
+  const [filteredOptions, setFilteredOptions] = useState<OptionProps[]>();
   const shouldOpen = !popoverActive;
+
+  useEffect(() => setFilteredOptions(options), [options]);
+
   const handleClose = useCallback(() => {
     setPopoverActive(false);
     onClose?.();

--- a/polaris-react/src/components/Picker/Picker.tsx
+++ b/polaris-react/src/components/Picker/Picker.tsx
@@ -1,9 +1,10 @@
 import React, {
-  useState,
-  useMemo,
-  useCallback,
+  createRef,
   isValidElement,
-  useEffect,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
 } from 'react';
 import {SearchIcon} from '@shopify/polaris-icons';
 
@@ -24,6 +25,7 @@ import {Listbox} from '../Listbox';
 import type {IconProps} from '../Icon';
 import {Icon} from '../Icon';
 import {escapeRegex} from '../../utilities/string';
+import {useIsomorphicLayoutEffect} from '../../utilities/use-isomorphic-layout-effect';
 
 import {Activator, SearchField} from './components';
 import type {SearchFieldProps, ActivatorProps} from './components';
@@ -33,7 +35,7 @@ export interface PickerProps extends Omit<ListboxProps, 'children'> {
   activator: ActivatorProps;
   /** Allows more than one option to be selected */
   allowMultiple?: boolean;
-  /** The options to be listed within the picker. Options should be memoized */
+  /** The options to be listed within the picker */
   options?: OptionProps[];
   /** Used to add a new picker option that isn't listed */
   addAction?: OptionProps & {icon?: IconProps['source']};
@@ -65,17 +67,22 @@ export function Picker({
   onClose,
   ...listboxProps
 }: PickerProps) {
-  const activatorRef = React.createRef<HTMLButtonElement>();
+  const optionsRef = useRef<OptionProps[]>();
+  const activatorRef = createRef<HTMLButtonElement>();
   const [activeItems, setActiveItems] = useState<string[]>([]);
   const [popoverActive, setPopoverActive] = useState(false);
   const [activeOptionId, setActiveOptionId] = useState<string>();
   const [textFieldLabelId, setTextFieldLabelId] = useState<string>();
   const [listboxId, setListboxId] = useState<string>();
   const [query, setQuery] = useState<string>('');
-  const [filteredOptions, setFilteredOptions] = useState(options);
+  const [filteredOptions, setFilteredOptions] = useState<OptionProps[]>();
   const shouldOpen = !popoverActive;
 
-  useEffect(() => setFilteredOptions(options), [options]);
+  useIsomorphicLayoutEffect(() => {
+    if (optionsRef.current?.length === options.length) return;
+    optionsRef.current = options;
+    setFilteredOptions(options);
+  }, [options]);
 
   const handleClose = useCallback(() => {
     setPopoverActive(false);

--- a/polaris-react/src/components/Picker/Picker.tsx
+++ b/polaris-react/src/components/Picker/Picker.tsx
@@ -72,7 +72,7 @@ export function Picker({
   const [textFieldLabelId, setTextFieldLabelId] = useState<string>();
   const [listboxId, setListboxId] = useState<string>();
   const [query, setQuery] = useState<string>('');
-  const [filteredOptions, setFilteredOptions] = useState<OptionProps[]>();
+  const [filteredOptions, setFilteredOptions] = useState(options);
   const shouldOpen = !popoverActive;
 
   useEffect(() => setFilteredOptions(options), [options]);


### PR DESCRIPTION
Currently when you add a new option it won't show up until the next render cycle, i.e. when the list is closed and re-opened. This fixes that issue but requires options to be memoized.