### PR TITLE
Fix typo in docs for item removal

### DIFF
--- a/.changeset/serious-snakes-protect.md
+++ b/.changeset/serious-snakes-protect.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Fixed a typo in the common actions overview

--- a/polaris.shopify.com/content/patterns/common-actions/variants/overview.mdx
+++ b/polaris.shopify.com/content/patterns/common-actions/variants/overview.mdx
@@ -426,7 +426,7 @@ url: /patterns/common-actions/overview
 
     ![A list of collections with one item in a hover state with the option to remove it displayed inline to the right using the "x" icon.](/images/patterns/common-actions/types/common-action-types-remove-on-hover@2x.png)
 
-    Show remove actions on hover when the merchant is using a curosr to navigate.
+    Show remove actions on hover when the merchant is using a cursor to navigate.
 
   </Medium>
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes a typo I noticed at https://polaris.shopify.com/patterns/common-actions/overview#remove

### WHAT is this pull request doing?

Changing the spelling of "cursor" in our docs file

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
