### PR TITLE
Update Pages basePath for the repo rename, add npm deprecation workflow

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -1,5 +1,8 @@
 # Publishes the archived polaris.shopify.com docs to GitHub Pages at
-# https://shopify.github.io/polaris-react/.
+# https://shopify.github.io/polaris-react-archive/.
+#
+# The URL path comes from the repository name, so it has to stay in sync with
+# the `basePath` default in `polaris.shopify.com/constants.js`.
 #
 # Deliberately `workflow_dispatch` only: this is meant to be run once, by hand,
 # before the repository is re-archived. GitHub Pages keeps serving the deployed

--- a/.github/workflows/npm-deprecate.yml
+++ b/.github/workflows/npm-deprecate.yml
@@ -1,0 +1,45 @@
+# Marks `@shopify/polaris` as deprecated on npm.
+#
+# Deliberately `workflow_dispatch` only: this is a one-shot job, meant to be run
+# by hand (alongside "Deploy to GitHub Pages") before the repository is
+# re-archived. No workflow can run once the repo is archived, so there is
+# nothing to gain from an automatic trigger. `npm deprecate` is reversible from
+# a workstation with publish rights (`npm deprecate "@shopify/polaris@*" ""`),
+# so it does not need to be re-runnable from here.
+#
+# Scope: `@shopify/polaris` only. `changeset publish` also releases
+# `@shopify/polaris-tokens`, `@shopify/polaris-icons`, `@shopify/polaris-migrator`
+# and `@shopify/stylelint-polaris` from this repo, but those have consumers
+# beyond Polaris React and the notice below does not apply to them, so they are
+# left alone on purpose.
+name: Deprecate npm package
+
+on:
+  workflow_dispatch:
+
+# Nothing here writes to the repository; the deprecation is authenticated
+# against npm with secrets.NPM_TOKEN. `contents: read` is only what setup-node
+# needs to pull a Node build it doesn't already have cached.
+permissions:
+  contents: read
+
+jobs:
+  deprecate:
+    name: npm deprecate @shopify/polaris
+    runs-on: ubuntu-latest
+    steps:
+      # No checkout: nothing here reads the repository. `registry-url` is what
+      # makes setup-node write the `~/.npmrc` that picks up NODE_AUTH_TOKEN,
+      # which is the same `secrets.NPM_TOKEN` the release workflow publishes
+      # with.
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20.10.0'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Deprecate all versions of @shopify/polaris
+        run: npm deprecate "@shopify/polaris@*" "$DEPRECATION_MESSAGE"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DEPRECATION_MESSAGE: 'Polaris React is deprecated and no longer maintained. For building Shopify admin experiences, use Polaris web components: https://shopify.dev/docs/api/polaris — archived docs for this package: https://shopify.github.io/polaris-react-archive/'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Polaris React (⚠️ Deprecated)
+# Polaris React (⚠️ Archived)
+
+> **This repository is archived and unmaintained.**
+>
+> - Archived documentation: <https://shopify.github.io/polaris-react-archive/>
+> - For current Shopify admin development, use Polaris on shopify.dev: <https://shopify.dev/docs/api/polaris>
 
 [![storybook](https://shields.io/badge/storybook-grey?logo=storybook&style=flat)](https://storybook.polaris.shopify.dev) [![npm version](https://img.shields.io/npm/v/@shopify/polaris.svg?label=@shopify/polaris)](https://www.npmjs.com/package/@shopify/polaris) [![CI](https://github.com/shopify/polaris/workflows/CI/badge.svg)](https://github.com/Shopify/polaris/actions?query=branch%3Amain)
 

--- a/polaris-react/README.md
+++ b/polaris-react/README.md
@@ -1,6 +1,11 @@
-# [Polaris React](https://polaris.shopify.com/)
+# Polaris React (⚠️ Archived)
 
-Polaris React is a component library designed to help developers create the best experience for merchants who use Shopify. Visit the [Polaris style guide](https://polaris.shopify.com) to learn more.
+> **`@shopify/polaris` is deprecated and this repository is archived and unmaintained.**
+>
+> - Archived documentation: <https://shopify.github.io/polaris-react-archive/>
+> - For current Shopify admin development, use Polaris on shopify.dev: <https://shopify.dev/docs/api/polaris>
+
+Polaris React is a component library designed to help developers create the best experience for merchants who use Shopify.
 
 ## Using the React components
 

--- a/polaris.shopify.com/README.md
+++ b/polaris.shopify.com/README.md
@@ -2,10 +2,10 @@
 
 The Polaris React style guide. **Archived.** polaris.shopify.com has been
 decommissioned; this is now published as a static, read-only snapshot to
-[https://shopify.github.io/polaris-react/](https://shopify.github.io/polaris-react/).
+[https://shopify.github.io/polaris-react-archive/](https://shopify.github.io/polaris-react-archive/).
 
 New Shopify admin development should use
-[Polaris web components](https://shopify.dev/docs/api/app-home/polaris-web-components).
+[Polaris on shopify.dev](https://shopify.dev/docs/api/polaris).
 
 ## Getting Started
 
@@ -16,13 +16,14 @@ pnpm dev
 
 ## Building and previewing the archive
 
-`pnpm build` produces a static export in `out/`, mounted at the `/polaris-react`
-base path so it works as a GitHub Pages project site. To preview it the way
-Pages serves it:
+`pnpm build` produces a static export in `out/`, mounted at the
+`/polaris-react-archive` base path (the repository name, which is what a GitHub
+Pages project site is served from) so it works as a GitHub Pages project site.
+To preview it the way Pages serves it:
 
 ```
 pnpm build
-pnpm serve   # http://localhost:3000/polaris-react
+pnpm serve   # http://localhost:3000/polaris-react-archive
 ```
 
 Set `POLARIS_BASE_PATH=""` to build or serve from the root of a domain instead;

--- a/polaris.shopify.com/constants.js
+++ b/polaris.shopify.com/constants.js
@@ -1,12 +1,15 @@
 // Not a TS file because our playroom.config.js needs to access it also, and can't understand ts imports.
 
 // The site is published as a static export to GitHub Pages at
-// https://shopify.github.io/polaris-react/, so every asset and route needs the
-// `/polaris-react` prefix. Set POLARIS_BASE_PATH to an empty string to build or
-// serve the site from the root of a domain (this is what `pnpm dev` does).
+// https://shopify.github.io/polaris-react-archive/, so every asset and route
+// needs the `/polaris-react-archive` prefix. A GitHub Pages project site is
+// served from a path named after the repository, so this has to track the
+// repository name (`Shopify/polaris-react-archive`). Set POLARIS_BASE_PATH to
+// an empty string to build or serve the site from the root of a domain (this
+// is what `pnpm dev` does).
 const basePath =
   process.env.POLARIS_BASE_PATH === undefined
-    ? '/polaris-react'
+    ? '/polaris-react-archive'
     : process.env.POLARIS_BASE_PATH;
 
 module.exports = {


### PR DESCRIPTION
## Why

[#14354](https://github.com/Shopify/polaris-react-archive/pull/14354) converted `polaris.shopify.com` to a static export for GitHub Pages and pinned it to the `/polaris-react` base path. The repository has since been renamed **`Shopify/polaris-react` → `Shopify/polaris-react-archive`**.

A GitHub Pages project site is served from a path named after the repository, so that base path is now wrong. Deploying as-is would publish to `https://shopify.github.io/polaris-react-archive/` while every asset and route still pointed at `/polaris-react/…` — a site of 404s.

While we're here: the npm package has no deprecation notice, and `npm` is where most people still meet Polaris React (~200k downloads/week). That notice has to be set before the repo is re-archived, because no workflow can run afterwards.

## What changed

**basePath (`17c8a5ce`)**
- `polaris.shopify.com/constants.js`: `POLARIS_BASE_PATH` default `/polaris-react` → `/polaris-react-archive`.
- That's the only functional change. `next.config.js`, `playroom.config.js`, `scripts/post-export.ts`, `scripts/serve-export.ts`, `scripts/gen-token-api.ts`, the SCSS `$basePath` and `NEXT_PUBLIC_BASE_PATH` all read that one constant, so nothing else needed touching.
- Remaining edits are comments and docs that spelled the old path out: `deploy-github-pages.yml` header, `polaris.shopify.com/README.md`.
- A repo-wide sweep confirmed no other hardcoded `/polaris-react` URL identity. Everything else matching `polaris-react` is the workspace directory name, the `@shopify/polaris-react` package name in old migration guides, or `github.com/Shopify/polaris` links — all left alone.

**READMEs (`17c8a5ce`)**
Short archive notice at the top of the root `README.md`, `polaris-react/README.md` (the copy npm renders on the package page) and `polaris.shopify.com/README.md`: repo archived and unmaintained → docs at <https://shopify.github.io/polaris-react-archive/> → current admin development uses <https://shopify.dev/docs/api/polaris>.

**`.github/workflows/npm-deprecate.yml` (`a3694ae1`)**
`workflow_dispatch`-only one-shot job that runs:

```
npm deprecate "@shopify/polaris@*" "Polaris React is deprecated and no longer maintained. For building Shopify admin experiences, use Polaris web components: https://shopify.dev/docs/api/polaris — archived docs for this package: https://shopify.github.io/polaris-react-archive/"
```

Auth is the existing `secrets.NPM_TOKEN`, the same secret `release.yml` publishes with; `actions/setup-node`'s `registry-url` writes the `~/.npmrc` that consumes `NODE_AUTH_TOKEN`, so no checkout is required. The action is pinned to the same full SHA the other workflows use.

**Scoped to `@shopify/polaris` on purpose.** `changeset publish` also releases `@shopify/polaris-tokens`, `@shopify/polaris-icons`, `@shopify/polaris-migrator` and `@shopify/stylelint-polaris` from this repo (all five confirmed live on the registry, none currently deprecated). Those have consumers beyond Polaris React and the message above doesn't describe them, so deprecating them is a separate call — flagging it here rather than doing it silently.

## Verification

`pnpm build` (the same command `deploy-github-pages.yml` runs), then grepping `polaris.shopify.com/out`:

```
=== HTML file count ===            907
=== stale '/polaris-react/' refs ===   0
=== files containing /polaris-react-archive/ === 903
=== files with noindex meta ===    907
```

The 4 pages without the prefix are legitimate: `foundations/content/app-release-notes.html`, `foundations/foundations/designing-apps.html` and `legal/license.html` are redirect stubs pointing at absolute off-site URLs, and `playroom/preview/index.html` uses relative asset paths. All four still carry `noindex`.

Sample from `out/index.html`:

```
href="/polaris-react-archive/_next/static/css/ee38ed26917c96c1.css"
href="/polaris-react-archive/fonts/inter/inter.css"
href="/polaris-react-archive/images/favicon.png"
href="/polaris-react-archive/components"
<meta name="robots" content="noindex, noai, noimageai"/>
```

Then `pnpm serve` (`scripts/serve-export.ts`, which mimics how Pages serves it) — every asset class resolves under the new prefix:

```
GET /                                                  302 -> /polaris-react-archive
GET /polaris-react-archive/                            200
GET /polaris-react-archive/components/actions/button   200  <meta name="robots" content="noindex, noai, noimageai"/>
GET /polaris-react-archive/_next/static/css/….css      200
GET /polaris-react-archive/fonts/inter/inter.css       200
GET /polaris-react-archive/search-index.json           200
GET /polaris-react-archive/playroom/index.html         200
GET /polaris-react-archive/api/tokens/v0/index.html    200
```

`pnpm lint` and `pnpm type-check` both pass (`Tasks: 7 successful, 7 total`).

## After merge

Both workflows are manual one-shots to run from the Actions tab, in this order, before the repo is re-archived:

1. **Deploy to GitHub Pages** — publishes the export to <https://shopify.github.io/polaris-react-archive/>.
2. **Deprecate npm package** — sets the npm notice, which links to that Pages URL.

No changeset: the repo is about to be archived and we don't want this to open a Version Packages PR or trigger another release. `check-changesets` only fails on `major` entries, so it stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)