### PR TITLE
[ResourceItem] Fix the property "url" does not prevent redirections while savebar activated 

### DIFF
--- a/polaris-react/src/components/ResourceItem/ResourceItem.tsx
+++ b/polaris-react/src/components/ResourceItem/ResourceItem.tsx
@@ -455,9 +455,25 @@ class BaseResourceItem extends Component<CombinedProps, State> {
     }
 
     if (url && anchor) {
-      anchor.click();
+      // PREVENT default navigation
+      event.preventDefault();
+      // Check savebar BEFORE navigating
+      this.handleNavigationWithSaveBarCheck(anchor);
     }
   };
+
+  private async handleNavigationWithSaveBarCheck(anchor: HTMLAnchorElement) {
+    try {
+      // Check if shopify saveBar is available and has active unsaved changes
+      if (typeof window !== 'undefined' && (window as any).shopify?.saveBar) {
+        await (window as any).shopify.saveBar.leaveConfirmation();
+      }
+      // Only navigate if confirmation succeeds
+      window.location.href = anchor.href;
+    } catch (error) {
+      // User cancelled - don't navigate
+    }
+  }
 
   // This fires onClick when there is a URL on the item
   private handleKeyUp = (event: React.KeyboardEvent<HTMLElement>) => {


### PR DESCRIPTION
### [ResourceItem] Fix navigation when SaveBar is active

### WHY are these changes introduced?

Fixes #13528 

While the SaveBar is active (some modifications are not saved), a click on the ResourceItem component with the `url` property set correctly checks for the savebar status (the savebar vibrates) but does not prevent the redirection. The component was calling `anchor.click()` which immediately triggered navigation before the async savebar confirmation could complete.

### WHAT is this pull request doing?

This PR modifies the ResourceItem component's click handling to properly respect SaveBar state:

**Before:**
- ResourceItem with `url` would navigate immediately on click
- SaveBar would detect the navigation attempt (causing vibration) but couldn't prevent it
- Users would lose unsaved changes without confirmation

**After:**
- ResourceItem prevents default navigation behavior with `event.preventDefault()`
- Checks for active SaveBar via `shopify.saveBar.leaveConfirmation()` before navigating
- Only navigates if user confirms they want to leave unsaved changes
- Navigation is cancelled if user chooses to stay

**Key changes:**
1. Added `event.preventDefault()` in `handleClick` method to stop immediate navigation
2. Created `handleNavigationWithSaveBarCheck()` method to handle async SaveBar confirmation
3. Manual navigation with `window.location.href` only occurs after confirmation
4. Graceful error handling when user cancels the leave confirmation

This ensures consistent behavior with the documented workaround of using `onClick` with manual `shopify.saveBar.leaveConfirmation()` calls, but built directly into the component.

### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

**Testing instructions:**
1. Create a Shopify app with a ResourceList containing ResourceItems with `url` properties
2. Activate the SaveBar with `shopify.saveBar.show('test-savebar')`
3. Click on a ResourceItem - should show leave confirmation dialog
4. Test both "Stay" and "Leave" options work correctly
5. Verify normal navigation still works when SaveBar is not active

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide