### PR TITLE
Disallow updating to buggy stylelint version (16.7.0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 100
+    ignore:
+      - dependency-name: 'stylelint'
+        # v16.7.0 introduced a regression where valid disables are being
+        # reported as errors.
+        # See Stylelint issue for more details:
+        # https://github.com/stylelint/stylelint/issues/7843
+        versions: ['16.7.0']


### PR DESCRIPTION
The `stylelint` peer dependency version range is limited to v16 through v16.6.1. This is due to a regression introduced in `stylelint` v16.7.0 where valid disables are being reported as errors. See Stylelint issue for more details: https://github.com/stylelint/stylelint/issues/7843

_update_: Looks like the stylelint [fix is going out in v16.8.0](https://github.com/stylelint/stylelint/issues/7880).