### PR TITLE
Fix outline on textfield focus

### DIFF
--- a/polaris-react/src/components/TextField/TextField.module.css
+++ b/polaris-react/src/components/TextField/TextField.module.css
@@ -27,6 +27,13 @@
     .Loading:has(+ .ClearButton) {
       margin-right: 0;
     }
+
+    /* Ensure backdrop has no border when focused */
+    .Backdrop {
+      @media (--p-breakpoints-sm-down) {
+        border: none;
+      }
+    }
   }
 
   &:not(:focus-within) {
@@ -81,6 +88,12 @@
     @mixin no-focus-ring;
     outline: var(--p-border-width-050) solid var(--p-color-border-focus);
     outline-offset: var(--p-space-025);
+
+     @media (--p-breakpoints-sm-down) {
+          border-color: var(--p-color-border-focus);
+          outline-width: var(--p-border-width-050);
+          outline-offset: 0;
+     }
   }
 }
 
@@ -269,7 +282,7 @@
   border: none;
   font-family: var(--p-font-family-sans);
   appearance: none;
-  caret-color: var(--p-color-text);
+  caret-color: var(--p-color-border-focus);
   color: var(--p-color-text);
   align-items: center;
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/temp-project-mover-Archetypically-20250917142713/issues/5 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->
Text field shows 2 borders on focus. 

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->
This PR fixes hides the border on focus and just displays the outline. Also, changes the cursor color.

### How to 🎩
- Go to [storybook](https://5d559397bae39100201eedc1-bdbixidfaf.chromatic.com/?path=/story/playground--details-page)
- In storybook navigate to textfield and ensure seeing only outline on the text field 
- Confirm only outline is displayed on the text field on focus
- Confirm cursor color is blue on focus on text field

Before|After
:---:|:---:
![IMG_4156](https://github.com/Shopify/polaris/assets/18360441/6c558c4d-fdd8-4596-a638-d176e780b5b8)|![IMG_4157](https://github.com/Shopify/polaris/assets/18360441/4079e9f9-1309-4974-81b0-80436f7ad9b0)

https://github.com/Shopify/polaris/assets/18360441/44d1e97a-b6cf-4384-aace-26858cf91b16



### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
