### PR TITLE
Add deprecation notice and redirect to new Polaris library

### DIFF
--- a/.changeset/proud-apples-push.md
+++ b/.changeset/proud-apples-push.md
@@ -1,0 +1,5 @@
+---
+'polaris.shopify.com': patch
+---
+
+Add deprecation notice and redirect to new Polaris library

--- a/polaris.shopify.com/src/components/Frame/Frame.module.scss
+++ b/polaris.shopify.com/src/components/Frame/Frame.module.scss
@@ -418,7 +418,7 @@ $breakpointNav: $breakpointTablet;
     }
   }
 
-  .ReleaseCandidate {
+  .NewLibrary {
     border: 1px solid #14c397;
     padding: 0 0.5rem;
     margin: 0 0.25rem;

--- a/polaris.shopify.com/src/components/Frame/Frame.tsx
+++ b/polaris.shopify.com/src/components/Frame/Frame.tsx
@@ -98,8 +98,8 @@ function Frame({darkMode, children}: Props) {
         <div>
           <a href="https://shopify.dev/beta/next-gen-dev-platform/polaris">
             {icons.Polaris()}
-            <strong>Introducing Polaris</strong> - Unified and for the web.{' '}
-            <span className={styles.ReleaseCandidate}>Release Candidate</span>
+            <strong>Polaris React is now deprecated</strong>{' '}
+            <span className={styles.NewLibrary}>Check out the new library</span>
             <Icon source={ArrowRightIcon} />
           </a>
         </div>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Open it as a draft if it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #979 [issue](https://github.com/orgs/shop/projects/782/views/1?sliceBy%5Bvalue%5D=%5B0%5D+Critical+for+GA&pane=issue&itemId=123407002&issue=shop%7Cissues-polaris%7C979l)

Polaris React is being deprecated in favour of the new web Polaris library built with web components. Users need to be clearly informed about this deprecation and directed to the new library to ensure a smooth migration.

### WHAT is this pull request doing?


This PR updates the global banner in the Polaris React documentation to:

- Mark the library as deprecated 


**Changes made:**
- Updated banner text from "Introducing Polaris - Unified and for the web" to deprecation notice

This ensures developers are aware they should migrate to the new Polaris library
### How to 🎩

🖥 [Local development instructions](https://github.com/Shopify/polaris/blob/main/README.md#install-dependencies-and-build-workspaces)
🗒 [General tophatting guidelines](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md)
📄 [Changelog guidelines](https://github.com/Shopify/polaris/blob/main/.github/CONTRIBUTING.md#changelog)

### 🎩 checklist

- [ ] Tested a [snapshot](https://github.com/Shopify/polaris/blob/main/documentation/Releasing.md#-snapshot-releases)
- [ ] Tested on [mobile](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting.md#cross-browser-testing)
- [ ] Tested on [multiple browsers](https://help.shopify.com/en/manual/shopify-admin/supported-browsers)
- [ ] Tested for [accessibility](https://github.com/Shopify/polaris/blob/main/documentation/Accessibility%20testing.md)
- [ ] Updated the component's `README.md` with documentation changes
- [ ] [Tophatted documentation](https://github.com/Shopify/polaris/blob/main/documentation/Tophatting%20documentation.md) changes in the style guide
