### PR TITLE
[IndexFilters] [Tab] - Fix pressed/active states on index table views

### DIFF
--- a/.changeset/friendly-papayas-prove.md
+++ b/.changeset/friendly-papayas-prove.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fixed switching tabs UI bug on Index Filters

--- a/polaris-react/src/components/Tabs/Tabs.module.css
+++ b/polaris-react/src/components/Tabs/Tabs.module.css
@@ -93,7 +93,7 @@
   }
 
   &:not([aria-disabled='true']):focus {
-    background-color: var(--p-color-bg-surface-hover);
+    background-color: var(--p-color-bg-fill-transparent-selected);
     color: var(--p-color-text);
   }
 
@@ -112,7 +112,7 @@
   }
 
   &:not([aria-disabled='true']):active {
-    background-color: var(--p-color-bg-surface-tertiary);
+    background-color: var(--p-color-bg-fill-transparent-selected);
     color: var(--p-color-text-brand);
     z-index: var(--p-z-index-1);
   }
@@ -133,7 +133,7 @@
   }
 
   &:not([aria-disabled='true']):hover,
-  &:not([aria-disabled='true']):focus {
+  &:not([aria-disabled='true']):focus-visible {
     background-color: var(--p-color-bg-fill-transparent-hover);
     color: var(--p-color-text-brand);
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/web/issues/139587 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

Tabs were getting stuck in a focus state after being clicked, leading to confusing visual feedback. When clicking a new tab/view, the pressed state was incorrectly applied to the current tab instead of the clicked tab. 

This change:
- Applies the pressed state to the clicked tab by making active/focus colors the same
- Prevents tabs from getting stuck in a focus state after mouse clicks by using `focus-visible` on `Tab-active`
- Preserves hover styles and keyboard focus styles for accessibility


<details><summary>See video of issue</summary>
<p>

https://github.com/user-attachments/assets/8f5fdca7-93f0-4522-8c6b-9ac679fdd5bc


</p>
</details> 



### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  Include a video if your changes include interactive content.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

  <details>
    <summary>Summary of your gif(s)</summary>
    <img src="..." alt="Description of what the gif shows">
  </details>
-->

### How to 🎩


<!--
🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)
-->

Sandbox with snapshot: https://codesandbox.io/p/sandbox/priceless-bush-ym9x9t

- Click on a tab that's not the current active one
- The active one does not produce visual feedback


### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
