### PR TITLE
[Inter] Remove temp fix for font-optical-sizing issue in Safari 16

### DIFF
--- a/.changeset/angry-clouds-cheat.md
+++ b/.changeset/angry-clouds-cheat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Removed workaround for `font-optical-sizing` issue in Safari 16

--- a/polaris-react/src/components/AppProvider/AppProvider.tsx
+++ b/polaris-react/src/components/AppProvider/AppProvider.tsx
@@ -108,25 +108,6 @@ export class AppProvider extends Component<AppProviderProps, State> {
       this.stickyManager.setContainer(document);
       this.setBodyStyles();
       this.setRootAttributes();
-
-      const isSafari16 =
-        navigator.userAgent.includes('Safari') &&
-        !navigator.userAgent.includes('Chrome') &&
-        (navigator.userAgent.includes('Version/16.1') ||
-          navigator.userAgent.includes('Version/16.2') ||
-          navigator.userAgent.includes('Version/16.3'));
-
-      const isMobileApp16 =
-        navigator.userAgent.includes('Shopify Mobile/iOS') &&
-        (navigator.userAgent.includes('OS 16_1') ||
-          navigator.userAgent.includes('OS 16_2') ||
-          navigator.userAgent.includes('OS 16_3'));
-
-      if (isSafari16 || isMobileApp16) {
-        document.documentElement.classList.add(
-          'Polaris-Safari-16-Font-Optical-Sizing-Patch',
-        );
-      }
     }
     measureScrollbars();
   }

--- a/polaris-react/src/components/AppProvider/global.css
+++ b/polaris-react/src/components/AppProvider/global.css
@@ -162,8 +162,3 @@ button::-moz-focus-inner,
 [type='submit']::-moz-focus-inner {
   border-style: none;
 }
-
-html[class~='Polaris-Safari-16-Font-Optical-Sizing-Patch'] {
-  /* Inter's "opsz" axis ranges from 14 to 32. This patch optimizes for smaller and less legible text by setting "opsz" 14 for all font sizes. */
-  font-variation-settings: 'opsz' 14;
-}


### PR DESCRIPTION
### WHY are these changes introduced?

Safari v18 was released September 16, 2024, marking 2 stable versions since the font-optical-sizing issue with Inter font in Safari 16 was resolved ([v16.4](https://github.com/WebKit/WebKit/pull/10126)). 

This PR removes the temporary workaround added in https://github.com/Shopify/polaris/pull/11503

| workaround removed (iOS 17.4) |
|-----|
|<img width="393" alt="Screenshot 2024-10-03 at 11 01 03" src="https://github.com/user-attachments/assets/ac5c6b9b-31a5-42c8-8794-fd32611979bb">|


### How to 🎩

1. Check out this branch
2. Load storybook in an iOS simulator, iOS v16.6 or above 
3. Navigate to the `Text` story. Ensure all text is legible. 

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers) (MacOS Chrome; MacOS Firefox; MacOS Safari; iOS Safari)

