### PR TITLE
[Tabs] Fix wrapping when badges are present

### DIFF
--- a/.changeset/tidy-onions-matter.md
+++ b/.changeset/tidy-onions-matter.md
@@ -1,0 +1,5 @@
+---
+'@shopify/polaris': patch
+---
+
+Fix tabs from wrapping when badges are present

--- a/polaris-react/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
+++ b/polaris-react/src/components/Tabs/components/TabMeasurer/TabMeasurer.tsx
@@ -78,6 +78,7 @@ export const TabMeasurer = memo(function TabMeasurer({
         content={tab.content}
         onTogglePopover={noop}
         onToggleModal={noop}
+        badge={tab.badge}
       />
     );
   });

--- a/polaris-react/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
+++ b/polaris-react/src/components/Tabs/components/TabMeasurer/tests/TabMeasurer.test.tsx
@@ -144,6 +144,25 @@ describe('<TabMeasurer />', () => {
 
       expect(tabMeasurer).toContainReactComponentTimes(Tab, 2);
     });
+
+    it('passes badge to Tab', () => {
+      const tabs = [
+        {
+          id: 'repeat-customers',
+          content: 'repeat-customers',
+          badge: '10+',
+        },
+      ];
+      const tabMeasurer = mountWithApp(
+        <TabMeasurer {...mockProps} tabs={tabs} />,
+      );
+
+      expect(tabMeasurer).toContainReactComponent(Tab, {
+        id: 'repeat-customersMeasurer',
+        content: 'repeat-customers',
+        badge: '10+',
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #11544

### WHAT is this pull request doing?

The TabMeasurer doesn't take badges into account, which causes the tabs to prematurely wrap instead of showing the "More views" disclos

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [x] Updated the component's `README.md` with documentation changes
- [x] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
