### PR TITLE
[MediaQueryProvider] Fix SSR hydration issues

### DIFF
--- a/.changeset/fast-chicken-help.md
+++ b/.changeset/fast-chicken-help.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix hydration issues with SSR

--- a/polaris-react/src/components/MediaQueryProvider/MediaQueryProvider.tsx
+++ b/polaris-react/src/components/MediaQueryProvider/MediaQueryProvider.tsx
@@ -13,9 +13,7 @@ interface Props {
 export const MediaQueryProvider = function MediaQueryProvider({
   children,
 }: Props) {
-  const [isNavigationCollapsed, setIsNavigationCollapsed] = useState(
-    navigationBarCollapsed().matches,
-  );
+  const [isNavigationCollapsed, setIsNavigationCollapsed] = useState(false);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleResize = useCallback(


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/polaris/issues/11886

Server-side rendering defaults to `isNavigationCollapsed` being `false`, which causes a React hydration issue when rendered on the client at smaller breakpoints (where the value evaluates as `true`).

### WHAT is this pull request doing?

This modifies the initial render state of `isNavigationCollapsed` to match the server-side rendered value (`false`) and relies on the existing `useEffect` to update the value on the client-side after hydration.

<details>
<summary>Before change - React hydration errors at small breakpoints</summary>

https://github.com/user-attachments/assets/78f45469-3ae3-44a3-97eb-94598c732a72

</details>

<details>
<summary>After change - No React hydration errors at small breakpoints</summary>

https://github.com/user-attachments/assets/f14efd84-00b3-4a62-9ea9-878f52da0d8d

</details>

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
