### PR TITLE
[Link] Update example code for external links (remove deprecated "external" prop)

### DIFF
--- a/polaris.shopify.com/pages/examples/link-external.tsx
+++ b/polaris.shopify.com/pages/examples/link-external.tsx
@@ -4,7 +4,7 @@ import {withPolarisExample} from '../../src/components/PolarisExampleWrapper';
 
 function LinkExample() {
   return (
-    <Link url="https://help.shopify.com/manual" external>
+    <Link url="https://help.shopify.com/manual" target="_blank">
       Shopify Help Center
     </Link>
   );


### PR DESCRIPTION
Updated documentation example code for external links of the Link component.

It was using the deprecated "external" prop, replaced with `target="_blank"`
