### PR TITLE
Link add rel prop

### DIFF
--- a/polaris-react/src/components/Link/Link.tsx
+++ b/polaris-react/src/components/Link/Link.tsx
@@ -18,6 +18,8 @@ export interface LinkProps {
    * @deprecated use `target` set to `_blank` instead
    */
   external?: boolean;
+  /** The relationship of the linked URL as space-separated link types. */
+  rel?: string;
   /** Where to display the url */
   target?: Target;
   /** Makes the link color the same as the current text color and adds an underline */
@@ -37,6 +39,7 @@ export function Link({
   children,
   onClick,
   external,
+  rel,
   target,
   id,
   monochrome,
@@ -60,6 +63,7 @@ export function Link({
             onClick={onClick}
             className={className}
             url={url}
+            rel={rel}
             external={external}
             target={target}
             id={id}

--- a/polaris-react/src/components/UnstyledLink/UnstyledLink.tsx
+++ b/polaris-react/src/components/UnstyledLink/UnstyledLink.tsx
@@ -36,9 +36,9 @@ export const UnstyledLink = memo(
     return (
       <a
         target={target}
+        rel={rel}
         {...rest}
         href={url}
-        rel={rel}
         {...unstyled.props}
         ref={_ref}
       />


### PR DESCRIPTION
To enable Polaris.Link to be used in Shopify app NavMenu [**]

### WHY are these changes introduced?

[**]

### WHAT is this pull request doing?

[**]

### How to 🎩

n/a

### 🎩 checklist

- [x] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [x] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [x] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [x] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
