### PR TITLE
Form with implictSubmit now working

### DIFF
--- a/.changeset/famous-pets-allow.md
+++ b/.changeset/famous-pets-allow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': minor
+---
+
+fixed form such that it now no longer submits when you hit enter if ImplicitSubmit is equal to true

--- a/polaris-react/src/components/Form/Form.tsx
+++ b/polaris-react/src/components/Form/Form.tsx
@@ -67,6 +67,15 @@ export function Form({
     [onSubmit, preventDefault],
   );
 
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (!implicitSubmit && event.key === 'Enter' && event.target instanceof HTMLInputElement) {
+        event.preventDefault();
+      }
+    },
+    [implicitSubmit],
+  );
+
   const autoCompleteInputs = normalizeAutoComplete(autoComplete);
 
   const submitMarkup = implicitSubmit ? (
@@ -88,6 +97,7 @@ export function Form({
       noValidate={noValidate}
       target={target}
       onSubmit={handleSubmit}
+      onKeyDown={handleKeyDown}
     >
       {submitMarkup}
       {children}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #12917

### WHAT is this pull request doing?

Form now no longer submits when you hit enter if ImplicitSubmit is equal to true

https://github.com/user-attachments/assets/1feb3f1a-55c0-4fe7-bf5b-9bb9e22e6ccf


### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes (unsure if needed)
- [ ] [Tophatted documentation] (unsure if needed)(https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
