### PR TITLE
Fixed on action in tabs for index filters

### DIFF
--- a/.changeset/unlucky-mugs-juggle.md
+++ b/.changeset/unlucky-mugs-juggle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+IndexFilters tabs were sometimes not selected if they were placed in the more view menu dropdown, modified this such that onSelect is used instead if the user is attempting to select a tab that is in the more views dropdown menu

--- a/polaris-react/src/components/IndexFilters/IndexFilters.tsx
+++ b/polaris-react/src/components/IndexFilters/IndexFilters.tsx
@@ -350,6 +350,17 @@ export function IndexFilters({
     beginEdit(IndexFiltersMode.Filtering);
   }
 
+  const handleTabSelect = useCallback(
+    (selectedTabIndex: number) => {
+      onSelect?.(selectedTabIndex);
+      const selectedTab = tabs[selectedTabIndex];
+      if (selectedTab?.onAction) {
+        selectedTab.onAction();
+      }
+    },
+    [onSelect, tabs],
+  );
+
   return (
     <div
       className={styles.IndexFiltersWrapper}
@@ -399,7 +410,7 @@ export function IndexFilters({
                         <Tabs
                           tabs={tabs}
                           selected={selected}
-                          onSelect={onSelect}
+                          onSelect={handleTabSelect}
                           disabled={Boolean(
                             mode !== IndexFiltersMode.Default || disabled,
                           )}

--- a/polaris-react/src/components/IndexFilters/tests/IndexFilters.test.tsx
+++ b/polaris-react/src/components/IndexFilters/tests/IndexFilters.test.tsx
@@ -592,4 +592,76 @@ describe('IndexFilters', () => {
       expect(onEditStart).toHaveBeenCalledWith(IndexFiltersMode.EditingColumns);
     });
   });
+
+  describe('tab actions', () => {
+    it('calls both onSelect and onAction when a tab is selected', () => {
+      const onSelect = jest.fn();
+      const onAction = jest.fn();
+      const tabs = [
+        {
+          id: 'tab1',
+          content: 'Tab 1',
+          onAction,
+        },
+      ];
+
+      const wrapper = mountWithApp(
+        <IndexFilters {...defaultProps} tabs={tabs} onSelect={onSelect} />,
+      );
+
+      wrapper.find(Tabs)!.trigger('onSelect', 0);
+
+      expect(onSelect).toHaveBeenCalledWith(0);
+      expect(onAction).toHaveBeenCalled();
+    });
+
+    it('calls onSelect but not onAction when selected tab has no onAction', () => {
+      const onSelect = jest.fn();
+      const tabs = [
+        {
+          id: 'tab1',
+          content: 'Tab 1',
+        },
+      ];
+
+      const wrapper = mountWithApp(
+        <IndexFilters {...defaultProps} tabs={tabs} onSelect={onSelect} />,
+      );
+
+      wrapper.find(Tabs)!.trigger('onSelect', 0);
+
+      expect(onSelect).toHaveBeenCalledWith(0);
+    });
+
+    it('calls the correct onAction when switching between tabs', () => {
+      const onAction1 = jest.fn();
+      const onAction2 = jest.fn();
+      const tabs = [
+        {
+          id: 'tab1',
+          content: 'Tab 1',
+          onAction: onAction1,
+        },
+        {
+          id: 'tab2',
+          content: 'Tab 2',
+          onAction: onAction2,
+        },
+      ];
+
+      const wrapper = mountWithApp(
+        <IndexFilters {...defaultProps} tabs={tabs} />,
+      );
+
+      // Select first tab
+      wrapper.find(Tabs)!.trigger('onSelect', 0);
+      expect(onAction1).toHaveBeenCalledTimes(1);
+      expect(onAction2).not.toHaveBeenCalled();
+
+      // Select second tab
+      wrapper.find(Tabs)!.trigger('onSelect', 1);
+      expect(onAction1).toHaveBeenCalledTimes(1);
+      expect(onAction2).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/polaris-react/src/components/IndexFilters/tests/IndexFilters.test.tsx
+++ b/polaris-react/src/components/IndexFilters/tests/IndexFilters.test.tsx
@@ -633,7 +633,7 @@ describe('IndexFilters', () => {
       expect(onSelect).toHaveBeenCalledWith(0);
     });
 
-    it('calls the correct onAction when switching between tabs', () => {
+    it('calls the valid onAction when switching between tabs', () => {
       const onAction1 = jest.fn();
       const onAction2 = jest.fn();
       const tabs = [


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes issue: #13041

### WHAT is this pull request doing?

On Select is now used as opposed to OnAction if the user attempts to select a tab in which onAction is undefined

https://github.com/user-attachments/assets/53c63be1-8bbb-40ca-90a6-c95d527fafe6

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes (unsure if required)
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide (unsure if required)
